### PR TITLE
feat: Introduce domain labels and use as group name fallback

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -54,5 +54,9 @@
   "exportMessage": { "message": "Settings exported." },
   "domainFilterTooltip": { "message": "Enter the domain (e.g., youtube.com) or a pattern (e.g., *google*). Rules apply to matching domains." },
   "deduplicationModeTooltip": { "message": "Exact Match: Tabs are duplicates if titles are identical. Includes Match: Tabs are duplicates if one title contains the other." },
-  "titleParsingRegExTooltip": { "message": "Select a preset or write a custom regex to extract a part of the tab title for grouping or deduplication. The first capture group (text inside parentheses) is used." }
+  "titleParsingRegExTooltip": { "message": "Select a preset or write a custom regex to extract a part of the tab title for grouping or deduplication. The first capture group (text inside parentheses) is used." },
+  "labelLabel": { "message": "Label" },
+  "errorLabelRequired": { "message": "Label is required." },
+  "errorLabelUnique": { "message": "Label must be unique." },
+  "labelTooltip": { "message": "A unique name for this domain rule. This label will be used as the group title if the title parsing regex fails or is not set." }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -54,5 +54,9 @@
   "exportMessage": { "message": "Configuración exportada." },
   "domainFilterTooltip": { "message": "Ingrese el dominio (por ejemplo, youtube.com) o un patrón (por ejemplo, _google_). Las reglas se aplican a los dominios coincidentes." },
   "deduplicationModeTooltip": { "message": "Coincidencia exacta: Las pestañas son duplicadas si los títulos son idénticos. Coincidencia incluida: Las pestañas son duplicadas si un título contiene al otro." },
-  "titleParsingRegExTooltip": { "message": "Seleccione un valor preestablecido o escriba una expresión regular personalizada para extraer una parte del título de la pestaña para agrupar o eliminar duplicados. Se utiliza el primer grupo de captura (texto dentro de paréntesis)." }
+  "titleParsingRegExTooltip": { "message": "Seleccione un valor preestablecido o escriba una expresión regular personalizada para extraer una parte del título de la pestaña para agrupar o eliminar duplicados. Se utiliza el primer grupo de captura (texto dentro de paréntesis)." },
+  "labelLabel": { "message": "Etiqueta" },
+  "errorLabelRequired": { "message": "La etiqueta es obligatoria." },
+  "errorLabelUnique": { "message": "La etiqueta debe ser única." },
+  "labelTooltip": { "message": "Un nombre único para esta regla de dominio. Esta etiqueta se usará como título del grupo si la expresión regular de análisis de título falla o no está configurada." }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -54,5 +54,9 @@
   "exportMessage": { "message": "Paramètres exportés." },
   "domainFilterTooltip": { "message": "Entrez le domaine (par exemple, youtube.com) ou un motif (par exemple, _google_). Les règles s'appliquent aux domaines correspondants." },
   "deduplicationModeTooltip": { "message": "Correspondance exacte : Les onglets sont des doublons si les titres sont identiques. Correspondance incluse : Les onglets sont des doublons si un titre contient l'autre." },
-  "titleParsingRegExTooltip": { "message": "Sélectionnez un préréglage ou écrivez une expression régulière personnalisée pour extraire une partie du titre de l'onglet pour le regroupement ou la suppression des doublons. Le premier groupe de capture (texte entre parenthèses) est utilisé." }
+  "titleParsingRegExTooltip": { "message": "Sélectionnez un préréglage ou écrivez une expression régulière personnalisée pour extraire une partie du titre de l'onglet pour le regroupement ou la suppression des doublons. Le premier groupe de capture (texte entre parenthèses) est utilisé." },
+  "labelLabel": { "message": "Étiquette" },
+  "errorLabelRequired": { "message": "L'étiquette est obligatoire." },
+  "errorLabelUnique": { "message": "L'étiquette doit être unique." },
+  "labelTooltip": { "message": "Un nom unique pour cette règle de domaine. Cette étiquette sera utilisée comme titre du groupe si l'expression régulière d'analyse du titre échoue ou n'est pas configurée." }
 }

--- a/data/default_settings.json
+++ b/data/default_settings.json
@@ -15,15 +15,15 @@
     { "id": "preset-redmine", "name": "Redmine Issue ID", "regex": "#(\\d+)" }
   ],
   "domainRules": [
-    { "id": "rule-jira", "enabled": true, "domainFilter": "*.atlassian.net", "titleParsingRegEx": "([A-Z]+-\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-gitlab", "enabled": true, "domainFilter": "gitlab.com", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-github", "enabled": true, "domainFilter": "github.com", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-trello", "enabled": true, "domainFilter": "trello.com", "titleParsingRegEx": "\\[#(\\d+)\\]", "deduplicationMatchMode": "exact" },
-    { "id": "rule-mantis", "enabled": true, "domainFilter": "mantisbt.org", "titleParsingRegEx": "0*(\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-asana", "enabled": true, "domainFilter": "app.asana.com", "titleParsingRegEx": "\\/(\\d{16})\\/", "deduplicationMatchMode": "exact" },
-    { "id": "rule-zendesk", "enabled": true, "domainFilter": "*.zendesk.com", "titleParsingRegEx": "\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-servicenow", "enabled": true, "domainFilter": "*.service-now.com", "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-freshdesk", "enabled": true, "domainFilter": "*.freshdesk.com", "titleParsingRegEx": "\\/a\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact" },
-    { "id": "rule-redmine", "enabled": true, "domainFilter": "redmine.org", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" }
+    { "id": "rule-jira", "enabled": true, "domainFilter": "*.atlassian.net", "label": "Jira/Atlassian", "titleParsingRegEx": "([A-Z]+-\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-gitlab", "enabled": true, "domainFilter": "gitlab.com", "label": "GitLab", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-github", "enabled": true, "domainFilter": "github.com", "label": "GitHub", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-trello", "enabled": true, "domainFilter": "trello.com", "label": "Trello", "titleParsingRegEx": "\\[#(\\d+)\\]", "deduplicationMatchMode": "exact" },
+    { "id": "rule-mantis", "enabled": true, "domainFilter": "mantisbt.org", "label": "MantisBT", "titleParsingRegEx": "0*(\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-asana", "enabled": true, "domainFilter": "app.asana.com", "label": "Asana", "titleParsingRegEx": "\\/(\\d{16})\\/", "deduplicationMatchMode": "exact" },
+    { "id": "rule-zendesk", "enabled": true, "domainFilter": "*.zendesk.com", "label": "Zendesk", "titleParsingRegEx": "\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-servicenow", "enabled": true, "domainFilter": "*.service-now.com", "label": "ServiceNow", "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-freshdesk", "enabled": true, "domainFilter": "*.freshdesk.com", "label": "Freshdesk", "titleParsingRegEx": "\\/a\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact" },
+    { "id": "rule-redmine", "enabled": true, "domainFilter": "redmine.org", "label": "Redmine", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact" }
   ]
 }

--- a/js/background.js
+++ b/js/background.js
@@ -97,27 +97,35 @@ async function handleGrouping(openerTab, newTab) {
         console.log(`[GROUPING_DEBUG] handleGrouping: Exiting early - No matching enabled rule for opener tab URL: ${openerTab.url}`);
         return;
     }
-    console.log(`[GROUPING_DEBUG] handleGrouping: Rule found for "${openerTab.url}": name: "${rule.name || 'N/A'}", filter: "${rule.domainFilter}"`);
+    // rule.label is available from settings, rule.name was from an older version.
+    console.log(`[GROUPING_DEBUG] handleGrouping: Rule found for "${openerTab.url}": label: "${rule.label || 'N/A'}", filter: "${rule.domainFilter}"`);
 
-    // Determine groupName from openerTab's title and rule's regex immediately
-    let groupName = "SmartGroup"; // Default group name
+    // Determine groupName: 1. Regex, 2. Rule Label, 3. "SmartGroup"
+    let groupName = rule.label; // Use rule's label as the initial default
+    if (!groupName || !groupName.trim()) { // Fallback if label is empty or whitespace
+        groupName = "SmartGroup";
+        console.log(`[GROUPING_DEBUG] handleGrouping: Rule label is empty or whitespace. Initial groupName set to "${groupName}".`);
+    } else {
+        console.log(`[GROUPING_DEBUG] handleGrouping: Initial groupName set from rule.label: "${groupName}".`);
+    }
+
     if (openerTab.title && rule.titleParsingRegEx) {
         try {
             const extracted = extractGroupNameFromTitle(openerTab.title, rule.titleParsingRegEx);
-            console.log(`[GROUPING_DEBUG] handleGrouping: Group name from OPENER tab - Extracted name: "${extracted}" from opener title "${openerTab.title}" using regex "${rule.titleParsingRegEx}"`);
             if (extracted && extracted.trim()) {
-                groupName = extracted.trim();
+                groupName = extracted.trim(); // Override with extracted name if successful
+                console.log(`[GROUPING_DEBUG] handleGrouping: Group name extracted from opener title "${openerTab.title}" using regex "${rule.titleParsingRegEx}": "${groupName}".`);
             } else {
-                 console.log(`[GROUPING_DEBUG] handleGrouping: Group name from OPENER tab - Title parsing resulted in empty/null/undefined or whitespace-only. Using default group name "${groupName}".`);
+                 console.log(`[GROUPING_DEBUG] handleGrouping: Title parsing from opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}" was empty or whitespace. Group name remains: "${groupName}".`);
             }
         } catch (e) {
-            console.warn(`[GROUPING_DEBUG] handleGrouping: Group name from OPENER tab - Error parsing opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}". Using default name. Details:`, e.message);
-            groupName = "SmartGroup"; // Ensure default on error
+            console.warn(`[GROUPING_DEBUG] handleGrouping: Error parsing opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}". Group name remains: "${groupName}". Details:`, e.message);
+            // On error, groupName remains rule.label (or "SmartGroup" if label was also empty)
         }
     } else {
-         console.log(`[GROUPING_DEBUG] handleGrouping: Group name from OPENER tab - No opener title ("${openerTab.title}") or no parsing regex ("${rule.titleParsingRegEx}"). Using default group name "${groupName}".`);
+         console.log(`[GROUPING_DEBUG] handleGrouping: No opener title ("${openerTab.title}") or no parsing regex ("${rule.titleParsingRegEx}"). Group name remains: "${groupName}".`);
     }
-    console.log(`[GROUPING_DEBUG] handleGrouping: Determined groupName (from opener tab): "${groupName}" for new tab ${newTab.id}.`);
+    console.log(`[GROUPING_DEBUG] handleGrouping: Final determined groupName: "${groupName}" for new tab ${newTab.id}.`);
 
     let hasProcessedTab = false;
 

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -54,6 +54,16 @@ export async function initializeDefaults() {
         // Ensure default IDs exist
         defaults.regexPresets.forEach(dp => { if (!merged.regexPresets.some(mp => mp.id === dp.id)) merged.regexPresets.push(dp); });
         defaults.domainRules.forEach(dr => { if (!merged.domainRules.some(mr => mr.id === dr.id)) merged.domainRules.push(dr); });
+
+        // Ensure all domain rules have a label
+        if (merged.domainRules && Array.isArray(merged.domainRules)) {
+            merged.domainRules.forEach(rule => {
+                if (typeof rule.label === 'undefined') {
+                    const defaultRule = defaults.domainRules.find(dr => dr.id === rule.id);
+                    rule.label = defaultRule ? defaultRule.label : rule.domainFilter || "Untitled Rule";
+                }
+            });
+        }
         await saveSettings(merged);
     }
     const localData = await chrome.storage.local.get('statistics');

--- a/options/options.js
+++ b/options/options.js
@@ -157,7 +157,8 @@ function RulesTab({ settings, updateRules, editingId, setEditingId }) {
 
     const handleAdd = () => {
         const newId = generateUUID();
-        const newRule = { id: newId, enabled: true, domainFilter: "", titleParsingRegEx: regexPresets[0]?.regex || "", deduplicationMatchMode: "exact" };
+        // Initialize label for new rules
+        const newRule = { id: newId, label: "", enabled: true, domainFilter: "", titleParsingRegEx: regexPresets[0]?.regex || "", deduplicationMatchMode: "exact" };
         setNewRuleInProgress(newRule);
         setEditingId(newId); // Ouvre le formulaire pour la nouvelle règle
     };
@@ -217,8 +218,8 @@ function RuleView({ rule, presets, onEdit, onDelete, onToggle }) {
             <div class="item-view">
                 <input type="checkbox" id="enable-${rule.id}" checked=${rule.enabled} onChange=${handleToggle} />
                 <label for="enable-${rule.id}" class="item-details">
-                    <span class="item-main ${disabledClass}">${rule.domainFilter}</span>
-                    <span class="item-sub ${disabledClass}">${presetName} | ${dedupMode}</span>
+                    <span class="item-main ${disabledClass}">${rule.label}</span>
+                    <span class="item-sub ${disabledClass}">${rule.domainFilter} | ${presetName} | ${dedupMode}</span>
                 </label>
                 <div class="item-actions">
                     <button onClick=${() => onEdit(rule.id)}>${getMessage('edit')}</button>
@@ -229,7 +230,7 @@ function RuleView({ rule, presets, onEdit, onDelete, onToggle }) {
     `;
 }
 
-function RuleEditForm({ rule, presets, onSave, onCancel }) {
+function RuleEditForm({ rule, presets, onSave, onCancel, allRules }) { // Added allRules for uniqueness check
     const [formData, setFormData] = useState(rule);
     const [errors, setErrors] = useState({});
 
@@ -264,9 +265,17 @@ function RuleEditForm({ rule, presets, onSave, onCancel }) {
         e.preventDefault();
         // --- Validation ---
         let currentErrors = {};
+        // Label validation
+        if (!formData.label || formData.label.trim() === "") {
+            currentErrors.label = getMessage('errorLabelRequired', 'Label is required'); // Fallback text
+        } else if (allRules && allRules.some(r => r.id !== formData.id && r.label.toLowerCase() === formData.label.toLowerCase())) {
+            // Uniqueness check for label (case-insensitive) using the passed 'allRules' prop
+            currentErrors.label = getMessage('errorLabelUnique', 'Label must be unique'); // Fallback text
+        }
+
         if (!isValidDomain(formData.domainFilter)) {
             currentErrors.domainFilter = getMessage('errorInvalidDomain');
-        } // Add duplicate check later if needed
+        }
         if (!isValidRegex(formData.titleParsingRegEx)) {
             currentErrors.titleParsingRegEx = getMessage('errorInvalidRegex');
         }
@@ -284,6 +293,12 @@ function RuleEditForm({ rule, presets, onSave, onCancel }) {
             <div class="item-edit">
                  <form onSubmit=${handleSubmit}>
                     <div class="form-grid">
+                        <div class="form-group tooltip-container">
+                            <label data-i18n="labelLabel">${getMessage('labelLabel', 'Label')}</label>
+                            <input type="text" name="label" value=${formData.label} onChange=${handleChange} required />
+                            <span class="tooltip-text" data-i18n="labelTooltip">${getMessage('labelTooltip', 'A unique, user-friendly name for this rule.')}</span>
+                            ${errors.label && html`<span class="error-message">${errors.label}</span>`}
+                        </div>
                         <div class="form-group tooltip-container">
                             <label>${getMessage('domainFilter')}</label>
                             <input type="text" name="domainFilter" value=${formData.domainFilter} onChange=${handleChange} required />


### PR DESCRIPTION
This commit implements the ability for you to define a 'label' for each domain rule. This label serves as a user-friendly identifier for the rule in the options page and, crucially, is now used as the tab group name if the configured title parsing regex fails to extract a name or if no regex is set.

Key changes:
- Modified `domainRules` data model to include a `label` field.
  - Default labels added for predefined rules in `default_settings.json`.
  - `js/modules/storage.js` updated to ensure existing users' rules are populated with a label upon extension update.
- Updated Options page (`options/options.js`):
  - `RuleEditForm` now includes an input field for the label, with validation for presence and uniqueness (case-insensitive).
  - `RuleView` now displays the label as the primary identifier for the rule.
  - Internationalization support added for new UI elements related to labels (English, Spanish, French).
- Modified tab grouping logic in `js/background.js`:
  - If title extraction via regex fails, the group name now defaults to the rule's `label`.
  - The generic "SmartGroup" name is now only used as a final fallback if both regex fails and the label is missing/empty.

This addresses the issue where "SmartGroup" was too generic, providing a more configurable and descriptive grouping experience. Existing ID fields (internal UUIDs) remain for list management but the label is the primary user-facing ID for a rule.