### PR TITLE
Add rule-level group source options

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -15,9 +15,9 @@
     * Cuando haces clic central en un enlace, si el dominio de la página de origen coincide con una regla configurada, la nueva pestaña se abre en un grupo.
     * Si la pestaña de origen ya está en un grupo, la nueva pestaña se une a él.
     * De lo contrario, se crea un nuevo grupo.
-* **🏷️ Nombrado de Grupos mediante RegEx:**
+* **🏷️ Nombrado Flexible mediante RegEx:**
     * Define expresiones regulares para dominios específicos.
-    * La extensión extrae texto del título de la pestaña de origen usando tu RegEx para nombrar automáticamente el grupo de pestañas.
+    * El nombre del grupo puede extraerse del título o de la URL de la pestaña, o pedirse manualmente al usuario cuando sea necesario.
     * Incluye preajustes para herramientas populares de gestión de tickets (Jira, GitLab, GitHub, Trello, etc.).
 * **🚫 Prevención de Duplicados:**
     * Evita abrir la misma URL varias veces.
@@ -53,6 +53,10 @@
 3.  **Activar Modo Desarrollador:** Marca la casilla "Modo desarrollador".
 4.  **Cargar Extensión:** Haz clic en "Cargar descomprimida" y selecciona la carpeta `SmartTab_Organizer` (la que contiene `manifest.json`).
 5.  ¡La extensión está lista!
+
+### Permisos
+
+Esta extensión solicita el permiso `scripting` para poder inyectar un pequeño script cuando sea necesario pedir al usuario el nombre del grupo.
 
 ## Uso 📖
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -15,9 +15,9 @@
     * Lorsque vous cliquez avec la molette sur un lien, si le domaine de la page source correspond à une règle configurée, le nouvel onglet s'ouvre dans un groupe.
     * Si l'onglet source est déjà dans un groupe, le nouvel onglet le rejoint.
     * Sinon, un nouveau groupe est créé.
-* **🏷️ Nommage de Groupe via RegEx :**
+* **🏷️ Nommage Flexible via RegEx :**
     * Définissez des expressions régulières pour des domaines spécifiques.
-    * L'extension extrait du texte du titre de l'onglet source à l'aide de votre RegEx pour nommer automatiquement le groupe d'onglets.
+    * Le nom de groupe peut être extrait du titre ou de l'URL de l'onglet, ou être saisi manuellement lorsque nécessaire.
     * Inclut des préréglages pour les outils de tickets populaires (Jira, GitLab, GitHub, Trello, etc.).
 * **🚫 Prévention des Doublons :**
     * Empêche l'ouverture plusieurs fois de la même URL.
@@ -53,6 +53,10 @@
 3.  **Activer le Mode Développeur :** Cochez la case "Mode développeur".
 4.  **Charger l'Extension :** Cliquez sur "Charger l'extension non empaquetée" et sélectionnez le dossier `SmartTab_Organizer` (celui contenant `manifest.json`).
 5.  L'extension est prête !
+
+### Permissions
+
+Cette extension requiert la permission `scripting` afin d'injecter un script lorsque le nom du groupe doit être saisi par l'utilisateur.
 
 ## Utilisation 📖
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
     * When you middle-click on a link, if the source page's domain matches a configured rule, the new tab opens in a group.
     * If the source tab is already in a group, the new tab joins it.
     * Otherwise, a new group is created.
-* **🏷️ Group Naming via RegEx:**
+* **🏷️ Flexible Group Naming via RegEx:**
     * Define regular expressions for specific domains.
-    * The extension extracts text from the source tab's title using your RegEx to automatically name the tab group.
+    * The extension can extract the group name from the tab title or the tab URL, or it can prompt you for a name when needed.
     * Includes presets for popular ticketing tools (Jira, GitLab, GitHub, Trello, etc.).
 * **🚫 Duplicate Prevention:**
     * Prevents opening the same URL multiple times.
@@ -53,6 +53,10 @@
 3.  **Enable Developer Mode:** Check the "Developer mode" box.
 4.  **Load Extension:** Click "Load unpacked" and select the `SmartTab_Organizer` folder (the one containing `manifest.json`).
 5.  The extension is ready!
+
+### Permissions
+
+This extension requests the `scripting` permission so it can temporarily inject a script when it needs to prompt you for a group name.
 
 ## Usage 📖
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -42,6 +42,8 @@
   "dedupTooltip": { "message": "'Exact': Identical URL. 'Includes': New URL contained within an existing one." },
   "presetNameTooltip": { "message": "Name to identify this RegEx preset." },
   "presetRegexTooltip": { "message": "The Regular Expression (must contain one capturing group)." },
+  "presetUrlRegex": { "message": "URL RegEx" },
+  "presetUrlRegexTooltip": { "message": "Regular expression to parse the URL. The first capture group will be used." },
   "errorInvalidDomain": { "message": "Invalid domain format." },
   "errorDuplicateDomain": { "message": "This domain filter already exists." },
   "errorInvalidRegex": { "message": "Invalid Regular Expression (must have capturing group ())." },
@@ -90,5 +92,13 @@
   "ruleCountSingular": { "message": "rule" },
   "ruleCountPlural": { "message": "rules" },
   "noGroupAssigned": { "message": "No group" },
-  "loadingText": { "message": "Loading..." }
+  "loadingText": { "message": "Loading..." },
+  "groupNameSource": { "message": "Group Name Source" },
+  "groupNameSourceTooltip": { "message": "How the group name should be determined for this rule." },
+  "sourceTitle": { "message": "From Title" },
+  "sourceURL": { "message": "From URL" },
+  "sourcePrompt": { "message": "Ask User" },
+  "urlRegex": { "message": "URL RegEx" },
+  "urlParsingRegExTooltip": { "message": "Regular expression to extract the group name from the tab URL. The first capture group is used." },
+  "promptGroupName": { "message": "Please enter a group name:" }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -20,6 +20,8 @@
   "deduplicationMode": { "message": "Deduplication Mode" },
   "exactMatch": { "message": "Exact URL" },
   "includesMatch": { "message": "URL Includes" },
+  "hostnameMatch": { "message": "Hostname" },
+  "hostnamePathMatch": { "message": "Hostname + Path" },
   "enabled": { "message": "Enabled" },
   "save": { "message": "Save" },
   "edit": { "message": "Edit" },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -20,6 +20,8 @@
   "deduplicationMode": { "message": "Modo Deduplicación" },
   "exactMatch": { "message": "URL Exacta" },
   "includesMatch": { "message": "URL Incluida" },
+  "hostnameMatch": { "message": "Nombre de host" },
+  "hostnamePathMatch": { "message": "Host + Ruta" },
   "enabled": { "message": "Habilitado" },
   "save": { "message": "Guardar" },
   "edit": { "message": "Editar" },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -42,6 +42,8 @@
   "dedupTooltip": { "message": "'Exacta': URL idéntica. 'Incluida': Nueva URL contenida en una existente." },
   "presetNameTooltip": { "message": "Nombre para identificar este preajuste RegEx." },
   "presetRegexTooltip": { "message": "La Expresión Regular (debe contener un grupo de captura)." },
+  "presetUrlRegex": { "message": "RegEx URL" },
+  "presetUrlRegexTooltip": { "message": "Expresión regular para analizar la URL. Se usará el primer grupo de captura." },
   "errorInvalidDomain": { "message": "Formato de dominio inválido." },
   "errorDuplicateDomain": { "message": "Este filtro de dominio ya existe." },
   "errorInvalidRegex": { "message": "Expresión Regular inválida (debe tener grupo de captura ())." },
@@ -90,5 +92,13 @@
   "ruleCountSingular": { "message": "regla" },
   "ruleCountPlural": { "message": "reglas" },
   "noGroupAssigned": { "message": "Sin grupo" },
-  "loadingText": { "message": "Cargando..." }
+  "loadingText": { "message": "Cargando..." },
+  "groupNameSource": { "message": "Fuente del nombre de grupo" },
+  "groupNameSourceTooltip": { "message": "Cómo determinar el nombre del grupo para esta regla." },
+  "sourceTitle": { "message": "Desde el título" },
+  "sourceURL": { "message": "Desde la URL" },
+  "sourcePrompt": { "message": "Solicitar al usuario" },
+  "urlRegex": { "message": "RegEx URL" },
+  "urlParsingRegExTooltip": { "message": "Expresión regular para extraer el nombre desde la URL de la pestaña. Se usa el primer grupo de captura." },
+  "promptGroupName": { "message": "Introduzca el nombre del grupo:" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -42,6 +42,8 @@
   "dedupTooltip": { "message": "'Exacte': URL identique. 'Incluse': Nouvelle URL contenue dans une existante." },
   "presetNameTooltip": { "message": "Nom pour identifier ce préréglage RegEx." },
   "presetRegexTooltip": { "message": "L'Expression Régulière (doit contenir un groupe capturant)." },
+  "presetUrlRegex": { "message": "RegEx URL" },
+  "presetUrlRegexTooltip": { "message": "Expression régulière pour analyser l'URL. Le premier groupe capturant sera utilisé." },
   "errorInvalidDomain": { "message": "Format de domaine invalide." },
   "errorDuplicateDomain": { "message": "Ce filtre de domaine existe déjà." },
   "errorInvalidRegex": { "message": "Expression Régulière invalide (doit avoir un groupe capturant ())." },
@@ -90,5 +92,13 @@
   "ruleCountSingular": { "message": "règle" },
   "ruleCountPlural": { "message": "règles" },
   "noGroupAssigned": { "message": "Aucun groupe" },
-  "loadingText": { "message": "Chargement..." }
+  "loadingText": { "message": "Chargement..." },
+  "groupNameSource": { "message": "Origine du nom de groupe" },
+  "groupNameSourceTooltip": { "message": "Comment déterminer le nom de groupe pour cette règle." },
+  "sourceTitle": { "message": "Depuis le titre" },
+  "sourceURL": { "message": "Depuis l\u0027URL" },
+  "sourcePrompt": { "message": "Demander \u00e0 l\u0027utilisateur" },
+  "urlRegex": { "message": "RegEx URL" },
+  "urlParsingRegExTooltip": { "message": "Expression régulière pour extraire le nom depuis l\u0027URL de l\u0027onglet. Le premier groupe de capture est utilisé." },
+  "promptGroupName": { "message": "Veuillez saisir le nom du groupe :" }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -20,6 +20,8 @@
   "deduplicationMode": { "message": "Mode Déduplication" },
   "exactMatch": { "message": "URL Exacte" },
   "includesMatch": { "message": "URL Incluse" },
+  "hostnameMatch": { "message": "Nom d'hôte" },
+  "hostnamePathMatch": { "message": "Hôte + Chemin" },
   "enabled": { "message": "Activé" },
   "save": { "message": "Enregistrer" },
   "edit": { "message": "Modifier" },

--- a/css/options.css
+++ b/css/options.css
@@ -126,7 +126,7 @@ footer { margin-top: 40px; padding-top: 15px; border-top: 1px solid var(--border
   transition: max-height 0.4s ease-out, opacity 0.3s ease-out, padding-bottom 0.4s ease-out; /* Added padding-bottom to transition */
   opacity: 0;
   padding-bottom: 0; /* No padding when collapsed */
-  /* margin-left: 20px; /* Indent rules slightly under their group - consider if needed */
+  /* margin-left: 20px; Indent rules slightly under their group - consider if needed */
 }
 
 .rules-group-content.expanded {

--- a/data/default_settings.json
+++ b/data/default_settings.json
@@ -3,30 +3,184 @@
   "globalDeduplicationEnabled": true,
   "darkModePreference": "system",
   "regexPresets": [
-    { "id": "preset-jira", "name": "Jira Ticket", "regex": "([A-Z]+-\\d+)" },
-    { "id": "preset-gitlab", "name": "GitLab Issue", "regex": "#(\\d+)" },
-    { "id": "preset-github", "name": "GitHub Issue", "regex": "#(\\d+)" },
-    { "id": "preset-trello", "name": "Trello Card", "regex": "\\[#(\\d+)\\]" },
-    { "id": "preset-mantis", "name": "Mantis Issue", "regex": "0*(\\d+)" },
-    { "id": "preset-asana", "name": "Asana Task ID", "regex": "\\/(\\d{16})\\/" },
-    { "id": "preset-zendesk", "name": "Zendesk Ticket ID", "regex": "\\/tickets\\/(\\d+)" },
-    { "id": "preset-servicenow", "name": "ServiceNow ID", "regex": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)" },
-    { "id": "preset-freshdesk", "name": "Freshdesk Ticket ID", "regex": "\\/a\\/tickets\\/(\\d+)" },
-    { "id": "preset-redmine", "name": "Redmine Issue ID", "regex": "#(\\d+)" }
+    {
+      "id": "preset-jira",
+      "name": "Jira Ticket",
+      "regex": "([A-Z]+-\\d+)",
+      "urlRegex": "browse/([A-Z]+-\\d+)"
+    },
+    {
+      "id": "preset-gitlab",
+      "name": "GitLab Issue",
+      "regex": "#(\\d+)",
+      "urlRegex": "issues/(\\d+)"
+    },
+    {
+      "id": "preset-github",
+      "name": "GitHub Issue",
+      "regex": "#(\\d+)",
+      "urlRegex": "issues/(\\d+)"
+    },
+    {
+      "id": "preset-trello",
+      "name": "Trello Card",
+      "regex": "\\[#(\\d+)\\]",
+      "urlRegex": "c/([A-Za-z0-9]+)/"
+    },
+    {
+      "id": "preset-mantis",
+      "name": "Mantis Issue",
+      "regex": "0*(\\d+)",
+      "urlRegex": "id=(\\d+)"
+    },
+    {
+      "id": "preset-asana",
+      "name": "Asana Task ID",
+      "regex": "\\/(\\d{16})\\/",
+      "urlRegex": "/(\\d{16})/"
+    },
+    {
+      "id": "preset-zendesk",
+      "name": "Zendesk Ticket ID",
+      "regex": "\\/tickets\\/(\\d+)",
+      "urlRegex": "tickets/(\\d+)"
+    },
+    {
+      "id": "preset-servicenow",
+      "name": "ServiceNow ID",
+      "regex": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)",
+      "urlRegex": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)"
+    },
+    {
+      "id": "preset-freshdesk",
+      "name": "Freshdesk Ticket ID",
+      "regex": "\\/a\\/tickets\\/(\\d+)",
+      "urlRegex": "tickets/(\\d+)"
+    },
+    {
+      "id": "preset-redmine",
+      "name": "Redmine Issue ID",
+      "regex": "#(\\d+)",
+      "urlRegex": "issues/(\\d+)"
+    }
   ],
   "logicalGroups": [
-    { "id": "issues", "label": "issues", "color": "grey" }
+    {
+      "id": "issues",
+      "label": "issues",
+      "color": "grey"
+    }
   ],
   "domainRules": [
-    { "id": "rule-jira", "enabled": true, "domainFilter": "*.atlassian.net", "label": "Jira/Atlassian", "titleParsingRegEx": "([A-Z]+-\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-gitlab", "enabled": true, "domainFilter": "gitlab.com", "label": "GitLab", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-github", "enabled": true, "domainFilter": "github.com", "label": "GitHub", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-trello", "enabled": true, "domainFilter": "trello.com", "label": "Trello", "titleParsingRegEx": "\\[#(\\d+)\\]", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-mantis", "enabled": true, "domainFilter": "mantisbt.org", "label": "MantisBT", "titleParsingRegEx": "0*(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-asana", "enabled": true, "domainFilter": "app.asana.com", "label": "Asana", "titleParsingRegEx": "\\/(\\d{16})\\/", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-zendesk", "enabled": true, "domainFilter": "*.zendesk.com", "label": "Zendesk", "titleParsingRegEx": "\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-servicenow", "enabled": true, "domainFilter": "*.service-now.com", "label": "ServiceNow", "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-freshdesk", "enabled": true, "domainFilter": "*.freshdesk.com", "label": "Freshdesk", "titleParsingRegEx": "\\/a\\/tickets\\/(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" },
-    { "id": "rule-redmine", "enabled": true, "domainFilter": "redmine.org", "label": "Redmine", "titleParsingRegEx": "#(\\d+)", "deduplicationMatchMode": "exact", "groupId": "issues" }
+    {
+      "id": "rule-jira",
+      "enabled": true,
+      "domainFilter": "*.atlassian.net",
+      "label": "Jira/Atlassian",
+      "titleParsingRegEx": "([A-Z]+-\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "browse/([A-Z]+-\\d+)"
+    },
+    {
+      "id": "rule-gitlab",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab",
+      "titleParsingRegEx": "#(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "issues/(\\d+)"
+    },
+    {
+      "id": "rule-github",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub",
+      "titleParsingRegEx": "#(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "issues/(\\d+)"
+    },
+    {
+      "id": "rule-trello",
+      "enabled": true,
+      "domainFilter": "trello.com",
+      "label": "Trello",
+      "titleParsingRegEx": "\\[#(\\d+)\\]",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "c/([A-Za-z0-9]+)/"
+    },
+    {
+      "id": "rule-mantis",
+      "enabled": true,
+      "domainFilter": "mantisbt.org",
+      "label": "MantisBT",
+      "titleParsingRegEx": "0*(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "id=(\\d+)"
+    },
+    {
+      "id": "rule-asana",
+      "enabled": true,
+      "domainFilter": "app.asana.com",
+      "label": "Asana",
+      "titleParsingRegEx": "\\/(\\d{16})\\/",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "/(\\d{16})/"
+    },
+    {
+      "id": "rule-zendesk",
+      "enabled": true,
+      "domainFilter": "*.zendesk.com",
+      "label": "Zendesk",
+      "titleParsingRegEx": "\\/tickets\\/(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "tickets/(\\d+)"
+    },
+    {
+      "id": "rule-servicenow",
+      "enabled": true,
+      "domainFilter": "*.service-now.com",
+      "label": "ServiceNow",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+)"
+    },
+    {
+      "id": "rule-freshdesk",
+      "enabled": true,
+      "domainFilter": "*.freshdesk.com",
+      "label": "Freshdesk",
+      "titleParsingRegEx": "\\/a\\/tickets\\/(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "tickets/(\\d+)"
+    },
+    {
+      "id": "rule-redmine",
+      "enabled": true,
+      "domainFilter": "redmine.org",
+      "label": "Redmine",
+      "titleParsingRegEx": "#(\\d+)",
+      "deduplicationMatchMode": "exact",
+      "groupId": "issues",
+      "groupNameSource": "title",
+      "urlParsingRegEx": "issues/(\\d+)"
+    }
   ]
 }

--- a/js/background.js
+++ b/js/background.js
@@ -1,8 +1,24 @@
 // js/background.js
 import { getSettings as storageGetSettings, incrementStat, initializeDefaults } from './modules/storage.js';
-import { matchesDomain, extractGroupNameFromTitle } from './modules/utils.js';
+import { matchesDomain, extractGroupNameFromTitle, extractGroupNameFromUrl } from './modules/utils.js';
+import { getMessage } from './modules/i18n.js';
 
 const middleClickedTabs = new Map();
+
+async function promptForGroupName(tabId, defaultName) {
+    try {
+        const promptText = getMessage('promptGroupName');
+        const [{ result }] = await chrome.scripting.executeScript({
+            target: { tabId },
+            func: (text, def) => prompt(text, def),
+            args: [promptText || 'Enter group name:', defaultName]
+        });
+        return result && result.trim() ? result.trim() : defaultName;
+    } catch (e) {
+        console.warn('Prompt for group name failed:', e);
+        return defaultName;
+    }
+}
 
 async function getSettings() {
     const settings = await storageGetSettings();
@@ -123,23 +139,7 @@ async function handleGrouping(openerTab, newTab) {
         console.log(`[GROUPING_DEBUG] handleGrouping: Initial groupName set from rule.label: "${groupName}".`);
     }
 
-    if (openerTab.title && rule.titleParsingRegEx) {
-        try {
-            const extracted = extractGroupNameFromTitle(openerTab.title, rule.titleParsingRegEx);
-            if (extracted && extracted.trim()) {
-                groupName = extracted.trim(); // Override with extracted name if successful
-                console.log(`[GROUPING_DEBUG] handleGrouping: Group name extracted from opener title "${openerTab.title}" using regex "${rule.titleParsingRegEx}": "${groupName}".`);
-            } else {
-                 console.log(`[GROUPING_DEBUG] handleGrouping: Title parsing from opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}" was empty or whitespace. Group name remains: "${groupName}".`);
-            }
-        } catch (e) {
-            console.warn(`[GROUPING_DEBUG] handleGrouping: Error parsing opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}". Group name remains: "${groupName}". Details:`, e.message);
-            // On error, groupName remains rule.label (or "SmartGroup" if label was also empty)
-        }
-    } else {
-         console.log(`[GROUPING_DEBUG] handleGrouping: No opener title ("${openerTab.title}") or no parsing regex ("${rule.titleParsingRegEx}"). Group name remains: "${groupName}".`);
-    }
-    console.log(`[GROUPING_DEBUG] handleGrouping: Final determined groupName: "${groupName}" for new tab ${newTab.id}.`);
+    console.log(`[GROUPING_DEBUG] handleGrouping: groupNameSource for rule is "${rule.groupNameSource}".`);
 
     let hasProcessedTab = false;
 
@@ -162,10 +162,20 @@ async function handleGrouping(openerTab, newTab) {
 
             hasProcessedTab = true;
             chrome.tabs.onUpdated.removeListener(listener);
-            // Note: 'tab' here is the newTab object from the onUpdated event.
-            console.log(`[GROUPING_DEBUG] onUpdated listener: Main condition met for newTab ${newTab.id}. URL: "${tab.url}", Title: "${tab.title}". Group name was already determined as "${groupName}". Listener removed.`);
 
-            // GroupName is already determined from openerTab. Now proceed with grouping.
+            // Determine group name now that tab URL and title are available
+            if (rule.groupNameSource === 'title' && openerTab.title && rule.titleParsingRegEx) {
+                const extracted = extractGroupNameFromTitle(openerTab.title, rule.titleParsingRegEx);
+                if (extracted && extracted.trim()) { groupName = extracted.trim(); }
+            } else if (rule.groupNameSource === 'url' && tab.url && rule.urlParsingRegEx) {
+                const extracted = extractGroupNameFromUrl(tab.url, rule.urlParsingRegEx);
+                if (extracted && extracted.trim()) { groupName = extracted.trim(); }
+            } else if (rule.groupNameSource === 'prompt') {
+                groupName = await promptForGroupName(tab.id, groupName);
+            }
+            console.log(`[GROUPING_DEBUG] onUpdated listener: Main condition met for newTab ${newTab.id}. URL: "${tab.url}", Title: "${tab.title}". Final groupName "${groupName}". Listener removed.`);
+
+            // Proceed with grouping using computed groupName
             try {
                 let currentOpenerTab = await chrome.tabs.get(openerTab.id); // Refresh openerTab state, though its title for grouping is already used.
                 const openerGroupId = currentOpenerTab.groupId;

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -52,7 +52,15 @@ export async function initializeDefaults() {
         console.log("Merging existing with JSON defaults...");
         const merged = mergeDeep(defaults, syncData.settings);
         // Ensure default IDs exist
-        defaults.regexPresets.forEach(dp => { if (!merged.regexPresets.some(mp => mp.id === dp.id)) merged.regexPresets.push(dp); });
+        defaults.regexPresets.forEach(dp => {
+            const existing = merged.regexPresets.find(mp => mp.id === dp.id);
+            if (!existing) {
+                merged.regexPresets.push(dp);
+            } else {
+                if (typeof existing.urlRegex === 'undefined' && dp.urlRegex)
+                    existing.urlRegex = dp.urlRegex;
+            }
+        });
         defaults.domainRules.forEach(dr => { if (!merged.domainRules.some(mr => mr.id === dr.id)) merged.domainRules.push(dr); });
 
         // Ensure logicalGroups are merged and the default "issues" group is present
@@ -71,11 +79,18 @@ export async function initializeDefaults() {
         if (merged.domainRules && Array.isArray(merged.domainRules)) {
             merged.domainRules.forEach(rule => {
                 if (typeof rule.label === 'undefined') {
-                    const defaultRule = defaults.domainRules.find(dr => dr.id === rule.id);
-                    rule.label = defaultRule ? defaultRule.label : rule.domainFilter || "Untitled Rule";
+                    const defRule = defaults.domainRules.find(dr => dr.id === rule.id);
+                    rule.label = defRule ? defRule.label : rule.domainFilter || "Untitled Rule";
                 }
                 if (typeof rule.groupId === 'undefined') {
-                    rule.groupId = "issues"; // Default to "issues" group
+                    rule.groupId = "issues"; // Default logical group
+                }
+                if (typeof rule.groupNameSource === 'undefined') {
+                    rule.groupNameSource = 'title';
+                }
+                if (typeof rule.urlParsingRegEx === 'undefined') {
+                    const defRule = defaults.domainRules.find(dr => dr.id === rule.id) || {};
+                    rule.urlParsingRegEx = defRule.urlParsingRegEx || '';
                 }
             });
         }

--- a/js/modules/utils.js
+++ b/js/modules/utils.js
@@ -11,5 +11,10 @@ export function extractGroupNameFromTitle(title, regexString) {
     try { const regex = new RegExp(regexString); const match = title.match(regex); return (match && match[1]) ? match[1].trim() : null; }
     catch (e) { console.error("Err extractGroupName:", title, regexString, e); return null; }
 }
+export function extractGroupNameFromUrl(url, regexString) {
+    if (!url || !regexString) return null;
+    try { const regex = new RegExp(regexString); const match = url.match(regex); return (match && match[1]) ? match[1].trim() : null; }
+    catch (e) { console.error("Err extractGroupNameUrl:", url, regexString, e); return null; }
+}
 export function isValidRegex(regex) { try { new RegExp(regex); return regex.includes('(') && regex.includes(')'); } catch (e) { return false; } }
 export function isValidDomain(domain) { return domain ? /^(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(domain.trim()) : false; }

--- a/options/components/PresetsTab.js
+++ b/options/components/PresetsTab.js
@@ -12,7 +12,7 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
 
     const handleAdd = () => {
         const newId = generateUUID();
-        const newPreset = { id: newId, name: "", regex: "()" }; // Start with basic group
+        const newPreset = { id: newId, name: "", regex: "()", urlRegex: "" };
         setNewPresetInProgress(newPreset);
         setEditingId(newId);
     };
@@ -22,25 +22,8 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
             updatePresets([...regexPresets, updatedPreset]);
             setNewPresetInProgress(null);
         } else {
-            const originalRegex = regexPresets.find(p => p.id === updatedPreset.id)?.regex;
             const newPresets = regexPresets.map(p => p.id === updatedPreset.id ? updatedPreset : p);
-
-            // Update rules using this preset if regex changed
-            if (originalRegex && originalRegex !== updatedPreset.regex) {
-                const newRules = domainRules.map(rule =>
-                    rule.titleParsingRegEx === originalRegex
-                        ? { ...rule, titleParsingRegEx: updatedPreset.regex }
-                        : rule
-                );
-                // We need to update settings directly here or pass a function
-                // For now, let's assume we pass an updateSettings function or handle this in parent
-                // A simpler way: just update presets, rely on user to update rules manually or handle later.
-                // Let's just update presets for now. The save effect will save settings.
-                // TODO: Consider updating settings.domainRules directly or via a passed callback
-                updatePresets(newPresets);
-            } else {
-                updatePresets(newPresets);
-            }
+            updatePresets(newPresets);
         }
         setEditingId(null);
     };
@@ -52,7 +35,7 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
 
     const handleDelete = (idToDelete) => {
         const preset = regexPresets.find(p => p.id === idToDelete);
-        const isInUse = domainRules.some(r => r.titleParsingRegEx === preset.regex);
+        const isInUse = domainRules.some(r => r.titleParsingRegEx === preset.regex || r.urlParsingRegEx === preset.urlRegex);
 
         if (isInUse) {
             alert(getMessage("errorPresetInUse"));
@@ -64,7 +47,7 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
         }
     };
 
-     const isPresetInUse = (regex) => domainRules.some(r => r.titleParsingRegEx === regex);
+    const isPresetInUse = (regex, urlRegex) => domainRules.some(r => r.titleParsingRegEx === regex || r.urlParsingRegEx === urlRegex);
 
     return html`
         <section id="presets-section">
@@ -73,7 +56,7 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
                 <${Fragment} key=${preset.id}>
                     ${editingId === preset.id && (!newPresetInProgress || newPresetInProgress.id !== preset.id)
                         ? html`<${PresetEditForm} preset=${preset} onSave=${handleSave} onCancel=${() => setEditingId(null)} />`
-                        : html`<${PresetView} preset=${preset} onEdit=${setEditingId} onDelete=${handleDelete} disabled=${isPresetInUse(preset.regex)} />`
+                        : html`<${PresetView} preset=${preset} onEdit=${setEditingId} onDelete=${handleDelete} disabled=${isPresetInUse(preset.regex, preset.urlRegex)} />`
                     }
                 <//>
             `)}
@@ -92,6 +75,7 @@ function PresetView({ preset, onEdit, onDelete, disabled }) {
                 <div class="item-details">
                     <span class="item-main">${preset.name}</span>
                     <code class="item-sub">${preset.regex}</code>
+                    ${preset.urlRegex && html`<code class="item-sub">${preset.urlRegex}</code>`}
                 </div>
                 <div class="item-actions">
                     <button onClick=${() => onEdit(preset.id)}>${getMessage('edit')}</button>
@@ -114,7 +98,7 @@ function PresetEditForm({ preset, onSave, onCancel }) {
     const handleSubmit = (e) => {
         e.preventDefault();
         setError('');
-        if (!isValidRegex(formData.regex)) {
+        if (!isValidRegex(formData.regex) || (formData.urlRegex && !isValidRegex(formData.urlRegex))) {
             setError(getMessage('errorInvalidRegex'));
             return;
         }
@@ -131,11 +115,16 @@ function PresetEditForm({ preset, onSave, onCancel }) {
                              <input type="text" name="name" value=${formData.name} onChange=${handleChange} required />
                              <span class="tooltip-text" data-i18n="presetNameTooltip">${getMessage('presetNameTooltip')}</span>
                         </div>
-                         <div class="form-group tooltip-container">
+                        <div class="form-group tooltip-container">
                             <label>${getMessage('presetRegex')}</label>
                             <input type="text" name="regex" value=${formData.regex} onChange=${handleChange} required />
                             <span class="tooltip-text" data-i18n="presetRegexTooltip">${getMessage('presetRegexTooltip')}</span>
                             ${error && html`<span class="error-message">${error}</span>`}
+                        </div>
+                        <div class="form-group tooltip-container">
+                            <label>${getMessage('presetUrlRegex')}</label>
+                            <input type="text" name="urlRegex" value=${formData.urlRegex || ''} onChange=${handleChange} />
+                            <span class="tooltip-text" data-i18n="presetUrlRegexTooltip">${getMessage('presetUrlRegexTooltip')}</span>
                         </div>
                     </div>
                      <div class="form-actions">

--- a/options/components/PresetsTab.js
+++ b/options/components/PresetsTab.js
@@ -6,7 +6,7 @@ import { generateUUID, isValidRegex } from './../../js/modules/utils.js';
 
 const html = htm.bind(h);
 
-function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
+function PresetsTab({ settings, updatePresets, updateRules, editingId, setEditingId }) {
     const { regexPresets, domainRules } = settings;
     const [newPresetInProgress, setNewPresetInProgress] = useState(null);
 
@@ -22,7 +22,29 @@ function PresetsTab({ settings, updatePresets, editingId, setEditingId }) {
             updatePresets([...regexPresets, updatedPreset]);
             setNewPresetInProgress(null);
         } else {
-            const newPresets = regexPresets.map(p => p.id === updatedPreset.id ? updatedPreset : p);
+            const original = regexPresets.find(p => p.id === updatedPreset.id);
+            const newPresets = regexPresets.map(p =>
+                p.id === updatedPreset.id ? updatedPreset : p
+            );
+
+            let newRules = domainRules;
+            if (original) {
+                if (original.regex !== updatedPreset.regex) {
+                    newRules = newRules.map(rule =>
+                        rule.titleParsingRegEx === original.regex
+                            ? { ...rule, titleParsingRegEx: updatedPreset.regex }
+                            : rule
+                    );
+                }
+                if (original.urlRegex !== updatedPreset.urlRegex) {
+                    newRules = newRules.map(rule =>
+                        rule.urlParsingRegEx === original.urlRegex
+                            ? { ...rule, urlParsingRegEx: updatedPreset.urlRegex }
+                            : rule
+                    );
+                }
+            }
+            updateRules(newRules);
             updatePresets(newPresets);
         }
         setEditingId(null);

--- a/options/components/RulesTab.js
+++ b/options/components/RulesTab.js
@@ -163,7 +163,13 @@ function RulesTab({ settings, updateRules, editingId, setEditingId }) {
 
 function RuleView({ rule, presets, logicalGroups, onEdit, onDelete, onToggle }) { // Added logicalGroups
     const presetName = presets.find(p => p.regex === rule.titleParsingRegEx)?.name || rule.titleParsingRegEx;
-    const dedupMode = getMessage(rule.deduplicationMatchMode === 'exact' ? 'exactMatch' : 'includesMatch');
+    const dedupModeKeyMap = {
+        'exact': 'exactMatch',
+        'includes': 'includesMatch',
+        'hostname': 'hostnameMatch',
+        'hostname_path': 'hostnamePathMatch'
+    };
+    const dedupMode = getMessage(dedupModeKeyMap[rule.deduplicationMatchMode] || 'exactMatch');
     const sourceLabel = getMessage(
         rule.groupNameSource === 'url' ? 'sourceURL' :
         rule.groupNameSource === 'prompt' ? 'sourcePrompt' : 'sourceTitle'
@@ -175,7 +181,7 @@ function RuleView({ rule, presets, logicalGroups, onEdit, onDelete, onToggle }) 
         const presetUrlName = presets.find(p => p.urlRegex === rule.urlParsingRegEx)?.name;
         regexInfo = presetUrlName || rule.urlParsingRegEx;
     }
-     const disabledClass = rule.enabled ? '' : 'disabled-text';
+    const disabledClass = rule.enabled ? '' : 'disabled-text';
 
      const handleToggle = (e) => {
         onToggle({ ...rule, enabled: e.target.checked });
@@ -326,6 +332,8 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
                             <select name="deduplicationMatchMode" value=${formData.deduplicationMatchMode} onChange=${handleChange}>
                                  <option value="exact">${getMessage('exactMatch')}</option>
                                  <option value="includes">${getMessage('includesMatch')}</option>
+                                 <option value="hostname">${getMessage('hostnameMatch')}</option>
+                                 <option value="hostname_path">${getMessage('hostnamePathMatch')}</option>
                             </select>
                             <span class="tooltip-text" data-i18n="deduplicationModeTooltip">${getMessage('deduplicationModeTooltip')}</span>
                         </div>

--- a/options/components/RulesTab.js
+++ b/options/components/RulesTab.js
@@ -53,6 +53,8 @@ function RulesTab({ settings, updateRules, editingId, setEditingId }) {
             enabled: true,
             domainFilter: "",
             titleParsingRegEx: regexPresets[0]?.regex || "",
+            urlParsingRegEx: "",
+            groupNameSource: "title",
             deduplicationMatchMode: "exact",
             groupId: null // Default to no group
         };
@@ -160,8 +162,19 @@ function RulesTab({ settings, updateRules, editingId, setEditingId }) {
 }
 
 function RuleView({ rule, presets, logicalGroups, onEdit, onDelete, onToggle }) { // Added logicalGroups
-     const presetName = presets.find(p => p.regex === rule.titleParsingRegEx)?.name || rule.titleParsingRegEx;
-     const dedupMode = getMessage(rule.deduplicationMatchMode === 'exact' ? 'exactMatch' : 'includesMatch');
+    const presetName = presets.find(p => p.regex === rule.titleParsingRegEx)?.name || rule.titleParsingRegEx;
+    const dedupMode = getMessage(rule.deduplicationMatchMode === 'exact' ? 'exactMatch' : 'includesMatch');
+    const sourceLabel = getMessage(
+        rule.groupNameSource === 'url' ? 'sourceURL' :
+        rule.groupNameSource === 'prompt' ? 'sourcePrompt' : 'sourceTitle'
+    );
+    let regexInfo = '';
+    if (rule.groupNameSource === 'title') {
+        regexInfo = presetName;
+    } else if (rule.groupNameSource === 'url') {
+        const presetUrlName = presets.find(p => p.urlRegex === rule.urlParsingRegEx)?.name;
+        regexInfo = presetUrlName || rule.urlParsingRegEx;
+    }
      const disabledClass = rule.enabled ? '' : 'disabled-text';
 
      const handleToggle = (e) => {
@@ -178,7 +191,8 @@ function RuleView({ rule, presets, logicalGroups, onEdit, onDelete, onToggle }) 
         subtitleParts.push(getMessage('noGroupAssigned', 'No group'));
     }
     subtitleParts.push(rule.domainFilter);
-    subtitleParts.push(presetName);
+    if (regexInfo) subtitleParts.push(regexInfo);
+    subtitleParts.push(sourceLabel);
     subtitleParts.push(dedupMode);
 
     return html`
@@ -201,12 +215,21 @@ function RuleView({ rule, presets, logicalGroups, onEdit, onDelete, onToggle }) 
 }
 
 function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules }) {
-    const [formData, setFormData] = useState({...rule, groupId: rule.groupId === undefined ? null : rule.groupId });
+    const [formData, setFormData] = useState({
+        ...rule,
+        groupId: rule.groupId === undefined ? null : rule.groupId,
+        groupNameSource: rule.groupNameSource || 'title',
+        urlParsingRegEx: rule.urlParsingRegEx || ''
+    });
     const [errors, setErrors] = useState({});
 
     const isPreset = presets.some(p => p.regex === formData.titleParsingRegEx);
     const [isCustom, setIsCustom] = useState(!isPreset);
     const [customValue, setCustomValue] = useState(isPreset ? '' : formData.titleParsingRegEx);
+
+    const isUrlPreset = presets.some(p => p.urlRegex === formData.urlParsingRegEx);
+    const [isUrlCustom, setIsUrlCustom] = useState(!isUrlPreset);
+    const [customUrlValue, setCustomUrlValue] = useState(isUrlPreset ? '' : formData.urlParsingRegEx);
 
     const handleChange = (e) => {
         const { name, value } = e.target;
@@ -224,12 +247,30 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
          }
     };
 
-     const handleCustomChange = (e) => {
+    const handleCustomChange = (e) => {
         setCustomValue(e.target.value);
         if (isCustom) {
             setFormData(prev => ({ ...prev, titleParsingRegEx: e.target.value }));
         }
-     };
+    };
+
+    const handleUrlSelectChange = (e) => {
+        const value = e.target.value;
+        if (value === 'custom') {
+            setIsUrlCustom(true);
+            setFormData(prev => ({ ...prev, urlParsingRegEx: customUrlValue }));
+        } else {
+            setIsUrlCustom(false);
+            setFormData(prev => ({ ...prev, urlParsingRegEx: value }));
+        }
+    };
+
+    const handleUrlCustomChange = (e) => {
+        setCustomUrlValue(e.target.value);
+        if (isUrlCustom) {
+            setFormData(prev => ({ ...prev, urlParsingRegEx: e.target.value }));
+        }
+    };
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -249,6 +290,9 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
         if (!isValidRegex(formData.titleParsingRegEx)) {
             currentErrors.titleParsingRegEx = getMessage('errorInvalidRegex');
         }
+        if (formData.groupNameSource === 'url' && !isValidRegex(formData.urlParsingRegEx)) {
+            currentErrors.urlParsingRegEx = getMessage('errorInvalidRegex');
+        }
         setErrors(currentErrors);
 
         if (Object.keys(currentErrors).length === 0) {
@@ -256,7 +300,8 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
         }
     };
 
-     const currentRegexValue = isCustom ? 'custom' : formData.titleParsingRegEx;
+    const currentRegexValue = isCustom ? 'custom' : formData.titleParsingRegEx;
+    const currentUrlRegexValue = isUrlCustom ? 'custom' : formData.urlParsingRegEx;
 
     // The following div was changed from full-width to allow group selector beside it potentially
     return html`
@@ -288,22 +333,42 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
                             <label>${getMessage('logicalGroup', 'Logical Group')}</label>
                             <select name="groupId" value=${formData.groupId === null ? "" : formData.groupId} onChange=${handleChange}>
                                 <option value="">${getMessage('noGroup', '-- No Group --')}</option>
-                                ${logicalGroups.map(g => html`
-                                    <option value=${g.id}>${g.label}</option>
-                                `)}
+                                ${logicalGroups.map(g => html`<option value=${g.id}>${g.label}</option>`)}
                             </select>
                             <span class="tooltip-text" data-i18n="logicalGroupRuleTooltip">${getMessage('logicalGroupRuleTooltip', 'Assign this rule to a logical group.')}</span>
                         </div>
-                        <div class="form-group tooltip-container full-width">
-                            <label>${getMessage('titleRegex')}</label>
-                            <select value=${currentRegexValue} onChange=${handleSelectChange}>
-                                ${presets.map(p => html`<option value=${p.regex}>${p.name}</option>`)}
-                                <option value="custom">${getMessage('customRegex')}</option>
+                        <div class="form-group tooltip-container">
+                            <label>${getMessage('groupNameSource')}</label>
+                            <select name="groupNameSource" value=${formData.groupNameSource} onChange=${handleChange}>
+                                <option value="title">${getMessage('sourceTitle')}</option>
+                                <option value="url">${getMessage('sourceURL')}</option>
+                                <option value="prompt">${getMessage('sourcePrompt')}</option>
                             </select>
-                            <input type="text" value=${customValue} onChange=${handleCustomChange} style=${{ display: isCustom ? 'block' : 'none', marginTop: '8px' }} />
-                            <span class="tooltip-text" data-i18n="titleParsingRegExTooltip">${getMessage('titleParsingRegExTooltip')}</span>
-                             ${errors.titleParsingRegEx && html`<span class="error-message">${errors.titleParsingRegEx}</span>`}
+                            <span class="tooltip-text" data-i18n="groupNameSourceTooltip">${getMessage('groupNameSourceTooltip')}</span>
                         </div>
+                        ${formData.groupNameSource === 'url' ? html`
+                            <div class="form-group tooltip-container full-width">
+                                <label>${getMessage('urlRegex')}</label>
+                                <select value=${currentUrlRegexValue} onChange=${handleUrlSelectChange}>
+                                    ${presets.map(p => html`<option value=${p.urlRegex}>${p.name}</option>`)}
+                                    <option value="custom">${getMessage('customRegex')}</option>
+                                </select>
+                                <input type="text" value=${customUrlValue} onChange=${handleUrlCustomChange} style=${{ display: isUrlCustom ? 'block' : 'none', marginTop: '8px' }} />
+                                <span class="tooltip-text" data-i18n="urlParsingRegExTooltip">${getMessage('urlParsingRegExTooltip')}</span>
+                                ${errors.urlParsingRegEx && html`<span class="error-message">${errors.urlParsingRegEx}</span>`}
+                            </div>
+                        ` : html`
+                            <div class="form-group tooltip-container full-width">
+                                <label>${getMessage('titleRegex')}</label>
+                                <select value=${currentRegexValue} onChange=${handleSelectChange}>
+                                    ${presets.map(p => html`<option value=${p.regex}>${p.name}</option>`)}
+                                    <option value="custom">${getMessage('customRegex')}</option>
+                                </select>
+                                <input type="text" value=${customValue} onChange=${handleCustomChange} style=${{ display: isCustom ? 'block' : 'none', marginTop: '8px' }} />
+                                <span class="tooltip-text" data-i18n="titleParsingRegExTooltip">${getMessage('titleParsingRegExTooltip')}</span>
+                                ${errors.titleParsingRegEx && html`<span class="error-message">${errors.titleParsingRegEx}</span>`}
+                            </div>
+                        `}
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="primary">${getMessage('save')}</button>

--- a/options/components/RulesTab.js
+++ b/options/components/RulesTab.js
@@ -293,7 +293,7 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
         if (!isValidDomain(formData.domainFilter)) {
             currentErrors.domainFilter = getMessage('errorInvalidDomain');
         }
-        if (!isValidRegex(formData.titleParsingRegEx)) {
+        if (formData.groupNameSource === 'title' && !isValidRegex(formData.titleParsingRegEx)) {
             currentErrors.titleParsingRegEx = getMessage('errorInvalidRegex');
         }
         if (formData.groupNameSource === 'url' && !isValidRegex(formData.urlParsingRegEx)) {
@@ -365,7 +365,7 @@ function RuleEditForm({ rule, presets, logicalGroups, onSave, onCancel, allRules
                                 <span class="tooltip-text" data-i18n="urlParsingRegExTooltip">${getMessage('urlParsingRegExTooltip')}</span>
                                 ${errors.urlParsingRegEx && html`<span class="error-message">${errors.urlParsingRegEx}</span>`}
                             </div>
-                        ` : html`
+                        ` : formData.groupNameSource === 'prompt' ? null : html`
                             <div class="form-group tooltip-container full-width">
                                 <label>${getMessage('titleRegex')}</label>
                                 <select value=${currentRegexValue} onChange=${handleSelectChange}>

--- a/options/options.js
+++ b/options/options.js
@@ -9,6 +9,7 @@ import { getMessage } from './../js/modules/i18n.js';
 import { applyTheme } from './../js/modules/theme.js';
 
 const html = htm.bind(h);
+const version = chrome.runtime.getManifest().version;
 
 import { Header } from './components/Header.js';
 import { Tabs } from './components/Tabs.js';
@@ -112,12 +113,12 @@ function OptionsApp() {
             <${Tabs} currentTab=${currentTab} onTabChange=${handleTabChange} />
             <main>
                 ${currentTab === 'rules' && html`<${RulesTab} settings=${settings} updateRules=${updateRules} editingId=${editingRuleId} setEditingId=${setEditingRuleId} />`}
-                ${currentTab === 'presets' && html`<${PresetsTab} settings=${settings} updatePresets=${updatePresets} editingId=${editingPresetId} setEditingId=${setEditingPresetId} />`}
+                ${currentTab === 'presets' && html`<${PresetsTab} settings=${settings} updatePresets=${updatePresets} updateRules=${updateRules} editingId=${editingPresetId} setEditingId=${setEditingPresetId} />`}
                 ${currentTab === 'logicalGroups' && html`<${LogicalGroupsTab} settings=${settings} setSettings=${setSettings} editingId=${editingLogicalGroupId} setEditingId=${setEditingLogicalGroupId} />`}
                 ${currentTab === 'importexport' && html`<${ImportExportTab} settings=${settings} setSettings=${setSettings} />`}
                 ${currentTab === 'stats' && html`<${StatsTab} stats=${stats} onReset=${handleResetStats} />`}
             </main>
-            <footer>SmartTab Organizer v1.0.2 - Licensed under GPL-3.0-only.</footer>
+            <footer>SmartTab Organizer v${version} - Licensed under GPL-3.0-only.</footer>
         </div>
     `;
 


### PR DESCRIPTION
## Summary
- configure how group names are resolved per domain rule
- handle URL parsing and manual prompt strategies
- add translations for the new settings
- update default settings with url patterns
- show group source options in the UI
- support url regex presets

## Testing
- `node -e "import('./options/components/RulesTab.js').then(()=>console.log('ok')).catch(err=>console.error('err',err))"`
- `node -e "import('./options/components/PresetsTab.js').then(()=>console.log('ok')).catch(err=>console.error('err', err))"`
- `node -e "import('./js/background.js').then(()=>console.log('ok')).catch(err=>console.error('err', err))"` *(fails: chrome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0a471ac832aa0a5ad36008d9c9d