### PR TITLE
Refactor components and integrate stats in popup

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,6 +1,6 @@
-import { h } from './../../js/lib/preact.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
+import { h } from './../js/lib/preact.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
 
 const html = htm.bind(h);
 

--- a/components/ImportExportTab.js
+++ b/components/ImportExportTab.js
@@ -1,7 +1,7 @@
-import { h } from './../../js/lib/preact.mjs';
-import { useState } from './../../js/lib/preact-hooks.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
+import { h } from './../js/lib/preact.mjs';
+import { useState } from './../js/lib/preact-hooks.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
 
 const html = htm.bind(h);
 

--- a/components/LogicalGroupsTab.js
+++ b/components/LogicalGroupsTab.js
@@ -1,8 +1,8 @@
-import { h, Fragment } from './../../js/lib/preact.mjs';
-import { useState, useEffect } from './../../js/lib/preact-hooks.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
-import { generateUUID } from './../../js/modules/utils.js';
+import { h, Fragment } from './../js/lib/preact.mjs';
+import { useState, useEffect } from './../js/lib/preact-hooks.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
+import { generateUUID } from './../js/modules/utils.js';
 
 const html = htm.bind(h);
 

--- a/components/PresetsTab.js
+++ b/components/PresetsTab.js
@@ -1,8 +1,8 @@
-import { h, Fragment } from './../../js/lib/preact.mjs';
-import { useState } from './../../js/lib/preact-hooks.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
-import { generateUUID, isValidRegex } from './../../js/modules/utils.js';
+import { h, Fragment } from './../js/lib/preact.mjs';
+import { useState } from './../js/lib/preact-hooks.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
+import { generateUUID, isValidRegex } from './../js/modules/utils.js';
 
 const html = htm.bind(h);
 

--- a/components/RulesTab.js
+++ b/components/RulesTab.js
@@ -1,8 +1,8 @@
-import { h, Fragment } from './../../js/lib/preact.mjs';
-import { useState, useEffect } from './../../js/lib/preact-hooks.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
-import { generateUUID, isValidDomain, isValidRegex } from './../../js/modules/utils.js';
+import { h, Fragment } from './../js/lib/preact.mjs';
+import { useState, useEffect } from './../js/lib/preact-hooks.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
+import { generateUUID, isValidDomain, isValidRegex } from './../js/modules/utils.js';
 
 const html = htm.bind(h);
 

--- a/components/StatsTab.js
+++ b/components/StatsTab.js
@@ -1,6 +1,6 @@
-import { h } from './../../js/lib/preact.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
+import { h } from './../js/lib/preact.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
 
 const html = htm.bind(h);
 

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -1,6 +1,6 @@
-import { h } from './../../js/lib/preact.mjs';
-import htm from './../../js/lib/htm.mjs';
-import { getMessage } from './../../js/modules/i18n.js';
+import { h } from './../js/lib/preact.mjs';
+import htm from './../js/lib/htm.mjs';
+import { getMessage } from './../js/modules/i18n.js';
 
 const html = htm.bind(h);
 

--- a/css/popup.css
+++ b/css/popup.css
@@ -23,3 +23,7 @@ hr { border: none; border-top: 1px solid var(--border-color); margin: 20px 0; }
 .stats p { margin: 8px 0; font-size: 0.9em; display: flex; justify-content: space-between; }
 .stats b { color: var(--primary-color); font-weight: 600; }
 .button { display: block; width: 100%; padding: 10px; font-size: 1em; font-weight: 500; margin-top: 10px; box-sizing: border-box; }
+
+.stats-display p { font-size: 1.1em; margin: 10px 0; }
+.stats-display p span { font-weight: 500; min-width: 200px; display: inline-block; }
+.stats-display button { margin-top: 15px; }

--- a/options/options.js
+++ b/options/options.js
@@ -11,13 +11,13 @@ import { applyTheme } from './../js/modules/theme.js';
 const html = htm.bind(h);
 const version = chrome.runtime.getManifest().version;
 
-import { Header } from './components/Header.js';
-import { Tabs } from './components/Tabs.js';
-import { RulesTab } from './components/RulesTab.js';
-import { PresetsTab } from './components/PresetsTab.js';
-import { ImportExportTab } from './components/ImportExportTab.js';
-import { StatsTab } from './components/StatsTab.js';
-import { LogicalGroupsTab } from './components/LogicalGroupsTab.js';
+import { Header } from '../components/Header.js';
+import { Tabs } from '../components/Tabs.js';
+import { RulesTab } from '../components/RulesTab.js';
+import { PresetsTab } from '../components/PresetsTab.js';
+import { ImportExportTab } from '../components/ImportExportTab.js';
+import { StatsTab } from '../components/StatsTab.js';
+import { LogicalGroupsTab } from '../components/LogicalGroupsTab.js';
 
 // --- Fonctions Utilitaires ---
 function Tooltip({ textKey, children }) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -3,9 +3,10 @@ import { h, render } from './../js/lib/preact.mjs';
 import { useState, useEffect, useCallback } from './../js/lib/preact-hooks.mjs';
 import htm from './../js/lib/htm.mjs';
 
-import { getSettings, saveSettings, getStatistics } from './../js/modules/storage.js';
+import { getSettings, saveSettings, getStatistics, resetStatistics } from './../js/modules/storage.js';
 import { getMessage } from './../js/modules/i18n.js';
 import { applyTheme } from './../js/modules/theme.js';
+import { StatsTab } from './../components/StatsTab.js';
 
 const html = htm.bind(h);
 
@@ -59,7 +60,12 @@ function PopupApp() {
         chrome.runtime.openOptionsPage();
     }, []);
 
-    const activeRulesCount = settings.domainRules?.filter(r => r.enabled).length || 0;
+    const handleResetStats = useCallback(async () => {
+        if (confirm(getMessage('confirmResetStats'))) {
+            const newStats = await resetStatistics();
+            setStats(newStats);
+        }
+    }, []);
 
     // --- Rendu ---
     return html`
@@ -90,12 +96,7 @@ function PopupApp() {
 
             <hr />
 
-            <h2>Stats</h2>
-            <div class="stats">
-                <p><span>${getMessage('activeRules')}</span> <b>${activeRulesCount}</b></p>
-                <p><span>${getMessage('groupsCreated')}</span> <b>${stats.tabGroupsCreatedCount || 0}</b></p>
-                <p><span>${getMessage('tabsDeduplicated')}</span> <b>${stats.tabsDeduplicatedCount || 0}</b></p>
-            </div>
+            <${StatsTab} stats=${stats} onReset=${handleResetStats} />
 
             <hr />
 


### PR DESCRIPTION
## Summary
- move options components to the project root so that popup can reuse them
- update imports after moving components
- show statistics in popup using shared `StatsTab`
- support stats reset from popup
- copy stats styles to popup CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684308176844832aa40fdb0ae196713c