### PR TITLE
Fix all TypeScript compilation errors (97 errors → 0)

### DIFF
--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -55,7 +55,7 @@ export function setupTabCreatedHandler(): void {
 }
 
 export function setupTabUpdatedHandler(): void {
-    browser.tabs.onUpdated.addListener(async (tabId: number, changeInfo: Browser.tabs.TabChangeInfo, tab: Browser.tabs.Tab) => {
+    browser.tabs.onUpdated.addListener(async (tabId: number, changeInfo: Browser.tabs.OnUpdatedInfo, tab: Browser.tabs.Tab) => {
         const urlToCheck = changeInfo.url || (changeInfo.status === 'complete' ? tab.url : null);
         
         if (urlToCheck && tab.windowId) {
@@ -67,7 +67,7 @@ export function setupTabUpdatedHandler(): void {
 async function handleGroupingWithRetry(openerTab: Browser.tabs.Tab, newTab: Browser.tabs.Tab): Promise<void> {
     let hasProcessedTab = false;
 
-    const listener = async (tabId: number, changeInfo: Browser.tabs.TabChangeInfo, tab: Browser.tabs.Tab) => {
+    const listener = async (tabId: number, changeInfo: Browser.tabs.OnUpdatedInfo, tab: Browser.tabs.Tab) => {
         if (hasProcessedTab) {
             try { 
                 browser.tabs.onUpdated.removeListener(listener); 

--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -150,7 +150,7 @@ export async function createNewGroup(
     groupColor: string | null
 ): Promise<number> {
     console.log(`[GROUPING_DEBUG] Calling browser.tabs.group to create new group with tabs [${tabsToGroup.join(', ')}]`);
-    const newGroupId = await browser.tabs.group({ tabIds: tabsToGroup });
+    const newGroupId = await browser.tabs.group({ tabIds: tabsToGroup as [number, ...number[]] });
     
     const updatePayload: any = { title: groupName, collapsed: false };
     if (groupColor) updatePayload.color = groupColor;
@@ -191,7 +191,7 @@ export async function handleManualGroupNaming(
         console.log(`[GROUPING_DEBUG] Group ${targetGroupId} renamed manually to "${manualName}".`);
     } else if (manualName === null) {
         try {
-            await browser.tabs.ungroup(groupedTabIds);
+            await browser.tabs.ungroup(groupedTabIds as [number, ...number[]]);
             console.log(`[GROUPING_DEBUG] Manual prompt cancelled. Ungrouped tabs ${groupedTabIds.join(', ')} from group ${targetGroupId}.`);
         } catch (ungroupErr) {
             console.error('[GROUPING_DEBUG] Failed to ungroup after manual cancel', ungroupErr);

--- a/src/components/Core/DomainRule/DomainRuleFormModal.stories.tsx
+++ b/src/components/Core/DomainRule/DomainRuleFormModal.stories.tsx
@@ -7,6 +7,8 @@ import type { SyncSettings } from '../../../types/syncSettings';
 const mockSyncSettings: SyncSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
+  notifyOnGrouping: true,
+  notifyOnDeduplication: true,
   domainRules: [
     {
       id: 'existing-rule-1',

--- a/src/components/Form/themed-callouts/themed-callouts.stories.tsx
+++ b/src/components/Form/themed-callouts/themed-callouts.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Flex, Text, Box } from '@radix-ui/themes';
+import { Flex, Text, Box, Heading } from '@radix-ui/themes';
 import { 
   InfoCallout, 
   WarningCallout, 
@@ -26,10 +26,10 @@ export const CalloutsGenericCallouts: StoryObj = {
   name: 'Generic Callouts',
   render: () => (
     <Flex direction="column" gap="4" p="4">
-      <Text as="h2" size="6" weight="bold" mb="4">Generic Callouts with Custom Themes</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Generic Callouts with Custom Themes</Heading>
       
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Default Colors</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Default Colors</Heading>
         <Flex direction="column" gap="3">
           <InfoCallout>
             This is an info callout with the default blue theme. It provides helpful information to users.
@@ -44,7 +44,7 @@ export const CalloutsGenericCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Custom Theme Colors</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Custom Theme Colors</Heading>
         <Flex direction="column" gap="3">
           <InfoCallout theme="purple">
             Info callout with purple theme (Domain Rules style).
@@ -62,7 +62,7 @@ export const CalloutsGenericCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Different Variants</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Different Variants</Heading>
         <Flex direction="column" gap="3">
           <InfoCallout variant="soft">Soft variant (default)</InfoCallout>
           <InfoCallout variant="surface">Surface variant</InfoCallout>
@@ -77,10 +77,10 @@ export const CalloutsFeatureCallouts: StoryObj = {
   name: 'Feature-Specific Callouts',
   render: () => (
     <Flex direction="column" gap="4" p="4">
-      <Text as="h2" size="6" weight="bold" mb="4">Feature-Specific Themed Callouts</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Feature-Specific Themed Callouts</Heading>
       
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Domain Rules Callouts (Purple)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Domain Rules Callouts (Purple)</Heading>
         <Flex direction="column" gap="2">
           <DomainRulesCallouts.Info>
             Domain rule configuration saved successfully. Your new rule will be applied to matching tabs.
@@ -95,7 +95,7 @@ export const CalloutsFeatureCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Regex Presets Callouts (Cyan)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Regex Presets Callouts (Cyan)</Heading>
         <Flex direction="column" gap="2">
           <RegexPresetsCallouts.Info>
             Regex preset applied successfully. Your pattern will be used for tab title parsing.
@@ -111,7 +111,7 @@ export const CalloutsFeatureCallouts: StoryObj = {
 
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Import Callouts (Jade)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Import Callouts (Jade)</Heading>
         <Flex direction="column" gap="2">
           <ImportCallouts.Info>
             Configuration file imported successfully. All settings have been applied.
@@ -126,7 +126,7 @@ export const CalloutsFeatureCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Export Callouts (Teal)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Export Callouts (Teal)</Heading>
         <Flex direction="column" gap="2">
           <ExportCallouts.Info>
             Configuration exported successfully. Your settings have been saved to the download folder.
@@ -141,7 +141,7 @@ export const CalloutsFeatureCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Statistics Callouts (Orange)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Statistics Callouts (Orange)</Heading>
         <Flex direction="column" gap="2">
           <StatisticsCallouts.Info>
             Statistics have been updated. Data is current as of the last browser session.
@@ -156,7 +156,7 @@ export const CalloutsFeatureCallouts: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Settings Callouts (Gray)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Settings Callouts (Gray)</Heading>
         <Flex direction="column" gap="2">
           <SettingsCallouts.Info>
             Settings saved successfully. Changes will take effect immediately.
@@ -177,7 +177,7 @@ export const CalloutsComparison: StoryObj = {
   name: 'Theme Comparison',
   render: () => (
     <Flex direction="column" gap="4" p="4">
-      <Text as="h2" size="6" weight="bold" mb="4">Theme Color Comparison</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Theme Color Comparison</Heading>
       
       <Text as="p" size="3" color="gray" mb="4">
         This story shows all feature themes side by side to demonstrate the visual distinction between different functional areas.
@@ -223,14 +223,14 @@ export const CalloutsNuancedColors: StoryObj = {
   name: 'Nuanced Colors by Type',
   render: () => (
     <Flex direction="column" gap="4" p="4">
-      <Text as="h2" size="6" weight="bold" mb="4">Nuanced Colors by Message Type</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Nuanced Colors by Message Type</Heading>
       
       <Text as="p" size="3" color="gray" mb="4">
         Each feature theme now uses different color nuances for Info, Warning, and Error messages to improve readability and semantic meaning.
       </Text>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Domain Rules (Purple Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Domain Rules (Purple Family)</Heading>
         <Flex direction="column" gap="2">
           <DomainRulesCallouts.Info>Purple for informational messages</DomainRulesCallouts.Info>
           <DomainRulesCallouts.Warning>Violet for warnings</DomainRulesCallouts.Warning>
@@ -239,7 +239,7 @@ export const CalloutsNuancedColors: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Regex Presets (Cyan Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Regex Presets (Cyan Family)</Heading>
         <Flex direction="column" gap="2">
           <RegexPresetsCallouts.Info>Cyan for informational messages</RegexPresetsCallouts.Info>
           <RegexPresetsCallouts.Warning>Sky for warnings</RegexPresetsCallouts.Warning>
@@ -249,7 +249,7 @@ export const CalloutsNuancedColors: StoryObj = {
 
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Import (Green Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Import (Green Family)</Heading>
         <Flex direction="column" gap="2">
           <ImportCallouts.Info>Jade for informational messages</ImportCallouts.Info>
           <ImportCallouts.Warning>Teal for warnings</ImportCallouts.Warning>
@@ -258,7 +258,7 @@ export const CalloutsNuancedColors: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Export (Teal Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Export (Teal Family)</Heading>
         <Flex direction="column" gap="2">
           <ExportCallouts.Info>Teal for informational messages</ExportCallouts.Info>
           <ExportCallouts.Warning>Cyan for warnings</ExportCallouts.Warning>
@@ -267,7 +267,7 @@ export const CalloutsNuancedColors: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Statistics (Orange Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Statistics (Orange Family)</Heading>
         <Flex direction="column" gap="2">
           <StatisticsCallouts.Info>Orange for informational messages</StatisticsCallouts.Info>
           <StatisticsCallouts.Warning>Amber for warnings (standard warning color)</StatisticsCallouts.Warning>
@@ -276,7 +276,7 @@ export const CalloutsNuancedColors: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Settings (Gray Family)</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Settings (Gray Family)</Heading>
         <Flex direction="column" gap="2">
           <SettingsCallouts.Info>Gray for informational messages</SettingsCallouts.Info>
           <SettingsCallouts.Warning>Slate for warnings</SettingsCallouts.Warning>
@@ -291,10 +291,10 @@ export const CalloutsUsageExamples: StoryObj = {
   name: 'Usage Examples',
   render: () => (
     <Flex direction="column" gap="4" p="4">
-      <Text as="h2" size="6" weight="bold" mb="4">Real-World Usage Examples</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Real-World Usage Examples</Heading>
       
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Form Validation Messages</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Form Validation Messages</Heading>
         <Flex direction="column" gap="2">
           <DomainRulesCallouts.Error>
             Domain filter is required. Please enter a valid domain pattern.
@@ -306,7 +306,7 @@ export const CalloutsUsageExamples: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Operation Status Messages</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Operation Status Messages</Heading>
         <Flex direction="column" gap="2">
           <ImportCallouts.Info>
             Import completed successfully. 15 domain rules and 8 regex presets were added.
@@ -318,7 +318,7 @@ export const CalloutsUsageExamples: StoryObj = {
       </Box>
 
       <Box>
-        <Text as="h3" size="4" weight="bold" mb="3">Configuration Guidance</Text>
+        <Heading as="h3" size="4" weight="bold" mb="3">Configuration Guidance</Heading>
         <Flex direction="column" gap="2">
           <RegexPresetsCallouts.Info style={{ marginTop: '16px' }}>
             No regex presets available. You can create custom presets to reuse common patterns across multiple rules.

--- a/src/components/Form/themes/themes.stories.tsx
+++ b/src/components/Form/themes/themes.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Button, Flex, Text, TextField, Select, Switch, Box } from '@radix-ui/themes';
+import { Button, Flex, Text, Heading, TextField, Select, Switch, Box } from '@radix-ui/themes';
 import { 
   DomainRulesTheme, 
   RegexPresetsTheme, 
@@ -21,7 +21,7 @@ export default meta;
 
 const ThemeShowcase = ({ ThemeComponent, title }: { ThemeComponent: React.ComponentType<{ children: React.ReactNode }>, title: string }) => (
   <Box style={{ border: '1px solid var(--gray-6)', borderRadius: '8px', padding: '16px', margin: '8px 0' }}>
-    <Text as="h3" size="4" weight="bold" mb="3">{title}</Text>
+    <Heading as="h3" size="4" weight="bold" mb="3">{title}</Heading>
     <ThemeComponent>
       <Flex direction="column" gap="3">
         <Flex gap="2" align="center">
@@ -58,7 +58,7 @@ export const ThemesAllThemes: StoryObj = {
   name: 'All Themes Showcase',
   render: () => (
     <Flex direction="column" gap="2">
-      <Text as="h2" size="6" weight="bold" mb="4">Feature Themes Showcase</Text>
+      <Heading as="h2" size="6" weight="bold" mb="4">Feature Themes Showcase</Heading>
       <ThemeShowcase ThemeComponent={DomainRulesTheme} title="Domain Rules Theme (Purple)" />
       <ThemeShowcase ThemeComponent={RegexPresetsTheme} title="Regex Presets Theme (Cyan)" />
       <ThemeShowcase ThemeComponent={ImportTheme} title="Import Theme (Jade)" />
@@ -74,7 +74,7 @@ export const ThemesDomainRules: StoryObj = {
   render: () => (
     <DomainRulesTheme>
       <Flex direction="column" gap="4" p="4">
-        <Text as="h2" size="6" weight="bold">Domain Rules Configuration</Text>
+        <Heading as="h2" size="6" weight="bold">Domain Rules Configuration</Heading>
         <Flex direction="column" gap="3">
           <Flex gap="2" align="center">
             <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Domain Filter:</Text>
@@ -101,7 +101,7 @@ export const ThemesRegexPresets: StoryObj = {
   render: () => (
     <RegexPresetsTheme>
       <Flex direction="column" gap="4" p="4">
-        <Text as="h2" size="6" weight="bold">Regex Presets Configuration</Text>
+        <Heading as="h2" size="6" weight="bold">Regex Presets Configuration</Heading>
         <Flex direction="column" gap="3">
           <Flex gap="2" align="center">
             <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Preset Name:</Text>
@@ -130,7 +130,7 @@ export const ThemesImportExport: StoryObj = {
     <Flex direction="column" gap="4">
       <ImportTheme>
         <Box style={{ border: '1px solid var(--gray-6)', borderRadius: '8px', padding: '16px' }}>
-          <Text as="h3" size="5" weight="bold" mb="3">Import Configuration</Text>
+          <Heading as="h3" size="5" weight="bold" mb="3">Import Configuration</Heading>
           <Flex direction="column" gap="3">
             <Flex gap="2" align="center">
               <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Import File:</Text>
@@ -147,7 +147,7 @@ export const ThemesImportExport: StoryObj = {
       
       <ExportTheme>
         <Box style={{ border: '1px solid var(--gray-6)', borderRadius: '8px', padding: '16px' }}>
-          <Text as="h3" size="5" weight="bold" mb="3">Export Configuration</Text>
+          <Heading as="h3" size="5" weight="bold" mb="3">Export Configuration</Heading>
           <Flex direction="column" gap="3">
             <Flex gap="2" align="center">
               <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Export Format:</Text>
@@ -176,7 +176,7 @@ export const ThemesStatistics: StoryObj = {
   render: () => (
     <StatisticsTheme>
       <Flex direction="column" gap="4" p="4">
-        <Text as="h2" size="6" weight="bold">Statistics Dashboard</Text>
+        <Heading as="h2" size="6" weight="bold">Statistics Dashboard</Heading>
         <Flex direction="column" gap="3">
           <Flex gap="2" align="center">
             <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Time Period:</Text>
@@ -206,7 +206,7 @@ export const ThemesSettings: StoryObj = {
   render: () => (
     <SettingsTheme>
       <Flex direction="column" gap="4" p="4">
-        <Text as="h2" size="6" weight="bold">Application Settings</Text>
+        <Heading as="h2" size="6" weight="bold">Application Settings</Heading>
         <Flex direction="column" gap="3">
           <Flex gap="2" align="center">
             <Text size="2" weight="medium" style={{ minWidth: '120px' }}>Theme:</Text>

--- a/src/components/UI/DataTable/DataTable.stories.tsx
+++ b/src/components/UI/DataTable/DataTable.stories.tsx
@@ -60,19 +60,19 @@ const userRowActions: Action<User>[] = [
     label: 'Edit',
     icon: Edit,
     handler: (user) => alert(`Edit user: ${user.name}`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'View',
     icon: Eye,
     handler: (user) => alert(`View user: ${user.name}`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'Delete',
     icon: Trash2,
     handler: (user) => alert(`Delete user: ${user.name}`),
-    variant: 'danger',
+    variant: 'outline',
     disabled: (user) => user.role === 'admin'
   }
 ];
@@ -82,13 +82,13 @@ const userBulkActions: Action<User[]>[] = [
     label: 'Archive',
     icon: Archive,
     handler: (users) => alert(`Archive ${users.length} users`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'Delete',
     icon: Trash2,
     handler: (users) => alert(`Delete ${users.length} users`),
-    variant: 'danger'
+    variant: 'outline'
   }
 ];
 
@@ -189,13 +189,13 @@ const productRowActions: Action<Product>[] = [
     label: 'Edit',
     icon: Edit,
     handler: (product) => alert(`Edit product: ${product.name}`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'Restock Alert',
     icon: AlertTriangle,
     handler: (product) => alert(`Restock alert for: ${product.name}`),
-    variant: 'secondary',
+    variant: 'soft',
     hidden: (product) => product.status === 'in_stock'
   }
 ];
@@ -205,13 +205,13 @@ const productBulkActions: Action<Product[]>[] = [
     label: 'Export',
     icon: Download,
     handler: (products) => alert(`Export ${products.length} products`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'Update Prices',
     icon: Settings,
     handler: (products) => alert(`Update prices for ${products.length} products`),
-    variant: 'primary'
+    variant: 'solid'
   }
 ];
 
@@ -308,13 +308,13 @@ const taskRowActions: Action<Task>[] = [
     label: 'Edit',
     icon: Edit,
     handler: (task) => alert(`Edit task: ${task.title}`),
-    variant: 'secondary'
+    variant: 'soft'
   },
   {
     label: 'View',
     icon: Eye,
     handler: (task) => alert(`View task: ${task.title}`),
-    variant: 'secondary'
+    variant: 'soft'
   }
 ];
 
@@ -323,13 +323,13 @@ const taskBulkActions: Action<Task[]>[] = [
     label: 'Assign',
     icon: Users,
     handler: (tasks) => alert(`Assign ${tasks.length} tasks`),
-    variant: 'primary'
+    variant: 'solid'
   },
   {
     label: 'Archive',
     icon: Archive,
     handler: (tasks) => alert(`Archive ${tasks.length} tasks`),
-    variant: 'secondary'
+    variant: 'soft'
   }
 ];
 

--- a/src/components/UI/DataTable/DataTable.tsx
+++ b/src/components/UI/DataTable/DataTable.tsx
@@ -123,7 +123,7 @@ export function DataTable<T extends Record<string, any>>({
                 <Button
                   key={index}
                   size="1"
-                  variant={action.variant || 'secondary'}
+                  variant={action.variant || 'soft'}
                   color={action.color}
                   onClick={() => action.handler(selectedRows)}
                 >

--- a/src/components/UI/DataTable/types.ts
+++ b/src/components/UI/DataTable/types.ts
@@ -13,7 +13,7 @@ export interface Action<T> {
   label: string;
   icon: LucideIcon;
   handler: (data: T) => void;
-  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  variant?: 'classic' | 'outline' | 'solid' | 'soft' | 'surface' | 'ghost';
   color?: 'red' | 'blue' | 'green' | 'yellow' | 'orange' | 'purple' | 'pink' | 'gray';
   disabled?: (data: T) => boolean;
   hidden?: (data: T) => boolean;

--- a/src/components/UI/Header/Header.stories.tsx
+++ b/src/components/UI/Header/Header.stories.tsx
@@ -8,9 +8,6 @@ const meta: Meta<typeof Header> = {
     layout: 'fullscreen',
   },
   tags: ['autodocs'],
-  argTypes: {
-    onThemeChange: { action: 'theme-changed' },
-  },
 } satisfies Meta<typeof Header>;
 
 export default meta;

--- a/src/components/UI/ImportExportPage/ImportExportPage.tsx
+++ b/src/components/UI/ImportExportPage/ImportExportPage.tsx
@@ -65,7 +65,7 @@ export function ImportExportPage({ syncSettings, onSettingsUpdate }: ImportExpor
           // Mise à jour seulement des domainRules
           const updatedSettings: SyncSettings = {
             ...syncSettings,
-            domainRules: validatedData.domainRules
+            domainRules: validatedData.domainRules as SyncSettings['domainRules']
           };
           
           onSettingsUpdate(updatedSettings);

--- a/src/components/UI/Sidebar/Sidebar.tsx
+++ b/src/components/UI/Sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import { SidebarFooter } from './SidebarFooter';
 export interface SidebarItem {
   id: string;
   label: string;
-  icon: React.ComponentType<{ size?: number }>;
+  icon: React.ComponentType<{ size?: number | string }>;
   href?: string;
   onClick?: () => void;
   badge?: string | number;

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { browser } from 'wxt/browser';
 import type { Statistics } from '../types/statistics.js';
 import { defaultStatistics } from '../types/statistics.js';
 
@@ -39,9 +40,9 @@ export function useStatistics(): UseStatisticsReturn {
         });
         
         // Assurer que les statistiques ont la bonne structure
-        const stats = { 
-          ...defaultStatistics, 
-          ...result.statistics 
+        const stats = {
+          ...defaultStatistics,
+          ...(result.statistics as Record<string, unknown>)
         };
         
         setStatistics(stats);
@@ -158,11 +159,11 @@ export function useStatistics(): UseStatisticsReturn {
         statistics: defaultStatistics
       });
       
-      const stats = { 
-        ...defaultStatistics, 
-        ...result.statistics 
+      const stats = {
+        ...defaultStatistics,
+        ...(result.statistics as Record<string, unknown>)
       };
-      
+
       setStatistics(stats);
     } catch (error) {
       console.error('Error reloading statistics:', error);

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { browser } from 'wxt/browser';
 import type { SyncSettings, DomainRuleSettings } from '../types/syncSettings.js';
 
 export interface UseSyncedSettingsReturn {
@@ -46,7 +47,7 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
           notifyOnDeduplication: true
         });
 
-        setSettings(result as SyncSettings);
+        setSettings(result as unknown as SyncSettings);
         setIsLoaded(true);
       } catch (error) {
         console.error('Error loading settings:', error);
@@ -122,7 +123,7 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
   ) => {
     setChangeCallbacks(prev => ({
       ...prev,
-      [field]: new Set([...(prev[field] || []), callback])
+      [field]: new Set([...(prev[field] || []), callback as any])
     }));
 
     // Retourner une fonction de nettoyage
@@ -130,7 +131,7 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
       setChangeCallbacks(prev => {
         const newCallbacks = { ...prev };
         if (newCallbacks[field]) {
-          newCallbacks[field]!.delete(callback);
+          (newCallbacks[field] as Set<any>).delete(callback);
           if (newCallbacks[field]!.size === 0) {
             delete newCallbacks[field];
           }
@@ -168,7 +169,7 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
         notifyOnDeduplication: true
       });
 
-      setSettings(result as SyncSettings);
+      setSettings(result as unknown as SyncSettings);
     } catch (error) {
       console.error('Error reloading settings:', error);
     }

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -8,7 +8,7 @@ import { browser } from 'wxt/browser';
  */
 export function getMessage(key: string, substitutions?: string | string[]): string {
   try {
-    return browser.i18n.getMessage(key, substitutions);
+    return browser.i18n.getMessage(key as 'extensionName', substitutions);
   } catch (e) {
     console.warn(`Clé i18n ${key} introuvable.`);
     return key;

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -5,7 +5,7 @@ import { defaultSyncSettings } from '../types/syncSettings.js';
 import { defaultStatistics } from '../types/statistics.js';
 import type { SyncSettings } from '../types/syncSettings.js';
 
-const defaultSettingsPath = 'data/default_settings.json';
+const defaultSettingsPath = '/data/default_settings.json' as const;
 let cachedDefaultSettings: SyncSettings | null = null;
 
 function isObject(item: any): item is Record<string, any> {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,4 +1,4 @@
-import { browser } from 'wxt/browser';
+import { browser, Browser } from 'wxt/browser';
 import { getMessage } from './i18n';
 import { markUrlToSkipDeduplication } from './deduplicationSkip';
 
@@ -36,9 +36,9 @@ const pendingUndoActions = new Map<string, UndoAction>();
 export async function showNotification({ title, message, type = 'info', undoAction }: ShowNotificationOptions): Promise<string> {
   const notificationId = `smarttab-${Date.now()}`;
 
-  const notificationOptions: browser.Notifications.CreateNotificationOptions = {
+  const notificationOptions: Browser.notifications.NotificationCreateOptions = {
     type: 'basic',
-    iconUrl: browser.runtime.getURL('icons/icon128.png'),
+    iconUrl: browser.runtime.getURL('/icons/icon128.png'),
     title,
     message
   };

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,3 +1,4 @@
+import { browser } from 'wxt/browser';
 import type { SyncSettings } from '../types/syncSettings.js';
 import { defaultSyncSettings } from '../types/syncSettings.js';
 
@@ -8,8 +9,8 @@ import { defaultSyncSettings } from '../types/syncSettings.js';
 
 export async function getSyncSettings(): Promise<SyncSettings> {
   try {
-    const result = await browser.storage.sync.get(defaultSyncSettings);
-    return result as SyncSettings;
+    const result = await browser.storage.sync.get({ ...defaultSyncSettings });
+    return result as unknown as SyncSettings;
   } catch (error) {
     console.error('Error getting sync settings:', error);
     return defaultSyncSettings;
@@ -37,7 +38,7 @@ export async function getGlobalGroupingEnabled(): Promise<boolean> {
     const result = await browser.storage.sync.get({
       globalGroupingEnabled: defaultSyncSettings.globalGroupingEnabled
     });
-    return result.globalGroupingEnabled;
+    return result.globalGroupingEnabled as boolean;
   } catch (error) {
     console.error('Error getting global grouping enabled:', error);
     return defaultSyncSettings.globalGroupingEnabled;
@@ -49,7 +50,7 @@ export async function getGlobalDeduplicationEnabled(): Promise<boolean> {
     const result = await browser.storage.sync.get({
       globalDeduplicationEnabled: defaultSyncSettings.globalDeduplicationEnabled
     });
-    return result.globalDeduplicationEnabled;
+    return result.globalDeduplicationEnabled as boolean;
   } catch (error) {
     console.error('Error getting global deduplication enabled:', error);
     return defaultSyncSettings.globalDeduplicationEnabled;
@@ -61,7 +62,7 @@ export async function getDomainRules(): Promise<SyncSettings['domainRules']> {
     const result = await browser.storage.sync.get({
       domainRules: defaultSyncSettings.domainRules
     });
-    return result.domainRules;
+    return result.domainRules as SyncSettings['domainRules'];
   } catch (error) {
     console.error('Error getting domain rules:', error);
     return defaultSyncSettings.domainRules;

--- a/src/utils/statisticsUtils.ts
+++ b/src/utils/statisticsUtils.ts
@@ -1,3 +1,4 @@
+import { browser } from 'wxt/browser';
 import type { Statistics } from '../types/statistics.js';
 import { defaultStatistics } from '../types/statistics.js';
 
@@ -12,9 +13,9 @@ export async function getStatisticsData(): Promise<Statistics> {
       statistics: defaultStatistics
     });
     
-    return { 
-      ...defaultStatistics, 
-      ...result.statistics 
+    return {
+      ...defaultStatistics,
+      ...(result.statistics as Record<string, unknown>)
     };
   } catch (error) {
     console.error('Error getting statistics:', error);

--- a/src/utils/themeConstants.ts
+++ b/src/utils/themeConstants.ts
@@ -46,7 +46,7 @@ export const FEATURE_CALLOUT_COLORS = {
   },
   SETTINGS: {
     INFO: 'gray',
-    WARNING: 'slate',  // Nuance plus foncée
+    WARNING: 'gray',   // Nuance neutre
     ERROR: 'red'       // Rouge standard pour erreur
   }
 } as const;

--- a/tests/hooks/useStatistics.test.ts
+++ b/tests/hooks/useStatistics.test.ts
@@ -55,6 +55,11 @@ const mockBrowser = {
 // Set global browser
 (globalThis as any).browser = mockBrowser;
 
+// Mock wxt/browser module to use the global mock
+vi.mock('wxt/browser', () => ({
+  get browser() { return (globalThis as any).browser; }
+}));
+
 describe('useStatistics', () => {
   beforeEach(() => {
     mockStorageData = {};

--- a/tests/hooks/useSyncedSettings.test.ts
+++ b/tests/hooks/useSyncedSettings.test.ts
@@ -54,6 +54,11 @@ const mockBrowser = {
 // Set global browser
 (globalThis as any).browser = mockBrowser;
 
+// Mock wxt/browser module to use the global mock
+vi.mock('wxt/browser', () => ({
+  get browser() { return (globalThis as any).browser; }
+}));
+
 describe('useSyncedSettings', () => {
   beforeEach(() => {
     mockStorageData = {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", ".wxt/wxt.d.ts"]
 }


### PR DESCRIPTION
- Add WXT type references to tsconfig.json (.wxt/wxt.d.ts) and skipLibCheck
- Add missing `import { browser } from 'wxt/browser'` in hooks and utils
- Fix Browser.tabs.TabChangeInfo → Browser.tabs.OnUpdatedInfo
- Fix tabs.group/ungroup tuple type with [number, ...number[]] casts
- Fix notifications type: Browser.notifications.NotificationCreateOptions
- Fix runtime.getURL path to use PublicPath with leading slash
- Fix i18n.getMessage generic string key with type cast
- Fix CalloutColor 'slate' → 'gray' (not a valid Radix accent color)
- Replace Text as="h2"/"h3" with Heading component in stories
- Fix DataTable Action variant type to match Radix Button variants
- Fix SidebarItem icon type to accept LucideIcon (size?: number | string)
- Add missing SyncSettings props in DomainRuleFormModal stories
- Fix storage API return type casts (as unknown as SyncSettings)
- Fix useSyncedSettings generic callback Set operations
- Remove invalid argTypes in Header stories
- Update test mocks to support wxt/browser module import