### PR TITLE
Add SearchableSelect and integrate into presets UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ storybook-static
 playwright-report/
 test-results/
 ctrf/
+/.idea

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/themes": "^3.2.1",
     "@vitejs/plugin-react": "^4.6.0",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.522.0",
     "next-themes": "^0.4.6",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1))
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react:
         specifier: ^0.522.0
         version: 0.522.0(react@18.3.1)
@@ -2017,6 +2020,12 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -5632,6 +5641,18 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cmdk@1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -56,6 +56,8 @@
   "noPresetSelected": { "message": "No preset selected" },
   "selectPreset": { "message": "Select a preset..." },
   "searchPreset": { "message": "Search presets..." },
+  "selectPresetPlaceholder": { "message": "Choose a preset..." },
+  "searchPresetPlaceholder": { "message": "Search a preset..." },
   "noPresetFound": { "message": "No preset found" },
   "loadingPresets": { "message": "Loading presets..." },
   "enableSelected": { "message": "Enable Selected" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -56,6 +56,8 @@
   "noPresetSelected": { "message": "Ningún preset seleccionado" },
   "selectPreset": { "message": "Seleccionar un preset..." },
   "searchPreset": { "message": "Buscar presets..." },
+  "selectPresetPlaceholder": { "message": "Elegir un preset..." },
+  "searchPresetPlaceholder": { "message": "Buscar un preset..." },
   "noPresetFound": { "message": "Ningún preset encontrado" },
   "loadingPresets": { "message": "Cargando presets..." },
   "enableSelected": { "message": "Activar Seleccionados" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -56,6 +56,8 @@
   "noPresetSelected": { "message": "Aucun preset sélectionné" },
   "selectPreset": { "message": "Sélectionner un preset..." },
   "searchPreset": { "message": "Rechercher des presets..." },
+  "selectPresetPlaceholder": { "message": "Choisir un preset..." },
+  "searchPresetPlaceholder": { "message": "Rechercher un preset..." },
   "noPresetFound": { "message": "Aucun preset trouvé" },
   "loadingPresets": { "message": "Chargement des presets..." },
   "enableSelected": { "message": "Activer Sélectionnés" },

--- a/src/components/Core/DomainRule/DomainRuleFormModal.tsx
+++ b/src/components/Core/DomainRule/DomainRuleFormModal.tsx
@@ -11,8 +11,9 @@ import { groupNameSourceOptions, deduplicationMatchModeOptions } from '../../../
 import { getMessage } from '../../../utils/i18n';
 import { CategoryPicker } from './CategoryPicker';
 import type { SyncSettings } from '../../../types/syncSettings';
-import { FieldLabel, FormField, RadioGroupField } from '../../Form/FormFields';
-import { getPresetById, loadPresets, type Preset } from '../../../utils/presetUtils';
+import { FieldLabel, FormField, RadioGroupField, SearchableSelect } from '../../Form/FormFields';
+import { getPresetById, loadPresets, type PresetCategory } from '../../../utils/presetUtils';
+import { presetsToSearchableGroups } from '../../../utils/presetsToSearchableGroups';
 
 interface DomainRuleFormModalProps {
   isOpen: boolean;
@@ -30,7 +31,7 @@ export function DomainRuleFormModal({
   syncSettings
 }: DomainRuleFormModalProps) {
   const isEditing = !!domainRule;
-  const [presetCategories, setPresetCategories] = useState<any[]>([]);
+  const [presetCategories, setPresetCategories] = useState<PresetCategory[]>([]);
   const [isLoadingPresets, setIsLoadingPresets] = useState(false);
   
   // Local state for config mode - calculated only when domainRule changes
@@ -126,7 +127,7 @@ export function DomainRuleFormModal({
 
   // Gérer la sélection d'un preset
   const handlePresetChange = useCallback(async (selectedPresetId: string) => {
-    if (selectedPresetId === 'null') {
+    if (!selectedPresetId) {
       setValue('presetId', null);
       return;
     }
@@ -301,38 +302,22 @@ export function DomainRuleFormModal({
                 {configMode === 'preset' && presetCategories.length > 0 && !isLoadingPresets ? (
                   <RegexPresetsTheme>
                   <Flex direction="column">
-                    <Text as="label" size="2" weight="bold">
+                    <Text as="label" htmlFor="presetId" size="2" weight="bold">
                       {getMessage('presetRuleLabel')}
                     </Text>
                     <Controller
                       name="presetId"
                       control={control}
                       render={({ field }) => (
-                        <Select.Root
-                          value={field.value === null ? 'null' : field.value}
+                        <SearchableSelect
+                          id="presetId"
+                          value={field.value ?? ''}
                           onValueChange={handlePresetChange}
-                        >
-                          <Select.Trigger
-                            variant="soft"
-                            placeholder={getMessage('selectPreset')}
-                            style={{ marginTop: '4px' }}
-                          />
-                          <Select.Content>
-                            <Select.Item value="null">
-                              {getMessage('noPresetSelected')}
-                            </Select.Item>
-                            {presetCategories.map((category) => (
-                              <Select.Group key={category.name}>
-                                <Select.Label>{category.name}</Select.Label>
-                                {category.presets.map((preset: Preset) => (
-                                  <Select.Item key={preset.id} value={preset.id}>
-                                    {preset.name}
-                                  </Select.Item>
-                                ))}
-                              </Select.Group>
-                            ))}
-                          </Select.Content>
-                        </Select.Root>
+                          groups={presetsToSearchableGroups(presetCategories)}
+                          placeholder={getMessage('selectPresetPlaceholder')}
+                          searchPlaceholder={getMessage('searchPresetPlaceholder')}
+                          emptyMessage={getMessage('noPresetFound')}
+                        />
                       )}
                     />
                   </Flex>

--- a/src/components/Form/FormFields/SearchableSelect.css
+++ b/src/components/Form/FormFields/SearchableSelect.css
@@ -1,0 +1,215 @@
+/* ── Root ─────────────────────────────────────────────────── */
+.ss-root {
+  position: relative;
+  width: 100%;
+}
+
+/* ── Trigger ─────────────────────────────────────────────── */
+.ss-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  height: 36px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--gray-a7);
+  border-radius: var(--radius-2);
+  background: var(--color-surface);
+  color: var(--gray-12);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-2);
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ss-trigger:hover:not(:disabled) {
+  border-color: var(--gray-a8);
+}
+
+.ss-trigger:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: 2px;
+  border-color: var(--accent-8);
+}
+
+.ss-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Trigger label ───────────────────────────────────────── */
+.ss-trigger__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  color: var(--gray-a10);
+}
+
+.ss-trigger__label--has-value {
+  color: var(--gray-12);
+}
+
+/* ── Trigger chevron ─────────────────────────────────────── */
+.ss-trigger__icon {
+  flex-shrink: 0;
+  color: var(--gray-a10);
+  transition: transform 0.2s ease;
+}
+
+.ss-trigger__icon--open {
+  transform: rotate(180deg);
+}
+
+/* ── Dropdown ────────────────────────────────────────────── */
+@keyframes ss-dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ss-dropdown {
+  z-index: 9999;
+  background: var(--color-panel-solid);
+  border: 1px solid var(--gray-a6);
+  border-radius: var(--radius-3);
+  box-shadow: var(--shadow-4);
+  overflow: hidden;
+}
+
+.ss-dropdown[data-state='open'] {
+  animation: ss-dropdown-in 0.12s ease;
+}
+
+/* ── Search zone ─────────────────────────────────────────── */
+.ss-search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--gray-a6);
+}
+
+.ss-search__icon {
+  flex-shrink: 0;
+  color: var(--gray-a10);
+}
+
+.ss-search__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--gray-12);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-2);
+}
+
+.ss-search__input::placeholder {
+  color: var(--gray-a10);
+}
+
+/* ── Scrollable list ─────────────────────────────────────── */
+.ss-list {
+  overflow-y: auto;
+  padding: var(--space-1) 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-a6) transparent;
+}
+
+.ss-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.ss-list::-webkit-scrollbar-thumb {
+  background: var(--gray-a6);
+  border-radius: var(--radius-2);
+}
+
+.ss-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* ── Empty state ─────────────────────────────────────────── */
+.ss-empty {
+  padding: var(--space-3) var(--space-4);
+  text-align: center;
+  font-size: var(--font-size-2);
+  color: var(--gray-a10);
+}
+
+/* ── Group heading ───────────────────────────────────────── */
+.ss-group [cmdk-group-heading] {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-1);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--gray-a10);
+  user-select: none;
+}
+
+/* ── Item ────────────────────────────────────────────────── */
+.ss-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-2);
+  color: var(--gray-12);
+  cursor: pointer;
+  border-radius: 0;
+  transition: background 0.1s ease;
+  outline: none;
+}
+
+.ss-item[aria-selected='true'] {
+  background: var(--gray-a3);
+}
+
+.ss-item--selected {
+  background: var(--accent-a3);
+  color: var(--accent-11);
+  font-weight: 500;
+}
+
+.ss-item--selected[aria-selected='true'] {
+  background: var(--accent-a4);
+}
+
+.ss-item--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.ss-item__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Checkmark ───────────────────────────────────────────── */
+.ss-item__check {
+  flex-shrink: 0;
+  width: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-9);
+  opacity: 0;
+}
+
+.ss-item--selected .ss-item__check {
+  opacity: 1;
+}

--- a/src/components/Form/FormFields/SearchableSelect.stories.tsx
+++ b/src/components/Form/FormFields/SearchableSelect.stories.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SearchableSelect, type SearchableSelectOption, type SearchableSelectGroup } from './SearchableSelect';
+
+const meta: Meta<typeof SearchableSelect> = {
+  title: 'Components/Form/FormFields/SearchableSelect',
+  component: SearchableSelect,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── Sample data ───────────────────────────────────────────────────────────────
+
+const devGroups: SearchableSelectGroup[] = [
+  {
+    label: 'Development & Code',
+    options: [
+      { value: 'github-repo', label: 'GitHub Repository' },
+      { value: 'github-issue', label: 'GitHub Issue' },
+      { value: 'stackoverflow-question', label: 'Stack Overflow Question' },
+      { value: 'gitlab-project', label: 'GitLab Project' },
+      { value: 'figma-file', label: 'Figma File' },
+      { value: 'npm-package', label: 'NPM Package' },
+    ],
+  },
+  {
+    label: 'Productivity & Tickets',
+    options: [
+      { value: 'jira-ticket', label: 'Jira Ticket' },
+      { value: 'trello-board', label: 'Trello Board' },
+      { value: 'notion-page', label: 'Notion Page' },
+      { value: 'asana-task', label: 'Asana Task' },
+      { value: 'miro-board', label: 'Miro Board' },
+    ],
+  },
+  {
+    label: 'Generic',
+    options: [
+      { value: 'numeric-id', label: 'Numeric ID' },
+      { value: 'alphanumeric-id', label: 'Alphanumeric ID' },
+      { value: 'uuid-pattern', label: 'UUID Pattern' },
+      { value: 'date-pattern', label: 'Date Pattern' },
+    ],
+  },
+];
+
+const flatOptions: SearchableSelectOption[] = [
+  { value: 'title', label: 'Title' },
+  { value: 'url', label: 'URL' },
+  { value: 'smart_title', label: 'Smart (Title)' },
+  { value: 'smart_url', label: 'Smart (URL)' },
+  { value: 'smart_preset', label: 'Smart (Preset)' },
+  { value: 'manual', label: 'Manual' },
+];
+
+// 40+ options for scroll/search testing
+const longListGroups: SearchableSelectGroup[] = [
+  {
+    label: 'Development',
+    options: [
+      { value: 'github-repo', label: 'GitHub Repository' },
+      { value: 'github-issue', label: 'GitHub Issue' },
+      { value: 'github-pr', label: 'GitHub Pull Request' },
+      { value: 'stackoverflow-question', label: 'Stack Overflow Question' },
+      { value: 'gitlab-project', label: 'GitLab Project' },
+      { value: 'gitlab-issue', label: 'GitLab Issue' },
+      { value: 'figma-file', label: 'Figma File' },
+      { value: 'figma-component', label: 'Figma Component' },
+      { value: 'npm-package', label: 'NPM Package' },
+      { value: 'pypi-package', label: 'PyPI Package' },
+    ],
+  },
+  {
+    label: 'Productivity',
+    options: [
+      { value: 'jira-ticket', label: 'Jira Ticket' },
+      { value: 'jira-sprint', label: 'Jira Sprint' },
+      { value: 'trello-board', label: 'Trello Board' },
+      { value: 'trello-card', label: 'Trello Card' },
+      { value: 'notion-page', label: 'Notion Page' },
+      { value: 'notion-db', label: 'Notion Database' },
+      { value: 'asana-task', label: 'Asana Task' },
+      { value: 'asana-project', label: 'Asana Project' },
+      { value: 'miro-board', label: 'Miro Board' },
+      { value: 'miro-frame', label: 'Miro Frame' },
+    ],
+  },
+  {
+    label: 'E-commerce',
+    options: [
+      { value: 'amazon-product', label: 'Amazon Product' },
+      { value: 'ebay-item', label: 'eBay Item' },
+      { value: 'shopify-admin', label: 'Shopify Admin' },
+      { value: 'shopify-product', label: 'Shopify Product' },
+      { value: 'etsy-listing', label: 'Etsy Listing' },
+    ],
+  },
+  {
+    label: 'Cloud & Infrastructure',
+    options: [
+      { value: 'aws-console', label: 'AWS Console' },
+      { value: 'aws-resource', label: 'AWS Resource' },
+      { value: 'azure-portal', label: 'Azure Portal' },
+      { value: 'gcp-console', label: 'GCP Console' },
+      { value: 'vercel-dashboard', label: 'Vercel Dashboard' },
+      { value: 'netlify-site', label: 'Netlify Site' },
+    ],
+  },
+  {
+    label: 'Search & Documentation',
+    options: [
+      { value: 'google-search', label: 'Google Search' },
+      { value: 'mdn-docs', label: 'MDN Documentation' },
+      { value: 'medium-article', label: 'Medium Article' },
+      { value: 'devto-post', label: 'Dev.to Post' },
+    ],
+  },
+  {
+    label: 'Social & Communication',
+    options: [
+      { value: 'linkedin-profile', label: 'LinkedIn Profile' },
+      { value: 'slack-workspace', label: 'Slack Workspace' },
+      { value: 'zoom-meeting', label: 'Zoom Meeting' },
+    ],
+  },
+];
+
+// ── Wrapper for interactive stories ──────────────────────────────────────────
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <div style={{ width: 360, padding: 24 }}>{children}</div>;
+}
+
+// ── Stories ───────────────────────────────────────────────────────────────────
+
+export const SearchableSelectDefault: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Wrapper>
+        <SearchableSelect
+          value={value}
+          onValueChange={setValue}
+          groups={devGroups}
+          placeholder="Choose a preset..."
+          searchPlaceholder="Search a preset..."
+          emptyMessage="No preset found."
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const SearchableSelectWithValue: Story = {
+  render: () => {
+    const [value, setValue] = useState('jira-ticket');
+    return (
+      <Wrapper>
+        <SearchableSelect
+          value={value}
+          onValueChange={setValue}
+          groups={devGroups}
+          placeholder="Choose a preset..."
+          searchPlaceholder="Search a preset..."
+          emptyMessage="No preset found."
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const SearchableSelectDisabled: Story = {
+  render: () => (
+    <Wrapper>
+      <SearchableSelect
+        value="github-repo"
+        onValueChange={() => {}}
+        groups={devGroups}
+        placeholder="Choose a preset..."
+        searchPlaceholder="Search a preset..."
+        emptyMessage="No preset found."
+        disabled
+      />
+    </Wrapper>
+  ),
+};
+
+export const SearchableSelectFlat: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Wrapper>
+        <SearchableSelect
+          value={value}
+          onValueChange={setValue}
+          options={flatOptions}
+          placeholder="Choose a group source..."
+          searchPlaceholder="Search..."
+          emptyMessage="No option found."
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const SearchableSelectLongList: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Wrapper>
+        <SearchableSelect
+          value={value}
+          onValueChange={setValue}
+          groups={longListGroups}
+          placeholder="Choose a preset..."
+          searchPlaceholder="Search a preset..."
+          emptyMessage="No preset found."
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const SearchableSelectNoResults: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <Wrapper>
+        <p style={{ marginBottom: 12, fontSize: 13, color: '#888' }}>
+          Type in the search to see no-results state (e.g. "zzz")
+        </p>
+        <SearchableSelect
+          value={value}
+          onValueChange={setValue}
+          groups={devGroups}
+          placeholder="Choose a preset..."
+          searchPlaceholder="Search a preset..."
+          emptyMessage="No preset found."
+        />
+      </Wrapper>
+    );
+  },
+};

--- a/src/components/Form/FormFields/SearchableSelect.tsx
+++ b/src/components/Form/FormFields/SearchableSelect.tsx
@@ -1,0 +1,231 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Command } from 'cmdk';
+import { ChevronDown, Check, Search } from 'lucide-react';
+import './SearchableSelect.css';
+
+export interface SearchableSelectOption {
+  value: string;
+  label: string;
+  /** Short label shown in trigger when selected (fallback to label) */
+  triggerLabel?: string;
+  disabled?: boolean;
+}
+
+export interface SearchableSelectGroup {
+  label: string;
+  options: SearchableSelectOption[];
+}
+
+export interface SearchableSelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Flat list — use either options or groups, not both */
+  options?: SearchableSelectOption[];
+  /** Grouped list */
+  groups?: SearchableSelectGroup[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  /** Max dropdown height in px (default: 320) */
+  maxHeight?: number;
+  className?: string;
+  /** For linking the trigger to a label via htmlFor */
+  id?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+function findOption(
+  value: string,
+  options?: SearchableSelectOption[],
+  groups?: SearchableSelectGroup[]
+): SearchableSelectOption | undefined {
+  if (options) return options.find((o) => o.value === value);
+  if (groups) {
+    for (const g of groups) {
+      const found = g.options.find((o) => o.value === value);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+export function SearchableSelect({
+  value,
+  onValueChange,
+  options,
+  groups,
+  placeholder,
+  searchPlaceholder,
+  emptyMessage,
+  disabled = false,
+  maxHeight = 320,
+  className,
+  id,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedOption = value ? findOption(value, options, groups) : undefined;
+  const triggerText = selectedOption
+    ? (selectedOption.triggerLabel ?? selectedOption.label)
+    : undefined;
+
+  // Compute position from trigger's viewport rect
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setDropdownStyle({
+      position: 'fixed',
+      top: r.bottom + 4,
+      left: r.left,
+      width: r.width,
+      maxHeight,
+      zIndex: 9999,
+    });
+  }, [maxHeight]);
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [open, updatePosition]);
+
+  // Auto-focus search input when dropdown opens
+  useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => inputRef.current?.focus(), 10);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (containerRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  const handleSelect = (optionValue: string) => {
+    onValueChange(optionValue);
+    setOpen(false);
+    setTimeout(() => triggerRef.current?.focus(), 0);
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+  };
+
+  const renderItem = (option: SearchableSelectOption) => {
+    const isSelected = option.value === value;
+    return (
+      <Command.Item
+        key={option.value}
+        value={`${option.value} ${option.label}`}
+        onSelect={() => {
+          if (!option.disabled) handleSelect(option.value);
+        }}
+        disabled={option.disabled}
+        className={[
+          'ss-item',
+          isSelected ? 'ss-item--selected' : '',
+          option.disabled ? 'ss-item--disabled' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        aria-selected={isSelected}
+      >
+        <span className="ss-item__check">
+          <Check size={14} aria-hidden="true" />
+        </span>
+        <span className="ss-item__label">{option.label}</span>
+      </Command.Item>
+    );
+  };
+
+  return (
+    <div ref={containerRef} className={['ss-root', className].filter(Boolean).join(' ')}>
+      <button
+        ref={triggerRef}
+        type="button"
+        id={id}
+        role="combobox"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        disabled={disabled}
+        className={['ss-trigger', open ? 'ss-trigger--open' : ''].filter(Boolean).join(' ')}
+        onClick={() => !disabled && setOpen((prev) => !prev)}
+      >
+        <span
+          className={[
+            'ss-trigger__label',
+            triggerText ? 'ss-trigger__label--has-value' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {triggerText ?? placeholder}
+        </span>
+        <ChevronDown
+          size={16}
+          aria-hidden="true"
+          className={['ss-trigger__icon', open ? 'ss-trigger__icon--open' : '']
+            .filter(Boolean)
+            .join(' ')}
+        />
+      </button>
+
+      {open && (
+        <div className="ss-dropdown" style={dropdownStyle}>
+          <Command>
+            <div className="ss-search">
+              <Search size={14} aria-hidden="true" className="ss-search__icon" />
+              <Command.Input
+                ref={inputRef}
+                placeholder={searchPlaceholder}
+                className="ss-search__input"
+                onKeyDown={handleInputKeyDown}
+              />
+            </div>
+            <Command.List className="ss-list" style={{ maxHeight: maxHeight - 48 }}>
+              <Command.Empty className="ss-empty">{emptyMessage}</Command.Empty>
+
+              {options && options.length > 0
+                ? options.map((option) => renderItem(option))
+                : groups?.map((group) => (
+                    <Command.Group
+                      key={group.label}
+                      heading={group.label}
+                      className="ss-group"
+                    >
+                      {group.options.map((option) => renderItem(option))}
+                    </Command.Group>
+                  ))}
+            </Command.List>
+          </Command>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Form/FormFields/index.ts
+++ b/src/components/Form/FormFields/index.ts
@@ -2,3 +2,5 @@ export { FieldLabel } from './FieldLabel';
 export { FieldError } from './FieldError';
 export { FormField } from './FormField';
 export { RadioGroupField } from './RadioGroupField';
+export { SearchableSelect } from './SearchableSelect';
+export type { SearchableSelectProps, SearchableSelectOption, SearchableSelectGroup } from './SearchableSelect';

--- a/src/utils/presetUtils.ts
+++ b/src/utils/presetUtils.ts
@@ -1,7 +1,7 @@
 import { type Preset, type PresetsFile, presetsFileSchema } from '../types/preset.js';
 
 // Re-export types pour faciliter l'import
-export type { Preset, PresetsFile } from '../types/preset.js';
+export type { Preset, PresetsFile, PresetCategory } from '../types/preset.js';
 
 // Cache pour les presets
 let presetsCache: PresetsFile | null = null;

--- a/src/utils/presetsToSearchableGroups.ts
+++ b/src/utils/presetsToSearchableGroups.ts
@@ -1,0 +1,15 @@
+import type { SearchableSelectGroup } from '../components/Form/FormFields/SearchableSelect';
+import type { PresetCategory } from '../types/preset';
+
+/**
+ * Transforms an array of preset categories into groups for SearchableSelect.
+ */
+export function presetsToSearchableGroups(categories: PresetCategory[]): SearchableSelectGroup[] {
+  return categories.map((cat) => ({
+    label: cat.name,
+    options: cat.presets.map((p) => ({
+      value: p.id,
+      label: p.name,
+    })),
+  }));
+}


### PR DESCRIPTION
Introduce a new SearchableSelect component (TSX + CSS) with Storybook stories to provide searchable, grouped dropdowns for selecting presets. Replace the old Select usage in DomainRuleFormModal with SearchableSelect and wire a presetsToSearchableGroups helper to convert preset categories into the component's groups. Export new types from FormFields and update presetUtils exports to include PresetCategory. Add i18n placeholder/search keys for presets, add cmdk as a dependency (pnpm lock updated), and ignore IDE config by adding /.idea to .gitignore.