### PR TITLE
Refine e2e tests, selectors and SW handling

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1, // Retry once locally too
   workers,
-  timeout: 60000, // Increased timeout for extension loading
+  timeout: 30000, // Timeout for extension loading
 
   use: {
     trace: 'on-first-retry',

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -360,18 +360,20 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
         // Wait for the tab to initialize
         await new Promise(resolve => setTimeout(resolve, 500));
 
-        // Directly call the grouping function
-        await sw.evaluate(async ({ openerTab, newTabId }) => {
+        // Directly call the grouping function with a fresh opener tab query so that
+        // any title/state changes (e.g. document.title set by tests) are reflected.
+        await sw.evaluate(async ({ openerTabId, newTabId }) => {
           const processGroupingForNewTab = (globalThis as any).processGroupingForNewTab;
 
           if (processGroupingForNewTab) {
+            const openerTab = await chrome.tabs.get(openerTabId);
             const newTab = await chrome.tabs.get(newTabId);
             console.log(`[TEST] Calling processGroupingForNewTab for opener ${openerTab.id} (${openerTab.url}) and new tab ${newTabId}`);
             await processGroupingForNewTab(openerTab, newTab);
           } else {
             console.error('[TEST] processGroupingForNewTab not available on globalThis');
           }
-        }, { openerTab: openerTabInfo, newTabId: newTabInfo.id });
+        }, { openerTabId: openerTabInfo.id, newTabId: newTabInfo.id });
 
         // Wait for grouping to complete
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -44,10 +44,10 @@ function makeRuleJson(label: string, domainFilter: string): string {
         label,
         domainFilter,
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -107,8 +107,8 @@ test.describe('Import / Export', () => {
 
       const dialog = page.getByRole('dialog');
       // Both mode tabs should be visible
-      await expect(dialog.getByText('File')).toBeVisible();
-      await expect(dialog.getByText('Text')).toBeVisible();
+      await expect(dialog.getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
+      await expect(dialog.getByRole('radio', { name: 'Text' }).locator('..')).toBeVisible();
 
       await page.close();
     });
@@ -139,7 +139,7 @@ test.describe('Import / Export', () => {
 
       const dialog = page.getByRole('dialog');
       // Switch to Text mode
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await expect(dialog.locator('textarea')).toBeVisible();
@@ -175,7 +175,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       // Enter invalid JSON
@@ -183,7 +183,7 @@ test.describe('Import / Export', () => {
       await page.waitForTimeout(300);
 
       // Should show an error indicator
-      await expect(dialog.getByText(/invalid/i)).toBeVisible();
+      await expect(dialog.getByText('Invalid JSON format')).toBeVisible();
 
       await page.close();
     });
@@ -197,7 +197,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       const validJson = makeRuleJson('Valid Rule', 'valid.com');
@@ -221,19 +221,19 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill('{ invalid }');
       await page.waitForTimeout(200);
-      await expect(dialog.getByText(/invalid/i)).toBeVisible();
+      await expect(dialog.getByText('Invalid JSON format')).toBeVisible();
 
       // Clear the textarea
       await dialog.locator('textarea').fill('');
       await page.waitForTimeout(200);
 
       // No error and no success indicator
-      await expect(dialog.getByText(/invalid/i)).not.toBeVisible();
+      await expect(dialog.getByText('Invalid JSON format')).not.toBeVisible();
       await expect(dialog.getByText(/rule.*found/i)).not.toBeVisible();
 
       await page.close();
@@ -252,7 +252,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(makeRuleJson('Brand New Rule', 'brandnew.com'));
@@ -277,10 +277,10 @@ test.describe('Import / Export', () => {
         label: 'Identical Rule',
         domainFilter: 'identical.com',
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -293,7 +293,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       // Import same rule (same label + same properties)
@@ -322,10 +322,10 @@ test.describe('Import / Export', () => {
         label: 'Conflict Rule',
         domainFilter: 'conflict.com',
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -341,7 +341,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
@@ -369,7 +369,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(makeRuleJson('Pre-Selected Rule', 'preselect.com'));
@@ -400,7 +400,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(makeRuleJson('Deselect Rule', 'deselect.com'));
@@ -433,10 +433,10 @@ test.describe('Import / Export', () => {
         label: 'CR Rule',
         domainFilter: 'cr.com',
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -451,7 +451,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
@@ -461,9 +461,9 @@ test.describe('Import / Export', () => {
       await page.waitForTimeout(300);
 
       // The conflict resolution segmented control should be visible
-      await expect(dialog.getByText('Overwrite')).toBeVisible();
-      await expect(dialog.getByText('Duplicate')).toBeVisible();
-      await expect(dialog.getByText('Ignore')).toBeVisible();
+      await expect(dialog.getByRole('radio', { name: 'Overwrite' })).toBeAttached();
+      await expect(dialog.getByRole('radio', { name: 'Duplicate' })).toBeAttached();
+      await expect(dialog.getByRole('radio', { name: 'Ignore' })).toBeAttached();
 
       await page.close();
     });
@@ -477,10 +477,10 @@ test.describe('Import / Export', () => {
         label: 'Ignore Rule',
         domainFilter: 'ignore.com',
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -495,7 +495,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
@@ -504,8 +504,9 @@ test.describe('Import / Export', () => {
       await dialog.getByRole('button', { name: /next/i }).click();
       await page.waitForTimeout(300);
 
-      // Switch to Ignore mode
-      await dialog.getByText('Ignore').click();
+      // Switch to Ignore mode (SegmentedControl item — use class selector to avoid strict-mode issues
+      // with duplicate spans and rule-card text that also contains "Ignore")
+      await dialog.locator('.rt-SegmentedControlItem').filter({ hasText: 'Ignore' }).first().click();
       await page.waitForTimeout(200);
 
       // Import count should be 0 (conflict ignored, no new rules)
@@ -527,10 +528,10 @@ test.describe('Import / Export', () => {
         label: 'Diff Rule',
         domainFilter: 'diff.com',
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
+        groupNameSource: 'title',
+        presetId: null,
         color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
@@ -545,7 +546,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
@@ -575,7 +576,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(makeRuleJson('Confirm Rule', 'confirm.com'));
@@ -604,7 +605,7 @@ test.describe('Import / Export', () => {
       await openImportWizard(page);
 
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
 
       await dialog.locator('textarea').fill(makeRuleJson('Import Close Rule', 'importclose.com'));
@@ -635,7 +636,7 @@ test.describe('Import / Export', () => {
       // First import
       await openImportWizard(page);
       const dialog = page.getByRole('dialog');
-      await dialog.getByText('Text').click();
+      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
       await page.waitForTimeout(200);
       await dialog.locator('textarea').fill(makeRuleJson('First Import', 'firstimport.com'));
       await page.waitForTimeout(300);
@@ -651,7 +652,7 @@ test.describe('Import / Export', () => {
       const dialog2 = page.getByRole('dialog');
       await expect(dialog2.getByText('Source')).toBeVisible();
       // Should be back at step 1 (file/text selector visible, not step 3 summary)
-      await expect(dialog2.getByText('File')).toBeVisible();
+      await expect(dialog2.getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
 
       await page.close();
     });
@@ -742,7 +743,7 @@ test.describe('Import / Export', () => {
       await expect(dialog.getByRole('button', { name: /next/i })).toBeDisabled();
 
       // Select All
-      await dialog.getByRole('button', { name: /select all/i }).click();
+      await dialog.getByRole('button', { name: 'Select All', exact: true }).click();
       await page.waitForTimeout(200);
       await expect(dialog.getByText(/1 rule.*selected/i)).toBeVisible();
       await expect(dialog.getByRole('button', { name: /next/i })).toBeEnabled();

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -38,6 +38,26 @@ async function setNotificationPrefs(
   await new Promise(r => setTimeout(r, 100));
 }
 
+/**
+ * Polls until executeNotificationUndoById is available on the SW's globalThis.
+ * Needed because the SW may be idle-terminated and restarting while the test waits,
+ * causing a race condition where background.ts hasn't finished re-initializing yet.
+ */
+async function getSwWithUndoFn(extensionContext: any, timeoutMs = 5000): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const sw = extensionContext.serviceWorkers()[0];
+    if (sw) {
+      const ready = await sw.evaluate(
+        () => typeof (globalThis as any).executeNotificationUndoById === 'function',
+      ).catch(() => false);
+      if (ready) return sw;
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  throw new Error('executeNotificationUndoById not available on SW globalThis after timeout');
+}
+
 // ─── suite ──────────────────────────────────────────────────────────────────
 
 test.describe('Notifications', () => {
@@ -146,7 +166,8 @@ test.describe('Notifications', () => {
       expect(notifId).toBeDefined();
 
       // Trigger the Undo action via the exposed globalThis helper
-      await sw.evaluate(async (id: string) => {
+      const undoSw = await getSwWithUndoFn(extensionContext);
+      await undoSw.evaluate(async (id: string) => {
         await (globalThis as any).executeNotificationUndoById(id);
       }, notifId!);
 
@@ -265,7 +286,8 @@ test.describe('Notifications', () => {
       expect(notifId).toBeDefined();
 
       // Trigger Undo to reopen the closed tab
-      await sw.evaluate(async (id: string) => {
+      const undoSw = await getSwWithUndoFn(extensionContext);
+      await undoSw.evaluate(async (id: string) => {
         await (globalThis as any).executeNotificationUndoById(id);
       }, notifId!);
 
@@ -317,7 +339,8 @@ test.describe('Notifications', () => {
       const countBeforeUndo = await helpers.getTabCount();
 
       // Trigger Undo to reopen the deduplicated tab
-      await sw.evaluate(async (id: string) => {
+      const undoSw = await getSwWithUndoFn(extensionContext);
+      await undoSw.evaluate(async (id: string) => {
         await (globalThis as any).executeNotificationUndoById(id);
       }, notifId!);
 


### PR DESCRIPTION
Reduce Playwright timeout (60s -> 30s) and harden e2e tests: update many import/export specs to use role-based selectors (radio/button) and more specific locator clicks, normalize imported rule defaults (groupNameSource -> 'title', add presetId null), and adjust expectations/messages for invalid JSON. In fixtures, call the background grouping helper with a fresh openerTab lookup (pass openerTabId and fetch via chrome.tabs.get) so title/state changes are reflected. In notifications tests, add getSwWithUndoFn polling helper to wait for executeNotificationUndoById on the service worker and use it to avoid race conditions when triggering Undo actions.