### PR TITLE
Add 'Organize All Tabs' feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-storybook": "storybook build"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.1",
+    "@playwright/test": "^1.58.2",
     "@storybook/addon-docs": "^9.0.13",
     "@storybook/react-vite": "^9.0.13",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 3.25.76
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.1
+        specifier: ^1.58.2
         version: 1.58.2
       '@storybook/addon-docs':
         specifier: ^9.0.13

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -415,5 +415,10 @@
   "importNotificationMessage": { "message": "$1 rule(s) added, $2 rule(s) overwritten" },
   "exportNotificationTitle": { "message": "Rules Exported" },
   "exportNotificationMessage": { "message": "Rules exported successfully" },
-  "exportOptions": { "message": "Export options" }
+  "exportOptions": { "message": "Export options" },
+
+  "organizeAllTabs": { "message": "Organize tabs" },
+  "organizingTabs": { "message": "Organizing..." },
+  "notifDeduplication": { "message": "$1 duplicate tab(s) removed" },
+  "notifGrouping": { "message": "$1 tab(s) grouped into $2 group(s)" }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -415,5 +415,10 @@
   "importNotificationMessage": { "message": "$1 regla(s) añadida(s), $2 regla(s) sobreescrita(s)" },
   "exportNotificationTitle": { "message": "Reglas exportadas" },
   "exportNotificationMessage": { "message": "Reglas exportadas correctamente" },
-  "exportOptions": { "message": "Opciones de exportación" }
+  "exportOptions": { "message": "Opciones de exportación" },
+
+  "organizeAllTabs": { "message": "Organizar pestañas" },
+  "organizingTabs": { "message": "Organizando..." },
+  "notifDeduplication": { "message": "$1 pestaña(s) duplicada(s) eliminada(s)" },
+  "notifGrouping": { "message": "$1 pestaña(s) agrupada(s) en $2 grupo(s)" }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -415,5 +415,10 @@
   "importNotificationMessage": { "message": "$1 règle(s) ajoutée(s), $2 règle(s) écrasée(s)" },
   "exportNotificationTitle": { "message": "Règles exportées" },
   "exportNotificationMessage": { "message": "Règles exportées avec succès" },
-  "exportOptions": { "message": "Options d'export" }
+  "exportOptions": { "message": "Options d'export" },
+
+  "organizeAllTabs": { "message": "Organiser les onglets" },
+  "organizingTabs": { "message": "Organisation en cours..." },
+  "notifDeduplication": { "message": "$1 onglet(s) en double supprimé(s)" },
+  "notifGrouping": { "message": "$1 onglet(s) regroupé(s) en $2 groupe(s)" }
 }

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js';
 import { handleMiddleClickMessage, findMiddleClickOpener } from './messaging.js';
 import { processTabForDeduplication } from './deduplication.js';
 import { processGroupingForNewTab } from './grouping.js';
+import { handleOrganizeAllTabs } from './organize.js';
 import { loadSessions } from '../utils/sessionStorage.js';
 import { restoreTabs } from '../utils/tabRestore.js';
 import { getMessage } from '../utils/i18n.js';
@@ -19,6 +20,12 @@ export function setupInstallationHandler(): void {
 
 export function setupMessageHandler(): void {
     browser.runtime.onMessage.addListener((request: any, sender: Browser.runtime.MessageSender, sendResponse: (response?: any) => void) => {
+        if (request.type === 'ORGANIZE_ALL_TABS') {
+            browser.windows.getCurrent()
+                .then(win => { if (win.id != null) return handleOrganizeAllTabs(win.id); })
+                .catch(e => logger.error('[ORGANIZE_ALL_TABS] Error:', e));
+            return false;
+        }
         if (request.type === 'RESTORE_PROFILE') {
             handleProfileRestore(
                 request.profileId as string,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,3 +4,4 @@ export * from './messaging.js';
 export * from './deduplication.js';
 export * from './grouping.js';
 export * from './event-handlers.js';
+export * from './organize.js';

--- a/src/background/organize.ts
+++ b/src/background/organize.ts
@@ -1,0 +1,334 @@
+import { browser, Browser } from 'wxt/browser';
+import { getSettings } from './settings.js';
+import {
+    findMatchingRule,
+    extractGroupNameFromRule,
+    determineGroupColor,
+    createNewGroup,
+    addToExistingGroup,
+} from './grouping.js';
+import { getMatchMode, isUrlMatch } from './deduplication.js';
+import { getStatisticsData, updateStatisticsData } from '../utils/statisticsUtils.js';
+import { getMessage } from '../utils/i18n.js';
+import { logger } from '../utils/logger.js';
+import type { DomainRuleSetting, SyncSettings } from '../types/syncSettings.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PlanEntry {
+    tab: Browser.tabs.Tab;
+    targetGroupName: string;
+    groupColor: string | null;
+    rule: DomainRuleSetting;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isOrganizableUrl(url: string | undefined): url is string {
+    return (
+        !!url &&
+        !url.startsWith('chrome:') &&
+        !url.startsWith('chrome-extension:') &&
+        !url.startsWith('about:')
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Batch deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicates all tabs in the window according to their matching domain rule.
+ * Independent of the global deduplication toggle (manual action per US-PO006).
+ * Returns the number of duplicate tabs removed.
+ */
+async function batchDeduplicateTabs(windowId: number, settings: SyncSettings): Promise<number> {
+    const allTabs = await browser.tabs.query({ windowId });
+    const organizable = allTabs
+        .filter(t => isOrganizableUrl(t.url))
+        .sort((a, b) => a.index - b.index);
+
+    // Group tabs by rule + matchMode bucket
+    const buckets = new Map<string, { rule: DomainRuleSetting; tabs: Browser.tabs.Tab[] }>();
+
+    for (const tab of organizable) {
+        const rule = findMatchingRule(tab.url!, settings.domainRules);
+        if (!rule || !rule.enabled || !rule.deduplicationEnabled) continue;
+
+        const mode = getMatchMode(rule);
+        const key = `${rule.id}:${mode}`;
+        if (!buckets.has(key)) buckets.set(key, { rule, tabs: [] });
+        buckets.get(key)!.tabs.push(tab);
+    }
+
+    const toRemove = new Set<number>();
+    const toReload = new Set<number>();
+
+    for (const { rule, tabs } of buckets.values()) {
+        const mode = getMatchMode(rule);
+
+        if (mode === 'exact') {
+            const seen = new Map<string, number>(); // url → tabId
+            for (const tab of tabs) {
+                if (toRemove.has(tab.id!)) continue; // already marked
+                if (seen.has(tab.url!)) {
+                    toRemove.add(tab.id!);
+                } else {
+                    seen.set(tab.url!, tab.id!);
+                    toReload.add(tab.id!);
+                }
+            }
+        } else {
+            // includes mode
+            const kept: Browser.tabs.Tab[] = [];
+            for (const tab of tabs) {
+                if (toRemove.has(tab.id!)) continue;
+                const isDup = kept.some(k => isUrlMatch(k.url!, tab.url!, 'includes'));
+                if (isDup) {
+                    toRemove.add(tab.id!);
+                } else {
+                    kept.push(tab);
+                    toReload.add(tab.id!);
+                }
+            }
+        }
+    }
+
+    // A tab can't be in both sets (e.g. matched by two different rule buckets)
+    for (const id of toRemove) toReload.delete(id);
+
+    // Reload keepers first (best-effort)
+    for (const id of toReload) {
+        await browser.tabs.reload(id).catch(() => {});
+    }
+
+    // Single batch remove
+    const removeIds = [...toRemove];
+    if (removeIds.length > 0) {
+        await browser.tabs.remove(removeIds as [number, ...number[]]).catch(e => {
+            logger.warn('[ORGANIZE] Error removing duplicate tabs:', e);
+        });
+
+        const stats = await getStatisticsData();
+        await updateStatisticsData({
+            tabsDeduplicatedCount: stats.tabsDeduplicatedCount + removeIds.length,
+        });
+    }
+
+    logger.debug(`[ORGANIZE] Dedup complete: ${removeIds.length} tab(s) removed.`);
+    return removeIds.length;
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Build grouping plan
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates target groups for all eligible tabs without modifying anything.
+ * Returns only entries whose target group has ≥ 2 members.
+ * Per US-PO008: single-member target groups are excluded.
+ */
+async function buildOrganizePlan(windowId: number, settings: SyncSettings): Promise<PlanEntry[]> {
+    // Re-query after dedup so removed tabs are no longer present
+    const allTabs = await browser.tabs.query({ windowId });
+    const organizable = allTabs.filter(t => isOrganizableUrl(t.url));
+
+    const allEntries: PlanEntry[] = [];
+
+    for (const tab of organizable) {
+        const rule = findMatchingRule(tab.url!, settings.domainRules);
+        if (!rule || !rule.enabled || !rule.groupingEnabled) continue;
+
+        // Skip sources that require user interaction — fall back to rule.label via smart_label
+        const effectiveRule: DomainRuleSetting =
+            rule.groupNameSource === 'manual' || rule.groupNameSource === 'smart_manual'
+                ? { ...rule, groupNameSource: 'smart_label' as const }
+                : rule;
+
+        // Pass the tab itself as "openerTab" — safe for label/url/title/smart sources
+        const targetGroupName = extractGroupNameFromRule(effectiveRule, tab as Browser.tabs.Tab);
+        const groupColor = determineGroupColor(rule);
+
+        allEntries.push({ tab, targetGroupName, groupColor, rule });
+    }
+
+    // Count members per target group name
+    const countByName = new Map<string, number>();
+    for (const entry of allEntries) {
+        countByName.set(entry.targetGroupName, (countByName.get(entry.targetGroupName) ?? 0) + 1);
+    }
+
+    // Exclude single-member groups (US-PO008)
+    return allEntries.filter(entry => {
+        const count = countByName.get(entry.targetGroupName) ?? 0;
+        if (count >= 2) return true;
+        // count < 2: exclude regardless of whether the tab is already in a group
+        // (tab already in a group stays there untouched)
+        return false;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Apply grouping plan
+// ---------------------------------------------------------------------------
+
+async function applyOrganizePlan(
+    plan: PlanEntry[],
+    windowId: number,
+): Promise<{ tabsGrouped: number; groupCount: number }> {
+    if (plan.length === 0) return { tabsGrouped: 0, groupCount: 0 };
+
+    // Fetch current groups to detect existing ones by title
+    const existingGroups = await (browser.tabGroups as any).query({ windowId }) as Array<{ id: number; title: string }>;
+    const existingByTitle = new Map<string, number>(); // title → groupId
+    for (const g of existingGroups) {
+        if (g.title) existingByTitle.set(g.title, g.id);
+    }
+
+    // Group plan entries by targetGroupName
+    const byName = new Map<string, PlanEntry[]>();
+    for (const entry of plan) {
+        if (!byName.has(entry.targetGroupName)) byName.set(entry.targetGroupName, []);
+        byName.get(entry.targetGroupName)!.push(entry);
+    }
+
+    let tabsGrouped = 0;
+    let groupCount = 0;
+
+    for (const [targetName, entries] of byName) {
+        const existingGroupId = existingByTitle.get(targetName);
+        const groupColor = entries[0].groupColor;
+
+        // Determine which tabs actually need to move:
+        // - not in any group, OR
+        // - in a group whose title ≠ targetName
+        const tabsToMove = entries.filter(e => {
+            const gid = e.tab.groupId;
+            if (gid == null || gid <= 0) return true; // not grouped
+            const currentTitle = existingGroups.find(g => g.id === gid)?.title ?? '';
+            return currentTitle !== targetName;
+        });
+
+        if (tabsToMove.length === 0) {
+            // All tabs already in the correct group — count them but skip API calls
+            tabsGrouped += entries.length;
+            groupCount += 1;
+            continue;
+        }
+
+        try {
+            if (existingGroupId != null) {
+                // Add to existing group
+                for (const entry of tabsToMove) {
+                    await addToExistingGroup(existingGroupId, entry.tab.id!);
+                }
+            } else {
+                // Create new group with all planned tab IDs
+                const tabIds = tabsToMove.map(e => e.tab.id!);
+                await createNewGroup(tabIds, targetName, groupColor);
+                groupCount += 1;
+            }
+
+            tabsGrouped += entries.length;
+        } catch (e) {
+            logger.error(`[ORGANIZE] Error grouping tabs for "${targetName}":`, e);
+        }
+    }
+
+    logger.debug(`[ORGANIZE] Grouping complete: ${tabsGrouped} tab(s) grouped into ${groupCount} group(s).`);
+    return { tabsGrouped, groupCount: byName.size };
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Reposition & collapse
+// ---------------------------------------------------------------------------
+
+/**
+ * Moves all tab groups to the front of the window (before ungrouped tabs),
+ * preserving their relative order, then collapses them all.
+ */
+async function repositionAndCollapseGroups(windowId: number): Promise<void> {
+    const allGroups = await (browser.tabGroups as any).query({ windowId }) as Array<{ id: number }>;
+    if (allGroups.length === 0) return;
+
+    // Find first-tab index for each group to establish current L→R order
+    const grouped = await Promise.all(
+        allGroups.map(async (g: { id: number }) => {
+            const tabs = await browser.tabs.query({ groupId: g.id, windowId });
+            const minIndex = tabs.length > 0 ? Math.min(...tabs.map(t => t.index)) : Infinity;
+            return { g, minIndex };
+        }),
+    );
+    grouped.sort((a, b) => a.minIndex - b.minIndex);
+
+    // Move in REVERSE order to index 0 — preserves original relative order
+    // Example: groups [A@2, B@7, C@15] sorted → reversed [C, B, A]
+    // Move C to 0 → [C,...], Move B to 0 → [B, C,...], Move A to 0 → [A, B, C,...]
+    for (const { g } of [...grouped].reverse()) {
+        await (browser.tabGroups as any).move(g.id, { index: 0 }).catch(() => {});
+    }
+
+    // Collapse all groups
+    for (const { g } of grouped) {
+        await (browser.tabGroups as any).update(g.id, { collapsed: true }).catch(() => {});
+    }
+
+    logger.debug(`[ORGANIZE] Repositioned and collapsed ${allGroups.length} group(s).`);
+}
+
+// ---------------------------------------------------------------------------
+// Main exported handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Orchestrates the full "Organize All Tabs" action:
+ * 1. Batch deduplication
+ * 2. Build grouping plan
+ * 3. Apply plan
+ * 4. Reposition & collapse groups
+ * 5. Show notifications
+ */
+export async function handleOrganizeAllTabs(windowId: number): Promise<void> {
+    logger.debug(`[ORGANIZE] Starting organize for window ${windowId}.`);
+
+    const settings = await getSettings();
+
+    // ── 1. Deduplication ────────────────────────────────────────────────────
+    const removedCount = await batchDeduplicateTabs(windowId, settings);
+
+    if (removedCount > 0 && settings.notifyOnDeduplication) {
+        (browser.notifications as any).create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon128.png'),
+            title: getMessage('extensionName'),
+            message: getMessage('notifDeduplication', [String(removedCount)]),
+        });
+    }
+
+    // ── 2. Plan grouping ────────────────────────────────────────────────────
+    const plan = await buildOrganizePlan(windowId, settings);
+
+    // ── 3. Apply plan ───────────────────────────────────────────────────────
+    const { tabsGrouped, groupCount } = await applyOrganizePlan(plan, windowId);
+
+    // ── 4. Reposition & collapse ────────────────────────────────────────────
+    await repositionAndCollapseGroups(windowId);
+
+    // ── 5. Grouping notification ────────────────────────────────────────────
+    if (tabsGrouped > 0 && settings.notifyOnGrouping) {
+        (browser.notifications as any).create({
+            type: 'basic',
+            iconUrl: browser.runtime.getURL('/icons/icon128.png'),
+            title: getMessage('extensionName'),
+            message: getMessage('notifGrouping', [String(tabsGrouped), String(groupCount)]),
+        });
+    }
+
+    logger.debug(
+        `[ORGANIZE] Done. Removed: ${removedCount} dup(s). Grouped: ${tabsGrouped} tab(s) in ${groupCount} group(s).`,
+    );
+}

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, Flex, Text } from '@radix-ui/themes';
-import { Camera, RotateCcw } from 'lucide-react';
+import { Camera, RotateCcw, Wand2 } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import { getMessage } from '../../../utils/i18n';
 import { loadSessions } from '../../../utils/sessionStorage';
@@ -23,10 +23,17 @@ async function openOptionsWithHash(hash: string) {
 
 export function PopupToolbar() {
   const [hasSessions, setHasSessions] = useState(false);
+  const [isOrganizing, setIsOrganizing] = useState(false);
 
   useEffect(() => {
     loadSessions().then((sessions) => setHasSessions(sessions.length > 0));
   }, []);
+
+  const handleOrganize = async () => {
+    setIsOrganizing(true);
+    await browser.runtime.sendMessage({ type: 'ORGANIZE_ALL_TABS' });
+    window.close();
+  };
 
   return (
     <Box
@@ -73,6 +80,27 @@ export function PopupToolbar() {
           <RotateCcw size={17} aria-hidden="true" />
           <Text as="span" size="1">
             {getMessage('popupRestore')}
+          </Text>
+        </Button>
+
+        <Button
+          variant="ghost"
+          disabled={isOrganizing}
+          onClick={() => void handleOrganize()}
+          aria-label={getMessage('organizeAllTabs')}
+          title={getMessage('organizeAllTabs')}
+          style={{
+            flex: 1,
+            flexDirection: 'column',
+            height: 'auto',
+            gap: 3,
+            paddingTop: 8,
+            paddingBottom: 8,
+          }}
+        >
+          <Wand2 size={17} aria-hidden="true" />
+          <Text as="span" size="1">
+            {isOrganizing ? getMessage('organizingTabs') : getMessage('organizeAllTabs')}
           </Text>
         </Button>
       </Flex>

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -5,6 +5,7 @@ import { startPeriodicCleanup } from '../background/deduplication.js';
 import { initNotificationListeners, executeNotificationUndoById } from '../utils/notifications.js';
 import { middleClickedTabs } from '../background/messaging.js';
 import { processGroupingForNewTab } from '../background/grouping.js';
+import { handleOrganizeAllTabs } from '../background/organize.js';
 import { initProfileSync } from '../background/profileSync.js';
 
 export default defineBackground(() => {
@@ -23,6 +24,7 @@ export default defineBackground(() => {
     // Expose functions for E2E testing
     (globalThis as any).middleClickedTabs = middleClickedTabs;
     (globalThis as any).processGroupingForNewTab = processGroupingForNewTab;
+    (globalThis as any).handleOrganizeAllTabs = handleOrganizeAllTabs;
     (globalThis as any).executeNotificationUndoById = executeNotificationUndoById;
 
     logger.debug("SmartTab Organizer Service Worker: Initialized with modular architecture.");

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -19,6 +19,10 @@ export interface MessageResponse {
   message?: string;
 }
 
+export interface OrganizeAllTabsMessage {
+  type: 'ORGANIZE_ALL_TABS';
+}
+
 // Union types for different contexts
 export type ContentMessage = MiddleClickMessage | AskGroupNameMessage;
-export type BackgroundMessage = MiddleClickMessage;
+export type BackgroundMessage = MiddleClickMessage | OrganizeAllTabsMessage;

--- a/tests/e2e/popup-organize.spec.ts
+++ b/tests/e2e/popup-organize.spec.ts
@@ -1,0 +1,555 @@
+/**
+ * E2E Tests — "Organize All Tabs" button in popup
+ *
+ * Covers:
+ * - US-PO006: Button visibility in popup
+ * - US-PO007: Batch deduplication
+ * - US-PO008: Batch grouping (plan + apply + reposition + collapse)
+ * - US-PO009: Existing auto-grouping behaviour unaffected
+ */
+
+import { test, expect, type ExtensionFixtures } from './fixtures';
+import { goToPopup } from './helpers/navigation';
+import type { BrowserContext, Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the service worker page, waiting up to 5 s for handleOrganizeAllTabs
+ * to be available on globalThis (set during SW initialisation).
+ */
+async function getServiceWorker(extensionContext: BrowserContext): Promise<Page> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const sw = extensionContext.serviceWorkers()[0];
+    if (sw) {
+      const ready = await sw
+        .evaluate(() => typeof (globalThis as any).handleOrganizeAllTabs === 'function')
+        .catch(() => false);
+      if (ready) return sw;
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  throw new Error('handleOrganizeAllTabs not available on SW globalThis after 5 s');
+}
+
+/**
+ * Triggers the organize operation directly via the service worker
+ * and waits for async operations to settle.
+ */
+async function triggerOrganize(sw: Page): Promise<void> {
+  await sw.evaluate(async () => {
+    const win = await chrome.windows.getCurrent();
+    await (globalThis as any).handleOrganizeAllTabs(win.id);
+  });
+  // Allow time for Chrome API calls and state to settle
+  await new Promise(r => setTimeout(r, 2000));
+}
+
+/** Clears all Chrome notifications via the service worker. */
+async function clearNotifications(sw: Page): Promise<void> {
+  await sw.evaluate(async () => {
+    const all = await new Promise<Record<string, any>>(resolve =>
+      chrome.notifications.getAll(n => resolve(n)),
+    );
+    await Promise.all(Object.keys(all).map(id => chrome.notifications.clear(id)));
+  });
+}
+
+/** Returns all current notification IDs. */
+async function getNotificationIds(sw: Page): Promise<string[]> {
+  return sw.evaluate(async () => {
+    return new Promise<string[]>(resolve =>
+      chrome.notifications.getAll(n => resolve(Object.keys(n))),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// [US-PO006] Button visibility
+// ---------------------------------------------------------------------------
+
+test.describe('[US-PO006] Organize button in popup', () => {
+  test('Organize button is visible in popup', async ({ extensionContext, extensionId }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    await expect(page.getByRole('button', { name: /organize/i })).toBeVisible();
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [US-PO007] Batch deduplication
+// ---------------------------------------------------------------------------
+
+test.describe('[US-PO007] Batch deduplication', () => {
+  test.beforeEach(async ({ helpers }) => {
+    await helpers.closeAllTestTabs();
+    await helpers.clearAllTabGroups();
+    await helpers.clearDomainRules();
+    // Disable global auto-dedup so tabs accumulate for the batch organize action to process
+    await helpers.setGlobalDeduplicationEnabled(false);
+    // Disable auto-grouping to isolate dedup behaviour
+    await helpers.setGlobalGroupingEnabled(false);
+    await helpers.resetStatistics();
+  });
+
+  test('removes duplicate tabs (exact mode) and increments stat [US-PO007]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+    await clearNotifications(sw);
+
+    await helpers.addDomainRule({
+      label: 'Dedup Rule',
+      domainFilter: 'example.com',
+      enabled: true,
+      deduplicationEnabled: true,
+      deduplicationMatchMode: 'exact',
+    });
+
+    await helpers.createTab('https://example.com/page');
+    await helpers.createTab('https://example.com/page'); // duplicate
+    await helpers.createTab('https://example.com/page'); // duplicate
+    await new Promise(r => setTimeout(r, 500));
+
+    const beforeCount = await helpers.getTabCount();
+    await triggerOrganize(sw);
+    const afterCount = await helpers.getTabCount();
+    const stats = await helpers.getStatistics();
+
+    expect(afterCount).toBeLessThan(beforeCount);
+    expect(stats.tabsDeduplicatedCount).toBeGreaterThan(0);
+  });
+
+  test('keeps the lowest-index (leftmost) tab when deduplicating [US-PO007]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'Dedup Rule',
+      domainFilter: 'example.com',
+      enabled: true,
+      deduplicationEnabled: true,
+      deduplicationMatchMode: 'exact',
+    });
+
+    // First tab created has the lowest index
+    const firstTab = await helpers.createTab('https://example.com/keep-me');
+    await helpers.createTab('https://example.com/keep-me');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    // Exactly one tab with this URL should remain
+    const remaining = await sw.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      return tabs.filter((t: any) => t.url === 'https://example.com/keep-me').length;
+    });
+    expect(remaining).toBe(1);
+
+    await firstTab.close().catch(() => {});
+  });
+
+  test('tabs without matching rule are not deduped [US-PO007]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    // No domain rules — no dedup should occur
+    await helpers.createTab('https://example.org/page');
+    await helpers.createTab('https://example.org/page');
+    await new Promise(r => setTimeout(r, 500));
+
+    const beforeCount = await helpers.getTabCount();
+    await triggerOrganize(sw);
+    const afterCount = await helpers.getTabCount();
+    const stats = await helpers.getStatistics();
+
+    expect(afterCount).toBe(beforeCount);
+    expect(stats.tabsDeduplicatedCount).toBe(0);
+  });
+
+  test('single notification shown for all duplicates removed [US-PO007]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+    await sw.evaluate(async () => {
+      await chrome.storage.sync.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
+    });
+    await clearNotifications(sw);
+
+    await helpers.addDomainRule({
+      label: 'Dedup Rule',
+      domainFilter: 'example.com',
+      enabled: true,
+      deduplicationEnabled: true,
+      deduplicationMatchMode: 'exact',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/a'); // dup
+    await helpers.createTab('https://example.com/b');
+    await helpers.createTab('https://example.com/b'); // dup
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const ids = await getNotificationIds(sw);
+    // One notification for all duplicates (not one per duplicate)
+    expect(ids.length).toBe(1);
+  });
+
+  test('no notification when no duplicates found [US-PO007]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+    await sw.evaluate(async () => {
+      await chrome.storage.sync.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
+    });
+    await clearNotifications(sw);
+
+    await helpers.addDomainRule({
+      label: 'Dedup Rule',
+      domainFilter: 'example.com',
+      enabled: true,
+      deduplicationEnabled: true,
+    });
+
+    await helpers.createTab('https://example.com/unique1');
+    await helpers.createTab('https://example.com/unique2');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const ids = await getNotificationIds(sw);
+    expect(ids.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [US-PO008] Batch grouping
+// ---------------------------------------------------------------------------
+
+test.describe('[US-PO008] Batch grouping', () => {
+  test.beforeEach(async ({ helpers }) => {
+    await helpers.closeAllTestTabs();
+    await helpers.clearAllTabGroups();
+    await helpers.clearDomainRules();
+    await helpers.resetStatistics();
+  });
+
+  test('groups 2+ matching tabs into a named group [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'Example',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const groups = await helpers.getTabGroups();
+    expect(groups.some(g => g.title === 'Example')).toBe(true);
+    const group = groups.find(g => g.title === 'Example')!;
+    expect(group.tabCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('single matching tab (no existing group) is NOT grouped [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'Solo',
+      domainFilter: 'httpbin.org',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+    await helpers.addDomainRule({
+      label: 'Pair',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://httpbin.org/solo'); // only one → should NOT be grouped
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const groups = await helpers.getTabGroups();
+    expect(groups.some(g => g.title === 'Solo')).toBe(false); // solo tab not grouped
+    expect(groups.some(g => g.title === 'Pair')).toBe(true);
+  });
+
+  test('tab already in an existing group stays when it would be solo in plan [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'MyGroup',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    // Manually put one tab into an existing group before triggering organize
+    const tab = await helpers.createTab('https://example.com/alone');
+    await new Promise(r => setTimeout(r, 300));
+
+    await sw.evaluate(async () => {
+      const tabs = await chrome.tabs.query({ url: 'https://example.com/alone' });
+      if (tabs[0]?.id != null) {
+        const gid = await chrome.tabs.group({ tabIds: [tabs[0].id] });
+        await (chrome as any).tabGroups.update(gid, { title: 'PreviousGroup' });
+      }
+    });
+    await new Promise(r => setTimeout(r, 300));
+
+    // No second example.com tab → plan count < 2 → tab must stay in PreviousGroup
+    await triggerOrganize(sw);
+
+    const stillGrouped = await sw.evaluate(async () => {
+      const tabs = await chrome.tabs.query({ url: 'https://example.com/alone' });
+      return tabs[0]?.groupId != null && tabs[0].groupId > 0;
+    });
+    expect(stillGrouped).toBe(true);
+
+    await tab.close().catch(() => {});
+  });
+
+  test('groups are collapsed after organize [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'CollapseTest',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const allCollapsed = await sw.evaluate(async () => {
+      const groups = await (chrome as any).tabGroups.query({});
+      return groups.length > 0 && groups.every((g: any) => g.collapsed === true);
+    });
+    expect(allCollapsed).toBe(true);
+  });
+
+  test('groups are moved before ungrouped tabs after organize [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'Front',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await helpers.createTab('https://httpbin.org/ungrouped'); // no rule → stays ungrouped
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const result = await sw.evaluate(async () => {
+      const groups = await (chrome as any).tabGroups.query({});
+      if (groups.length === 0) return { groupMinIndex: -1, ungroupedIndex: -1 };
+      const groupTabs = await chrome.tabs.query({ groupId: groups[0].id });
+      const groupMinIndex = Math.min(...groupTabs.map((t: any) => t.index));
+      const ungroupedTabs = await chrome.tabs.query({ groupId: chrome.tabs.TAB_ID_NONE });
+      const httpbinTab = ungroupedTabs.find((t: any) => t.url?.includes('httpbin.org'));
+      return { groupMinIndex, ungroupedIndex: httpbinTab?.index ?? -1 };
+    });
+
+    expect(result.groupMinIndex).toBeGreaterThanOrEqual(0);
+    expect(result.ungroupedIndex).toBeGreaterThan(result.groupMinIndex);
+  });
+
+  test('tabs without matching rule are not grouped [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'Example',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await helpers.createTab('https://httpbin.org/no-rule');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const httpbinGrouped = await sw.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      const httpbin = tabs.find((t: any) => t.url?.includes('httpbin.org'));
+      return httpbin != null && httpbin.groupId != null && httpbin.groupId > 0;
+    });
+    expect(httpbinGrouped).toBe(false);
+  });
+
+  test('single grouping notification when tabs are grouped [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+    await sw.evaluate(async () => {
+      await chrome.storage.sync.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
+    });
+    await clearNotifications(sw);
+
+    await helpers.addDomainRule({
+      label: 'Notif',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const ids = await getNotificationIds(sw);
+    expect(ids.length).toBe(1);
+  });
+
+  test('no grouping notification when no tabs are grouped [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+    await sw.evaluate(async () => {
+      await chrome.storage.sync.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
+    });
+    await clearNotifications(sw);
+
+    await helpers.addDomainRule({
+      label: 'Solo',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/only-one'); // single tab → not grouped
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const ids = await getNotificationIds(sw);
+    expect(ids.length).toBe(0);
+  });
+
+  test('tabGroupsCreatedCount incremented for new groups [US-PO008]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    const sw = await getServiceWorker(extensionContext);
+
+    await helpers.addDomainRule({
+      label: 'StatTest',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    await helpers.createTab('https://example.com/a');
+    await helpers.createTab('https://example.com/b');
+    await new Promise(r => setTimeout(r, 500));
+
+    await triggerOrganize(sw);
+
+    const stats = await helpers.getStatistics();
+    expect(stats.tabGroupsCreatedCount).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [US-PO009] Automatic grouping unaffected
+// ---------------------------------------------------------------------------
+
+test.describe('[US-PO009] Automatic grouping unaffected by organize rules', () => {
+  test.beforeEach(async ({ helpers }) => {
+    await helpers.closeAllTestTabs();
+    await helpers.clearAllTabGroups();
+    await helpers.clearDomainRules();
+    await helpers.resetStatistics();
+    await helpers.setGlobalGroupingEnabled(true);
+  });
+
+  test('auto-grouping still creates a group with a single new tab [US-PO009]', async ({
+    extensionContext,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({
+      label: 'AutoGroup',
+      domainFilter: 'example.com',
+      enabled: true,
+      groupingEnabled: true,
+      groupNameSource: 'label',
+    });
+
+    // createTabFromOpener invokes processGroupingForNewTab directly (no min-member check)
+    const openerPage = await helpers.createTab('https://example.com/opener');
+    await helpers.createTabFromOpener(openerPage, 'https://example.com/child');
+
+    const groups = await helpers.getTabGroups();
+    expect(groups.some(g => g.title === 'AutoGroup')).toBe(true);
+
+    await openerPage.close().catch(() => {});
+  });
+});

--- a/user-stories/US-PO-organise.md
+++ b/user-stories/US-PO-organise.md
@@ -1,0 +1,90 @@
+# User Stories — Domaine PO : Bouton "Organiser les onglets"
+
+> Comportements à tester dans `tests/e2e/popup-organize.spec.ts`.
+> Les US numérotées ci-dessous font suite à US-PO005.
+
+---
+
+## US-PO006 — Bouton "Organiser les onglets" dans le popup
+
+**En tant qu'** utilisateur de l'extension,
+**je veux** un bouton dans le popup qui déclenche la déduplication puis le regroupement de tous mes onglets ouverts,
+**afin d'** organiser en un clic tous mes onglets existants selon mes règles configurées.
+
+### Critères d'acceptation
+
+- [ ] Le popup affiche un bouton libellé "Organiser les onglets" (i18n : clé `organizeAllTabs`) avec l'icône `Wand2` de Lucide.
+- [ ] Le bouton est désactivé (`disabled`) pendant l'exécution de l'opération, avec un indicateur visuel de chargement.
+- [ ] Cliquer le bouton ferme le popup après déclenchement de l'opération (le traitement continue en background).
+- [ ] Le bouton est toujours visible dans le popup, même si les toggles de regroupement ou de déduplication globaux sont désactivés. L'action manuelle est indépendante des toggles automatiques.
+
+---
+
+## US-PO007 — Déduplication manuelle globale
+
+**En tant qu'** utilisateur qui clique sur "Organiser les onglets",
+**je veux** que tous les doublons d'onglets des domaines couverts par des règles actives soient fermés,
+**afin d'** éliminer les doublons existants avant le regroupement.
+
+### Critères d'acceptation
+
+- [ ] Seuls les onglets dont le domaine correspond à une règle **active** (`enabled = true`) avec `deduplicationEnabled = true` sont traités.
+- [ ] Pour chaque groupe de doublons (selon le mode de correspondance de la règle concernée), l'onglet conservé est celui dont l'`index` est le plus faible dans la fenêtre (le plus à gauche).
+- [ ] L'onglet conservé est rechargé (`chrome.tabs.reload`).
+- [ ] Tous les onglets dédupliqués sont fermés via `chrome.tabs.remove` en une seule opération batch (appel unique avec un tableau d'IDs).
+- [ ] Le compteur `tabsDeduplicatedCount` est incrémenté du nombre d'onglets fermés.
+- [ ] Si aucun doublon n'est trouvé, aucune notification n'est affichée pour la déduplication.
+- [ ] Si au moins un doublon est trouvé, une notification Chrome unique est affichée à la fin indiquant le nombre total d'onglets fermés (ex. : "3 onglets en double supprimés"), sans notification individuelle par onglet.
+- [ ] Les onglets avec des schémas spéciaux (`chrome:`, `chrome-extension:`, `about:`) sont ignorés.
+
+---
+
+## US-PO008 — Regroupement manuel global
+
+**En tant qu'** utilisateur qui clique sur "Organiser les onglets",
+**je veux** que tous les onglets ouverts dont le domaine correspond à une règle active soient regroupés selon cette règle,
+**afin d'** organiser en groupes les onglets existants qui ne l'ont pas encore été.
+
+### Critères d'acceptation
+
+**Phase de planification (avant toute modification)**
+
+- [ ] Le regroupement s'exécute **après** la déduplication (les onglets fermés à l'étape précédente ne sont plus présents).
+- [ ] Avant toute modification, une phase de planification calcule pour chaque onglet éligible son groupe cible (nom + règle). Aucun onglet n'est déplacé pendant cette phase.
+- [ ] Seuls les onglets dont le domaine correspond à une règle **active** (`enabled = true`) avec `groupingEnabled = true` sont éligibles.
+- [ ] Pour chaque onglet éligible, le nom du groupe cible est calculé selon `groupNameSource` et `titleParsingRegEx` / `urlParsingRegEx` de la règle correspondante (même logique que le regroupement automatique existant).
+- [ ] Un groupe cible dont le plan ne contient qu'un seul onglet **non encore groupé** est abandonné : l'onglet reste sans groupe.
+- [ ] Un onglet déjà présent dans un groupe Chrome existant **avant l'action Organiser**, et dont le groupe cible planifié ne compterait qu'un seul membre, est laissé dans son groupe existant sans modification.
+
+**Phase d'application**
+
+- [ ] Un onglet déjà présent dans un groupe Chrome dont le titre correspond au groupe cible planifié n'est pas déplacé.
+- [ ] Un onglet déjà dans un groupe dont le titre **ne correspond pas** au groupe cible planifié est retiré de son groupe actuel et replacé dans le groupe correct, sous réserve que ce groupe cible compte au moins deux membres dans le plan.
+- [ ] Les onglets sans règle correspondante ne sont pas touchés.
+- [ ] Les onglets avec des schémas spéciaux (`chrome:`, `chrome-extension:`, `about:`) sont ignorés.
+- [ ] Le compteur `tabGroupsCreatedCount` est incrémenté uniquement pour les nouveaux groupes créés (pas pour les groupes déjà existants où des onglets sont simplement ajoutés).
+
+**Repositionnement et repli (fenêtre active uniquement)**
+
+- [ ] Une fois le regroupement terminé, tous les groupes d'onglets de la fenêtre active sont déplacés en premières positions (indices les plus bas), avant les onglets non groupés.
+- [ ] L'ordre relatif des groupes entre eux est conservé (le groupe qui était le plus à gauche reste le plus à gauche parmi les groupes).
+- [ ] Tous les groupes d'onglets de la fenêtre active sont repliés (`collapsed: true`) via `chrome.tabGroups.update`.
+- [ ] Les onglets non groupés ne sont pas déplacés (ils se retrouvent après les groupes).
+
+**Notifications**
+
+- [ ] Si au moins un groupe a été créé ou modifié, une notification Chrome unique est affichée à la fin (ex. : "5 onglets regroupés en 3 groupes").
+- [ ] Si aucun onglet n'a été regroupé, aucune notification n'est affichée.
+
+---
+
+## US-PO009 — Comportement du regroupement automatique existant inchangé
+
+**En tant qu'** utilisateur qui ouvre des onglets normalement (clic molette, clic droit),
+**je veux** que le comportement automatique de regroupement ne soit pas affecté par les nouvelles règles de l'action Organiser,
+**afin de** garder mon flux de travail habituel intact.
+
+### Critères d'acceptation
+
+- [ ] Le regroupement automatique (déclenché à l'ouverture d'un onglet) ne vérifie pas le nombre de membres du groupe cible : un onglet peut être placé seul dans un nouveau groupe comme avant.
+- [ ] Le regroupement automatique ne replie pas et ne repositionne pas les groupes existants.


### PR DESCRIPTION
Implements a new manual "Organize All Tabs" action and integrates it into the popup.

- Add background/organize.ts: orchestrates batch deduplication, grouping plan, applying groups, repositioning/collapsing groups, and notifications; updates statistics accordingly.
- Wire up message handling and exports: event-handlers, background index and entrypoint expose handleOrganizeAllTabs and listen for ORGANIZE_ALL_TABS messages.
- Popup UI: add an "Organize tabs" button (Wand2 icon) that sends ORGANIZE_ALL_TABS and shows a working state.
- Types & messaging: add OrganizeAllTabsMessage type and extend BackgroundMessage union.
- i18n: add English/Spanish/French strings for organize labels and notifications.
- Tests & docs: add E2E Playwright tests (tests/e2e/popup-organize.spec.ts) and user story doc (user-stories/US-PO-organise.md) covering requirements and acceptance criteria.
- Dev dependency bump: upgrade @playwright/test to ^1.58.2 (pnpm lock updated).

The change reuses existing grouping and deduplication utilities and keeps automatic grouping behavior unchanged while providing a manual, window-scoped organize operation.