### PR TITLE
Use storageItems abstraction for storage access

### DIFF
--- a/src/background/profileSync.ts
+++ b/src/background/profileSync.ts
@@ -4,9 +4,12 @@ import { logger } from '../utils/logger.js';
 import { getProfileWindowMap } from '../utils/profileWindowMap.js';
 import { generateUUID } from '../utils/utils.js';
 import type { SavedTab, SavedTabGroup } from '../types/session';
+import {
+  profileSyncDraftsItem,
+  editingProfileIdItem,
+  sessionsItem,
+} from '../utils/storageItems.js';
 
-const SYNC_DRAFTS_KEY = 'profileSyncDrafts';
-const EDITING_PROFILE_KEY = 'editingProfileId';
 const ALARM_NAME = 'auto-sync-profiles';
 
 export interface SyncDraft {
@@ -21,17 +24,15 @@ export type SyncDraftsMap = Record<string, SyncDraft>;
 // --- Storage helpers ---
 
 export async function getSyncDrafts(): Promise<SyncDraftsMap> {
-  const data = await (browser.storage as any).session.get(SYNC_DRAFTS_KEY);
-  return (data[SYNC_DRAFTS_KEY] as SyncDraftsMap) ?? {};
+  return profileSyncDraftsItem.getValue();
 }
 
 export async function saveSyncDrafts(drafts: SyncDraftsMap): Promise<void> {
-  await (browser.storage as any).session.set({ [SYNC_DRAFTS_KEY]: drafts });
+  await profileSyncDraftsItem.setValue(drafts);
 }
 
 async function getEditingProfileId(): Promise<string | null> {
-  const data = await (browser.storage as any).session.get(EDITING_PROFILE_KEY);
-  return (data[EDITING_PROFILE_KEY] as string) ?? null;
+  return editingProfileIdItem.getValue();
 }
 
 // --- Tab capture for a specific window ---
@@ -127,7 +128,7 @@ function hasTabsChanged(
 
 /**
  * For each auto-sync profile with an open window, capture tabs and update the
- * in-memory draft (chrome.storage.session). The persisted profile is NOT touched.
+ * in-memory draft (session storage). The persisted profile is NOT touched.
  */
 export async function updateSyncDrafts(): Promise<void> {
   const sessions = await loadSessions();
@@ -165,7 +166,7 @@ export async function updateSyncDrafts(): Promise<void> {
 }
 
 /**
- * Persist the in-memory draft for a profile to chrome.storage.local.
+ * Persist the in-memory draft for a profile to local storage.
  * Called when the associated window is closed.
  * Skips if the user is currently editing the profile.
  */
@@ -230,12 +231,10 @@ export function initProfileSync(): void {
   });
 
   // Re-evaluate the alarm whenever sessions change (covers create, update, delete)
-  browser.storage.local.onChanged.addListener((changes) => {
-    if ('sessions' in changes) {
-      updateSyncAlarm().catch(e =>
-        logger.error('[AUTO_SYNC] Error updating alarm:', e),
-      );
-    }
+  sessionsItem.watch(() => {
+    updateSyncAlarm().catch(e =>
+      logger.error('[AUTO_SYNC] Error updating alarm:', e),
+    );
   });
 
   // Set initial alarm state based on current sessions

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -1,28 +1,32 @@
-import { useState, useEffect, useCallback } from 'react';
-import { browser } from 'wxt/browser';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Statistics } from '../types/statistics.js';
 import { defaultStatistics } from '../types/statistics.js';
 import { logger } from '../utils/logger';
+import { statisticsItem } from '../utils/storageItems.js';
 
 export interface UseStatisticsReturn {
   // État actuel
   statistics: Statistics | null;
   isLoaded: boolean;
-  
+
   // Setters pour chaque champ
   setTabGroupsCreatedCount: (value: number) => Promise<void>;
   setTabsDeduplicatedCount: (value: number) => Promise<void>;
-  
+
   // Callbacks de changement pour chaque champ
   onTabGroupsCreatedCountChange: (callback: (value: number) => void) => () => void;
   onTabsDeduplicatedCountChange: (callback: (value: number) => void) => () => void;
-  
+
   // Utilitaires
   updateStatistics: (updates: Partial<Statistics>) => Promise<void>;
   resetStatistics: () => Promise<void>;
   incrementTabGroupsCreated: () => Promise<void>;
   incrementTabsDeduplicated: () => Promise<void>;
   reloadStatistics: () => Promise<void>;
+}
+
+function mergeWithDefaults(value: Statistics | null): Statistics {
+  return { ...defaultStatistics, ...value };
 }
 
 export function useStatistics(): UseStatisticsReturn {
@@ -32,90 +36,73 @@ export function useStatistics(): UseStatisticsReturn {
     [K in keyof Statistics]?: Set<(value: Statistics[K]) => void>;
   }>({});
 
+  // Ref pour éviter de réagir aux changements qu'on a nous-même déclenchés
+  const isLocalUpdate = useRef(false);
+  const changeCallbacksRef = useRef(changeCallbacks);
+  changeCallbacksRef.current = changeCallbacks;
+
   // Chargement initial
   useEffect(() => {
-    async function loadStatistics() {
-      try {
-        const result = await browser.storage.local.get({
-          statistics: defaultStatistics
-        });
-        
-        // Assurer que les statistiques ont la bonne structure
-        const stats = {
-          ...defaultStatistics,
-          ...(result.statistics as Record<string, unknown>)
-        };
-        
-        setStatistics(stats);
+    statisticsItem.getValue()
+      .then(value => {
+        setStatistics(mergeWithDefaults(value));
         setIsLoaded(true);
-      } catch (error) {
-        logger.error('Error loading statistics:', error);
-      }
-    }
-    loadStatistics();
+      })
+      .catch(error => logger.error('Error loading statistics:', error));
   }, []);
 
-  // Listener pour les changements de storage
+  // Watcher pour les changements de storage
   useEffect(() => {
-    const storageListener = (changes: any, areaName: string) => {
-      if (areaName === 'local' && changes.statistics) {
-        const newStatistics = { 
-          ...defaultStatistics, 
-          ...changes.statistics.newValue 
-        } as Statistics;
-        const oldStatistics = statistics;
-        setStatistics(newStatistics);
-        
+    return statisticsItem.watch((newValue) => {
+      if (isLocalUpdate.current) return;
+
+      const newStatistics = mergeWithDefaults(newValue);
+      setStatistics(prev => {
         // Déclencher les callbacks pour les champs modifiés
-        if (oldStatistics) {
-          Object.keys(newStatistics).forEach((key) => {
-            const field = key as keyof Statistics;
-            if (newStatistics[field] !== oldStatistics[field]) {
-              const callbacks = changeCallbacks[field];
-              if (callbacks) {
-                callbacks.forEach(callback => callback(newStatistics[field]));
-              }
+        if (prev) {
+          (Object.keys(newStatistics) as (keyof Statistics)[]).forEach(field => {
+            if (newStatistics[field] !== prev[field]) {
+              const callbacks = changeCallbacksRef.current[field];
+              if (callbacks) callbacks.forEach(cb => cb(newStatistics[field]));
             }
           });
         }
-      }
-    };
-
-    browser.storage.onChanged.addListener(storageListener);
-    return () => browser.storage.onChanged.removeListener(storageListener);
-  }, [statistics, changeCallbacks]);
+        return newStatistics;
+      });
+    });
+  }, []); // Pas de dépendances - le watcher reste stable
 
   // Fonction générique pour mettre à jour un champ
   const updateField = useCallback(async <K extends keyof Statistics>(
-    field: K, 
+    field: K,
     value: Statistics[K]
   ) => {
     if (!statistics) return;
-    
-    const updatedStatistics = { ...statistics, [field]: value };
-    await browser.storage.local.set({ statistics: updatedStatistics });
-    setStatistics(updatedStatistics);
+    isLocalUpdate.current = true;
+    try {
+      const updatedStatistics = { ...statistics, [field]: value };
+      await statisticsItem.setValue(updatedStatistics);
+      setStatistics(updatedStatistics);
+    } finally {
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
+    }
   }, [statistics]);
 
   // Fonction générique pour enregistrer un callback de changement
   const registerChangeCallback = useCallback(<K extends keyof Statistics>(
-    field: K, 
+    field: K,
     callback: (value: Statistics[K]) => void
   ) => {
     setChangeCallbacks(prev => ({
       ...prev,
       [field]: new Set([...(prev[field] || []), callback])
     }));
-
-    // Retourner une fonction de nettoyage
     return () => {
       setChangeCallbacks(prev => {
         const newCallbacks = { ...prev };
         if (newCallbacks[field]) {
           newCallbacks[field]!.delete(callback);
-          if (newCallbacks[field]!.size === 0) {
-            delete newCallbacks[field];
-          }
+          if (newCallbacks[field]!.size === 0) delete newCallbacks[field];
         }
         return newCallbacks;
       });
@@ -125,47 +112,44 @@ export function useStatistics(): UseStatisticsReturn {
   // Fonction pour mettre à jour plusieurs champs
   const updateStatistics = useCallback(async (updates: Partial<Statistics>) => {
     if (!statistics) return;
-    
-    const updatedStatistics = { ...statistics, ...updates };
-    await browser.storage.local.set({ statistics: updatedStatistics });
-    setStatistics(updatedStatistics);
+    isLocalUpdate.current = true;
+    try {
+      const updatedStatistics = { ...statistics, ...updates };
+      await statisticsItem.setValue(updatedStatistics);
+      setStatistics(updatedStatistics);
+    } finally {
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
+    }
   }, [statistics]);
 
   // Fonction pour reset les statistiques
   const resetStatistics = useCallback(async () => {
-    await browser.storage.local.set({ statistics: defaultStatistics });
-    setStatistics(defaultStatistics);
+    isLocalUpdate.current = true;
+    try {
+      await statisticsItem.setValue(defaultStatistics);
+      setStatistics(defaultStatistics);
+    } finally {
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
+    }
   }, []);
 
   // Fonction pour incrémenter les groupes créés
   const incrementTabGroupsCreated = useCallback(async () => {
     if (!statistics) return;
-    
-    const newCount = statistics.tabGroupsCreatedCount + 1;
-    await updateField('tabGroupsCreatedCount', newCount);
+    await updateField('tabGroupsCreatedCount', statistics.tabGroupsCreatedCount + 1);
   }, [statistics, updateField]);
 
   // Fonction pour incrémenter les onglets dédupliqués
   const incrementTabsDeduplicated = useCallback(async () => {
     if (!statistics) return;
-    
-    const newCount = statistics.tabsDeduplicatedCount + 1;
-    await updateField('tabsDeduplicatedCount', newCount);
+    await updateField('tabsDeduplicatedCount', statistics.tabsDeduplicatedCount + 1);
   }, [statistics, updateField]);
 
   // Fonction pour recharger les statistiques
   const reloadStatistics = useCallback(async () => {
     try {
-      const result = await browser.storage.local.get({
-        statistics: defaultStatistics
-      });
-      
-      const stats = {
-        ...defaultStatistics,
-        ...(result.statistics as Record<string, unknown>)
-      };
-
-      setStatistics(stats);
+      const value = await statisticsItem.getValue();
+      setStatistics(mergeWithDefaults(value));
     } catch (error) {
       logger.error('Error reloading statistics:', error);
     }
@@ -174,15 +158,15 @@ export function useStatistics(): UseStatisticsReturn {
   return {
     statistics,
     isLoaded,
-    
+
     // Setters
-    setTabGroupsCreatedCount: (value: number) => updateField('tabGroupsCreatedCount', value),
-    setTabsDeduplicatedCount: (value: number) => updateField('tabsDeduplicatedCount', value),
-    
+    setTabGroupsCreatedCount: (value) => updateField('tabGroupsCreatedCount', value),
+    setTabsDeduplicatedCount: (value) => updateField('tabsDeduplicatedCount', value),
+
     // Change callbacks
-    onTabGroupsCreatedCountChange: (callback) => registerChangeCallback('tabGroupsCreatedCount', callback),
-    onTabsDeduplicatedCountChange: (callback) => registerChangeCallback('tabsDeduplicatedCount', callback),
-    
+    onTabGroupsCreatedCountChange: (cb) => registerChangeCallback('tabGroupsCreatedCount', cb),
+    onTabsDeduplicatedCountChange: (cb) => registerChangeCallback('tabsDeduplicatedCount', cb),
+
     // Utilitaires
     updateStatistics,
     resetStatistics,

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -1,7 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { browser } from 'wxt/browser';
+import { storage } from 'wxt/utils/storage';
 import type { SyncSettings, DomainRuleSettings } from '../types/syncSettings.js';
 import { logger } from '../utils/logger';
+import {
+  globalGroupingEnabledItem,
+  globalDeduplicationEnabledItem,
+  domainRulesItem,
+  notifyOnGroupingItem,
+  notifyOnDeduplicationItem,
+} from '../utils/storageItems.js';
 
 export interface UseSyncedSettingsReturn {
   // État actuel
@@ -23,6 +30,23 @@ export interface UseSyncedSettingsReturn {
   reloadSettings: () => Promise<void>;
 }
 
+async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
+  const results = await storage.getItems([
+    globalGroupingEnabledItem,
+    globalDeduplicationEnabledItem,
+    domainRulesItem,
+    notifyOnGroupingItem,
+    notifyOnDeduplicationItem,
+  ]);
+  return {
+    globalGroupingEnabled: results[0].value as boolean,
+    globalDeduplicationEnabled: results[1].value as boolean,
+    domainRules: results[2].value as DomainRuleSettings,
+    notifyOnGrouping: results[3].value as boolean,
+    notifyOnDeduplication: results[4].value as boolean,
+  };
+}
+
 export function useSyncedSettings(): UseSyncedSettingsReturn {
   const [settings, setSettings] = useState<SyncSettings | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -38,104 +62,67 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
 
   // Chargement initial
   useEffect(() => {
-    async function loadSettings() {
-      try {
-        const result = await browser.storage.sync.get({
-          globalGroupingEnabled: true,
-          globalDeduplicationEnabled: true,
-          domainRules: [] as DomainRuleSettings,
-          notifyOnGrouping: true,
-          notifyOnDeduplication: true
-        });
-
-        setSettings(result as unknown as SyncSettings);
-        setIsLoaded(true);
-      } catch (error) {
-        logger.error('Error loading settings:', error);
-      }
-    }
-    loadSettings();
+    loadSyncSettingsFromStorage()
+      .then(s => { setSettings(s); setIsLoaded(true); })
+      .catch(error => logger.error('Error loading settings:', error));
   }, []);
 
-  // Listener pour les changements de storage (provenant d'autres sources)
+  // Watchers pour les changements de storage (provenant d'autres sources)
   useEffect(() => {
-    const storageListener = (changes: any, areaName: string) => {
-      if (areaName !== 'sync') return;
-
-      // Ignorer les changements qu'on a nous-même déclenchés
-      if (isLocalUpdate.current) {
-        return;
-      }
-
-      // Mettre à jour l'état en utilisant le callback pour avoir la valeur la plus récente
-      setSettings(prevSettings => {
-        if (!prevSettings) return prevSettings;
-
-        let newSettings = { ...prevSettings };
-        let hasChanges = false;
-
-        Object.keys(changes).forEach((key) => {
-          const field = key as keyof SyncSettings;
-          if (field in newSettings) {
-            const newValue = changes[key].newValue;
-            (newSettings as any)[field] = newValue;
-            hasChanges = true;
-
-            // Déclencher les callbacks pour ce champ
-            const callbacks = changeCallbacksRef.current[field];
-            if (callbacks) {
-              callbacks.forEach(callback => callback(newValue));
-            }
-          }
-        });
-
-        return hasChanges ? newSettings : prevSettings;
+    function applyExternalChange<K extends keyof SyncSettings>(field: K, newValue: SyncSettings[K]) {
+      if (isLocalUpdate.current) return;
+      setSettings(prev => {
+        if (!prev) return prev;
+        const callbacks = changeCallbacksRef.current[field];
+        if (callbacks) callbacks.forEach(cb => cb(newValue));
+        return { ...prev, [field]: newValue };
       });
-    };
+    }
 
-    browser.storage.onChanged.addListener(storageListener);
-    return () => browser.storage.onChanged.removeListener(storageListener);
-  }, []); // Pas de dépendances - le listener reste stable
+    const unwatchers = [
+      globalGroupingEnabledItem.watch(v => applyExternalChange('globalGroupingEnabled', v)),
+      globalDeduplicationEnabledItem.watch(v => applyExternalChange('globalDeduplicationEnabled', v)),
+      domainRulesItem.watch(v => applyExternalChange('domainRules', v)),
+      notifyOnGroupingItem.watch(v => applyExternalChange('notifyOnGrouping', v)),
+      notifyOnDeduplicationItem.watch(v => applyExternalChange('notifyOnDeduplication', v)),
+    ];
+
+    return () => unwatchers.forEach(u => u());
+  }, []); // Pas de dépendances - les watchers restent stables
 
   // Fonction générique pour mettre à jour un champ
   const updateField = useCallback(async <K extends keyof SyncSettings>(
     field: K,
-    value: SyncSettings[K]
+    value: SyncSettings[K],
+    setValue: (v: SyncSettings[K]) => Promise<void>,
   ) => {
-    // Marquer comme mise à jour locale pour ignorer l'événement storage
     isLocalUpdate.current = true;
     try {
       // Mettre à jour l'état local d'abord pour une UI réactive
       setSettings(prev => prev ? { ...prev, [field]: value } : null);
       // Puis persister dans le storage
-      await browser.storage.sync.set({ [field]: value });
+      await setValue(value);
     } finally {
       // Réactiver l'écoute des changements externes après un court délai
-      setTimeout(() => {
-        isLocalUpdate.current = false;
-      }, 100);
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
     }
   }, []);
 
   // Fonction générique pour enregistrer un callback de changement
   const registerChangeCallback = useCallback(<K extends keyof SyncSettings>(
-    field: K, 
+    field: K,
     callback: (value: SyncSettings[K]) => void
   ) => {
     setChangeCallbacks(prev => ({
       ...prev,
       [field]: new Set([...(prev[field] || []), callback as any])
     }));
-
-    // Retourner une fonction de nettoyage
     return () => {
       setChangeCallbacks(prev => {
         const newCallbacks = { ...prev };
         if (newCallbacks[field]) {
           (newCallbacks[field] as Set<any>).delete(callback);
-          if (newCallbacks[field]!.size === 0) {
-            delete newCallbacks[field];
-          }
+          if (newCallbacks[field]!.size === 0) delete newCallbacks[field];
         }
         return newCallbacks;
       });
@@ -144,33 +131,30 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
 
   // Fonction pour mettre à jour plusieurs champs
   const updateSettings = useCallback(async (updates: Partial<SyncSettings>) => {
-    // Marquer comme mise à jour locale pour ignorer l'événement storage
     isLocalUpdate.current = true;
     try {
-      // Mettre à jour l'état local d'abord pour une UI réactive
       setSettings(prev => prev ? { ...prev, ...updates } : null);
-      // Puis persister dans le storage
-      await browser.storage.sync.set(updates);
+      const items: Parameters<typeof storage.setItems>[0] = [];
+      if ('globalGroupingEnabled' in updates)
+        items.push({ item: globalGroupingEnabledItem, value: updates.globalGroupingEnabled! });
+      if ('globalDeduplicationEnabled' in updates)
+        items.push({ item: globalDeduplicationEnabledItem, value: updates.globalDeduplicationEnabled! });
+      if ('domainRules' in updates)
+        items.push({ item: domainRulesItem, value: updates.domainRules! });
+      if ('notifyOnGrouping' in updates)
+        items.push({ item: notifyOnGroupingItem, value: updates.notifyOnGrouping! });
+      if ('notifyOnDeduplication' in updates)
+        items.push({ item: notifyOnDeduplicationItem, value: updates.notifyOnDeduplication! });
+      if (items.length > 0) await storage.setItems(items);
     } finally {
-      // Réactiver l'écoute des changements externes après un court délai
-      setTimeout(() => {
-        isLocalUpdate.current = false;
-      }, 100);
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
     }
   }, []);
 
   // Fonction pour recharger les settings
   const reloadSettings = useCallback(async () => {
     try {
-      const result = await browser.storage.sync.get({
-        globalGroupingEnabled: true,
-        globalDeduplicationEnabled: true,
-        domainRules: [] as DomainRuleSettings,
-        notifyOnGrouping: true,
-        notifyOnDeduplication: true
-      });
-
-      setSettings(result as unknown as SyncSettings);
+      setSettings(await loadSyncSettingsFromStorage());
     } catch (error) {
       logger.error('Error reloading settings:', error);
     }
@@ -179,17 +163,17 @@ export function useSyncedSettings(): UseSyncedSettingsReturn {
   return {
     settings,
     isLoaded,
-    
+
     // Setters
-    setGlobalGroupingEnabled: (value: boolean) => updateField('globalGroupingEnabled', value),
-    setGlobalDeduplicationEnabled: (value: boolean) => updateField('globalDeduplicationEnabled', value),
-    setDomainRules: (value: DomainRuleSettings) => updateField('domainRules', value),
-    
+    setGlobalGroupingEnabled: (v) => updateField('globalGroupingEnabled', v, globalGroupingEnabledItem.setValue),
+    setGlobalDeduplicationEnabled: (v) => updateField('globalDeduplicationEnabled', v, globalDeduplicationEnabledItem.setValue),
+    setDomainRules: (v) => updateField('domainRules', v, domainRulesItem.setValue),
+
     // Change callbacks
-    onGlobalGroupingEnabledChange: (callback) => registerChangeCallback('globalGroupingEnabled', callback),
-    onGlobalDeduplicationEnabledChange: (callback) => registerChangeCallback('globalDeduplicationEnabled', callback),
-    onDomainRulesChange: (callback) => registerChangeCallback('domainRules', callback),
-    
+    onGlobalGroupingEnabledChange: (cb) => registerChangeCallback('globalGroupingEnabled', cb),
+    onGlobalDeduplicationEnabledChange: (cb) => registerChangeCallback('globalDeduplicationEnabled', cb),
+    onDomainRulesChange: (cb) => registerChangeCallback('domainRules', cb),
+
     // Utilitaires
     updateSettings,
     reloadSettings

--- a/src/utils/profileWindowMap.ts
+++ b/src/utils/profileWindowMap.ts
@@ -1,41 +1,34 @@
-import { browser } from 'wxt/browser';
+import { profileWindowMapItem } from './storageItems.js';
 
 /** Map from profileId → windowId, stored ephemerally for the browser session. */
 export type ProfileWindowMap = Record<string, number>;
 
-const KEY = 'profileWindowMap';
-
-async function getMap(): Promise<ProfileWindowMap> {
-  const data = await (browser.storage as any).session.get(KEY);
-  return (data[KEY] as ProfileWindowMap) ?? {};
-}
-
 export async function getProfileWindowMap(): Promise<ProfileWindowMap> {
-  return getMap();
+  return profileWindowMapItem.getValue();
 }
 
 /** Associate a profile with a window. Enforces one profile per window. */
 export async function setProfileWindow(profileId: string, windowId: number): Promise<void> {
-  const map = await getMap();
+  const map = await profileWindowMapItem.getValue();
   // Remove any existing profile that was previously associated with this window
   for (const pid of Object.keys(map)) {
     if (map[pid] === windowId) delete map[pid];
   }
   map[profileId] = windowId;
-  await (browser.storage as any).session.set({ [KEY]: map });
+  await profileWindowMapItem.setValue(map);
 }
 
 /** Remove the association for a profile (e.g. on unpin or delete). */
 export async function removeProfileWindow(profileId: string): Promise<void> {
-  const map = await getMap();
+  const map = await profileWindowMapItem.getValue();
   if (!(profileId in map)) return;
   delete map[profileId];
-  await (browser.storage as any).session.set({ [KEY]: map });
+  await profileWindowMapItem.setValue(map);
 }
 
 /** Remove all profiles associated with a given window (called on windows.onRemoved). */
 export async function removeWindowAssociations(windowId: number): Promise<void> {
-  const map = await getMap();
+  const map = await profileWindowMapItem.getValue();
   let changed = false;
   for (const pid of Object.keys(map)) {
     if (map[pid] === windowId) {
@@ -43,18 +36,18 @@ export async function removeWindowAssociations(windowId: number): Promise<void> 
       changed = true;
     }
   }
-  if (changed) await (browser.storage as any).session.set({ [KEY]: map });
+  if (changed) await profileWindowMapItem.setValue(map);
 }
 
 /** Returns the windowId associated with a profile, or null if not open. */
 export async function getWindowForProfile(profileId: string): Promise<number | null> {
-  const map = await getMap();
+  const map = await profileWindowMapItem.getValue();
   return map[profileId] ?? null;
 }
 
 /** Returns the profileId associated with a window, or null if none. */
 export async function getProfileForWindow(windowId: number): Promise<string | null> {
-  const map = await getMap();
+  const map = await profileWindowMapItem.getValue();
   for (const [pid, wid] of Object.entries(map)) {
     if (wid === windowId) return pid;
   }

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -1,15 +1,12 @@
-import { browser } from 'wxt/browser';
 import type { Session } from '../types/session';
 import { sessionsArraySchema } from '../schemas/session';
 import { logger } from './logger.js';
-
-const SESSIONS_STORAGE_KEY = 'sessions';
+import { sessionsItem } from './storageItems.js';
 
 /** Load all sessions from storage, validated with Zod */
 export async function loadSessions(): Promise<Session[]> {
   try {
-    const result = await browser.storage.local.get({ [SESSIONS_STORAGE_KEY]: [] });
-    const raw = result[SESSIONS_STORAGE_KEY];
+    const raw = await sessionsItem.getValue();
     const parsed = sessionsArraySchema.safeParse(raw);
     if (parsed.success) {
       return parsed.data as Session[];
@@ -24,7 +21,7 @@ export async function loadSessions(): Promise<Session[]> {
 
 /** Save all sessions to storage */
 export async function saveSessions(sessions: Session[]): Promise<void> {
-  await browser.storage.local.set({ [SESSIONS_STORAGE_KEY]: sessions });
+  await sessionsItem.setValue(sessions);
 }
 
 /** Add a new session */

--- a/src/utils/sessionsHelpPrefs.ts
+++ b/src/utils/sessionsHelpPrefs.ts
@@ -1,25 +1,17 @@
-import { browser } from 'wxt/browser';
-
-const KEY = 'sessionsHelpPrefs';
+import { sessionsHelpPrefsItem } from './storageItems.js';
 
 export interface SessionsHelpPrefs {
   sessionsIntroHidden: boolean;
   profileOnboardingShown: boolean;
 }
 
-const DEFAULTS: SessionsHelpPrefs = {
-  sessionsIntroHidden: false,
-  profileOnboardingShown: false,
-};
-
 export async function getSessionsHelpPrefs(): Promise<SessionsHelpPrefs> {
-  const result = await browser.storage.local.get({ [KEY]: {} });
-  return { ...DEFAULTS, ...(result[KEY] as Partial<SessionsHelpPrefs>) };
+  return sessionsHelpPrefsItem.getValue();
 }
 
 export async function updateSessionsHelpPrefs(
   updates: Partial<SessionsHelpPrefs>,
 ): Promise<void> {
   const current = await getSessionsHelpPrefs();
-  await browser.storage.local.set({ [KEY]: { ...current, ...updates } });
+  await sessionsHelpPrefsItem.setValue({ ...current, ...updates });
 }

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,7 +1,15 @@
-import { browser } from 'wxt/browser';
+import { storage } from 'wxt/utils/storage';
 import type { SyncSettings } from '../types/syncSettings.js';
 import { defaultSyncSettings } from '../types/syncSettings.js';
 import { logger } from './logger.js';
+import {
+  globalGroupingEnabledItem,
+  globalDeduplicationEnabledItem,
+  domainRulesItem,
+  notifyOnGroupingItem,
+  notifyOnDeduplicationItem,
+  syncSettingsItemMap,
+} from './storageItems.js';
 
 /**
  * Utilitaires pour les settings utilisables dans tous les contextes
@@ -10,8 +18,20 @@ import { logger } from './logger.js';
 
 export async function getSyncSettings(): Promise<SyncSettings> {
   try {
-    const result = await browser.storage.sync.get({ ...defaultSyncSettings });
-    return result as unknown as SyncSettings;
+    const results = await storage.getItems([
+      globalGroupingEnabledItem,
+      globalDeduplicationEnabledItem,
+      domainRulesItem,
+      notifyOnGroupingItem,
+      notifyOnDeduplicationItem,
+    ]);
+    return {
+      globalGroupingEnabled: results[0].value as boolean,
+      globalDeduplicationEnabled: results[1].value as boolean,
+      domainRules: results[2].value as SyncSettings['domainRules'],
+      notifyOnGrouping: results[3].value as boolean,
+      notifyOnDeduplication: results[4].value as boolean,
+    };
   } catch (error) {
     logger.error('Error getting sync settings:', error);
     return defaultSyncSettings;
@@ -20,7 +40,13 @@ export async function getSyncSettings(): Promise<SyncSettings> {
 
 export async function setSyncSettings(settings: SyncSettings): Promise<void> {
   try {
-    await browser.storage.sync.set(settings);
+    await storage.setItems([
+      { item: globalGroupingEnabledItem, value: settings.globalGroupingEnabled },
+      { item: globalDeduplicationEnabledItem, value: settings.globalDeduplicationEnabled },
+      { item: domainRulesItem, value: settings.domainRules },
+      { item: notifyOnGroupingItem, value: settings.notifyOnGrouping },
+      { item: notifyOnDeduplicationItem, value: settings.notifyOnDeduplication },
+    ]);
   } catch (error) {
     logger.error('Error setting sync settings:', error);
   }
@@ -28,7 +54,18 @@ export async function setSyncSettings(settings: SyncSettings): Promise<void> {
 
 export async function updateSyncSettings(updates: Partial<SyncSettings>): Promise<void> {
   try {
-    await browser.storage.sync.set(updates);
+    const items: Parameters<typeof storage.setItems>[0] = [];
+    if ('globalGroupingEnabled' in updates)
+      items.push({ item: globalGroupingEnabledItem, value: updates.globalGroupingEnabled! });
+    if ('globalDeduplicationEnabled' in updates)
+      items.push({ item: globalDeduplicationEnabledItem, value: updates.globalDeduplicationEnabled! });
+    if ('domainRules' in updates)
+      items.push({ item: domainRulesItem, value: updates.domainRules! });
+    if ('notifyOnGrouping' in updates)
+      items.push({ item: notifyOnGroupingItem, value: updates.notifyOnGrouping! });
+    if ('notifyOnDeduplication' in updates)
+      items.push({ item: notifyOnDeduplicationItem, value: updates.notifyOnDeduplication! });
+    if (items.length > 0) await storage.setItems(items);
   } catch (error) {
     logger.error('Error updating sync settings:', error);
   }
@@ -36,10 +73,7 @@ export async function updateSyncSettings(updates: Partial<SyncSettings>): Promis
 
 export async function getGlobalGroupingEnabled(): Promise<boolean> {
   try {
-    const result = await browser.storage.sync.get({
-      globalGroupingEnabled: defaultSyncSettings.globalGroupingEnabled
-    });
-    return result.globalGroupingEnabled as boolean;
+    return await globalGroupingEnabledItem.getValue();
   } catch (error) {
     logger.error('Error getting global grouping enabled:', error);
     return defaultSyncSettings.globalGroupingEnabled;
@@ -48,10 +82,7 @@ export async function getGlobalGroupingEnabled(): Promise<boolean> {
 
 export async function getGlobalDeduplicationEnabled(): Promise<boolean> {
   try {
-    const result = await browser.storage.sync.get({
-      globalDeduplicationEnabled: defaultSyncSettings.globalDeduplicationEnabled
-    });
-    return result.globalDeduplicationEnabled as boolean;
+    return await globalDeduplicationEnabledItem.getValue();
   } catch (error) {
     logger.error('Error getting global deduplication enabled:', error);
     return defaultSyncSettings.globalDeduplicationEnabled;
@@ -60,16 +91,12 @@ export async function getGlobalDeduplicationEnabled(): Promise<boolean> {
 
 export async function getDomainRules(): Promise<SyncSettings['domainRules']> {
   try {
-    const result = await browser.storage.sync.get({
-      domainRules: defaultSyncSettings.domainRules
-    });
-    return result.domainRules as SyncSettings['domainRules'];
+    return await domainRulesItem.getValue();
   } catch (error) {
     logger.error('Error getting domain rules:', error);
     return defaultSyncSettings.domainRules;
   }
 }
-
 
 // getRegexPresets function removed - presets are now static in JSON file
 
@@ -78,20 +105,16 @@ export async function getDomainRules(): Promise<SyncSettings['domainRules']> {
  * Retourne une fonction de cleanup
  */
 export function watchSyncSettings(
-  callback: (settings: SyncSettings) => void
+  callback: (settings: SyncSettings) => void,
 ): () => void {
-  const listener = (changes: any, areaName: string) => {
-    if (areaName === 'sync') {
-      // Reconstruction des settings à partir des changements
-      getSyncSettings().then(callback);
-    }
-  };
-
-  browser.storage.onChanged.addListener(listener);
-  
-  return () => {
-    browser.storage.onChanged.removeListener(listener);
-  };
+  const unwatchers = [
+    globalGroupingEnabledItem.watch(() => getSyncSettings().then(callback)),
+    globalDeduplicationEnabledItem.watch(() => getSyncSettings().then(callback)),
+    domainRulesItem.watch(() => getSyncSettings().then(callback)),
+    notifyOnGroupingItem.watch(() => getSyncSettings().then(callback)),
+    notifyOnDeduplicationItem.watch(() => getSyncSettings().then(callback)),
+  ];
+  return () => unwatchers.forEach(u => u());
 }
 
 /**
@@ -99,17 +122,10 @@ export function watchSyncSettings(
  */
 export function watchSyncSettingsField<K extends keyof SyncSettings>(
   field: K,
-  callback: (value: SyncSettings[K]) => void
+  callback: (value: SyncSettings[K]) => void,
 ): () => void {
-  const listener = (changes: any, areaName: string) => {
-    if (areaName === 'sync' && changes[field]) {
-      callback(changes[field].newValue);
-    }
-  };
-
-  browser.storage.onChanged.addListener(listener);
-  
-  return () => {
-    browser.storage.onChanged.removeListener(listener);
-  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (syncSettingsItemMap[field] as any).watch(
+    (newValue: SyncSettings[K]) => callback(newValue),
+  );
 }

--- a/src/utils/statisticsUtils.ts
+++ b/src/utils/statisticsUtils.ts
@@ -1,7 +1,7 @@
-import { browser } from 'wxt/browser';
 import type { Statistics } from '../types/statistics.js';
 import { defaultStatistics } from '../types/statistics.js';
 import { logger } from './logger.js';
+import { statisticsItem } from './storageItems.js';
 
 /**
  * Utilitaires pour les statistiques utilisables dans tous les contextes
@@ -10,14 +10,8 @@ import { logger } from './logger.js';
 
 export async function getStatisticsData(): Promise<Statistics> {
   try {
-    const result = await browser.storage.local.get({
-      statistics: defaultStatistics
-    });
-    
-    return {
-      ...defaultStatistics,
-      ...(result.statistics as Record<string, unknown>)
-    };
+    const value = await statisticsItem.getValue();
+    return { ...defaultStatistics, ...value };
   } catch (error) {
     logger.error('Error getting statistics:', error);
     return defaultStatistics;
@@ -26,7 +20,7 @@ export async function getStatisticsData(): Promise<Statistics> {
 
 export async function setStatisticsData(statistics: Statistics): Promise<void> {
   try {
-    await browser.storage.local.set({ statistics });
+    await statisticsItem.setValue(statistics);
   } catch (error) {
     logger.error('Error setting statistics:', error);
   }
@@ -45,8 +39,8 @@ export async function updateStatisticsData(updates: Partial<Statistics>): Promis
 export async function incrementTabGroupsCreated(): Promise<void> {
   try {
     const current = await getStatisticsData();
-    await updateStatisticsData({ 
-      tabGroupsCreatedCount: current.tabGroupsCreatedCount + 1 
+    await updateStatisticsData({
+      tabGroupsCreatedCount: current.tabGroupsCreatedCount + 1,
     });
   } catch (error) {
     logger.error('Error incrementing tab groups created:', error);
@@ -56,8 +50,8 @@ export async function incrementTabGroupsCreated(): Promise<void> {
 export async function incrementTabsDeduplicated(): Promise<void> {
   try {
     const current = await getStatisticsData();
-    await updateStatisticsData({ 
-      tabsDeduplicatedCount: current.tabsDeduplicatedCount + 1 
+    await updateStatisticsData({
+      tabsDeduplicatedCount: current.tabsDeduplicatedCount + 1,
     });
   } catch (error) {
     logger.error('Error incrementing tabs deduplicated:', error);
@@ -89,21 +83,9 @@ export async function resetStatisticsData(): Promise<void> {
  * Retourne une fonction de cleanup
  */
 export function watchStatisticsData(
-  callback: (statistics: Statistics) => void
+  callback: (statistics: Statistics) => void,
 ): () => void {
-  const listener = (changes: any, areaName: string) => {
-    if (areaName === 'local' && changes.statistics) {
-      const statistics = { 
-        ...defaultStatistics, 
-        ...changes.statistics.newValue 
-      };
-      callback(statistics);
-    }
-  };
-
-  browser.storage.onChanged.addListener(listener);
-  
-  return () => {
-    browser.storage.onChanged.removeListener(listener);
-  };
+  return statisticsItem.watch((newValue) => {
+    callback({ ...defaultStatistics, ...newValue });
+  });
 }

--- a/src/utils/storageItems.ts
+++ b/src/utils/storageItems.ts
@@ -1,0 +1,79 @@
+import { storage } from 'wxt/utils/storage';
+import type { SyncSettings, DomainRuleSettings } from '../types/syncSettings.js';
+import { defaultSyncSettings } from '../types/syncSettings.js';
+import type { Statistics } from '../types/statistics.js';
+import { defaultStatistics } from '../types/statistics.js';
+import type { Session } from '../types/session.js';
+import type { SessionsHelpPrefs } from './sessionsHelpPrefs.js';
+import type { ProfileWindowMap } from './profileWindowMap.js';
+import type { SyncDraftsMap } from '../background/profileSync.js';
+
+// --- Sync storage items ---
+
+export const globalGroupingEnabledItem = storage.defineItem<boolean>(
+  'sync:globalGroupingEnabled',
+  { defaultValue: defaultSyncSettings.globalGroupingEnabled },
+);
+
+export const globalDeduplicationEnabledItem = storage.defineItem<boolean>(
+  'sync:globalDeduplicationEnabled',
+  { defaultValue: defaultSyncSettings.globalDeduplicationEnabled },
+);
+
+export const domainRulesItem = storage.defineItem<DomainRuleSettings>(
+  'sync:domainRules',
+  { defaultValue: defaultSyncSettings.domainRules },
+);
+
+export const notifyOnGroupingItem = storage.defineItem<boolean>(
+  'sync:notifyOnGrouping',
+  { defaultValue: defaultSyncSettings.notifyOnGrouping },
+);
+
+export const notifyOnDeduplicationItem = storage.defineItem<boolean>(
+  'sync:notifyOnDeduplication',
+  { defaultValue: defaultSyncSettings.notifyOnDeduplication },
+);
+
+// --- Local storage items ---
+
+export const statisticsItem = storage.defineItem<Statistics>(
+  'local:statistics',
+  { defaultValue: defaultStatistics },
+);
+
+export const sessionsItem = storage.defineItem<Session[]>(
+  'local:sessions',
+  { defaultValue: [] },
+);
+
+export const sessionsHelpPrefsItem = storage.defineItem<SessionsHelpPrefs>(
+  'local:sessionsHelpPrefs',
+  { defaultValue: { sessionsIntroHidden: false, profileOnboardingShown: false } },
+);
+
+// --- Session storage items ---
+
+export const profileWindowMapItem = storage.defineItem<ProfileWindowMap>(
+  'session:profileWindowMap',
+  { defaultValue: {} },
+);
+
+export const profileSyncDraftsItem = storage.defineItem<SyncDraftsMap>(
+  'session:profileSyncDrafts',
+  { defaultValue: {} },
+);
+
+export const editingProfileIdItem = storage.defineItem<string | null>(
+  'session:editingProfileId',
+  { defaultValue: null },
+);
+
+// Map des items sync par champ (pour watchSyncSettingsField)
+export const syncSettingsItemMap = {
+  globalGroupingEnabled: globalGroupingEnabledItem,
+  globalDeduplicationEnabled: globalDeduplicationEnabledItem,
+  domainRules: domainRulesItem,
+  notifyOnGrouping: notifyOnGroupingItem,
+  notifyOnDeduplication: notifyOnDeduplicationItem,
+} as const;

--- a/tests/hooks/useStatistics.test.ts
+++ b/tests/hooks/useStatistics.test.ts
@@ -1,72 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { fakeBrowser } from 'wxt/testing';
 import { useStatistics } from '../../src/hooks/useStatistics';
 import { defaultStatistics } from '../../src/types/statistics';
 
-// Mock storage data
-let mockStorageData: Record<string, any> = {};
-const storageListeners: Array<(changes: Record<string, any>, areaName: string) => void> = [];
-
-// Create mock browser object
-const mockBrowser = {
-  storage: {
-    local: {
-      get: vi.fn(async (defaults) => {
-        if (typeof defaults === 'object' && defaults !== null) {
-          const result: Record<string, any> = {};
-          for (const key of Object.keys(defaults)) {
-            result[key] = mockStorageData[key] !== undefined ? mockStorageData[key] : defaults[key];
-          }
-          return result;
-        }
-        return mockStorageData;
-      }),
-      set: vi.fn(async (data) => {
-        const changes: Record<string, any> = {};
-        for (const key of Object.keys(data)) {
-          changes[key] = { oldValue: mockStorageData[key], newValue: data[key] };
-        }
-        Object.assign(mockStorageData, data);
-        // Notify listeners
-        storageListeners.forEach(listener => listener(changes, 'local'));
-      }),
-      remove: vi.fn(async (keys) => {
-        if (typeof keys === 'string') {
-          delete mockStorageData[keys];
-        } else if (Array.isArray(keys)) {
-          keys.forEach(key => delete mockStorageData[key]);
-        }
-      })
-    },
-    onChanged: {
-      addListener: vi.fn((callback) => {
-        storageListeners.push(callback);
-      }),
-      removeListener: vi.fn((callback) => {
-        const index = storageListeners.indexOf(callback);
-        if (index > -1) {
-          storageListeners.splice(index, 1);
-        }
-      })
-    }
-  }
-};
-
-// Set global browser
-(globalThis as any).browser = mockBrowser;
-
-// Mock wxt/browser module to use the global mock
-vi.mock('wxt/browser', () => ({
-  get browser() { return (globalThis as any).browser; }
-}));
+// fakeBrowser.reset() est appelé avant chaque test via tests/setup.ts
 
 describe('useStatistics', () => {
-  beforeEach(() => {
-    mockStorageData = {};
-    storageListeners.length = 0;
-    vi.clearAllMocks();
-  });
-
   afterEach(() => {
     cleanup();
   });
@@ -82,9 +22,9 @@ describe('useStatistics', () => {
   });
 
   it('devrait charger les statistiques existantes', async () => {
-    mockStorageData = {
+    await fakeBrowser.storage.local.set({
       statistics: { tabGroupsCreatedCount: 5, tabsDeduplicatedCount: 10 }
-    };
+    });
 
     const { result } = renderHook(() => useStatistics());
 
@@ -125,9 +65,9 @@ describe('useStatistics', () => {
   });
 
   it('devrait incrémenter le compteur de groupes', async () => {
-    mockStorageData = {
+    await fakeBrowser.storage.local.set({
       statistics: { tabGroupsCreatedCount: 5, tabsDeduplicatedCount: 0 }
-    };
+    });
 
     const { result } = renderHook(() => useStatistics());
 
@@ -143,9 +83,9 @@ describe('useStatistics', () => {
   });
 
   it('devrait incrémenter le compteur de déduplication', async () => {
-    mockStorageData = {
+    await fakeBrowser.storage.local.set({
       statistics: { tabGroupsCreatedCount: 0, tabsDeduplicatedCount: 3 }
-    };
+    });
 
     const { result } = renderHook(() => useStatistics());
 
@@ -179,9 +119,9 @@ describe('useStatistics', () => {
   });
 
   it('devrait réinitialiser les statistiques', async () => {
-    mockStorageData = {
+    await fakeBrowser.storage.local.set({
       statistics: { tabGroupsCreatedCount: 50, tabsDeduplicatedCount: 100 }
-    };
+    });
 
     const { result } = renderHook(() => useStatistics());
 
@@ -204,9 +144,11 @@ describe('useStatistics', () => {
     });
 
     // Modifier directement le storage mock
-    mockStorageData = {
-      statistics: { tabGroupsCreatedCount: 999, tabsDeduplicatedCount: 888 }
-    };
+    await act(async () => {
+      await fakeBrowser.storage.local.set({
+        statistics: { tabGroupsCreatedCount: 999, tabsDeduplicatedCount: 888 }
+      });
+    });
 
     await act(async () => {
       await result.current.reloadStatistics();

--- a/tests/hooks/useSyncedSettings.test.ts
+++ b/tests/hooks/useSyncedSettings.test.ts
@@ -1,71 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { fakeBrowser } from 'wxt/testing';
 import { useSyncedSettings } from '../../src/hooks/useSyncedSettings';
 
-// Mock storage data
-let mockStorageData: Record<string, any> = {};
-const storageListeners: Array<(changes: Record<string, any>, areaName: string) => void> = [];
-
-// Create mock browser object
-const mockBrowser = {
-  storage: {
-    sync: {
-      get: vi.fn(async (defaults) => {
-        if (typeof defaults === 'object' && defaults !== null) {
-          const result: Record<string, any> = {};
-          for (const key of Object.keys(defaults)) {
-            result[key] = mockStorageData[key] !== undefined ? mockStorageData[key] : defaults[key];
-          }
-          return result;
-        }
-        return mockStorageData;
-      }),
-      set: vi.fn(async (data) => {
-        const changes: Record<string, any> = {};
-        for (const key of Object.keys(data)) {
-          changes[key] = { oldValue: mockStorageData[key], newValue: data[key] };
-        }
-        Object.assign(mockStorageData, data);
-        // Notify listeners
-        storageListeners.forEach(listener => listener(changes, 'sync'));
-      }),
-      remove: vi.fn(async (keys) => {
-        if (typeof keys === 'string') {
-          delete mockStorageData[keys];
-        } else if (Array.isArray(keys)) {
-          keys.forEach(key => delete mockStorageData[key]);
-        }
-      })
-    },
-    onChanged: {
-      addListener: vi.fn((callback) => {
-        storageListeners.push(callback);
-      }),
-      removeListener: vi.fn((callback) => {
-        const index = storageListeners.indexOf(callback);
-        if (index > -1) {
-          storageListeners.splice(index, 1);
-        }
-      })
-    }
-  }
-};
-
-// Set global browser
-(globalThis as any).browser = mockBrowser;
-
-// Mock wxt/browser module to use the global mock
-vi.mock('wxt/browser', () => ({
-  get browser() { return (globalThis as any).browser; }
-}));
+// fakeBrowser.reset() est appelé avant chaque test via tests/setup.ts
 
 describe('useSyncedSettings', () => {
-  beforeEach(() => {
-    mockStorageData = {};
-    storageListeners.length = 0;
-    vi.clearAllMocks();
-  });
-
   afterEach(() => {
     cleanup();
   });
@@ -83,11 +23,11 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait charger les paramètres existants', async () => {
-    mockStorageData = {
+    await fakeBrowser.storage.sync.set({
       globalGroupingEnabled: false,
       globalDeduplicationEnabled: true,
       domainRules: [{ id: '1', label: 'Test Rule' }]
-    };
+    });
 
     const { result } = renderHook(() => useSyncedSettings());
 
@@ -171,12 +111,14 @@ describe('useSyncedSettings', () => {
       expect(result.current.isLoaded).toBe(true);
     });
 
-    // Modifier directement le storage mock
-    mockStorageData = {
-      globalGroupingEnabled: false,
-      globalDeduplicationEnabled: false,
-      domainRules: [{ id: 'new', label: 'New Rule' }]
-    };
+    // Modifier directement le storage
+    await act(async () => {
+      await fakeBrowser.storage.sync.set({
+        globalGroupingEnabled: false,
+        globalDeduplicationEnabled: false,
+        domainRules: [{ id: 'new', label: 'New Rule' }]
+      });
+    });
 
     await act(async () => {
       await result.current.reloadSettings();


### PR DESCRIPTION
Add a centralized storageItems module and migrate all storage access to it. Created src/utils/storageItems.ts which defines typed storage items (local, sync, session) and exposes get/set/watch helpers. Updated background/profileSync, hooks/useStatistics, hooks/useSyncedSettings, utils/profileWindowMap, utils/sessionStorage, utils/sessionsHelpPrefs, utils/settingsUtils, utils/statisticsUtils to use the new items and storage utilities, simplified watchers and added local-update suppression logic. Tests for useStatistics and useSyncedSettings were updated to use the fakeBrowser test helpers instead of custom global mocks. Overall this consolidates storage handling, improves type safety and standardizes change notifications.