### PR TITLE
fix(e2e): update 7 failing tests to match new session card UI

### DIFF
--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -219,7 +219,7 @@ test.describe('[US-O01] Tooltips', () => {
     await page.close();
   });
 
-  test('auto-sync help icon has an accessible aria-label matching the tooltip [US-O004]', async ({
+  test('Unpin button has an accessible aria-label on profile cards [US-O004]', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -229,21 +229,19 @@ test.describe('[US-O01] Tooltips', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // HelpCircle icon button should have aria-label with the tooltip text
-    await expect(
-      page.getByRole('button', { name: /when enabled.*window/i }),
-    ).toBeVisible();
+    // Unpin button (for a pinned profile card) should be accessible with aria-label
+    await expect(page.getByRole('button', { name: /unpin/i })).toBeVisible();
     await page.close();
   });
 
-  test('auto-sync help icon shows tooltip on hover [US-O004]', async ({ extensionContext, extensionId }) => {
+  test('Unpin button shows tooltip on hover [US-O004]', async ({ extensionContext, extensionId }) => {
     const profile = createTestProfile({ name: 'Profile With Tooltip' });
     await seedSessions(extensionContext, [profile]);
 
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /when enabled.*window/i }).hover();
+    await page.getByRole('button', { name: /unpin/i }).hover();
     await expect(page.getByRole('tooltip')).toBeVisible({ timeout: 2000 });
     await page.close();
   });

--- a/tests/e2e/profiles.spec.ts
+++ b/tests/e2e/profiles.spec.ts
@@ -90,19 +90,21 @@ test.describe('[US-P01] Pin / Unpin', () => {
 // Icon selection
 // ---------------------------------------------------------------------------
 test.describe('[US-P02] Profile icon', () => {
-  test('icon block button is accessible for all sessions (pencil overlay) [US-P008]', async ({ extensionContext, extensionId }) => {
+  test('category picker is accessible in the edit dialog [US-P008]', async ({ extensionContext, extensionId }) => {
     const profile = createTestProfile({ name: 'Icon Profile' });
     await seedSessions(extensionContext, [profile]);
 
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // The icon block is now a role="button" with aria-label "Change Icon"
-    await expect(page.getByRole('button', { name: /change icon/i })).toBeVisible();
+    // Category picker (replacing icon picker) is accessible via the Edit dialog
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+    await expect(page.getByRole('dialog').getByRole('button', { name: /no category/i })).toBeVisible();
     await page.close();
   });
 
-  test('clicking icon block opens the icon picker [US-P008]', async ({
+  test('clicking category picker in edit dialog opens category options [US-P008]', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -112,8 +114,10 @@ test.describe('[US-P02] Profile icon', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /change icon/i }).click();
-    // The ProfileIconPicker popover should open (contains radio buttons for each icon)
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+    await page.getByRole('dialog').getByRole('button', { name: /no category/i }).click();
+    // The CategoryPicker popover should open (contains radio buttons for each category)
     await expect(page.getByRole('radio').first()).toBeVisible({ timeout: 2000 });
     await page.close();
   });
@@ -204,7 +208,7 @@ test.describe('[US-P03] New Profile wizard', () => {
     await page.close();
   });
 
-  test('profile icon block is accessible as a button with Change Icon label [US-P009]', async ({
+  test('category picker button is accessible in the edit dialog [US-P009]', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -214,8 +218,10 @@ test.describe('[US-P03] New Profile wizard', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // The icon block is now a role="button" with aria-label "Change Icon" for all sessions
-    await expect(page.getByRole('button', { name: /change icon/i })).toBeVisible();
+    // Category picker is accessible via the Edit dialog
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+    await expect(page.getByRole('dialog').getByRole('button', { name: /no category/i })).toBeVisible();
     await page.close();
   });
 
@@ -237,7 +243,7 @@ test.describe('[US-P03] New Profile wizard', () => {
     await page.close();
   });
 
-  test('profile wizard shows icon picker in Selection step', async ({
+  test('profile wizard shows category picker in Selection step', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -248,12 +254,12 @@ test.describe('[US-P03] New Profile wizard', () => {
     await page.getByText('Your First Profile!').waitFor({ timeout: 2000 });
     await page.getByRole('button', { name: /got it/i }).click();
 
-    // The icon picker label should be visible in step 1
-    await expect(page.getByRole('dialog').getByText('Profile icon')).toBeVisible();
+    // The category picker trigger should be visible in the Selection step
+    await expect(page.getByRole('dialog').getByRole('button', { name: /no category/i })).toBeVisible();
     await page.close();
   });
 
-  test('profile wizard shows auto-sync toggle in Confirmation step', async ({
+  test('profile wizard shows Save Profile button in Confirmation step', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -268,11 +274,11 @@ test.describe('[US-P03] New Profile wizard', () => {
     await page.getByText('Your First Profile!').waitFor({ timeout: 2000 });
     await page.getByRole('button', { name: /got it/i }).click();
 
-    // Advance to Confirmation step where the auto-sync toggle appears
+    // Advance to Confirmation step where Save Profile button appears
     await page.waitForTimeout(800);
     await page.getByRole('button', { name: 'Next' }).click();
 
-    await expect(page.getByRole('dialog').getByRole('switch', { name: /auto-sync/i })).toBeVisible();
+    await expect(page.getByRole('dialog').getByRole('button', { name: 'Save Profile' })).toBeVisible();
     await extraTab.close();
     await page.close();
   });


### PR DESCRIPTION
- profiles.spec.ts: replace "Change Icon" button tests with CategoryPicker tests (via Edit dialog), replace auto-sync wizard confirmation test with Save Profile button check, and replace icon picker wizard step with category picker check — all reflecting the replacement of ProfileIconPicker with CategoryPicker and the removal of the auto-sync toggle
- onboarding.spec.ts: replace auto-sync help icon tooltip tests with Unpin button tooltip tests, since the auto-sync feature was removed from cards

https://claude.ai/code/session_01NKpvxMu8tCPosLx4fApPA6