### PR TITLE
Ignore Chrome profile and add webExt profile config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ playwright-report/
 test-results/
 ctrf/
 /.idea
+.chrome-profile/

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'wxt';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   srcDir: 'src',
@@ -26,6 +27,10 @@ export default defineConfig({
       '48': 'icons/icon48.png',
       '128': 'icons/icon128.png'
     }
+  },
+  webExt: {
+    chromiumProfile: resolve('.chrome-profile'),
+    keepProfileChanges: true,
   },
   vite: () => ({
     plugins: [react()],


### PR DESCRIPTION
Add .chrome-profile to .gitignore and configure webExt in wxt.config.ts to use a local Chromium profile (resolve('.chrome-profile')) with keepProfileChanges enabled. Also import resolve from path. This allows persisting browser profile state across extension runs for testing/debugging.