### PR TITLE
Add 'More actions' dropdown for domain rules

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -271,6 +271,7 @@
   "sessionRenameLabel": { "message": "Session name" },
   "sessionConfirmRename": { "message": "Confirm rename" },
   "sessionMoreActions": { "message": "More actions" },
+  "ruleMoreActions": { "message": "More actions" },
   "sessionRestoreOptions": { "message": "Restore options" },
   "sessionRestoreCurrentWindow": { "message": "In current window" },
   "sessionRestoreNewWindow": { "message": "In new window" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -271,6 +271,7 @@
   "sessionRenameLabel": { "message": "Nombre de la sesión" },
   "sessionConfirmRename": { "message": "Confirmar cambio de nombre" },
   "sessionMoreActions": { "message": "Más acciones" },
+  "ruleMoreActions": { "message": "Más acciones" },
   "sessionRestoreOptions": { "message": "Opciones de restauración" },
   "sessionRestoreCurrentWindow": { "message": "En la ventana actual" },
   "sessionRestoreNewWindow": { "message": "En una ventana nueva" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -271,6 +271,7 @@
   "sessionRenameLabel": { "message": "Nom de la session" },
   "sessionConfirmRename": { "message": "Confirmer le renommage" },
   "sessionMoreActions": { "message": "Plus d'actions" },
+  "ruleMoreActions": { "message": "Plus d'actions" },
   "sessionRestoreOptions": { "message": "Options de restauration" },
   "sessionRestoreCurrentWindow": { "message": "Dans la fenêtre actuelle" },
   "sessionRestoreNewWindow": { "message": "Dans une nouvelle fenêtre" },

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useRef } from 'react';
-import { Button, Switch, Text, HoverCard, Box, Flex, Badge, Card, Checkbox, IconButton, TextField, Separator } from '@radix-ui/themes';
-import { Edit, Trash2, Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload } from 'lucide-react';
+import { Button, Switch, Text, HoverCard, Box, Flex, Badge, Card, Checkbox, IconButton, TextField, Separator, DropdownMenu } from '@radix-ui/themes';
+import { Pencil, Trash2, Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, MoreHorizontal } from 'lucide-react';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { DomainRuleFormModal } from '../components/Core/DomainRule/DomainRuleFormModal';
 import { ImportWizard } from '../components/UI/ImportExportPage/ImportWizard';
@@ -416,27 +416,30 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                       </Flex>
 
                       {/* Right: Actions */}
-                      <Flex gap="2" align="center" role="gridcell" style={{ flexShrink: 0 }}>
-                        <IconButton
-                          variant="ghost"
-                          color="gray"
-                          size="2"
-                          title={getMessage('edit')}
-                          onClick={() => handleEditRule(rule)}
-                        >
-                          <Edit size={16} />
-                        </IconButton>
-                        <IconButton
-                          variant="ghost"
-                          color="red"
-                          size="2"
-                          title={getMessage('delete')}
-                          onClick={() => {
-                            setDeleteTarget({ type: 'single', ruleId: rule.id });
-                          }}
-                        >
-                          <Trash2 size={16} />
-                        </IconButton>
+                      <Flex align="center" role="gridcell" style={{ flexShrink: 0 }}>
+                        <DropdownMenu.Root>
+                          <DropdownMenu.Trigger>
+                            <IconButton
+                              size="2"
+                              variant="ghost"
+                              color="gray"
+                              aria-label={getMessage('ruleMoreActions')}
+                            >
+                              <MoreHorizontal size={16} aria-hidden="true" />
+                            </IconButton>
+                          </DropdownMenu.Trigger>
+                          <DropdownMenu.Content>
+                            <DropdownMenu.Item onClick={() => handleEditRule(rule)}>
+                              <Pencil size={14} aria-hidden="true" />
+                              {getMessage('edit')}
+                            </DropdownMenu.Item>
+                            <DropdownMenu.Separator />
+                            <DropdownMenu.Item color="red" onClick={() => setDeleteTarget({ type: 'single', ruleId: rule.id })}>
+                              <Trash2 size={14} aria-hidden="true" />
+                              {getMessage('delete')}
+                            </DropdownMenu.Item>
+                          </DropdownMenu.Content>
+                        </DropdownMenu.Root>
                       </Flex>
                     </Flex>
                   </Card>

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * E2E tests for the Domain Rules page — CRUD via the "…" dropdown menu.
+ * Covers: more-actions menu visibility, Edit modal, Delete confirmation.
+ *
+ * NOTE: The browser context is worker-scoped and shared across spec files.
+ * Other tests running in parallel may seed their own rules.
+ * All selectors are scoped to the specific row for the rule under test to
+ * avoid strict-mode violations from unrelated rules on the page.
+ */
+import { test, expect } from './fixtures';
+import { goToDomainRulesSection } from './helpers/navigation';
+
+test.beforeEach(async ({ helpers }) => {
+  await helpers.clearDomainRules();
+});
+
+// ---------------------------------------------------------------------------
+// More-actions dropdown
+// ---------------------------------------------------------------------------
+test.describe('Domain rule more-actions menu', () => {
+  test('shows "More actions" button for a rule', async ({ extensionContext, extensionId, helpers }) => {
+    await helpers.addDomainRule({ label: 'Jira/Atlassian', domainFilter: '*.atlassian.net' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await expect(
+      page.getByRole('row', { name: /Jira\/Atlassian/i }).getByLabel('More actions'),
+    ).toBeVisible();
+    await page.close();
+  });
+
+  test('clicking "More actions" opens dropdown with Edit and Delete items', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: '*.github.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /GitHub/i }).getByLabel('More actions').click();
+
+    await expect(page.getByRole('menuitem', { name: /edit/i })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: /delete/i })).toBeVisible();
+    await page.close();
+  });
+
+  test('dropdown does NOT contain a Rename item', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Google', domainFilter: '*.google.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Google/i }).getByLabel('More actions').click();
+
+    await expect(page.getByRole('menuitem', { name: /rename/i })).not.toBeAttached();
+    await page.close();
+  });
+
+  test('each added rule has its own More actions button', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: '*.a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: '*.b.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await expect(
+      page.getByRole('row', { name: /Rule A/i }).getByLabel('More actions'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('row', { name: /Rule B/i }).getByLabel('More actions'),
+    ).toBeVisible();
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit via dropdown
+// ---------------------------------------------------------------------------
+test.describe('Edit rule via dropdown', () => {
+  test('clicking Edit opens the Edit Rule modal', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Slack', domainFilter: '*.slack.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Slack/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByText('Edit Rule')).toBeVisible();
+    await page.close();
+  });
+
+  test('Edit modal is pre-filled with the rule data', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Notion', domainFilter: '*.notion.so' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Notion/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.locator('input[name="label"]')).toHaveValue('Notion');
+    await expect(page.locator('input[name="domainFilter"]')).toHaveValue('*.notion.so');
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete via dropdown
+// ---------------------------------------------------------------------------
+test.describe('Delete rule via dropdown', () => {
+  test('clicking Delete opens a confirmation dialog', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Linear', domainFilter: '*.linear.app' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Linear/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /delete/i }).click();
+
+    await expect(page.getByRole('alertdialog')).toBeVisible();
+    await page.close();
+  });
+
+  test('confirming Delete removes the rule from the list', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Figma', domainFilter: '*.figma.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Figma/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /delete/i }).click();
+    // Click the red "Delete" confirm button
+    await page.getByRole('button', { name: /delete/i }).last().click();
+
+    await expect(page.getByRole('row', { name: /Figma/i })).not.toBeAttached();
+    await page.close();
+  });
+
+  test('cancelling Delete keeps the rule in the list', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Vercel', domainFilter: '*.vercel.app' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /delete/i }).click();
+    await page.getByRole('button', { name: /cancel/i }).click();
+
+    await expect(
+      page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions'),
+    ).toBeVisible();
+    await page.close();
+  });
+});

--- a/tests/e2e/helpers/navigation.ts
+++ b/tests/e2e/helpers/navigation.ts
@@ -46,6 +46,23 @@ export async function goToSessionsSectionWithSnapshot(page: Page, extensionId: s
     .waitFor({ state: 'visible', timeout: 10_000 });
 }
 
+/**
+ * Navigate to the Domain Rules section and wait for the page to be ready.
+ */
+export async function goToDomainRulesSection(page: Page, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html#rules`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => {
+      const body = document.body.textContent ?? '';
+      return !body.includes('Chargement') && body.length > 50;
+    },
+    null,
+    { timeout: 10_000 },
+  );
+  await page.waitForTimeout(300);
+}
+
 /** Navigate to the extension popup page. */
 export async function goToPopup(page: Page, extensionId: string): Promise<void> {
   await page.goto(`chrome-extension://${extensionId}/popup.html`);

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -502,7 +502,12 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
   test('Customize wizard restores directly when no conflicts exist', async ({
     extensionContext,
     extensionId,
+    helpers,
   }) => {
+    // Close any tabs left open by previous tests that could match the session URLs
+    // (example.com, google.com, github.com) and trigger conflict resolution.
+    await helpers.closeAllTestTabs();
+
     const session = createTestSession({ name: 'No Conflict Session' });
     await seedSessions(extensionContext, [session]);
 


### PR DESCRIPTION
Replace inline Edit/Delete buttons with a single "More actions" DropdownMenu in DomainRulesPage (uses MoreHorizontal/Pencil icons and menu items for Edit/Delete). Add i18n key `ruleMoreActions` to en/es/fr locales. Introduce e2e tests (tests/e2e/domain-rules.spec.ts) covering the more-actions menu, edit modal, and delete confirmation, and add goToDomainRulesSection helper for navigation. Also add a small test setup fix in sessions.spec.ts to close leftover test tabs before a restore test.