### PR TITLE
Downgrade Playwright; fix options deep-linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "screenshots": "pnpm build && xvfb-maybe node_modules/.bin/playwright test --config=e2e-screenshots/playwright.screenshots.config.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.57.0",
     "@storybook/addon-docs": "^9.0.13",
     "@storybook/react-vite": "^9.0.13",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.57.0
+        version: 1.57.0
       '@storybook/addon-docs':
         specifier: ^9.0.13
         version: 9.1.20(@types/react@18.3.28)(storybook@9.1.20(@testing-library/dom@9.3.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)))
@@ -730,8 +730,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3054,16 +3054,16 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
     engines: {node: '>=18'}
     hasBin: true
 
   playwright-ctrf-json-reporter@0.0.27:
     resolution: {integrity: sha512-FZ8KadoHJc7xhf5XM0R9F8XBsTSm4vywa5/fhmeo2nZhN31UmapYwRfxaBsGk6AbsvGmft5G+MVmkBjTJZic/Q==}
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4318,9 +4318,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.57.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.57.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -6709,13 +6709,13 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.57.0: {}
 
   playwright-ctrf-json-reporter@0.0.27: {}
 
-  playwright@1.58.2:
+  playwright@1.57.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -55,18 +55,19 @@ function OptionsContent() {
     // Deep linking: navigate to the right section on mount and on hash changes
     // (hashchange fires when an existing tab's URL hash is updated externally)
     useEffect(() => {
+        const validSections = ['rules', 'importexport', 'sessions', 'stats', 'settings'];
+
         function handleHash() {
             const hash = window.location.hash; // e.g. '#sessions?action=snapshot'
             if (!hash.startsWith('#')) return;
             const questionMark = hash.indexOf('?');
             const section = questionMark === -1 ? hash.slice(1) : hash.slice(1, questionMark);
-            if (section === 'sessions') {
-                setCurrentTab('sessions');
-                if (questionMark !== -1) {
-                    const params = new URLSearchParams(hash.slice(questionMark + 1));
-                    if (params.get('action') === 'snapshot') {
-                        setOpenSnapshotWizard(true);
-                    }
+            if (!validSections.includes(section)) return;
+            setCurrentTab(section);
+            if (section === 'sessions' && questionMark !== -1) {
+                const params = new URLSearchParams(hash.slice(questionMark + 1));
+                if (params.get('action') === 'snapshot') {
+                    setOpenSnapshotWizard(true);
                 }
             }
         }
@@ -95,6 +96,7 @@ function OptionsContent() {
     }, []);
 
     const handleTabChange = useCallback((tab: string) => {
+        window.location.hash = tab;
         setCurrentTab(tab);
     }, []);
 
@@ -107,16 +109,16 @@ function OptionsContent() {
             accentColor: FEATURE_BASE_COLORS.DOMAIN_RULES,
         },
         {
-            id: 'importexport',
-            label: getMessage('importExportTab'),
-            icon: FileText as any,
-            accentColor: FEATURE_BASE_COLORS.IMPORT, // Utilise la couleur Import pour l'onglet combiné
-        },
-        {
             id: 'sessions',
             label: getMessage('sessionsTab'),
             icon: Archive as any,
             accentColor: FEATURE_BASE_COLORS.SESSIONS,
+        },
+        {
+            id: 'importexport',
+            label: getMessage('importExportTab'),
+            icon: FileText as any,
+            accentColor: FEATURE_BASE_COLORS.IMPORT, // Utilise la couleur Import pour l'onglet combiné
         },
         {
             id: 'stats',


### PR DESCRIPTION
Downgrade @playwright/test and related Playwright packages from 1.58.2 to 1.57.0 in package.json and pnpm-lock.yaml to align dependencies and lockfile.

Update src/pages/options.tsx to improve deep-linking: add a list of valid sections, ignore unknown hashes, set the current tab from the hash, only trigger the snapshot wizard when the sessions section includes the action param, and sync window.location.hash when changing tabs. Also reorder the import/export tab entry (cosmetic).