### PR TITLE
fix: make test failures actually block CI checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test
-        continue-on-error: true
 
       - name: Upload CTRF report
         uses: actions/upload-artifact@v4
@@ -61,7 +60,6 @@ jobs:
 
       - name: Run Playwright tests
         run: xvfb-run --auto-servernum -- pnpm exec playwright test
-        continue-on-error: true
 
       - name: Upload CTRF report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove continue-on-error from unit and E2E test steps so that failing tests mark the job as failed instead of silently passing.

https://claude.ai/code/session_01KB3paFJTmQcnJNpCU6aNJN