### PR TITLE
fix(logger): afficher debug/log en dev, warn/error toujours

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,15 +1,13 @@
 /**
  * Project logger — mirrors WXT's internal logger pattern.
- * All methods are no-ops in production builds (`import.meta.env.MODE === "production"`).
+ * debug/log are no-ops in production; warn/error always pass through.
  */
-function print(method: (...args: unknown[]) => void, ...args: unknown[]): void {
-  if (import.meta.env.MODE === 'production') return;
-  method('[smart-tab-organizer]', ...args);
-}
+const PREFIX = '[smart-tab-organizer]';
+const isDev = import.meta.env.MODE !== 'production';
 
 export const logger = {
-  debug: (...args: unknown[]) => print(console.debug, ...args),
-  log: (...args: unknown[]) => print(console.log, ...args),
-  warn: (...args: unknown[]) => print(console.warn, ...args),
-  error: (...args: unknown[]) => print(console.error, ...args),
+  debug: (...args: unknown[]) => isDev && console.debug(PREFIX, ...args),
+  log: (...args: unknown[]) => isDev && console.log(PREFIX, ...args),
+  warn: (...args: unknown[]) => console.warn(PREFIX, ...args),
+  error: (...args: unknown[]) => console.error(PREFIX, ...args),
 };


### PR DESCRIPTION
En mode production, debug() et log() sont silencieux. warn() et error() passent toujours, quelle que soit l'env.

https://claude.ai/code/session_01RBY8Ut3RHKaf1JNk3cSJnr