### PR TITLE
Exclude Storybook files from TypeScript compilation

### DIFF
--- a/src/components/Core/DomainRule/DomainRuleFormModal.tsx
+++ b/src/components/Core/DomainRule/DomainRuleFormModal.tsx
@@ -374,7 +374,7 @@ export function DomainRuleFormModal({
                       <Flex align="center" gap="1">
                         {getMessage(({ preset: 'configModePreset', ask: 'configModeAsk', manual: 'configModeManual' } as const)[mode])}
                         <HoverCard.Root openDelay={300} closeDelay={100}>
-                          <HoverCard.Trigger asChild>
+                          <HoverCard.Trigger>
                             <Box as="span" style={{ display: 'inline-flex', alignItems: 'center', cursor: 'default', lineHeight: 0 }}>
                               <Info size={12} aria-hidden="true" />
                             </Box>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     },
     "skipLibCheck": true
   },
-  "include": ["src/**/*", ".wxt/wxt.d.ts"]
+  "include": ["src/**/*", ".wxt/wxt.d.ts"],
+  "exclude": ["src/**/*.stories.tsx", "src/stories/**/*"]
 }


### PR DESCRIPTION
## Summary
This PR excludes Storybook story files from TypeScript compilation and removes an unnecessary `asChild` prop from a Radix UI component.

## Key Changes
- **TypeScript Configuration**: Added `exclude` pattern to `tsconfig.json` to skip Storybook story files (`*.stories.tsx`) and the stories directory from compilation
- **Component Fix**: Removed the `asChild` prop from `HoverCard.Trigger` in `DomainRuleFormModal.tsx` to align with proper Radix UI usage

## Details
The TypeScript exclusion prevents Storybook files from being included in the build output, reducing compilation overhead and keeping the compiled source focused on production code. The `HoverCard.Trigger` change removes an unnecessary prop that was wrapping the Box component, simplifying the component hierarchy.

https://claude.ai/code/session_016LWSwgHo2zA6gCz7vAGRW7