### PR TITLE
fix(migration): check correct WXT storage key to prevent rules reset

### DIFF
--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -44,14 +44,18 @@ async function loadDefaultSettings(): Promise<SyncSettings> {
 
 export async function initializeDefaults(): Promise<void> {
   const defaults = await loadDefaultSettings();
-  const syncData = await browser.storage.sync.get('settings');
-  
-  if (!syncData.settings) {
+  // WXT stores each setting as an individual key (e.g. 'domainRules'), not as a
+  // single 'settings' object. Check for the presence of 'domainRules' to detect
+  // whether the extension has been installed before.
+  const rawSync = await browser.storage.sync.get('domainRules');
+
+  if (rawSync.domainRules === undefined) {
     logger.debug("Init defaults from JSON...");
     await setSyncSettings(defaults);
   } else {
     logger.debug("Merging existing with JSON defaults...");
-    const merged = mergeDeep(defaults, syncData.settings);
+    const currentSettings = await getSyncSettings();
+    const merged = mergeDeep(defaults, currentSettings);
     
     // Ensure default domain rules exist
     defaults.domainRules.forEach(dr => {


### PR DESCRIPTION
## Changes

- Fixed storage key detection in `initializeDefaults()` to check for `domainRules` instead of `settings`
- WXT stores each setting as an individual key rather than a single object, so checking for the non-existent `settings` key was incorrectly triggering default initialization on every update
- Added clarifying comment explaining the storage structure
- Updated merge logic to use `getSyncSettings()` for proper deserialization instead of raw storage data

## Impact

Prevents domain rules and other settings from being reset during extension updates.