### PR TITLE
Skip grouping for tabs in non-normal windows

### DIFF
--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -256,6 +256,15 @@ export async function processGroupingForNewTab(openerTab: Browser.tabs.Tab, newT
         return;
     }
 
+    // Skip grouping if the opener tab is in a non-normal window (Chrome installed app / PWA)
+    if (openerTab.windowId != null) {
+        const openerWindow = await browser.windows.get(openerTab.windowId).catch(() => null);
+        if (openerWindow && openerWindow.type !== 'normal') {
+            logger.debug(`[GROUPING_DEBUG] Skipping grouping: opener tab is in a non-normal window (type: ${openerWindow.type}).`);
+            return;
+        }
+    }
+
     const rule = findMatchingRule(openerTab.url, settings.domainRules);
     if (!rule) {
         logger.debug(`[GROUPING_DEBUG] No matching rule for opener tab URL: ${openerTab.url}`);


### PR DESCRIPTION
Avoid grouping new tabs when the opener tab resides in a non-normal window (e.g. Chrome installed app / PWA). Add a guard that fetches the opener window (if openerTab.windowId is present), bail out and log a debug message when the window.type !== 'normal'. Errors from browser.windows.get are caught and treated as a non-blocking miss.