### PR TITLE
Skip grouping when name extraction fails

### DIFF
--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -35,9 +35,9 @@ export function determineGroupColor(rule: DomainRuleSetting, settings?: any): st
     return null;
 }
 
-export function extractGroupNameFromRule(rule: DomainRuleSetting, openerTab: Browser.tabs.Tab): string {
+export function extractGroupNameFromRule(rule: DomainRuleSetting, openerTab: Browser.tabs.Tab): string | null {
     let groupName = rule.label || "SmartGroup";
-    
+
     if (rule.groupNameSource === 'title') {
         // Essaie le titre en priorité, puis l'URL si le titre ne donne rien
         let extracted: string | null = null;
@@ -57,7 +57,11 @@ export function extractGroupNameFromRule(rule: DomainRuleSetting, openerTab: Bro
                 logger.warn(`[GROUPING_DEBUG] Error parsing opener URL "${openerTab.url}" with regex "${rule.urlParsingRegEx}".`, e.message);
             }
         }
-        if (extracted?.trim()) groupName = extracted.trim();
+        if (extracted?.trim()) {
+            groupName = extracted.trim();
+        } else {
+            return null;
+        }
     } else if (rule.groupNameSource === 'url') {
         // Essaie l'URL en priorité, puis le titre si l'URL ne donne rien
         let extracted: string | null = null;
@@ -77,7 +81,11 @@ export function extractGroupNameFromRule(rule: DomainRuleSetting, openerTab: Bro
                 logger.warn(`[GROUPING_DEBUG] Error parsing opener title "${openerTab.title}" with regex "${rule.titleParsingRegEx}".`, e.message);
             }
         }
-        if (extracted?.trim()) groupName = extracted.trim();
+        if (extracted?.trim()) {
+            groupName = extracted.trim();
+        } else {
+            return null;
+        }
     } else if (rule.groupNameSource === 'smart_manual') {
         // smart_manual: Si on ne trouve pas de nom de groupe, le demander à l'utilisateur
         const extracted = tryExtractGroupNameFromPresetOrFallback(rule, openerTab);
@@ -106,11 +114,13 @@ export function extractGroupNameFromRule(rule: DomainRuleSetting, openerTab: Bro
             logger.debug(`[GROUPING_DEBUG] Using rule label as fallback: "${groupName}".`);
         }
     } else if (rule.groupNameSource === 'smart') {
-        // smart: Essayer d'extraire intelligemment avec les regex de la règle
+        // smart: Essayer d'extraire intelligemment avec les regex de la règle ; pas de fallback
         const extracted = tryExtractGroupNameFromPresetOrFallback(rule, openerTab);
-        if (extracted) {
-            groupName = extracted;
+        if (!extracted) {
+            logger.debug(`[GROUPING_DEBUG] Smart mode: no name could be extracted for rule "${rule.label}". Skipping grouping.`);
+            return null;
         }
+        groupName = extracted;
     }
     
     const category = getRuleCategory(rule.categoryId);
@@ -151,14 +161,15 @@ function tryExtractGroupNameFromPresetOrFallback(rule: DomainRuleSetting, opener
 }
 
 export function createGroupingContext(
-    rule: DomainRuleSetting, 
-    openerTab: Browser.tabs.Tab, 
-    newTab: Browser.tabs.Tab, 
+    rule: DomainRuleSetting,
+    openerTab: Browser.tabs.Tab,
+    newTab: Browser.tabs.Tab,
     settings: any
-): GroupingContext {
+): GroupingContext | null {
     const groupName = extractGroupNameFromRule(rule, openerTab);
+    if (groupName === null) return null;
     const groupColor = determineGroupColor(rule, settings);
-    
+
     return {
         rule,
         groupName,
@@ -277,6 +288,10 @@ export async function processGroupingForNewTab(openerTab: Browser.tabs.Tab, newT
     }
 
     const context = createGroupingContext(rule, openerTab, newTab, settings);
+    if (context === null) {
+        logger.debug(`[GROUPING_DEBUG] Skipping grouping: no name could be extracted for rule "${rule.label}".`);
+        return;
+    }
     logger.debug(`[GROUPING_DEBUG] Rule found: "${rule.label}", groupName: "${context.groupName}"`);
 
     try {

--- a/tests/e2e/grouping.spec.ts
+++ b/tests/e2e/grouping.spec.ts
@@ -269,7 +269,7 @@ test.describe('Tab Grouping', () => {
       expect(groups.find(g => g.title === 'Smart Label Fallback')).toBeDefined();
     });
 
-    test('invalid regex falls back gracefully (no crash) [US-G003]', async ({ helpers }) => {
+    test('invalid regex ne crashe pas et ne groupe pas (title, sans fallback) [US-G003]', async ({ helpers }) => {
       await helpers.addDomainRule({
         label: 'Invalid Regex Fallback',
         domainFilter: 'example.com',
@@ -283,9 +283,10 @@ test.describe('Tab Grouping', () => {
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      // Should not crash; extension still creates a group using label as fallback
-      const groups = await helpers.waitForTabGrouped();
-      expect(groups.length).toBeGreaterThan(0);
+      // Should not crash; title mode without fallback → no grouping when extraction fails
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      expect(groups.length).toBe(0);
     });
   });
 

--- a/tests/e2e/naming.spec.ts
+++ b/tests/e2e/naming.spec.ts
@@ -133,8 +133,8 @@ test.describe('Group Naming Modes', () => {
 
       const groups = await helpers.waitForTabGrouped();
       expect(groups.length).toBeGreaterThan(0);
-      // Should have extracted "Beta" from the title; fallback to label if extraction fails
-      expect(['Beta', 'Smart Preset Rule']).toContain(groups[0].title);
+      // Should have extracted "Beta" from the title
+      expect(groups[0].title).toBe('Beta');
     });
 
     test('smart mode: extracts group name from opener URL when title regex fails [US-G012]', async ({
@@ -157,8 +157,8 @@ test.describe('Group Naming Modes', () => {
 
       const groups = await helpers.waitForTabGrouped();
       expect(groups.length).toBeGreaterThan(0);
-      // Should extract "projects" from URL; fallback to label if extraction fails
-      expect(['projects', 'Smart URL Rule']).toContain(groups[0].title);
+      // Should extract "projects" from URL
+      expect(groups[0].title).toBe('projects');
     });
 
     test('smart mode without presetId: extrait quand même via regex [US-G012]', async ({
@@ -184,7 +184,7 @@ test.describe('Group Naming Modes', () => {
       expect(groups[0].title).toBe('projects');
     });
 
-    test('smart mode without presetId: utilise le label si les deux regex échouent [US-G012]', async ({
+    test('smart mode without presetId: ne groupe pas si les deux regex échouent [US-G012]', async ({
       helpers,
     }) => {
       await helpers.addDomainRule({
@@ -201,11 +201,13 @@ test.describe('Group Naming Modes', () => {
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      const groups = await helpers.waitForTabGrouped('Smart No Preset');
-      expect(groups.find(g => g.title === 'Smart No Preset')).toBeDefined();
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      // Smart mode without fallback: no grouping when extraction fails
+      expect(groups.length).toBe(0);
     });
 
-    test('smart mode: falls back to label when both regex extractions fail [US-G012]', async ({
+    test('smart mode: ne groupe pas quand les deux regex échouent [US-G012]', async ({
       helpers,
     }) => {
       await helpers.addDomainRule({
@@ -223,8 +225,10 @@ test.describe('Group Naming Modes', () => {
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      const groups = await helpers.waitForTabGrouped('Smart Fallback Label');
-      expect(groups.find(g => g.title === 'Smart Fallback Label')).toBeDefined();
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      // Smart mode without fallback: no grouping when extraction fails
+      expect(groups.length).toBe(0);
     });
   });
 
@@ -406,7 +410,7 @@ test.describe('Group Naming Modes', () => {
       expect(groups.find(g => g.title === 'Label Fallback')).toBeDefined();
     });
 
-    test('invalid regex falls back gracefully without crashing [US-G015]', async ({ helpers }) => {
+    test('invalid regex ne crashe pas et ne groupe pas (smart, sans fallback) [US-G015]', async ({ helpers }) => {
       await helpers.addDomainRule({
         label: 'Invalid Regex Chain',
         domainFilter: 'example.com',
@@ -422,9 +426,10 @@ test.describe('Group Naming Modes', () => {
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      // Should not crash; extension falls back to label
-      const groups = await helpers.waitForTabGrouped();
-      expect(groups.length).toBeGreaterThan(0);
+      // Should not crash; smart mode without fallback → no grouping when extraction fails
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      expect(groups.length).toBe(0);
     });
   });
 
@@ -520,7 +525,7 @@ test.describe('Group Naming Modes', () => {
       expect(['section', 'URL Regex Valid']).toContain(groups[0].title);
     });
 
-    test('invalid regex syntax: falls back to label without crashing [US-G017]', async ({
+    test('invalid regex syntax: ne crashe pas et ne groupe pas (title, sans fallback) [US-G017]', async ({
       helpers,
     }) => {
       await helpers.addDomainRule({
@@ -536,12 +541,13 @@ test.describe('Group Naming Modes', () => {
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      // Extension should not crash; group is still created using label
-      const groups = await helpers.waitForTabGrouped();
-      expect(groups.length).toBeGreaterThan(0);
+      // Extension should not crash; title mode without fallback → no grouping when extraction fails
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      expect(groups.length).toBe(0);
     });
 
-    test('regex without capture group: falls back to label [US-G017]', async ({ helpers }) => {
+    test('regex without capture group: ne groupe pas (title, sans fallback) [US-G017]', async ({ helpers }) => {
       await helpers.addDomainRule({
         label: 'No Capture Group',
         domainFilter: 'example.com',
@@ -559,9 +565,10 @@ test.describe('Group Naming Modes', () => {
 
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
 
-      // Without capture group, extraction returns null → falls back to label
-      const groups = await helpers.waitForTabGrouped('No Capture Group');
-      expect(groups.find(g => g.title === 'No Capture Group')).toBeDefined();
+      // Without capture group, extraction returns null → title mode has no fallback → no grouping
+      await helpers.waitForGrouping();
+      const groups = await helpers.getTabGroups();
+      expect(groups.length).toBe(0);
     });
   });
 });

--- a/tests/grouping.test.ts
+++ b/tests/grouping.test.ts
@@ -195,7 +195,7 @@ describe('grouping', () => {
         expect(result).toBe('Example');
       });
 
-      it('devrait utiliser le label si le titre et l\'URL ne trouvent rien', () => {
+      it('devrait retourner null si le titre et l\'URL ne trouvent rien', () => {
         const rule = createMockRule({
           groupNameSource: 'title',
           titleParsingRegEx: 'NoMatch - (\\w+)',
@@ -205,10 +205,10 @@ describe('grouping', () => {
 
         const result = extractGroupNameFromRule(rule, tab);
 
-        expect(result).toBe('Fallback Label');
+        expect(result).toBeNull();
       });
 
-      it('devrait utiliser SmartGroup si pas de label et aucune extraction', () => {
+      it('devrait retourner null si pas de label et aucune extraction', () => {
         const rule = createMockRule({
           groupNameSource: 'title',
           titleParsingRegEx: 'NoMatch',
@@ -218,7 +218,7 @@ describe('grouping', () => {
 
         const result = extractGroupNameFromRule(rule, tab);
 
-        expect(result).toBe('SmartGroup');
+        expect(result).toBeNull();
       });
 
       it('devrait utiliser l\'URL comme fallback si le titre ne donne rien', () => {
@@ -252,7 +252,7 @@ describe('grouping', () => {
         expect(result).toBe('products');
       });
 
-      it('devrait utiliser le label si l\'URL et le titre ne trouvent rien', () => {
+      it('devrait retourner null si l\'URL et le titre ne trouvent rien', () => {
         const rule = createMockRule({
           groupNameSource: 'url',
           urlParsingRegEx: 'nomatch/(\\w+)',
@@ -262,7 +262,7 @@ describe('grouping', () => {
 
         const result = extractGroupNameFromRule(rule, tab);
 
-        expect(result).toBe('URL Fallback');
+        expect(result).toBeNull();
       });
 
       it('devrait utiliser le titre comme fallback si l\'URL ne donne rien', () => {
@@ -345,9 +345,23 @@ describe('grouping', () => {
 
         expect(result).toBe('projects');
       });
+
+      it('devrait retourner null si aucune extraction ne réussit', () => {
+        const rule = createMockRule({
+          groupNameSource: 'smart',
+          titleParsingRegEx: 'NoMatch',
+          urlParsingRegEx: 'NoMatch',
+          label: 'Should Not Be Used'
+        });
+        const tab = createMockTab({ title: 'No match', url: 'https://example.com/page' });
+
+        const result = extractGroupNameFromRule(rule, tab);
+
+        expect(result).toBeNull();
+      });
     });
 
-    it('devrait gérer une regex invalide gracieusement', () => {
+    it('devrait gérer une regex invalide gracieusement et retourner null', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const rule = createMockRule({
@@ -359,7 +373,7 @@ describe('grouping', () => {
 
       const result = extractGroupNameFromRule(rule, tab);
 
-      expect(result).toBe('Fallback');
+      expect(result).toBeNull();
       consoleSpy.mockRestore();
     });
 
@@ -397,7 +411,7 @@ describe('grouping', () => {
       expect(context.newTab).toBe(newTab);
     });
 
-    it('devrait utiliser le label comme nom de groupe par défaut', () => {
+    it('devrait retourner null quand l\'extraction échoue (pas de fallback label)', () => {
       const rule = createMockRule({
         label: 'Default Label',
         groupNameSource: 'title',
@@ -408,7 +422,7 @@ describe('grouping', () => {
 
       const context = createGroupingContext(rule, openerTab, newTab, {});
 
-      expect(context.groupName).toBe('Default Label');
+      expect(context).toBeNull();
     });
   });
 });

--- a/user-stories/US-G-nommage.md
+++ b/user-stories/US-G-nommage.md
@@ -80,16 +80,17 @@
 | Mode | Priorité |
 |---|---|
 | `label` | label de la règle → `"SmartGroup"` |
-| `url` | extraction URL → label → `"SmartGroup"` |
-| `title` | extraction titre → label → `"SmartGroup"` |
+| `url` | extraction URL → extraction titre → **pas de groupage si échec** |
+| `title` | extraction titre → extraction URL → **pas de groupage si échec** |
 | `smart_label` | extraction (titre puis URL) → label → `"SmartGroup"` |
-| `smart` | extraction (titre puis URL via preset) → label → `"SmartGroup"` |
+| `smart` | extraction (titre puis URL) → **pas de groupage si échec** |
 | `smart_preset` | extraction → nom du preset → label → `"SmartGroup"` |
 | `smart_manual` | extraction → invite utilisateur → dégroupage si annulation |
 | `manual` | invite utilisateur (label proposé) → dégroupage si annulation |
 
-- [ ] Le nom de dernier recours absolu est `"SmartGroup"` (utilisé quand le label est lui-même vide).
-- [ ] Une erreur de regex (syntaxe invalide) est tracée en avertissement mais n'empêche pas la création du groupe : le fallback est appliqué.
+- [ ] Le nom de dernier recours absolu est `"SmartGroup"` (utilisé quand le label est lui-même vide) — s'applique aux modes avec fallback explicite : `label`, `smart_label`, `smart_preset`.
+- [ ] Les modes sans suffixe de fallback (`title`, `url`, `smart`) ne groupent pas le tab si aucune extraction ne réussit.
+- [ ] Une erreur de regex (syntaxe invalide) est tracée en avertissement mais n'empêche pas la tentative des autres sources : si toutes échouent, le comportement du mode s'applique (pas de groupage pour `title`/`url`/`smart`, fallback pour les autres).
 - [ ] L'extraction utilise toujours le **premier groupe de capture** `(...)` de l'expression régulière.
 
 ---


### PR DESCRIPTION
Change extractGroupNameFromRule to return null when no group name can be extracted for modes that have no fallback (title, url, smart). Add early returns and debug logging so createGroupingContext/processGroupingForNewTab skip grouping when extraction fails. Update createGroupingContext signature to allow null result and adjust callers accordingly. Update unit tests to expect null in these failure cases and add a test for smart mode with no extraction. Update user story docs to reflect the new no-grouping behavior for modes without fallback.