### PR TITLE
Stop injecting default domain rules on init

### DIFF
--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -56,42 +56,19 @@ export async function initializeDefaults(): Promise<void> {
     logger.debug("Merging existing with JSON defaults...");
     const currentSettings = await getSyncSettings();
     const merged = mergeDeep(defaults, currentSettings);
-    
-    // Ensure default domain rules exist
-    defaults.domainRules.forEach(dr => {
-      const existing = merged.domainRules.find((mr: any) => mr.id === dr.id);
-      if (!existing) {
-        merged.domainRules.push(dr);
-      }
-    });
 
-    defaults.domainRules.forEach(dr => {
-      const existing = merged.domainRules.find((mr: any) => mr.id === dr.id);
-      if (!existing) {
-        merged.domainRules.push(dr);
-      } else {
-        if (typeof existing.urlParsingRegEx === 'undefined' && typeof dr.urlParsingRegEx !== 'undefined') {
-          existing.urlParsingRegEx = dr.urlParsingRegEx;
-        }
-        if (typeof existing.groupNameSource === 'undefined' && typeof dr.groupNameSource !== 'undefined') {
-          existing.groupNameSource = dr.groupNameSource;
-        }
-      }
-    });
-
-    // Ensure all domain rules have a label, color and new fields
+    // Migrate missing fields on existing rules (never inject new default rules)
     if (merged.domainRules && Array.isArray(merged.domainRules)) {
       merged.domainRules.forEach((rule: any) => {
         if (typeof rule.label === 'undefined') {
           const defaultRule = defaults.domainRules.find(dr => dr.id === rule.id);
           rule.label = defaultRule ? defaultRule.label : rule.domainFilter || "Untitled Rule";
         }
-        // Remove old groupId field and add color field
         if (typeof rule.groupId !== 'undefined') {
           delete rule.groupId;
         }
         if (typeof rule.color === 'undefined') {
-          rule.color = "grey"; // Default color
+          rule.color = "grey";
         }
         if (typeof rule.urlParsingRegEx === 'undefined') {
           rule.urlParsingRegEx = '';


### PR DESCRIPTION
Remove duplicated logic that forcibly added default domainRules into user settings during initialization. Instead, only migrate missing fields on existing domain rules (fill label, color, urlParsingRegEx and remove deprecated groupId) so defaults are not injected as new rules. This avoids overwriting or expanding a user's rule set while preserving necessary per-rule migrations.