### PR TITLE
feat: enforce unique session names like domain rule labels

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -131,6 +131,7 @@
   "labelLabel": { "message": "Label" },
   "errorLabelRequired": { "message": "Label is required." },
   "errorLabelUnique": { "message": "Label must be unique." },
+  "errorSessionNameUnique": { "message": "Session name must be unique." },
   "labelTooltip": { "message": "A unique name for this domain rule. This label will be used as the group title if the title parsing regex fails or is not set." },
   "noPreset": { "message": "-- No Preset --" },
   "loadingText": { "message": "Loading..." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -131,6 +131,7 @@
   "labelLabel": { "message": "Etiqueta" },
   "errorLabelRequired": { "message": "La etiqueta es obligatoria." },
   "errorLabelUnique": { "message": "La etiqueta debe ser única." },
+  "errorSessionNameUnique": { "message": "El nombre de la sesión debe ser único." },
   "labelTooltip": { "message": "Un nombre único para esta regla de dominio. Esta etiqueta se usará como título del grupo si la expresión regular de análisis de título falla o no está configurada." },
   "noPreset": { "message": "-- Sin Preajuste --" },
   "loadingText": { "message": "Cargando..." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -131,6 +131,7 @@
   "labelLabel": { "message": "Étiquette" },
   "errorLabelRequired": { "message": "L'étiquette est obligatoire." },
   "errorLabelUnique": { "message": "L'étiquette doit être unique." },
+  "errorSessionNameUnique": { "message": "Le nom de la session doit être unique." },
   "labelTooltip": { "message": "Un nom unique pour cette règle de domaine. Cette étiquette sera utilisée comme titre du groupe si l'expression régulière d'analyse du titre échoue ou n'est pas configurée." },
   "noPreset": { "message": "-- Aucun Préréglage --" },
   "loadingText": { "message": "Chargement..." },

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -21,6 +21,7 @@ import type { Session } from '../../../types/session';
 
 interface SessionCardProps {
   session: Session;
+  existingSessions: Session[];
   onRestore: (session: Session) => void;
   onRestoreCurrentWindow: (session: Session) => void;
   onRestoreNewWindow: (session: Session) => void;
@@ -45,6 +46,7 @@ interface SessionCardProps {
 
 export function SessionCard({
   session,
+  existingSessions,
   onRestore,
   onRestoreCurrentWindow,
   onRestoreNewWindow,
@@ -59,6 +61,7 @@ export function SessionCard({
 }: SessionCardProps) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [nameValue, setNameValue] = useState(session.name);
+  const [renameError, setRenameError] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
 
   // When a search match forces the preview open, open it.
@@ -81,13 +84,21 @@ export function SessionCard({
   const handleRenameSubmit = useCallback(async () => {
     const trimmed = nameValue.trim();
     if (trimmed && trimmed !== session.name) {
+      const isDuplicate = existingSessions.some(
+        s => s.id !== session.id && s.name.toLowerCase() === trimmed.toLowerCase(),
+      );
+      if (isDuplicate) {
+        setRenameError(getMessage('errorSessionNameUnique'));
+        return;
+      }
       await onRename(session.id, trimmed);
     }
     setIsRenaming(false);
-  }, [nameValue, session.id, session.name, onRename]);
+  }, [nameValue, session.id, session.name, onRename, existingSessions]);
 
   const handleRenameCancel = useCallback(() => {
     setNameValue(session.name);
+    setRenameError(null);
     setIsRenaming(false);
   }, [session.name]);
 
@@ -144,17 +155,24 @@ export function SessionCard({
           <Flex align="center" gap="2" style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}>
             {isRenaming ? (
               <>
-                <TextField.Root
-                  value={nameValue}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setNameValue(e.target.value)
-                  }
-                  onKeyDown={handleKeyDown}
-                  autoFocus
-                  size="2"
-                  style={{ flex: 1 }}
-                  aria-label={getMessage('sessionRenameLabel')}
-                />
+                <Flex direction="column" style={{ flex: 1 }}>
+                  <TextField.Root
+                    value={nameValue}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setNameValue(e.target.value);
+                      setRenameError(null);
+                    }}
+                    onKeyDown={handleKeyDown}
+                    autoFocus
+                    size="2"
+                    aria-label={getMessage('sessionRenameLabel')}
+                  />
+                  {renameError && (
+                    <Text size="1" color="red" style={{ marginTop: 2 }}>
+                      {renameError}
+                    </Text>
+                  )}
+                </Flex>
                 <IconButton
                   size="1"
                   variant="soft"
@@ -180,6 +198,7 @@ export function SessionCard({
                   weight="medium"
                   onDoubleClick={() => {
                     setNameValue(session.name);
+                    setRenameError(null);
                     setIsRenaming(true);
                   }}
                   style={{
@@ -232,6 +251,7 @@ export function SessionCard({
                 <DropdownMenu.Item
                   onClick={() => {
                     setNameValue(session.name);
+                    setRenameError(null);
                     setIsRenaming(true);
                   }}
                 >

--- a/src/components/Core/Session/SessionEditDialog.tsx
+++ b/src/components/Core/Session/SessionEditDialog.tsx
@@ -26,6 +26,7 @@ interface SessionEditDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Called with the updated session when the user clicks Save */
   onSave: (updatedSession: Session) => Promise<void>;
+  existingSessions: Session[];
 }
 
 /**
@@ -37,6 +38,7 @@ export function SessionEditDialog({
   open,
   onOpenChange,
   onSave,
+  existingSessions,
 }: SessionEditDialogProps) {
   if (!session) return null;
 
@@ -48,6 +50,7 @@ export function SessionEditDialog({
       open={open}
       onOpenChange={onOpenChange}
       onSave={onSave}
+      existingSessions={existingSessions}
     />
   );
 }
@@ -57,18 +60,28 @@ interface InnerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (updatedSession: Session) => Promise<void>;
+  existingSessions: Session[];
 }
 
-function SessionEditDialogInner({ session, open, onOpenChange, onSave }: InnerProps) {
+function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingSessions }: InnerProps) {
   const editor = useSessionEditor(session);
   const [showUnsavedAlert, setShowUnsavedAlert] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [categoryId, setCategoryId] = useState<string | null>(session.categoryId ?? null);
+  const [saveNameError, setSaveNameError] = useState<string | null>(null);
 
   const tabCount = countSessionTabs(editor.editedSession);
   const groupCount = editor.editedSession.groups.length;
 
   async function handleSave() {
+    const name = editor.editedSession.name.trim();
+    const isDuplicate = existingSessions.some(
+      s => s.id !== session.id && s.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (isDuplicate) {
+      setSaveNameError(getMessage('errorSessionNameUnique'));
+      return;
+    }
     setIsSaving(true);
     try {
       await onSave({
@@ -159,13 +172,19 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave }: InnerPr
                 <TextField.Root
                   id="session-edit-name"
                   value={editor.editedSession.name}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    editor.updateSessionName(e.target.value)
-                  }
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    editor.updateSessionName(e.target.value);
+                    setSaveNameError(null);
+                  }}
                   size="2"
                   style={{ width: '100%' }}
                   aria-label={getMessage('sessionEditorNameLabel')}
                 />
+                {saveNameError && (
+                  <Text size="1" color="red" style={{ marginTop: 2 }}>
+                    {saveNameError}
+                  </Text>
+                )}
               </Box>
             </Flex>
           </Box>

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -18,9 +18,10 @@ interface SnapshotWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (session: Session) => Promise<void>;
+  existingSessions: Session[];
 }
 
-export function SnapshotWizard({ open, onOpenChange, onSave }: SnapshotWizardProps) {
+export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions }: SnapshotWizardProps) {
   const [sessionName, setSessionName] = useState('');
   const [treeData, setTreeData] = useState<TabTreeData | null>(null);
   const [ungroupedTabs, setUngroupedTabs] = useState<SavedTab[]>([]);
@@ -72,7 +73,15 @@ export function SnapshotWizard({ open, onOpenChange, onSave }: SnapshotWizardPro
   }, [selectedTabIds, numericIdToSavedTabId]);
 
   const handleSave = useCallback(async () => {
-    if (!sessionName.trim()) return;
+    const trimmed = sessionName.trim();
+    if (!trimmed) return;
+    const isDuplicate = existingSessions.some(
+      s => s.name.toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (isDuplicate) {
+      setSaveError(getMessage('errorSessionNameUnique'));
+      return;
+    }
     setIsSaving(true);
     setSaveError(null);
     try {
@@ -80,21 +89,21 @@ export function SnapshotWizard({ open, onOpenChange, onSave }: SnapshotWizardPro
         ungroupedTabs,
         groups,
         selectedSavedTabIds,
-        sessionName.trim(),
+        trimmed,
         { categoryId: categoryId ?? null },
       );
       await onSave(session);
       onOpenChange(false);
       showSuccessNotification(
         getMessage('snapshotNotificationTitle'),
-        getMessage('sessionNotificationMessage', [sessionName.trim()]),
+        getMessage('sessionNotificationMessage', [trimmed]),
       );
     } catch {
       setSaveError(getMessage('sessionSaveError'));
     } finally {
       setIsSaving(false);
     }
-  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, onSave]);
+  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, onSave, existingSessions]);
 
   return (
     <SessionsTheme>

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -247,6 +247,7 @@ export function SessionsPage({
                   <SessionCard
                     key={session.id}
                     session={session}
+                    existingSessions={sessions}
                     onRestore={s => setRestoreSession(s)}
                     onRestoreCurrentWindow={handleRestoreCurrentWindow}
                     onRestoreNewWindow={handleRestoreNewWindow}
@@ -271,6 +272,7 @@ export function SessionsPage({
               if (!open) onSnapshotWizardOpenChange?.(false);
             }}
             onSave={handleSaveSession}
+            existingSessions={sessions}
           />
 
           <SessionEditDialog
@@ -280,6 +282,7 @@ export function SessionsPage({
               if (!isOpen) setEditTarget(null);
             }}
             onSave={handleSaveEditedSession}
+            existingSessions={sessions}
           />
 
           <RestoreWizard

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { idSchema } from './common.js';
+import { getMessage } from '../utils/i18n';
 
 const chromeGroupColorSchema = z.enum([
   'grey', 'blue', 'red', 'yellow', 'green',
@@ -32,3 +33,18 @@ export const sessionSchema = z.object({
 });
 
 export const sessionsArraySchema = z.array(sessionSchema);
+
+export type SessionForUniqueness = { id: string; name: string };
+
+// Schéma avec validation d'unicité du nom pour une session individuelle
+export const createSessionSchemaWithUniqueness = (existingSessions: SessionForUniqueness[], editingSessionId?: string) => {
+  return sessionSchema.refine((data) => {
+    const existingNames = existingSessions
+      .filter(s => editingSessionId ? s.id !== editingSessionId : true)
+      .map(s => s.name.toLowerCase());
+    return !existingNames.includes(data.name.toLowerCase());
+  }, () => ({
+    message: getMessage('errorSessionNameUnique'),
+    path: ['name'],
+  }));
+};

--- a/tests/schemas/session.test.ts
+++ b/tests/schemas/session.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSessionSchemaWithUniqueness } from '../../src/schemas/session';
+
+vi.mock('../../src/utils/i18n.js', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+const makeSession = (id: string, name: string) => ({
+  id,
+  name,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  groups: [],
+  ungroupedTabs: [],
+  isPinned: false,
+  categoryId: null,
+});
+
+const validSession = makeSession('new-id', 'My Session');
+
+describe('createSessionSchemaWithUniqueness', () => {
+  it('accepte un nom unique (liste vide)', () => {
+    const schema = createSessionSchemaWithUniqueness([]);
+    const result = schema.safeParse(validSession);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte un nom unique parmi des sessions existantes', () => {
+    const existing = [makeSession('a', 'Work'), makeSession('b', 'Personal')];
+    const schema = createSessionSchemaWithUniqueness(existing);
+    const result = schema.safeParse(makeSession('c', 'Unique Name'));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejette un nom identique à une session existante (exact)', () => {
+    const existing = [makeSession('a', 'Work')];
+    const schema = createSessionSchemaWithUniqueness(existing);
+    const result = schema.safeParse(makeSession('new-id', 'Work'));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const nameError = result.error.issues.find(i => i.path.includes('name'));
+      expect(nameError).toBeDefined();
+      expect(nameError?.message).toBe('errorSessionNameUnique');
+    }
+  });
+
+  it('rejette un nom identique en casse différente (case-insensitive)', () => {
+    const existing = [makeSession('a', 'Work')];
+    const schema = createSessionSchemaWithUniqueness(existing);
+    const resultLower = schema.safeParse(makeSession('new-id', 'work'));
+    expect(resultLower.success).toBe(false);
+
+    const resultUpper = schema.safeParse(makeSession('new-id', 'WORK'));
+    expect(resultUpper.success).toBe(false);
+  });
+
+  it('accepte le même nom lors de l\'édition de la même session (editingSessionId)', () => {
+    const existing = [makeSession('a', 'Work')];
+    const schema = createSessionSchemaWithUniqueness(existing, 'a');
+    const result = schema.safeParse(makeSession('a', 'Work'));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte le même nom en casse différente lors de l\'édition de la même session', () => {
+    const existing = [makeSession('a', 'Work')];
+    const schema = createSessionSchemaWithUniqueness(existing, 'a');
+    const result = schema.safeParse(makeSession('a', 'work'));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejette le nom d\'une autre session lors de l\'édition', () => {
+    const existing = [makeSession('a', 'Work'), makeSession('b', 'Personal')];
+    const schema = createSessionSchemaWithUniqueness(existing, 'a');
+    const result = schema.safeParse(makeSession('a', 'Personal'));
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Prevents creating or renaming sessions to a name already taken (case-insensitive), mirroring the domain rules uniqueness pattern.

- Add createSessionSchemaWithUniqueness() factory to session schema
- Add errorSessionNameUnique i18n key to EN/FR/ES locales
- Validate uniqueness in SnapshotWizard (show Callout error)
- Validate uniqueness in SessionCard inline rename (show inline error)
- Validate uniqueness in SessionEditDialog on save (show inline error)
- Pass existingSessions prop from SessionsPage to all three components
- Add unit tests in tests/schemas/session.test.ts (7 test cases)

https://claude.ai/code/session_01QQrcwiVrMVVXocAD6jGjw2