### PR TITLE
feat(popup): disable Save button when no capturable tabs

### DIFF
--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -4,6 +4,7 @@ import { Camera, RotateCcw, Wand2 } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import { getMessage } from '../../../utils/i18n';
 import { loadSessions } from '../../../utils/sessionStorage';
+import { hasCapturableTabs } from '../../../utils/tabCapture';
 
 /** Focus an existing Options tab or open a new one with the given hash. */
 async function openOptionsWithHash(hash: string) {
@@ -23,10 +24,12 @@ async function openOptionsWithHash(hash: string) {
 
 export function PopupToolbar() {
   const [hasSessions, setHasSessions] = useState(false);
+  const [canSave, setCanSave] = useState(false);
   const [isOrganizing, setIsOrganizing] = useState(false);
 
   useEffect(() => {
     loadSessions().then((sessions) => setHasSessions(sessions.length > 0));
+    hasCapturableTabs().then(setCanSave);
   }, []);
 
   const handleOrganize = async () => {
@@ -46,6 +49,7 @@ export function PopupToolbar() {
       <Flex gap="1">
         <Button
           variant="ghost"
+          disabled={!canSave}
           onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
           aria-label={getMessage('popupSaveSession')}
           style={{

--- a/src/utils/tabCapture.ts
+++ b/src/utils/tabCapture.ts
@@ -32,6 +32,15 @@ interface CaptureResult {
 }
 
 /**
+ * Returns true if the current window contains at least one capturable tab
+ * (i.e. a tab whose URL is not a system URL).
+ */
+export async function hasCapturableTabs(): Promise<boolean> {
+  const tabs = await browser.tabs.query({ currentWindow: true });
+  return tabs.some(tab => !isSystemUrl(tab.url));
+}
+
+/**
  * Capture the current window's tabs and groups.
  * Returns both TabTreeData (for display) and Session-ready data (for saving).
  */


### PR DESCRIPTION
Adds hasCapturableTabs() to tabCapture.ts (reusing the existing isSystemUrl filter) and consumes it in PopupToolbar to disable the camera button when all open tabs are system URLs (chrome://, about:, edge://, etc.).

https://claude.ai/code/session_01HHyk8W8Ms6sqdyKWEHoCgK