### PR TITLE
feat(popup): split save button for active tab group (US-PO006/007)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -378,6 +378,9 @@
   "popupSave": { "message": "Save" },
   "popupRestore": { "message": "Restore" },
   "popupSaveSession": { "message": "Save session" },
+  "popupSaveActiveGroup": { "message": "Save active tab group" },
+  "popupSaveAllTabs": { "message": "Save all tabs" },
+  "popupSaveGroupOptions": { "message": "More save options" },
   "popupRestoreSession": { "message": "Restore session" },
   "popupPinnedSessionsLabel": { "message": "Pinned sessions" },
 

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -379,6 +379,9 @@
   "popupSave": { "message": "Guardar" },
   "popupRestore": { "message": "Restaurar" },
   "popupSaveSession": { "message": "Guardar sesión" },
+  "popupSaveActiveGroup": { "message": "Guardar grupo activo" },
+  "popupSaveAllTabs": { "message": "Guardar todas las pestañas" },
+  "popupSaveGroupOptions": { "message": "Más opciones de guardado" },
   "popupRestoreSession": { "message": "Restaurar sesión" },
   "popupPinnedSessionsLabel": { "message": "Sesiones fijadas" },
 

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -379,6 +379,9 @@
   "popupSave": { "message": "Sauvegarder" },
   "popupRestore": { "message": "Restaurer" },
   "popupSaveSession": { "message": "Sauvegarder la session" },
+  "popupSaveActiveGroup": { "message": "Sauvegarder le groupe actif" },
+  "popupSaveAllTabs": { "message": "Sauvegarder tous les onglets" },
+  "popupSaveGroupOptions": { "message": "Plus d'options de sauvegarde" },
   "popupRestoreSession": { "message": "Restaurer une session" },
   "popupPinnedSessionsLabel": { "message": "Sessions épinglées" },
 

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, Flex, Text } from '@radix-ui/themes';
-import { Camera, RotateCcw, Wand2 } from 'lucide-react';
+import { Box, Button, DropdownMenu, Flex, Text } from '@radix-ui/themes';
+import { Camera, ChevronDown, RotateCcw, Wand2 } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import { getMessage } from '../../../utils/i18n';
 import { loadSessions } from '../../../utils/sessionStorage';
@@ -26,10 +26,15 @@ export function PopupToolbar() {
   const [hasSessions, setHasSessions] = useState(false);
   const [canSave, setCanSave] = useState(false);
   const [isOrganizing, setIsOrganizing] = useState(false);
+  const [activeTabGroupId, setActiveTabGroupId] = useState<number | null>(null);
 
   useEffect(() => {
     loadSessions().then((sessions) => setHasSessions(sessions.length > 0));
     hasCapturableTabs().then(setCanSave);
+    browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+      const groupId = (tabs[0] as any)?.groupId;
+      setActiveTabGroupId(typeof groupId === 'number' && groupId >= 0 ? groupId : null);
+    });
   }, []);
 
   const handleOrganize = async () => {
@@ -47,25 +52,88 @@ export function PopupToolbar() {
       }}
     >
       <Flex gap="1">
-        <Button
-          variant="ghost"
-          disabled={!canSave}
-          onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
-          aria-label={getMessage('popupSaveSession')}
-          style={{
-            flex: 1,
-            flexDirection: 'column',
-            height: 'auto',
-            gap: 3,
-            paddingTop: 8,
-            paddingBottom: 8,
-          }}
-        >
-          <Camera size={17} aria-hidden="true" />
-          <Text as="span" size="1">
-            {getMessage('popupSave')}
-          </Text>
-        </Button>
+        {activeTabGroupId !== null && canSave ? (
+          <Flex style={{ flex: 1 }}>
+            <Button
+              variant="ghost"
+              onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
+              aria-label={getMessage('popupSaveSession')}
+              style={{
+                flex: 1,
+                flexDirection: 'column',
+                height: 'auto',
+                gap: 3,
+                paddingTop: 8,
+                paddingBottom: 8,
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+              }}
+            >
+              <Camera size={17} aria-hidden="true" />
+              <Text as="span" size="1">
+                {getMessage('popupSave')}
+              </Text>
+            </Button>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger>
+                <Button
+                  variant="ghost"
+                  aria-label={getMessage('popupSaveGroupOptions')}
+                  title={getMessage('popupSaveGroupOptions')}
+                  style={{
+                    borderTopLeftRadius: 0,
+                    borderBottomLeftRadius: 0,
+                    borderLeft: '1px solid var(--gray-a6)',
+                    paddingLeft: 4,
+                    paddingRight: 4,
+                    minWidth: 20,
+                    height: 'auto',
+                    paddingTop: 8,
+                    paddingBottom: 8,
+                  }}
+                >
+                  <ChevronDown size={12} aria-hidden="true" />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item
+                  onClick={() =>
+                    void openOptionsWithHash(
+                      `#sessions?action=snapshot&groupId=${activeTabGroupId}`,
+                    )
+                  }
+                >
+                  {getMessage('popupSaveActiveGroup')}
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
+                >
+                  {getMessage('popupSaveAllTabs')}
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          </Flex>
+        ) : (
+          <Button
+            variant="ghost"
+            disabled={!canSave}
+            onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
+            aria-label={getMessage('popupSaveSession')}
+            style={{
+              flex: 1,
+              flexDirection: 'column',
+              height: 'auto',
+              gap: 3,
+              paddingTop: 8,
+              paddingBottom: 8,
+            }}
+          >
+            <Camera size={17} aria-hidden="true" />
+            <Text as="span" size="1">
+              {getMessage('popupSave')}
+            </Text>
+          </Button>
+        )}
 
         <Button
           variant="ghost"

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -19,9 +19,11 @@ interface SnapshotWizardProps {
   onOpenChange: (open: boolean) => void;
   onSave: (session: Session) => Promise<void>;
   existingSessions: Session[];
+  /** Chrome numeric groupId: if set, pre-select only that group's tabs and use the group title as default name. */
+  initialGroupId?: number;
 }
 
-export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions }: SnapshotWizardProps) {
+export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, initialGroupId }: SnapshotWizardProps) {
   const [sessionName, setSessionName] = useState('');
   const [treeData, setTreeData] = useState<TabTreeData | null>(null);
   const [ungroupedTabs, setUngroupedTabs] = useState<SavedTab[]>([]);
@@ -53,7 +55,26 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions }:
         setUngroupedTabs(data.ungroupedTabs);
         setGroups(data.groups);
         setNumericIdToSavedTabId(data.numericIdToSavedTabId);
-        // Pre-select all tabs
+
+        if (initialGroupId !== undefined) {
+          const savedGroupId = data.chromeGroupIdToSavedGroupId.get(initialGroupId);
+          const targetGroup = data.groups.find(g => g.id === savedGroupId);
+          if (targetGroup) {
+            const groupTabUuids = new Set(targetGroup.tabs.map(t => t.id));
+            const preSelected = new Set<number>();
+            for (const [numId, uuid] of data.numericIdToSavedTabId) {
+              if (groupTabUuids.has(uuid)) preSelected.add(numId);
+            }
+            setSelectedTabIds(preSelected);
+            if (targetGroup.title) {
+              setSessionName(targetGroup.title);
+            }
+            setIsCapturing(false);
+            return;
+          }
+        }
+
+        // Default: pre-select all tabs
         setSelectedTabIds(new Set(data.numericIdToSavedTabId.keys()));
         setIsCapturing(false);
       })

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -24,12 +24,18 @@ interface SessionsPageProps {
   snapshotWizardOpen?: boolean;
   /** Called by SessionsPage to let options.tsx know the wizard closed (or page unmounted). */
   onSnapshotWizardOpenChange?: (open: boolean) => void;
+  /** Chrome numeric groupId to pre-select in the snapshot wizard (null = all tabs). */
+  snapshotGroupId?: number | null;
+  /** Called when the snapshot wizard closes to reset the group context. */
+  onSnapshotGroupIdChange?: (id: number | null) => void;
 }
 
 export function SessionsPage({
   syncSettings,
   snapshotWizardOpen = false,
   onSnapshotWizardOpenChange,
+  snapshotGroupId,
+  onSnapshotGroupIdChange,
 }: SessionsPageProps) {
   const { sessions, isLoaded, createSession, renameSession, removeSession, reload } = useSessions();
   // Internal open state; initialized from external prop so the wizard opens immediately on mount.
@@ -269,10 +275,14 @@ export function SessionsPage({
             open={snapshotOpen}
             onOpenChange={(open) => {
               setSnapshotOpen(open);
-              if (!open) onSnapshotWizardOpenChange?.(false);
+              if (!open) {
+                onSnapshotWizardOpenChange?.(false);
+                onSnapshotGroupIdChange?.(null);
+              }
             }}
             onSave={handleSaveSession}
             existingSessions={sessions}
+            initialGroupId={snapshotGroupId ?? undefined}
           />
 
           <SessionEditDialog

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -51,6 +51,7 @@ function OptionsContent() {
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
     const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
     const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
+    const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
 
     // Deep linking: navigate to the right section on mount and on hash changes
     // (hashchange fires when an existing tab's URL hash is updated externally)
@@ -68,6 +69,8 @@ function OptionsContent() {
                 const params = new URLSearchParams(hash.slice(questionMark + 1));
                 if (params.get('action') === 'snapshot') {
                     setOpenSnapshotWizard(true);
+                    const groupIdParam = params.get('groupId');
+                    setSnapshotGroupId(groupIdParam ? parseInt(groupIdParam, 10) : null);
                 }
             }
         }
@@ -300,6 +303,8 @@ function OptionsContent() {
                             syncSettings={settings}
                             snapshotWizardOpen={openSnapshotWizard}
                             onSnapshotWizardOpenChange={setOpenSnapshotWizard}
+                            snapshotGroupId={snapshotGroupId}
+                            onSnapshotGroupIdChange={setSnapshotGroupId}
                         />
                     )}
                     {currentTab === 'stats' && (

--- a/src/utils/tabCapture.ts
+++ b/src/utils/tabCapture.ts
@@ -29,6 +29,8 @@ interface CaptureResult {
   groups: SavedTabGroup[];
   /** Map from numeric TabTree ID to SavedTab UUID */
   numericIdToSavedTabId: Map<number, string>;
+  /** Map from Chrome's numeric groupId to SavedTabGroup UUID */
+  chromeGroupIdToSavedGroupId: Map<number, string>;
 }
 
 /**
@@ -126,10 +128,12 @@ export async function captureCurrentTabs(): Promise<CaptureResult> {
   // Filter out groups with no tabs (all were system URLs)
   const savedGroups: SavedTabGroup[] = [];
   const treeGroups: TabGroupItem[] = [];
-  for (const entry of groupMap.values()) {
+  const chromeGroupIdToSavedGroupId = new Map<number, string>();
+  for (const [chromeId, entry] of groupMap) {
     if (entry.savedGroup.tabs.length > 0) {
       savedGroups.push(entry.savedGroup);
       treeGroups.push(entry.treeGroup);
+      chromeGroupIdToSavedGroupId.set(chromeId, entry.savedGroup.id);
     }
   }
 
@@ -138,5 +142,6 @@ export async function captureCurrentTabs(): Promise<CaptureResult> {
     ungroupedTabs: ungroupedSavedTabs,
     groups: savedGroups,
     numericIdToSavedTabId,
+    chromeGroupIdToSavedGroupId,
   };
 }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -107,10 +107,15 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       const candidates = [
         // CI / manually pre-installed custom build
         path.join(os.homedir(), '.cache/ms-playwright/chromium-custom/chrome-linux64/chrome'),
+        // /opt/pw-browsers layout (alternative CI install path)
+        '/opt/pw-browsers/chromium-custom/chrome-linux64/chrome',
+        '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
         // Playwright 1.58 expected version
         path.join(os.homedir(), '.cache/ms-playwright/chromium-1208/chrome-linux64/chrome'),
+        '/opt/pw-browsers/chromium-1208/chrome-linux64/chrome',
         // Playwright 1.57 expected version
         path.join(os.homedir(), '.cache/ms-playwright/chromium-1200/chrome-linux64/chrome'),
+        '/opt/pw-browsers/chromium-1200/chrome-linux64/chrome',
         // Older Playwright version that may already be present
         path.join(os.homedir(), '.cache/ms-playwright/chromium-1194/chrome-linux/chrome'),
       ];

--- a/tests/e2e/popup-save-group.spec.ts
+++ b/tests/e2e/popup-save-group.spec.ts
@@ -17,6 +17,9 @@ test.beforeEach(async ({ extensionContext }) => {
   await clearHelpPrefs(extensionContext);
 });
 
+// A non-system URL that captures correctly (about: is filtered by isSystemUrl)
+const CAPTURABLE_URL = 'https://example.com';
+
 // ---------------------------------------------------------------------------
 // Helper: create a tab group in the browser via service worker
 // ---------------------------------------------------------------------------
@@ -27,15 +30,15 @@ async function createTabGroupWithTitle(
 ): Promise<{ groupId: number; tabId: number }> {
   const sw = extensionContext.serviceWorkers()[0];
 
-  // Create a tab and group it
+  // Use a real (non-system) URL so captureCurrentTabs() includes it
   const result = await sw.evaluate(
-    async ({ title, color }: { title: string; color: string }) => {
-      const tab = await chrome.tabs.create({ url: 'about:blank', active: false });
+    async ({ url, title, color }: { url: string; title: string; color: string }) => {
+      const tab = await chrome.tabs.create({ url, active: false });
       const groupId = await chrome.tabs.group({ tabIds: [tab.id!] });
       await (chrome as any).tabGroups.update(groupId, { title, color });
       return { groupId, tabId: tab.id! };
     },
-    { title, color },
+    { url: CAPTURABLE_URL, title, color },
   );
   return result;
 }
@@ -69,12 +72,22 @@ test.describe('[US-PO006] Popup save button', () => {
     extensionContext,
     extensionId,
   }) => {
+    // Create a capturable (non-system) tab so canSave becomes true
+    const sw = extensionContext.serviceWorkers()[0];
+    const tabId = await sw.evaluate(async (url: string) => {
+      const tab = await chrome.tabs.create({ url, active: false });
+      return tab.id!;
+    }, CAPTURABLE_URL);
+
     const page = await extensionContext.newPage();
     await goToPopup(page, extensionId);
 
+    const saveBtn = page.getByRole('button', { name: /save session/i });
+    await expect(saveBtn).toBeEnabled({ timeout: 5000 });
+
     const [newPage] = await Promise.all([
       extensionContext.waitForEvent('page'),
-      page.getByRole('button', { name: /save session/i }).click(),
+      saveBtn.click(),
     ]);
     await newPage.waitForLoadState('domcontentloaded');
     expect(newPage.url()).toContain('options.html');
@@ -83,6 +96,7 @@ test.describe('[US-PO006] Popup save button', () => {
 
     await page.close();
     await newPage.close();
+    await sw.evaluate(async (id: number) => chrome.tabs.remove(id), tabId);
   });
 });
 

--- a/tests/e2e/popup-save-group.spec.ts
+++ b/tests/e2e/popup-save-group.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E tests for the "Save active tab group" SplitButton feature.
+ * Covers: US-PO006 (SplitButton rendering) and US-PO007 (group snapshot deep link).
+ *
+ * Note: The popup SplitButton rendering depends on the active tab being in a Chrome
+ * tab group at the moment the popup opens. In Playwright, opening popup.html as a
+ * new tab makes itself the active tab (not in any group), so we test that case directly.
+ * The group pre-selection flow is tested via the options page deep link.
+ */
+import { test, expect } from './fixtures';
+import { goToPopup } from './helpers/navigation';
+import { clearSessions, clearHelpPrefs } from './helpers/seed';
+import type { BrowserContext } from '@playwright/test';
+
+test.beforeEach(async ({ extensionContext }) => {
+  await clearSessions(extensionContext);
+  await clearHelpPrefs(extensionContext);
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a tab group in the browser via service worker
+// ---------------------------------------------------------------------------
+async function createTabGroupWithTitle(
+  extensionContext: BrowserContext,
+  title: string,
+  color: string = 'blue',
+): Promise<{ groupId: number; tabId: number }> {
+  const sw = extensionContext.serviceWorkers()[0];
+
+  // Create a tab and group it
+  const result = await sw.evaluate(
+    async ({ title, color }: { title: string; color: string }) => {
+      const tab = await chrome.tabs.create({ url: 'about:blank', active: false });
+      const groupId = await chrome.tabs.group({ tabIds: [tab.id!] });
+      await (chrome as any).tabGroups.update(groupId, { title, color });
+      return { groupId, tabId: tab.id! };
+    },
+    { title, color },
+  );
+  return result;
+}
+
+async function closeTab(extensionContext: BrowserContext, tabId: number): Promise<void> {
+  const sw = extensionContext.serviceWorkers()[0];
+  await sw.evaluate(async (id: number) => {
+    await chrome.tabs.remove(id);
+  }, tabId);
+}
+
+// ---------------------------------------------------------------------------
+// US-PO006 — Popup save button: plain button when active tab is not in a group
+// ---------------------------------------------------------------------------
+test.describe('[US-PO006] Popup save button', () => {
+  test('shows plain save button when active tab is not in a group', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    // The popup page itself is the active tab (not in any group) → plain button
+    await expect(page.getByRole('button', { name: /save session/i })).toBeVisible();
+    // The dropdown trigger (chevron for group options) should NOT be present
+    await expect(page.getByRole('button', { name: /more save options/i })).not.toBeVisible();
+    await page.close();
+  });
+
+  test('plain save button click navigates to snapshot wizard', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    const [newPage] = await Promise.all([
+      extensionContext.waitForEvent('page'),
+      page.getByRole('button', { name: /save session/i }).click(),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    expect(newPage.url()).toContain('options.html');
+    expect(newPage.url()).toContain('action=snapshot');
+    expect(newPage.url()).not.toContain('groupId');
+
+    await page.close();
+    await newPage.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// US-PO007 — Deep link: snapshot wizard pre-selects group tabs
+// ---------------------------------------------------------------------------
+test.describe('[US-PO007] Save active tab group via deep link', () => {
+  test('#sessions?action=snapshot&groupId opens wizard with group name as default session name', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const { groupId, tabId } = await createTabGroupWithTitle(extensionContext, 'Work Tabs', 'blue');
+
+    try {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#sessions?action=snapshot&groupId=${groupId}`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+
+      // Wait for the wizard dialog to open
+      await page.getByRole('dialog').waitFor({ state: 'visible', timeout: 10_000 });
+      await expect(page.getByText('Save Session Snapshot')).toBeVisible();
+
+      // Default session name should be the group title
+      const nameInput = page.getByRole('textbox', { name: /session name/i });
+      await expect(nameInput).toHaveValue('Work Tabs');
+
+      await page.close();
+    } finally {
+      await closeTab(extensionContext, tabId);
+    }
+  });
+
+  test('#sessions?action=snapshot&groupId with untitled group uses default Snapshot name', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const { groupId, tabId } = await createTabGroupWithTitle(extensionContext, '', 'red');
+
+    try {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#sessions?action=snapshot&groupId=${groupId}`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.getByRole('dialog').waitFor({ state: 'visible', timeout: 10_000 });
+
+      // Empty group title → fallback to "Snapshot <date>"
+      const nameInput = page.getByRole('textbox', { name: /session name/i });
+      const value = await nameInput.inputValue();
+      expect(value).toMatch(/^Snapshot /);
+
+      await page.close();
+    } finally {
+      await closeTab(extensionContext, tabId);
+    }
+  });
+
+  test('#sessions?action=snapshot with unknown groupId falls back to all tabs selected', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    // Use a groupId that certainly doesn't exist (very large number)
+    await page.goto(
+      `chrome-extension://${extensionId}/options.html#sessions?action=snapshot&groupId=999999`,
+    );
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('dialog').waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Should fallback to default snapshot name (not a group name)
+    const nameInput = page.getByRole('textbox', { name: /session name/i });
+    const value = await nameInput.inputValue();
+    expect(value).toMatch(/^Snapshot /);
+
+    await page.close();
+  });
+
+  test('#sessions?action=snapshot without groupId shows all tabs (original behavior)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await page.goto(
+      `chrome-extension://${extensionId}/options.html#sessions?action=snapshot`,
+    );
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('dialog').waitFor({ state: 'visible', timeout: 10_000 });
+    await expect(page.getByText('Save Session Snapshot')).toBeVisible();
+
+    // Default name should be "Snapshot <date>"
+    const nameInput = page.getByRole('textbox', { name: /session name/i });
+    const value = await nameInput.inputValue();
+    expect(value).toMatch(/^Snapshot /);
+
+    await page.close();
+  });
+});

--- a/tests/tabCapture.test.ts
+++ b/tests/tabCapture.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { captureCurrentTabs, hasCapturableTabs } from '../src/utils/tabCapture';
+
+// Mock wxt/browser
+vi.mock('wxt/browser', () => {
+  const mockTabsQuery = vi.fn();
+  const mockTabGroupsGet = vi.fn();
+  return {
+    browser: {
+      tabs: { query: mockTabsQuery },
+      tabGroups: { get: mockTabGroupsGet },
+    },
+  };
+});
+
+import { browser } from 'wxt/browser';
+
+const mockTabsQuery = browser.tabs.query as ReturnType<typeof vi.fn>;
+const mockTabGroupsGet = (browser.tabGroups as any).get as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('hasCapturableTabs', () => {
+  it('returns true when at least one non-system tab exists', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, url: 'https://example.com', title: 'Example' },
+    ]);
+    expect(await hasCapturableTabs()).toBe(true);
+  });
+
+  it('returns false when all tabs are system URLs', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, url: 'chrome://newtab/', title: 'New Tab' },
+      { id: 2, url: 'about:blank', title: 'Blank' },
+    ]);
+    expect(await hasCapturableTabs()).toBe(false);
+  });
+
+  it('returns false when there are no tabs', async () => {
+    mockTabsQuery.mockResolvedValue([]);
+    expect(await hasCapturableTabs()).toBe(false);
+  });
+});
+
+describe('captureCurrentTabs', () => {
+  it('returns chromeGroupIdToSavedGroupId with correct mapping', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+      { id: 11, index: 1, url: 'https://b.com', title: 'B', groupId: 5 },
+      { id: 12, index: 2, url: 'https://c.com', title: 'C', groupId: -1 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'blue' });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.chromeGroupIdToSavedGroupId.size).toBe(1);
+    expect(result.chromeGroupIdToSavedGroupId.has(5)).toBe(true);
+    // The saved group UUID corresponds to an entry in groups
+    const savedGroupId = result.chromeGroupIdToSavedGroupId.get(5);
+    expect(result.groups.some(g => g.id === savedGroupId)).toBe(true);
+  });
+
+  it('does not include groupId -1 in chromeGroupIdToSavedGroupId', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: -1 },
+    ]);
+
+    const result = await captureCurrentTabs();
+
+    expect(result.chromeGroupIdToSavedGroupId.size).toBe(0);
+    expect(result.ungroupedTabs).toHaveLength(1);
+  });
+
+  it('excludes groups whose tabs are all system URLs from chromeGroupIdToSavedGroupId', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'chrome://settings/', title: 'Settings', groupId: 7 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'System', color: 'grey' });
+
+    const result = await captureCurrentTabs();
+
+    // Group 7 has no capturable tabs, so it should not appear in the map
+    expect(result.chromeGroupIdToSavedGroupId.has(7)).toBe(false);
+    expect(result.groups).toHaveLength(0);
+  });
+
+  it('maps multiple groups independently', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 3 },
+      { id: 11, index: 1, url: 'https://b.com', title: 'B', groupId: 4 },
+    ]);
+    mockTabGroupsGet
+      .mockResolvedValueOnce({ title: 'Group A', color: 'red' })
+      .mockResolvedValueOnce({ title: 'Group B', color: 'green' });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.chromeGroupIdToSavedGroupId.size).toBe(2);
+    expect(result.chromeGroupIdToSavedGroupId.has(3)).toBe(true);
+    expect(result.chromeGroupIdToSavedGroupId.has(4)).toBe(true);
+
+    const idA = result.chromeGroupIdToSavedGroupId.get(3);
+    const idB = result.chromeGroupIdToSavedGroupId.get(4);
+    expect(idA).not.toBe(idB);
+
+    const groupA = result.groups.find(g => g.id === idA);
+    const groupB = result.groups.find(g => g.id === idB);
+    expect(groupA?.title).toBe('Group A');
+    expect(groupB?.title).toBe('Group B');
+  });
+
+  it('returns numericIdToSavedTabId only for non-system tabs', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://example.com', title: 'Example', groupId: -1 },
+      { id: 11, index: 1, url: 'chrome://newtab/', title: 'New Tab', groupId: -1 },
+    ]);
+
+    const result = await captureCurrentTabs();
+
+    expect(result.numericIdToSavedTabId.size).toBe(1);
+    expect(result.ungroupedTabs).toHaveLength(1);
+  });
+});

--- a/user-stories/US-PO-save-group.md
+++ b/user-stories/US-PO-save-group.md
@@ -1,0 +1,49 @@
+# User Stories — Domaine PO : Sauvegarde d'un groupe d'onglets actif
+
+> Comportements couverts par `tests/e2e/popup.spec.ts` et `tests/tabCapture.test.ts`.
+> Les US numérotées ci-dessous reprennent la continuité à partir de US-PO006.
+
+---
+
+## US-PO006 — Transformation du bouton Save en SplitButton quand l'onglet actif est dans un groupe
+
+**En tant qu'** utilisateur dont l'onglet actif appartient à un groupe Chrome,
+**je veux** que le bouton « Save » du popup se transforme en SplitButton (bouton principal + flèche déroulante),
+**afin de** pouvoir choisir entre sauvegarder tous les onglets ou uniquement le groupe actif.
+
+### Critères d'acceptation
+
+- [ ] Quand l'onglet actif **n'appartient pas** à un groupe Chrome, le bouton Save s'affiche comme un bouton simple (icône appareil photo + texte « Save »), comportement inchangé.
+- [ ] Quand l'onglet actif **appartient à un groupe** Chrome, le bouton Save se transforme en SplitButton : la partie principale (icône + texte) reste identique visuellement, et une petite flèche (chevron) est ajoutée à sa droite.
+- [ ] Cliquer sur la **partie principale** du SplitButton (icône + texte) déclenche le comportement actuel : ouverture du SnapshotWizard avec tous les onglets pré-cochés.
+- [ ] Cliquer sur la **flèche** du SplitButton ouvre un menu déroulant avec deux options :
+  - « Save active tab group »
+  - « Save all tabs »
+- [ ] L'option « Save all tabs » du menu déclenche le même comportement que le clic sur la partie principale.
+- [ ] Quand le bouton est désactivé (`canSave = false`), ni la partie principale ni la flèche ne sont actives.
+
+---
+
+## US-PO007 — Sauvegarde du groupe d'onglets actif
+
+**En tant qu'** utilisateur dont l'onglet actif appartient à un groupe Chrome,
+**je veux** pouvoir sauvegarder uniquement ce groupe d'onglets via l'option « Save active tab group »,
+**afin de** créer rapidement une session dédiée au groupe sans avoir à désélectionner manuellement les autres onglets.
+
+### Critères d'acceptation
+
+- [ ] Sélectionner « Save active tab group » dans le menu ouvre le SnapshotWizard (dialogue « Save Session Snapshot »).
+- [ ] Le SnapshotWizard s'ouvre avec **uniquement les onglets du groupe actif pré-cochés** ; les autres onglets (hors groupe ou d'autres groupes) ne sont pas cochés.
+- [ ] La pré-sélection est **modifiable** : l'utilisateur peut cocher/décocher librement des onglets.
+- [ ] Le **nom de session par défaut** est le titre du groupe Chrome (ex : « Travail »).
+- [ ] Si le groupe **n'a pas de titre** (groupe sans nom), le nom par défaut est « Snapshot \<date\> » (comportement habituel).
+- [ ] Le deep link `options.html#sessions?action=snapshot&groupId=<id>` ouvre le SnapshotWizard avec la pré-sélection et le nom du groupe correspondant.
+- [ ] Si le `groupId` passé en paramètre ne correspond à aucun groupe capturé (groupe entre-temps supprimé), le SnapshotWizard s'ouvre avec tous les onglets pré-cochés (fallback habituel).
+
+### Règles métier
+
+| Situation | Nom de session par défaut | Onglets pré-cochés |
+|---|---|---|
+| Groupe avec titre | Titre du groupe | Onglets du groupe uniquement |
+| Groupe sans titre | « Snapshot \<date\> » | Onglets du groupe uniquement |
+| `groupId` inconnu au moment de la capture | « Snapshot \<date\> » | Tous les onglets |


### PR DESCRIPTION
When the active tab belongs to a Chrome tab group, the Save button in the popup becomes a SplitButton: the primary click still saves all tabs, while the dropdown arrow exposes two options:
  - "Save active tab group": opens SnapshotWizard with only the group's tabs pre-selected and the group title as default session name
  - "Save all tabs": same as the primary click

Implementation:
- tabCapture: extend CaptureResult with chromeGroupIdToSavedGroupId map
- PopupToolbar: detect active tab group on mount, render SplitButton conditionally using inline DropdownMenu
- options.tsx: parse groupId from #sessions?action=snapshot&groupId=<n>
- SessionsPage: thread snapshotGroupId prop through to SnapshotWizard
- SnapshotWizard: accept initialGroupId, pre-select group tabs and use group title as default name when provided
- i18n: add popupSaveActiveGroup / popupSaveAllTabs / popupSaveGroupOptions in EN, FR, ES
- tests: unit tests for tabCapture, E2E tests for deep-link group flow
- user-stories: US-PO006 and US-PO007

https://claude.ai/code/session_014iff2Bc5SMzWp6vm6fkt6n