### PR TITLE
refactor: découpler les 4 composants React critiques

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Callout, Dialog, Flex, Grid, HoverCard, ScrollArea, SegmentedControl, Select, Text, TextField, Box } from '@radix-ui/themes';
+import { Button, Callout, Dialog, Flex, Grid, ScrollArea, Select, Text, TextField, Box } from '@radix-ui/themes';
 import { Info, X } from 'lucide-react';
 import { useState, useCallback, useEffect } from 'react';
 import { getMessage } from '../../../utils/i18n';
@@ -7,8 +7,9 @@ import { RegexPresetsCallouts } from '../../Form/themed-callouts';
 import { FormField, SearchableSelect } from '../../Form/FormFields';
 import { groupNameSourceOptions, type GroupNameSourceValue } from '../../../schemas/enums';
 import type { PresetCategory } from '../../../utils/presetUtils';
-import { getPresetById } from '../../../utils/presetUtils';
+import { getPresetById, presetsToSearchableGroups } from '../../../utils/presetUtils';
 import { logger } from '../../../utils/logger';
+import { ConfigModeSelector } from './ConfigModeSelector';
 
 export interface ConfigEditValues {
   configMode: 'preset' | 'ask' | 'manual';
@@ -25,13 +26,6 @@ interface ConfigEditModalProps {
   initial: ConfigEditValues;
   presetCategories: PresetCategory[];
   isLoadingPresets: boolean;
-}
-
-function presetsToSearchableGroups(categories: PresetCategory[]) {
-  return categories.map((cat) => ({
-    label: cat.name,
-    options: cat.presets.map((p) => ({ value: p.id, label: p.name })),
-  }));
 }
 
 export function ConfigEditModal({
@@ -105,37 +99,7 @@ export function ConfigEditModal({
               )}
 
               {/* Config Mode SegmentedControl */}
-              <Flex direction="column" gap="1">
-                <Text as="label" size="2" weight="bold">
-                  {getMessage('configurationMode')}
-                </Text>
-                <SegmentedControl.Root
-                  value={configMode}
-                  onValueChange={(v) => setConfigMode(v as 'preset' | 'ask' | 'manual')}
-                  size="2"
-                >
-                  {(['preset', 'ask', 'manual'] as const).map((mode) => (
-                    <SegmentedControl.Item key={mode} value={mode}>
-                      <Flex align="center" gap="1">
-                        {getMessage(({ preset: 'configModePreset', ask: 'configModeAsk', manual: 'configModeManual' } as const)[mode])}
-                        <HoverCard.Root openDelay={300} closeDelay={100}>
-                          <HoverCard.Trigger>
-                            <Box as="span" style={{ display: 'inline-flex', alignItems: 'center', cursor: 'default', lineHeight: 0 }}>
-                              <Info size={12} aria-hidden="true" />
-                            </Box>
-                          </HoverCard.Trigger>
-                          <HoverCard.Content size="1" maxWidth="240px" side="top" sideOffset={4}
-                            align={mode === 'manual' ? 'end' : 'center'}>
-                            <Text size="2">
-                              {getMessage(({ preset: 'configModePresetHelp', ask: 'configModeAskHelp', manual: 'configModeManualHelp' } as const)[mode])}
-                            </Text>
-                          </HoverCard.Content>
-                        </HoverCard.Root>
-                      </Flex>
-                    </SegmentedControl.Item>
-                  ))}
-                </SegmentedControl.Root>
-              </Flex>
+              <ConfigModeSelector value={configMode} onValueChange={setConfigMode} />
 
               {/* Preset Selection */}
               {configMode === 'preset' && presetCategories.length > 0 && !isLoadingPresets && (

--- a/src/components/Core/DomainRule/ConfigModeSelector.tsx
+++ b/src/components/Core/DomainRule/ConfigModeSelector.tsx
@@ -1,0 +1,71 @@
+import { Box, Flex, HoverCard, SegmentedControl, Text } from '@radix-ui/themes';
+import { Info } from 'lucide-react';
+import { getMessage } from '../../../utils/i18n';
+
+export type ConfigMode = 'preset' | 'ask' | 'manual';
+
+const CONFIG_MODES: ConfigMode[] = ['preset', 'ask', 'manual'];
+
+const MODE_LABELS: Record<ConfigMode, Parameters<typeof getMessage>[0]> = {
+  preset: 'configModePreset',
+  ask: 'configModeAsk',
+  manual: 'configModeManual',
+};
+
+const MODE_HELP_LABELS: Record<ConfigMode, Parameters<typeof getMessage>[0]> = {
+  preset: 'configModePresetHelp',
+  ask: 'configModeAskHelp',
+  manual: 'configModeManualHelp',
+};
+
+interface ConfigModeSelectorProps {
+  value: ConfigMode;
+  onValueChange: (mode: ConfigMode) => void;
+}
+
+/**
+ * Segmented control for choosing between preset / ask / manual config modes.
+ * Each item shows a HoverCard tooltip with the mode description.
+ * Shared between ConfigEditModal and WizardStep2Config.
+ */
+export function ConfigModeSelector({ value, onValueChange }: ConfigModeSelectorProps) {
+  return (
+    <Flex direction="column" gap="1">
+      <Text as="label" size="2" weight="bold">
+        {getMessage('configurationMode')}
+      </Text>
+      <SegmentedControl.Root
+        value={value}
+        onValueChange={(v) => onValueChange(v as ConfigMode)}
+        size="2"
+      >
+        {CONFIG_MODES.map((mode) => (
+          <SegmentedControl.Item key={mode} value={mode}>
+            <Flex align="center" gap="1">
+              {getMessage(MODE_LABELS[mode])}
+              <HoverCard.Root openDelay={300} closeDelay={100}>
+                <HoverCard.Trigger>
+                  <Box
+                    as="span"
+                    style={{ display: 'inline-flex', alignItems: 'center', cursor: 'default', lineHeight: 0 }}
+                  >
+                    <Info size={12} aria-hidden="true" />
+                  </Box>
+                </HoverCard.Trigger>
+                <HoverCard.Content
+                  size="1"
+                  maxWidth="240px"
+                  side="top"
+                  sideOffset={4}
+                  align={mode === 'manual' ? 'end' : 'center'}
+                >
+                  <Text size="2">{getMessage(MODE_HELP_LABELS[mode])}</Text>
+                </HoverCard.Content>
+              </HoverCard.Root>
+            </Flex>
+          </SegmentedControl.Item>
+        ))}
+      </SegmentedControl.Root>
+    </Flex>
+  );
+}

--- a/src/components/Core/DomainRule/RuleDetailPopover.tsx
+++ b/src/components/Core/DomainRule/RuleDetailPopover.tsx
@@ -1,0 +1,100 @@
+import { Flex, Text, Box, Badge } from '@radix-ui/themes';
+import { getMessage } from '../../../utils/i18n';
+import { AccessibleHighlight } from '../../UI/AccessibleHighlight/AccessibleHighlight';
+import { getRadixColor } from '../../../utils/utils';
+import { getRuleCategory } from '../../../schemas/enums';
+import type { DomainRuleSetting } from '../../../types/syncSettings';
+
+interface RuleDetailPopoverProps {
+  rule: DomainRuleSetting;
+  searchTerm: string;
+}
+
+export function RuleDetailPopover({ rule, searchTerm }: RuleDetailPopoverProps) {
+  const cat = getRuleCategory(rule.categoryId);
+
+  return (
+    <Flex direction="column" gap="3">
+      <Flex justify="between" align="center" pb="2" style={{ borderBottom: '1px solid var(--gray-5)' }}>
+        <Text size="3" weight="bold">
+          <AccessibleHighlight text={rule.label} searchTerm={searchTerm} />
+        </Text>
+        <Badge color={rule.enabled ? 'green' : 'gray'} variant="soft">
+          {getMessage(rule.enabled ? 'enabled' : 'disabled')}
+        </Badge>
+      </Flex>
+
+      <Box style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '8px 12px', alignItems: 'baseline' }}>
+        <Text size="1" weight="bold" color="gray">{getMessage('domainFilter')}</Text>
+        <Text size="2">
+          <code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px' }}>
+            <AccessibleHighlight text={rule.domainFilter} searchTerm={searchTerm} />
+          </code>
+        </Text>
+
+        <Text size="1" weight="bold" color="gray">{getMessage('tabGroupColor')}</Text>
+        <Flex align="center" gap="2">
+          {cat ? (
+            <>
+              <div style={{
+                width: '16px', height: '16px',
+                backgroundColor: `var(--${getRadixColor(cat.color)}-9)`,
+                borderRadius: '50%',
+                border: '1px solid var(--gray-6)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: '10px',
+              }}>
+                {cat.emoji}
+              </div>
+              <Text size="2">{getMessage(cat.labelKey as any)}</Text>
+            </>
+          ) : (
+            <Text size="2" color="gray">{getMessage('categoryNone')}</Text>
+          )}
+        </Flex>
+
+        <Text size="1" weight="bold" color="gray">{getMessage('groupNameSource')}</Text>
+        <Text size="2">
+          {getMessage(`groupNameSource${rule.groupNameSource.split('_').map(
+            (part: string) => part.charAt(0).toUpperCase() + part.slice(1)
+          ).join('')}`)}
+        </Text>
+
+        {rule.presetId && (
+          <>
+            <Text size="1" weight="bold" color="gray">{getMessage('presetLabel')}</Text>
+            <Text size="2">{rule.presetId}</Text>
+          </>
+        )}
+        {rule.titleParsingRegEx && (
+          <>
+            <Text size="1" weight="bold" color="gray">{getMessage('titleRegex')}</Text>
+            <Text size="2">
+              <code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px', wordBreak: 'break-all' }}>
+                {rule.titleParsingRegEx}
+              </code>
+            </Text>
+          </>
+        )}
+        {rule.urlParsingRegEx && (
+          <>
+            <Text size="1" weight="bold" color="gray">{getMessage('urlRegex')}</Text>
+            <Text size="2">
+              <code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px', wordBreak: 'break-all' }}>
+                {rule.urlParsingRegEx}
+              </code>
+            </Text>
+          </>
+        )}
+
+        <Text size="1" weight="bold" color="gray">{getMessage('deduplicationMode')}</Text>
+        <Text size="2">{getMessage(`${rule.deduplicationMatchMode}Match`)}</Text>
+
+        <Text size="1" weight="bold" color="gray">{getMessage('deduplicationEnabled')}</Text>
+        <Badge size="1" color={rule.deduplicationEnabled ? 'green' : 'red'} variant="soft">
+          {rule.deduplicationEnabled ? getMessage('yes') : getMessage('no')}
+        </Badge>
+      </Box>
+    </Flex>
+  );
+}

--- a/src/components/Core/DomainRule/WizardStep2Config.tsx
+++ b/src/components/Core/DomainRule/WizardStep2Config.tsx
@@ -1,4 +1,4 @@
-import { Box, Callout, Flex, Grid, HoverCard, SegmentedControl, Select, Text, TextField } from '@radix-ui/themes';
+import { Box, Callout, Flex, Grid, Select, Text, TextField } from '@radix-ui/themes';
 import { Info } from 'lucide-react';
 import { Controller, type Control, type FieldErrors } from 'react-hook-form';
 import { getMessage } from '../../../utils/i18n';
@@ -8,6 +8,8 @@ import { FormField, SearchableSelect } from '../../Form/FormFields';
 import { groupNameSourceOptions, type GroupNameSourceValue } from '../../../schemas/enums';
 import type { DomainRule } from '../../../schemas/domainRule';
 import type { PresetCategory } from '../../../utils/presetUtils';
+import { presetsToSearchableGroups } from '../../../utils/presetUtils';
+import { ConfigModeSelector } from './ConfigModeSelector';
 
 interface WizardStep2ConfigProps {
   control: Control<DomainRule>;
@@ -40,42 +42,7 @@ export function WizardStep2Config({
       )}
 
       {/* Configuration Mode Selection */}
-      <Flex direction="column" gap="1">
-        <Text as="label" size="2" weight="bold">
-          {getMessage('configurationMode')}
-        </Text>
-        <SegmentedControl.Root
-          value={configMode}
-          onValueChange={(v) => onConfigModeChange(v as 'preset' | 'ask' | 'manual')}
-          size="2"
-        >
-          {(['preset', 'ask', 'manual'] as const).map((mode) => (
-            <SegmentedControl.Item key={mode} value={mode}>
-              <Flex align="center" gap="1">
-                {getMessage(({ preset: 'configModePreset', ask: 'configModeAsk', manual: 'configModeManual' } as const)[mode])}
-                <HoverCard.Root openDelay={300} closeDelay={100}>
-                  <HoverCard.Trigger>
-                    <Box as="span" style={{ display: 'inline-flex', alignItems: 'center', cursor: 'default', lineHeight: 0 }}>
-                      <Info size={12} aria-hidden="true" />
-                    </Box>
-                  </HoverCard.Trigger>
-                  <HoverCard.Content
-                    size="1"
-                    maxWidth="240px"
-                    side="top"
-                    sideOffset={4}
-                    align={mode === 'manual' ? 'end' : 'center'}
-                  >
-                    <Text size="2">
-                      {getMessage(({ preset: 'configModePresetHelp', ask: 'configModeAskHelp', manual: 'configModeManualHelp' } as const)[mode])}
-                    </Text>
-                  </HoverCard.Content>
-                </HoverCard.Root>
-              </Flex>
-            </SegmentedControl.Item>
-          ))}
-        </SegmentedControl.Root>
-      </Flex>
+      <ConfigModeSelector value={configMode} onValueChange={onConfigModeChange} />
 
       {/* Preset Selection */}
       {configMode === 'preset' && presetCategories.length > 0 && !isLoadingPresets && (
@@ -207,15 +174,4 @@ export function WizardStep2Config({
       )}
     </Flex>
   );
-}
-
-// Local helper (avoids importing from utils to keep the component self-contained)
-function presetsToSearchableGroups(categories: PresetCategory[]) {
-  return categories.map((cat) => ({
-    label: cat.name,
-    options: cat.presets.map((p) => ({
-      value: p.id,
-      label: p.name,
-    })),
-  }));
 }

--- a/src/components/Core/TabTree/GroupEditRow.tsx
+++ b/src/components/Core/TabTree/GroupEditRow.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Flex, Box, TextField, Button } from '@radix-ui/themes';
+import { getMessage } from '../../../utils/i18n';
+import { ChromeColorPicker } from './ChromeColorPicker';
+import type { ChromeGroupColor } from './tabTreeTypes';
+
+export interface GroupEditRowProps {
+  name: string;
+  color: ChromeGroupColor;
+  level: number;
+  onNameChange: (name: string) => void;
+  onColorChange: (color: ChromeGroupColor) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function GroupEditRow({
+  name,
+  color,
+  level,
+  onNameChange,
+  onColorChange,
+  onSave,
+  onCancel,
+}: GroupEditRowProps) {
+  return (
+    <Box
+      style={{
+        paddingLeft: (level - 1) * 20 + 8,
+        paddingRight: 'var(--space-2)',
+        paddingTop: 'var(--space-2)',
+        paddingBottom: 'var(--space-2)',
+      }}
+    >
+      <Flex direction="column" gap="2">
+        <Flex align="center" gap="2">
+          <TextField.Root
+            value={name}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onNameChange(e.target.value)}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter') onSave();
+              if (e.key === 'Escape') onCancel();
+            }}
+            size="1"
+            style={{ flex: 1 }}
+            placeholder={getMessage('tabEditorGroupNameLabel')}
+            aria-label={getMessage('tabEditorGroupNameLabel')}
+            autoFocus
+          />
+          <ChromeColorPicker value={color} onChange={onColorChange} />
+        </Flex>
+        <Flex gap="2" justify="end">
+          <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+            {getMessage('cancel')}
+          </Button>
+          <Button size="1" onClick={onSave}>
+            {getMessage('save')}
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/Core/TabTree/MoveTabDropdown.tsx
+++ b/src/components/Core/TabTree/MoveTabDropdown.tsx
@@ -1,0 +1,48 @@
+import { DropdownMenu, IconButton } from '@radix-ui/themes';
+import { ArrowUpRight } from 'lucide-react';
+import { getMessage } from '../../../utils/i18n';
+import type { SavedTabGroup } from '../../../types/session';
+
+export interface MoveTabDropdownProps {
+  currentGroupId: string | null;
+  groups: SavedTabGroup[];
+  onMove: (targetGroupId: string | null) => void;
+}
+
+export function MoveTabDropdown({ currentGroupId, groups, onMove }: MoveTabDropdownProps) {
+  const otherGroups = groups.filter((g) => g.id !== currentGroupId);
+  const canUngroup = currentGroupId !== null;
+
+  if (otherGroups.length === 0 && !canUngroup) return null;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <IconButton
+          size="1"
+          variant="ghost"
+          color="gray"
+          aria-label={getMessage('tabEditorMoveTab')}
+          title={getMessage('tabEditorMoveTab')}
+        >
+          <ArrowUpRight size={12} aria-hidden="true" />
+        </IconButton>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        {otherGroups.map((g) => (
+          <DropdownMenu.Item key={g.id} onClick={() => onMove(g.id)}>
+            {g.title}
+          </DropdownMenu.Item>
+        ))}
+        {canUngroup && (
+          <>
+            {otherGroups.length > 0 && <DropdownMenu.Separator />}
+            <DropdownMenu.Item onClick={() => onMove(null)}>
+              {getMessage('tabEditorUngroupedTabs')}
+            </DropdownMenu.Item>
+          </>
+        )}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/components/Core/TabTree/TabEditRow.tsx
+++ b/src/components/Core/TabTree/TabEditRow.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Flex, Text, Box, TextField, Button } from '@radix-ui/themes';
+import { getMessage } from '../../../utils/i18n';
+import styles from './TabTreeEditor.module.css';
+
+export interface TabEditRowProps {
+  url: string;
+  error: string | null;
+  level: number;
+  onChange: (url: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function TabEditRow({ url, error, level, onChange, onSave, onCancel }: TabEditRowProps) {
+  return (
+    <Box
+      style={{
+        paddingLeft: (level - 1) * 20 + 8,
+        paddingRight: 'var(--space-2)',
+        paddingTop: 'var(--space-2)',
+        paddingBottom: 'var(--space-2)',
+      }}
+    >
+      <Flex direction="column" gap="2">
+        <Flex align="center" gap="2">
+          <Text size="1" color="gray" style={{ flexShrink: 0 }}>
+            {getMessage('tabEditorUrlLabel')}:
+          </Text>
+          <TextField.Root
+            value={url}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter') onSave();
+              if (e.key === 'Escape') onCancel();
+            }}
+            size="1"
+            style={{ flex: 1 }}
+            placeholder="https://example.com"
+            aria-label={getMessage('tabEditorUrlLabel')}
+            autoFocus
+          />
+        </Flex>
+        {error && (
+          <Text size="1" className={styles.urlError}>
+            {error}
+          </Text>
+        )}
+        <Flex gap="2" justify="end">
+          <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+            {getMessage('cancel')}
+          </Button>
+          <Button size="1" onClick={onSave}>
+            {getMessage('save')}
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/Core/TabTree/TabTreeEditor.tsx
+++ b/src/components/Core/TabTree/TabTreeEditor.tsx
@@ -1,23 +1,23 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import {
   Flex,
   Text,
   Box,
   IconButton,
-  TextField,
   Button,
   ScrollArea,
-  DropdownMenu,
   AlertDialog,
 } from '@radix-ui/themes';
-import { ChevronUp, ChevronDown, Pencil, Trash2, ArrowUpRight } from 'lucide-react';
+import { ChevronUp, ChevronDown, Pencil, Trash2 } from 'lucide-react';
 import { getMessage } from '../../../utils/i18n';
 import { extractDomain } from './tabTreeUtils';
 import { TabRowBase } from './TabRowBase';
 import { GroupRowBase } from './GroupRowBase';
-import { ChromeColorPicker } from './ChromeColorPicker';
-import type { ChromeGroupColor } from './tabTreeTypes';
-import type { Session, SavedTab, SavedTabGroup } from '../../../types/session';
+import { TabEditRow } from './TabEditRow';
+import { GroupEditRow } from './GroupEditRow';
+import { MoveTabDropdown } from './MoveTabDropdown';
+import { useTabTreeEditor } from './useTabTreeEditor';
+import type { Session } from '../../../types/session';
 import styles from './TabTreeEditor.module.css';
 
 export interface TabTreeEditorProps {
@@ -29,212 +29,33 @@ export interface TabTreeEditorProps {
   maxHeight?: number | string;
 }
 
-type AlertDialogState =
-  | { type: 'delete_last_tab'; tabId: string; groupId: string }
-  | { type: 'delete_group'; groupId: string; groupTitle: string; tabCount: number }
-  | null;
-
 export function TabTreeEditor({ session, onSessionChange, maxHeight }: TabTreeEditorProps) {
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => new Set(session.groups.map((g) => g.id))
-  );
-  const [editingItemId, setEditingItemId] = useState<string | null>(null);
-  const [editUrl, setEditUrl] = useState('');
-  const [editGroupName, setEditGroupName] = useState('');
-  const [editGroupColor, setEditGroupColor] = useState<ChromeGroupColor>('grey');
-  const [urlError, setUrlError] = useState<string | null>(null);
-  const [alertDialog, setAlertDialog] = useState<AlertDialogState>(null);
-
-  // Auto-expand newly added groups
-  useEffect(() => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      let changed = false;
-      for (const group of session.groups) {
-        if (!next.has(group.id)) {
-          next.add(group.id);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [session.groups]);
-
-  const now = () => new Date().toISOString();
-
-  const toggleGroup = useCallback((groupId: string) => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(groupId)) next.delete(groupId);
-      else next.add(groupId);
-      return next;
-    });
-  }, []);
-
-  function openTabEdit(tab: SavedTab) {
-    setEditingItemId(tab.id);
-    setEditUrl(tab.url);
-    setUrlError(null);
-  }
-
-  function openGroupEdit(group: SavedTabGroup) {
-    setEditingItemId(group.id);
-    setEditGroupName(group.title);
-    setEditGroupColor(group.color);
-  }
-
-  function cancelEdit() {
-    setEditingItemId(null);
-    setUrlError(null);
-  }
-
-  function saveTabEdit(tabId: string) {
-    let url = editUrl.trim();
-    // Auto-prefix https:// if no scheme is present
-    if (url && !/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url)) {
-      url = 'https://' + url;
-    }
-    try {
-      new URL(url);
-    } catch {
-      setUrlError(getMessage('tabEditorUrlInvalid'));
-      return;
-    }
-    onSessionChange({
-      ...session,
-      ungroupedTabs: session.ungroupedTabs.map((t) => (t.id === tabId ? { ...t, url } : t)),
-      groups: session.groups.map((g) => ({
-        ...g,
-        tabs: g.tabs.map((t) => (t.id === tabId ? { ...t, url } : t)),
-      })),
-      updatedAt: now(),
-    });
-    setEditingItemId(null);
-    setUrlError(null);
-  }
-
-  function saveGroupEdit(groupId: string) {
-    onSessionChange({
-      ...session,
-      groups: session.groups.map((g) =>
-        g.id === groupId ? { ...g, title: editGroupName, color: editGroupColor } : g
-      ),
-      updatedAt: now(),
-    });
-    setEditingItemId(null);
-  }
-
-  function moveTabInContext(tabId: string, direction: 'up' | 'down', contextGroupId: string | null) {
-    if (contextGroupId === null) {
-      const tabs = [...session.ungroupedTabs];
-      const idx = tabs.findIndex((t) => t.id === tabId);
-      if (idx === -1) return;
-      const newIdx = direction === 'up' ? idx - 1 : idx + 1;
-      if (newIdx < 0 || newIdx >= tabs.length) return;
-      [tabs[idx], tabs[newIdx]] = [tabs[newIdx], tabs[idx]];
-      onSessionChange({ ...session, ungroupedTabs: tabs, updatedAt: now() });
-    } else {
-      const groups = session.groups.map((g) => {
-        if (g.id !== contextGroupId) return g;
-        const tabs = [...g.tabs];
-        const idx = tabs.findIndex((t) => t.id === tabId);
-        if (idx === -1) return g;
-        const newIdx = direction === 'up' ? idx - 1 : idx + 1;
-        if (newIdx < 0 || newIdx >= tabs.length) return g;
-        [tabs[idx], tabs[newIdx]] = [tabs[newIdx], tabs[idx]];
-        return { ...g, tabs };
-      });
-      onSessionChange({ ...session, groups, updatedAt: now() });
-    }
-  }
-
-  function moveGroupInList(groupId: string, direction: 'up' | 'down') {
-    const groups = [...session.groups];
-    const idx = groups.findIndex((g) => g.id === groupId);
-    if (idx === -1) return;
-    const newIdx = direction === 'up' ? idx - 1 : idx + 1;
-    if (newIdx < 0 || newIdx >= groups.length) return;
-    [groups[idx], groups[newIdx]] = [groups[newIdx], groups[idx]];
-    onSessionChange({ ...session, groups, updatedAt: now() });
-  }
-
-  function moveTabToGroup(
-    tabId: string,
-    sourceGroupId: string | null,
-    targetGroupId: string | null
-  ) {
-    let tab: SavedTab | undefined;
-    let newUngrouped = session.ungroupedTabs;
-    let newGroups = session.groups;
-
-    if (sourceGroupId === null) {
-      tab = session.ungroupedTabs.find((t) => t.id === tabId);
-      newUngrouped = session.ungroupedTabs.filter((t) => t.id !== tabId);
-    } else {
-      const group = session.groups.find((g) => g.id === sourceGroupId);
-      tab = group?.tabs.find((t) => t.id === tabId);
-      newGroups = session.groups.map((g) =>
-        g.id === sourceGroupId ? { ...g, tabs: g.tabs.filter((t) => t.id !== tabId) } : g
-      );
-    }
-
-    if (!tab) return;
-
-    if (targetGroupId === null) {
-      newUngrouped = [...newUngrouped, tab];
-    } else {
-      newGroups = newGroups.map((g) =>
-        g.id === targetGroupId ? { ...g, tabs: [...g.tabs, tab!] } : g
-      );
-    }
-
-    onSessionChange({ ...session, ungroupedTabs: newUngrouped, groups: newGroups, updatedAt: now() });
-  }
-
-  function handleDeleteTab(tabId: string, sourceGroupId: string | null) {
-    if (sourceGroupId !== null) {
-      const group = session.groups.find((g) => g.id === sourceGroupId);
-      if (group && group.tabs.length === 1) {
-        setAlertDialog({ type: 'delete_last_tab', tabId, groupId: sourceGroupId });
-        return;
-      }
-    }
-    performDeleteTab(tabId, sourceGroupId, false);
-  }
-
-  function performDeleteTab(
-    tabId: string,
-    sourceGroupId: string | null,
-    deleteEmptyGroup: boolean
-  ) {
-    const newUngrouped = session.ungroupedTabs.filter((t) => t.id !== tabId);
-    let newGroups = session.groups.map((g) => ({
-      ...g,
-      tabs: g.tabs.filter((t) => t.id !== tabId),
-    }));
-    if (deleteEmptyGroup && sourceGroupId) {
-      newGroups = newGroups.filter((g) => g.id !== sourceGroupId);
-    }
-    onSessionChange({ ...session, ungroupedTabs: newUngrouped, groups: newGroups, updatedAt: now() });
-    setAlertDialog(null);
-  }
-
-  function handleDeleteGroup(groupId: string, action: 'delete_tabs' | 'ungroup_tabs') {
-    const group = session.groups.find((g) => g.id === groupId);
-    if (!group) return;
-    const newUngrouped =
-      action === 'ungroup_tabs'
-        ? [...session.ungroupedTabs, ...group.tabs]
-        : session.ungroupedTabs;
-    const newGroups = session.groups.filter((g) => g.id !== groupId);
-    onSessionChange({
-      ...session,
-      ungroupedTabs: newUngrouped,
-      groups: newGroups,
-      updatedAt: now(),
-    });
-    setAlertDialog(null);
-  }
+  const {
+    expandedGroups,
+    editingItemId,
+    editUrl,
+    setEditUrl,
+    setUrlError,
+    editGroupName,
+    setEditGroupName,
+    editGroupColor,
+    setEditGroupColor,
+    urlError,
+    alertDialog,
+    setAlertDialog,
+    toggleGroup,
+    openTabEdit,
+    openGroupEdit,
+    cancelEdit,
+    saveTabEdit,
+    saveGroupEdit,
+    moveTabInContext,
+    moveGroupInList,
+    moveTabToGroup,
+    handleDeleteTab,
+    performDeleteTab,
+    handleDeleteGroup,
+  } = useTabTreeEditor(session, onSessionChange);
 
   const content = (
     <Box className={styles.container} role="list">
@@ -604,164 +425,4 @@ export function TabTreeEditor({ session, onSessionChange, maxHeight }: TabTreeEd
   }
 
   return content;
-}
-
-/* ─── Sub-components ──────────────────────────────────────────────────────── */
-
-interface TabEditRowProps {
-  url: string;
-  error: string | null;
-  level: number;
-  onChange: (url: string) => void;
-  onSave: () => void;
-  onCancel: () => void;
-}
-
-function TabEditRow({ url, error, level, onChange, onSave, onCancel }: TabEditRowProps) {
-  return (
-    <Box
-      style={{
-        paddingLeft: (level - 1) * 20 + 8,
-        paddingRight: 'var(--space-2)',
-        paddingTop: 'var(--space-2)',
-        paddingBottom: 'var(--space-2)',
-      }}
-    >
-      <Flex direction="column" gap="2">
-        <Flex align="center" gap="2">
-          <Text size="1" color="gray" style={{ flexShrink: 0 }}>
-            {getMessage('tabEditorUrlLabel')}:
-          </Text>
-          <TextField.Root
-            value={url}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-            onKeyDown={(e: React.KeyboardEvent) => {
-              if (e.key === 'Enter') onSave();
-              if (e.key === 'Escape') onCancel();
-            }}
-            size="1"
-            style={{ flex: 1 }}
-            placeholder="https://example.com"
-            aria-label={getMessage('tabEditorUrlLabel')}
-            autoFocus
-          />
-        </Flex>
-        {error && (
-          <Text size="1" className={styles.urlError}>
-            {error}
-          </Text>
-        )}
-        <Flex gap="2" justify="end">
-          <Button size="1" variant="soft" color="gray" onClick={onCancel}>
-            {getMessage('cancel')}
-          </Button>
-          <Button size="1" onClick={onSave}>
-            {getMessage('save')}
-          </Button>
-        </Flex>
-      </Flex>
-    </Box>
-  );
-}
-
-interface GroupEditRowProps {
-  name: string;
-  color: ChromeGroupColor;
-  level: number;
-  onNameChange: (name: string) => void;
-  onColorChange: (color: ChromeGroupColor) => void;
-  onSave: () => void;
-  onCancel: () => void;
-}
-
-function GroupEditRow({
-  name,
-  color,
-  level,
-  onNameChange,
-  onColorChange,
-  onSave,
-  onCancel,
-}: GroupEditRowProps) {
-  return (
-    <Box
-      style={{
-        paddingLeft: (level - 1) * 20 + 8,
-        paddingRight: 'var(--space-2)',
-        paddingTop: 'var(--space-2)',
-        paddingBottom: 'var(--space-2)',
-      }}
-    >
-      <Flex direction="column" gap="2">
-        <Flex align="center" gap="2">
-          <TextField.Root
-            value={name}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onNameChange(e.target.value)}
-            onKeyDown={(e: React.KeyboardEvent) => {
-              if (e.key === 'Enter') onSave();
-              if (e.key === 'Escape') onCancel();
-            }}
-            size="1"
-            style={{ flex: 1 }}
-            placeholder={getMessage('tabEditorGroupNameLabel')}
-            aria-label={getMessage('tabEditorGroupNameLabel')}
-            autoFocus
-          />
-          <ChromeColorPicker value={color} onChange={onColorChange} />
-        </Flex>
-        <Flex gap="2" justify="end">
-          <Button size="1" variant="soft" color="gray" onClick={onCancel}>
-            {getMessage('cancel')}
-          </Button>
-          <Button size="1" onClick={onSave}>
-            {getMessage('save')}
-          </Button>
-        </Flex>
-      </Flex>
-    </Box>
-  );
-}
-
-interface MoveTabDropdownProps {
-  currentGroupId: string | null;
-  groups: SavedTabGroup[];
-  onMove: (targetGroupId: string | null) => void;
-}
-
-function MoveTabDropdown({ currentGroupId, groups, onMove }: MoveTabDropdownProps) {
-  const otherGroups = groups.filter((g) => g.id !== currentGroupId);
-  const canUngroup = currentGroupId !== null;
-
-  if (otherGroups.length === 0 && !canUngroup) return null;
-
-  return (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
-        <IconButton
-          size="1"
-          variant="ghost"
-          color="gray"
-          aria-label={getMessage('tabEditorMoveTab')}
-          title={getMessage('tabEditorMoveTab')}
-        >
-          <ArrowUpRight size={12} aria-hidden="true" />
-        </IconButton>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        {otherGroups.map((g) => (
-          <DropdownMenu.Item key={g.id} onClick={() => onMove(g.id)}>
-            {g.title}
-          </DropdownMenu.Item>
-        ))}
-        {canUngroup && (
-          <>
-            {otherGroups.length > 0 && <DropdownMenu.Separator />}
-            <DropdownMenu.Item onClick={() => onMove(null)}>
-              {getMessage('tabEditorUngroupedTabs')}
-            </DropdownMenu.Item>
-          </>
-        )}
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
-  );
 }

--- a/src/components/Core/TabTree/useTabTreeEditor.ts
+++ b/src/components/Core/TabTree/useTabTreeEditor.ts
@@ -1,0 +1,225 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getMessage } from '../../../utils/i18n';
+import type { Session, SavedTab, SavedTabGroup } from '../../../types/session';
+import type { ChromeGroupColor } from './tabTreeTypes';
+
+export type AlertDialogState =
+  | { type: 'delete_last_tab'; tabId: string; groupId: string }
+  | { type: 'delete_group'; groupId: string; groupTitle: string; tabCount: number }
+  | null;
+
+export function useTabTreeEditor(session: Session, onSessionChange: (updated: Session) => void) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(session.groups.map((g) => g.id))
+  );
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [editUrl, setEditUrl] = useState('');
+  const [editGroupName, setEditGroupName] = useState('');
+  const [editGroupColor, setEditGroupColor] = useState<ChromeGroupColor>('grey');
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [alertDialog, setAlertDialog] = useState<AlertDialogState>(null);
+
+  // Auto-expand newly added groups
+  useEffect(() => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      let changed = false;
+      for (const group of session.groups) {
+        if (!next.has(group.id)) {
+          next.add(group.id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [session.groups]);
+
+  const now = () => new Date().toISOString();
+
+  const toggleGroup = useCallback((groupId: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  function openTabEdit(tab: SavedTab) {
+    setEditingItemId(tab.id);
+    setEditUrl(tab.url);
+    setUrlError(null);
+  }
+
+  function openGroupEdit(group: SavedTabGroup) {
+    setEditingItemId(group.id);
+    setEditGroupName(group.title);
+    setEditGroupColor(group.color);
+  }
+
+  function cancelEdit() {
+    setEditingItemId(null);
+    setUrlError(null);
+  }
+
+  function saveTabEdit(tabId: string) {
+    let url = editUrl.trim();
+    if (url && !/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url)) {
+      url = 'https://' + url;
+    }
+    try {
+      new URL(url);
+    } catch {
+      setUrlError(getMessage('tabEditorUrlInvalid'));
+      return;
+    }
+    onSessionChange({
+      ...session,
+      ungroupedTabs: session.ungroupedTabs.map((t) => (t.id === tabId ? { ...t, url } : t)),
+      groups: session.groups.map((g) => ({
+        ...g,
+        tabs: g.tabs.map((t) => (t.id === tabId ? { ...t, url } : t)),
+      })),
+      updatedAt: now(),
+    });
+    setEditingItemId(null);
+    setUrlError(null);
+  }
+
+  function saveGroupEdit(groupId: string) {
+    onSessionChange({
+      ...session,
+      groups: session.groups.map((g) =>
+        g.id === groupId ? { ...g, title: editGroupName, color: editGroupColor } : g
+      ),
+      updatedAt: now(),
+    });
+    setEditingItemId(null);
+  }
+
+  function moveTabInContext(tabId: string, direction: 'up' | 'down', contextGroupId: string | null) {
+    if (contextGroupId === null) {
+      const tabs = [...session.ungroupedTabs];
+      const idx = tabs.findIndex((t) => t.id === tabId);
+      if (idx === -1) return;
+      const newIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (newIdx < 0 || newIdx >= tabs.length) return;
+      [tabs[idx], tabs[newIdx]] = [tabs[newIdx], tabs[idx]];
+      onSessionChange({ ...session, ungroupedTabs: tabs, updatedAt: now() });
+    } else {
+      const groups = session.groups.map((g) => {
+        if (g.id !== contextGroupId) return g;
+        const tabs = [...g.tabs];
+        const idx = tabs.findIndex((t) => t.id === tabId);
+        if (idx === -1) return g;
+        const newIdx = direction === 'up' ? idx - 1 : idx + 1;
+        if (newIdx < 0 || newIdx >= tabs.length) return g;
+        [tabs[idx], tabs[newIdx]] = [tabs[newIdx], tabs[idx]];
+        return { ...g, tabs };
+      });
+      onSessionChange({ ...session, groups, updatedAt: now() });
+    }
+  }
+
+  function moveGroupInList(groupId: string, direction: 'up' | 'down') {
+    const groups = [...session.groups];
+    const idx = groups.findIndex((g) => g.id === groupId);
+    if (idx === -1) return;
+    const newIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (newIdx < 0 || newIdx >= groups.length) return;
+    [groups[idx], groups[newIdx]] = [groups[newIdx], groups[idx]];
+    onSessionChange({ ...session, groups, updatedAt: now() });
+  }
+
+  function moveTabToGroup(tabId: string, sourceGroupId: string | null, targetGroupId: string | null) {
+    let tab: SavedTab | undefined;
+    let newUngrouped = session.ungroupedTabs;
+    let newGroups = session.groups;
+
+    if (sourceGroupId === null) {
+      tab = session.ungroupedTabs.find((t) => t.id === tabId);
+      newUngrouped = session.ungroupedTabs.filter((t) => t.id !== tabId);
+    } else {
+      const group = session.groups.find((g) => g.id === sourceGroupId);
+      tab = group?.tabs.find((t) => t.id === tabId);
+      newGroups = session.groups.map((g) =>
+        g.id === sourceGroupId ? { ...g, tabs: g.tabs.filter((t) => t.id !== tabId) } : g
+      );
+    }
+
+    if (!tab) return;
+
+    if (targetGroupId === null) {
+      newUngrouped = [...newUngrouped, tab];
+    } else {
+      newGroups = newGroups.map((g) =>
+        g.id === targetGroupId ? { ...g, tabs: [...g.tabs, tab!] } : g
+      );
+    }
+
+    onSessionChange({ ...session, ungroupedTabs: newUngrouped, groups: newGroups, updatedAt: now() });
+  }
+
+  function handleDeleteTab(tabId: string, sourceGroupId: string | null) {
+    if (sourceGroupId !== null) {
+      const group = session.groups.find((g) => g.id === sourceGroupId);
+      if (group && group.tabs.length === 1) {
+        setAlertDialog({ type: 'delete_last_tab', tabId, groupId: sourceGroupId });
+        return;
+      }
+    }
+    performDeleteTab(tabId, sourceGroupId, false);
+  }
+
+  function performDeleteTab(tabId: string, sourceGroupId: string | null, deleteEmptyGroup: boolean) {
+    const newUngrouped = session.ungroupedTabs.filter((t) => t.id !== tabId);
+    let newGroups = session.groups.map((g) => ({
+      ...g,
+      tabs: g.tabs.filter((t) => t.id !== tabId),
+    }));
+    if (deleteEmptyGroup && sourceGroupId) {
+      newGroups = newGroups.filter((g) => g.id !== sourceGroupId);
+    }
+    onSessionChange({ ...session, ungroupedTabs: newUngrouped, groups: newGroups, updatedAt: now() });
+    setAlertDialog(null);
+  }
+
+  function handleDeleteGroup(groupId: string, action: 'delete_tabs' | 'ungroup_tabs') {
+    const group = session.groups.find((g) => g.id === groupId);
+    if (!group) return;
+    const newUngrouped =
+      action === 'ungroup_tabs'
+        ? [...session.ungroupedTabs, ...group.tabs]
+        : session.ungroupedTabs;
+    const newGroups = session.groups.filter((g) => g.id !== groupId);
+    onSessionChange({ ...session, ungroupedTabs: newUngrouped, groups: newGroups, updatedAt: now() });
+    setAlertDialog(null);
+  }
+
+  return {
+    expandedGroups,
+    editingItemId,
+    editUrl,
+    setEditUrl,
+    editGroupName,
+    setEditGroupName,
+    editGroupColor,
+    setEditGroupColor,
+    urlError,
+    setUrlError,
+    alertDialog,
+    setAlertDialog,
+    toggleGroup,
+    openTabEdit,
+    openGroupEdit,
+    cancelEdit,
+    saveTabEdit,
+    saveGroupEdit,
+    moveTabInContext,
+    moveGroupInList,
+    moveTabToGroup,
+    handleDeleteTab,
+    performDeleteTab,
+    handleDeleteGroup,
+  };
+}

--- a/src/components/UI/ImportExportPage/ExportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportPage/ExportSessionsWizard.tsx
@@ -6,6 +6,12 @@ import { SplitButton } from '../SplitButton/SplitButton';
 import { getMessage } from '../../../utils/i18n';
 import { showSuccessNotification } from '../../../utils/notifications';
 import { loadSessions } from '../../../utils/sessionStorage';
+import {
+  formatSessionDateShort,
+  getSessionGroupLabel,
+  getSessionTabLabel,
+  countSessionTabs,
+} from '../../../utils/sessionUtils';
 import type { Session } from '../../../types/session';
 
 interface ExportSessionsWizardProps {
@@ -107,23 +113,6 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
     );
   }, [getExportJson, selectedSessions.length, onOpenChange]);
 
-  const formatDate = (iso: string) => {
-    try {
-      return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'medium' });
-    } catch {
-      return iso;
-    }
-  };
-
-  const getTabCount = (session: Session) =>
-    session.groups.reduce((sum, g) => sum + g.tabs.length, 0) + session.ungroupedTabs.length;
-
-  const getGroupLabel = (count: number) =>
-    count === 1 ? getMessage('sessionGroupOne') : getMessage('sessionGroupCount').replace('$1', String(count));
-
-  const getTabLabel = (count: number) =>
-    count === 1 ? getMessage('sessionTabOne') : getMessage('sessionTabCount').replace('$1', String(count));
-
   return (
     <SessionsTheme>
       <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -153,7 +142,7 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
             <ScrollArea type="auto" scrollbars="vertical" style={{ maxHeight: '40vh' }}>
               <Flex direction="column" gap="2" pr="3">
                 {sessions.map(session => {
-                  const tabCount = getTabCount(session);
+                  const tabCount = countSessionTabs(session);
                   const groupCount = session.groups.length;
                   return (
                     <Flex
@@ -174,7 +163,7 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
                       <Flex direction="column" gap="1" style={{ flex: 1 }}>
                         <Text size="2" weight="medium">{session.name}</Text>
                         <Text size="1" color="gray">
-                          {formatDate(session.createdAt)} · {getGroupLabel(groupCount)} · {getTabLabel(tabCount)}
+                          {formatSessionDateShort(session.createdAt)} · {getSessionGroupLabel(groupCount)} · {getSessionTabLabel(tabCount)}
                         </Text>
                       </Flex>
                       {session.isPinned && (

--- a/src/components/UI/ImportExportPage/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportPage/ImportSessionsWizard.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import {
-  Dialog, Flex, Button, Checkbox, Text, Separator, Badge, Box,
-  ScrollArea, TextArea, SegmentedControl, Popover, Callout
+  Dialog, Flex, Button, Text, Separator, Box,
+  ScrollArea, TextArea, SegmentedControl, Callout
 } from '@radix-ui/themes';
-import { Upload, FileUp, CheckCircle, AlertTriangle, XCircle, Eye } from 'lucide-react';
+import { Upload, FileUp, CheckCircle, AlertTriangle, XCircle } from 'lucide-react';
 import { z } from 'zod';
 import { SessionsTheme } from '../../Form/themes';
 import { getMessage } from '../../../utils/i18n';
@@ -12,12 +12,10 @@ import { sessionsArraySchema } from '../../../schemas/session';
 import {
   classifyImportedSessions,
   type SessionClassification,
-  type ConflictingSession,
-  type SessionDiff,
-  type GroupDiff,
 } from '../../../utils/sessionClassification';
 import { generateUUID } from '../../../utils/utils';
 import { loadSessions, saveSessions } from '../../../utils/sessionStorage';
+import { SessionRow, ConflictSessionRow } from './SessionImportRows';
 import type { Session } from '../../../types/session';
 
 type ConflictMode = 'overwrite' | 'duplicate' | 'ignore';
@@ -44,14 +42,12 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
   const [fileName, setFileName] = useState<string | null>(null);
   const [existingSessions, setExistingSessions] = useState<Session[]>([]);
 
-  // Step 1 state
   const [classification, setClassification] = useState<SessionClassification | null>(null);
   const [newSessionSelectedIds, setNewSessionSelectedIds] = useState<Set<string>>(new Set());
   const [conflictMode, setConflictMode] = useState<ConflictMode>('overwrite');
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Load existing sessions and reset state when dialog opens
   useEffect(() => {
     if (open) {
       loadSessions().then(loaded => setExistingSessions(loaded));
@@ -83,11 +79,7 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
       if (error instanceof SyntaxError) {
         setParseError(getMessage('invalidJson'));
       } else if (error instanceof z.ZodError) {
-        const messages = error.issues.map(issue => {
-          const path = issue.path.join('.');
-          return `${path}: ${issue.message}`;
-        });
-        setParseError(messages.join('\n'));
+        setParseError(error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`).join('\n'));
       } else {
         setParseError(getMessage('errorImportInvalidStructure'));
       }
@@ -114,9 +106,7 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
     e.preventDefault();
     setIsDragOver(false);
     const file = e.dataTransfer.files[0];
-    if (file && file.name.endsWith('.json')) {
-      handleFileRead(file);
-    }
+    if (file && file.name.endsWith('.json')) handleFileRead(file);
   }, [handleFileRead]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -124,20 +114,15 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
     setIsDragOver(true);
   }, []);
 
-  const handleDragLeave = useCallback(() => {
-    setIsDragOver(false);
-  }, []);
+  const handleDragLeave = useCallback(() => setIsDragOver(false), []);
 
-  const handleBrowse = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
+  const handleBrowse = useCallback(() => fileInputRef.current?.click(), []);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) handleFileRead(file);
   }, [handleFileRead]);
 
-  // Transition to step 1: classify sessions
   const goToStep1 = useCallback(() => {
     if (!parsedSessions) return;
     const result = classifyImportedSessions(parsedSessions, existingSessions);
@@ -149,16 +134,12 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
   const toggleNewSession = useCallback((id: string) => {
     setNewSessionSelectedIds(prev => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   }, []);
 
-  // Compute import count for step 1
   const importCount = useMemo(() => {
     if (!classification) return 0;
     const newCount = classification.newSessions.filter(s => newSessionSelectedIds.has(s.id)).length;
@@ -175,7 +156,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
     const takenNames = new Set<string>(existingSessions.map(s => s.name.toLowerCase()));
 
-    // Add selected new sessions
     for (const session of classification.newSessions) {
       if (newSessionSelectedIds.has(session.id)) {
         updatedSessions.push(session);
@@ -184,7 +164,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
       }
     }
 
-    // Handle conflicts
     for (const conflict of classification.conflictingSessions) {
       if (conflictMode === 'overwrite') {
         const idx = updatedSessions.findIndex(
@@ -200,7 +179,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
         updatedSessions.push({ ...conflict.imported, id: generateUUID(), name: uniqueName });
         added++;
       }
-      // 'ignore': do nothing
     }
 
     await saveSessions(updatedSessions);
@@ -210,23 +188,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
       getMessage('importSessionsNotificationMessage', [String(added), String(overwritten)]),
     );
   }, [classification, existingSessions, newSessionSelectedIds, conflictMode, onOpenChange]);
-
-  const formatDate = (iso: string) => {
-    try {
-      return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'medium' });
-    } catch {
-      return iso;
-    }
-  };
-
-  const getTabCount = (session: Session) =>
-    session.groups.reduce((sum, g) => sum + g.tabs.length, 0) + session.ungroupedTabs.length;
-
-  const getGroupLabel = (count: number) =>
-    count === 1 ? getMessage('sessionGroupOne') : getMessage('sessionGroupCount').replace('$1', String(count));
-
-  const getTabLabel = (count: number) =>
-    count === 1 ? getMessage('sessionTabOne') : getMessage('sessionTabCount').replace('$1', String(count));
 
   const hasConflicts = (classification?.conflictingSessions.length ?? 0) > 0;
 
@@ -254,12 +215,8 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                 onValueChange={(v: string) => setSourceMode(v as 'file' | 'text')}
                 size="2"
               >
-                <SegmentedControl.Item value="file">
-                  {getMessage('sourceFile')}
-                </SegmentedControl.Item>
-                <SegmentedControl.Item value="text">
-                  {getMessage('sourceText')}
-                </SegmentedControl.Item>
+                <SegmentedControl.Item value="file">{getMessage('sourceFile')}</SegmentedControl.Item>
+                <SegmentedControl.Item value="text">{getMessage('sourceText')}</SegmentedControl.Item>
               </SegmentedControl.Root>
 
               <Box mt="3">
@@ -292,15 +249,11 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                       onClick={handleBrowse}
                     >
                       <FileUp size={32} style={{ color: 'var(--gray-9)' }} aria-hidden="true" />
-                      <Text size="2" color="gray">
-                        {getMessage('dragDropZone')}
-                      </Text>
+                      <Text size="2" color="gray">{getMessage('dragDropZone')}</Text>
                       <Button variant="soft" size="1" onClick={(e: React.MouseEvent) => { e.stopPropagation(); handleBrowse(); }}>
                         {getMessage('browse')}
                       </Button>
-                      {fileName && (
-                        <Text size="1" color="gray" mt="1">{fileName}</Text>
-                      )}
+                      {fileName && <Text size="1" color="gray" mt="1">{fileName}</Text>}
                     </Flex>
                   </>
                 )}
@@ -316,23 +269,16 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                 )}
               </Box>
 
-              {/* Validation feedback */}
               {parseError && (
                 <Callout.Root color="red" variant="soft" mt="3">
-                  <Callout.Icon>
-                    <XCircle size={16} />
-                  </Callout.Icon>
-                  <Callout.Text style={{ whiteSpace: 'pre-wrap', fontSize: 12 }}>
-                    {parseError}
-                  </Callout.Text>
+                  <Callout.Icon><XCircle size={16} /></Callout.Icon>
+                  <Callout.Text style={{ whiteSpace: 'pre-wrap', fontSize: 12 }}>{parseError}</Callout.Text>
                 </Callout.Root>
               )}
 
               {parsedSessions && (
                 <Callout.Root color="green" variant="soft" mt="3">
-                  <Callout.Icon>
-                    <CheckCircle size={16} />
-                  </Callout.Icon>
+                  <Callout.Icon><CheckCircle size={16} /></Callout.Icon>
                   <Callout.Text>
                     {getMessage('sessionsFoundCount').replace('{count}', String(parsedSessions.length))}
                   </Callout.Text>
@@ -346,7 +292,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
             <Box mt="4">
               <ScrollArea type="auto" scrollbars="vertical" style={{ maxHeight: '50vh' }}>
                 <Flex direction="column" gap="3" pr="3">
-                  {/* New sessions group */}
                   {classification.newSessions.length > 0 && (
                     <>
                       <Text size="3" weight="bold">
@@ -360,17 +305,12 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                             checkbox
                             checked={newSessionSelectedIds.has(session.id)}
                             onToggle={() => toggleNewSession(session.id)}
-                            formatDate={formatDate}
-                            getGroupLabel={getGroupLabel}
-                            getTabLabel={getTabLabel}
-                            getTabCount={getTabCount}
                           />
                         ))}
                       </Flex>
                     </>
                   )}
 
-                  {/* Conflicting sessions group */}
                   {classification.conflictingSessions.length > 0 && (
                     <>
                       {classification.newSessions.length > 0 && <Separator size="4" />}
@@ -385,34 +325,20 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                           onValueChange={(v: string) => setConflictMode(v as ConflictMode)}
                           size="1"
                         >
-                          <SegmentedControl.Item value="overwrite">
-                            {getMessage('conflictModeOverwrite')}
-                          </SegmentedControl.Item>
-                          <SegmentedControl.Item value="duplicate">
-                            {getMessage('conflictModeDuplicate')}
-                          </SegmentedControl.Item>
-                          <SegmentedControl.Item value="ignore">
-                            {getMessage('conflictModeIgnore')}
-                          </SegmentedControl.Item>
+                          <SegmentedControl.Item value="overwrite">{getMessage('conflictModeOverwrite')}</SegmentedControl.Item>
+                          <SegmentedControl.Item value="duplicate">{getMessage('conflictModeDuplicate')}</SegmentedControl.Item>
+                          <SegmentedControl.Item value="ignore">{getMessage('conflictModeIgnore')}</SegmentedControl.Item>
                         </SegmentedControl.Root>
                       </Flex>
 
                       <Flex direction="column" gap="2">
                         {classification.conflictingSessions.map(conflict => (
-                          <ConflictSessionRow
-                            key={conflict.imported.id}
-                            conflict={conflict}
-                            formatDate={formatDate}
-                            getGroupLabel={getGroupLabel}
-                            getTabLabel={getTabLabel}
-                            getTabCount={getTabCount}
-                          />
+                          <ConflictSessionRow key={conflict.imported.id} conflict={conflict} />
                         ))}
                       </Flex>
                     </>
                   )}
 
-                  {/* Identical sessions group */}
                   {classification.identicalSessions.length > 0 && (
                     <>
                       {(classification.newSessions.length > 0 || classification.conflictingSessions.length > 0) && (
@@ -428,10 +354,6 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
                             session={session}
                             dimmed
                             statusBadge={getMessage('alreadyExists')}
-                            formatDate={formatDate}
-                            getGroupLabel={getGroupLabel}
-                            getTabLabel={getTabLabel}
-                            getTabCount={getTabCount}
                           />
                         ))}
                       </Flex>
@@ -446,12 +368,8 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
               {hasConflicts && conflictMode === 'overwrite' && (
                 <Callout.Root color="orange" variant="soft" mt="3">
-                  <Callout.Icon>
-                    <AlertTriangle size={16} />
-                  </Callout.Icon>
-                  <Callout.Text>
-                    {getMessage('sessionImportOverwriteWarning')}
-                  </Callout.Text>
+                  <Callout.Icon><AlertTriangle size={16} /></Callout.Icon>
+                  <Callout.Text>{getMessage('sessionImportOverwriteWarning')}</Callout.Text>
                 </Callout.Root>
               )}
             </Box>
@@ -459,14 +377,11 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
           <Separator size="4" mt="4" style={{ opacity: 0.3 }} />
 
-          {/* Footer */}
           <Flex gap="3" justify="end" mt="3">
             {step === 0 && (
               <>
                 <Dialog.Close>
-                  <Button variant="soft" color="gray">
-                    {getMessage('cancel')}
-                  </Button>
+                  <Button variant="soft" color="gray">{getMessage('cancel')}</Button>
                 </Dialog.Close>
                 <Button onClick={goToStep1} disabled={!parsedSessions}>
                   {getMessage('next')}
@@ -487,248 +402,5 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
         </Dialog.Content>
       </Dialog.Root>
     </SessionsTheme>
-  );
-}
-
-// --- Sub-components ---
-
-interface SessionRowProps {
-  session: Session;
-  checkbox?: boolean;
-  checked?: boolean;
-  onToggle?: () => void;
-  dimmed?: boolean;
-  statusBadge?: string;
-  formatDate: (iso: string) => string;
-  getGroupLabel: (count: number) => string;
-  getTabLabel: (count: number) => string;
-  getTabCount: (session: Session) => number;
-}
-
-function SessionRow({
-  session,
-  checkbox,
-  checked,
-  onToggle,
-  dimmed,
-  statusBadge,
-  formatDate,
-  getGroupLabel,
-  getTabLabel,
-  getTabCount,
-}: SessionRowProps) {
-  const tabCount = getTabCount(session);
-  const groupCount = session.groups.length;
-
-  return (
-    <Flex
-      align="center"
-      gap="3"
-      p="2"
-      style={{
-        borderRadius: 'var(--radius-2)',
-        backgroundColor: 'var(--gray-a2)',
-        opacity: dimmed ? 0.6 : 1,
-      }}
-    >
-      {checkbox && (
-        <Checkbox
-          checked={checked}
-          onCheckedChange={onToggle}
-          aria-label={session.name}
-        />
-      )}
-      <Flex direction="column" gap="1" style={{ flex: 1 }}>
-        <Text size="2" weight="medium">{session.name}</Text>
-        <Text size="1" color="gray">
-          {formatDate(session.createdAt)} · {getGroupLabel(groupCount)} · {getTabLabel(tabCount)}
-        </Text>
-      </Flex>
-      {session.isPinned && (
-        <Badge color="indigo" variant="soft" size="1">
-          {getMessage('pinnedBadge')}
-        </Badge>
-      )}
-      {statusBadge && (
-        <Badge color="gray" variant="outline" size="1">
-          {statusBadge}
-        </Badge>
-      )}
-    </Flex>
-  );
-}
-
-interface ConflictSessionRowProps {
-  conflict: ConflictingSession;
-  formatDate: (iso: string) => string;
-  getGroupLabel: (count: number) => string;
-  getTabLabel: (count: number) => string;
-  getTabCount: (session: Session) => number;
-}
-
-function ConflictSessionRow({
-  conflict,
-  formatDate,
-  getGroupLabel,
-  getTabLabel,
-  getTabCount,
-}: ConflictSessionRowProps) {
-  const session = conflict.imported;
-  const tabCount = getTabCount(session);
-  const groupCount = session.groups.length;
-
-  return (
-    <Flex
-      align="center"
-      gap="3"
-      p="2"
-      style={{
-        borderRadius: 'var(--radius-2)',
-        backgroundColor: 'var(--orange-a2)',
-      }}
-    >
-      <AlertTriangle size={16} style={{ color: 'var(--orange-9)', flexShrink: 0 }} aria-hidden="true" />
-      <Flex direction="column" gap="1" style={{ flex: 1 }}>
-        <Text size="2" weight="medium">{session.name}</Text>
-        <Text size="1" color="gray">
-          {formatDate(session.createdAt)} · {getGroupLabel(groupCount)} · {getTabLabel(tabCount)}
-        </Text>
-      </Flex>
-      {session.isPinned && (
-        <Badge color="indigo" variant="soft" size="1">
-          {getMessage('pinnedBadge')}
-        </Badge>
-      )}
-      <Popover.Root>
-        <Popover.Trigger>
-          <Button variant="ghost" size="1" aria-label={getMessage('viewDiff')} title={getMessage('viewDiff')}>
-            <Eye size={14} aria-hidden="true" />
-          </Button>
-        </Popover.Trigger>
-        <Popover.Content style={{ maxWidth: 380 }}>
-          <Text size="3" weight="bold" mb="2">
-            {getMessage('differences')} — {session.name}
-          </Text>
-          <SessionDiffView diff={conflict.diff} />
-        </Popover.Content>
-      </Popover.Root>
-    </Flex>
-  );
-}
-
-interface SessionDiffViewProps {
-  diff: SessionDiff;
-}
-
-function SessionDiffView({ diff }: SessionDiffViewProps) {
-  const hasContent =
-    diff.isPinned !== undefined ||
-    diff.categoryId !== undefined ||
-    diff.groupsAdded.length > 0 ||
-    diff.groupsRemoved.length > 0 ||
-    diff.groupsChanged.length > 0 ||
-    diff.ungroupedTabsAdded.length > 0 ||
-    diff.ungroupedTabsRemoved.length > 0;
-
-  if (!hasContent) return null;
-
-  return (
-    <Flex direction="column" gap="3">
-      {diff.isPinned !== undefined && (
-        <Box>
-          <Text size="2" weight="medium" mb="1">isPinned</Text>
-          <Flex direction="column" gap="1">
-            <Flex align="center" gap="2">
-              <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
-              <Text size="1">{String(diff.isPinned.current)}</Text>
-            </Flex>
-            <Flex align="center" gap="2">
-              <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
-              <Text size="1">{String(diff.isPinned.imported)}</Text>
-            </Flex>
-          </Flex>
-        </Box>
-      )}
-
-      {diff.categoryId !== undefined && (
-        <Box>
-          <Text size="2" weight="medium" mb="1">categoryId</Text>
-          <Flex direction="column" gap="1">
-            <Flex align="center" gap="2">
-              <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
-              <Text size="1">{String(diff.categoryId.current ?? 'null')}</Text>
-            </Flex>
-            <Flex align="center" gap="2">
-              <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
-              <Text size="1">{String(diff.categoryId.imported ?? 'null')}</Text>
-            </Flex>
-          </Flex>
-        </Box>
-      )}
-
-      {diff.groupsAdded.length > 0 && (
-        <Box>
-          <Text size="2" weight="medium" mb="1">Groups added</Text>
-          {diff.groupsAdded.map(title => (
-            <Text key={title} size="1" color="green" as="p">{title}</Text>
-          ))}
-        </Box>
-      )}
-
-      {diff.groupsRemoved.length > 0 && (
-        <Box>
-          <Text size="2" weight="medium" mb="1">Groups removed</Text>
-          {diff.groupsRemoved.map(title => (
-            <Text key={title} size="1" color="red" as="p">{title}</Text>
-          ))}
-        </Box>
-      )}
-
-      {diff.groupsChanged.map(groupDiff => (
-        <GroupDiffView key={groupDiff.title} groupDiff={groupDiff} />
-      ))}
-
-      {(diff.ungroupedTabsAdded.length > 0 || diff.ungroupedTabsRemoved.length > 0) && (
-        <Box>
-          <Text size="2" weight="medium" mb="1">Ungrouped tabs</Text>
-          {diff.ungroupedTabsAdded.map(url => (
-            <Text key={url} size="1" color="green" as="p" style={{ wordBreak: 'break-all' }}>+ {url}</Text>
-          ))}
-          {diff.ungroupedTabsRemoved.map(url => (
-            <Text key={url} size="1" color="red" as="p" style={{ wordBreak: 'break-all' }}>- {url}</Text>
-          ))}
-        </Box>
-      )}
-    </Flex>
-  );
-}
-
-interface GroupDiffViewProps {
-  groupDiff: GroupDiff;
-}
-
-function GroupDiffView({ groupDiff }: GroupDiffViewProps) {
-  return (
-    <Box>
-      <Text size="2" weight="medium" mb="1">Group: {groupDiff.title}</Text>
-      {groupDiff.colorChanged && (
-        <Flex direction="column" gap="1" mb="1">
-          <Flex align="center" gap="2">
-            <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
-            <Text size="1">{groupDiff.colorChanged.current}</Text>
-          </Flex>
-          <Flex align="center" gap="2">
-            <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
-            <Text size="1">{groupDiff.colorChanged.imported}</Text>
-          </Flex>
-        </Flex>
-      )}
-      {groupDiff.tabsAdded.map(url => (
-        <Text key={url} size="1" color="green" as="p" style={{ wordBreak: 'break-all' }}>+ {url}</Text>
-      ))}
-      {groupDiff.tabsRemoved.map(url => (
-        <Text key={url} size="1" color="red" as="p" style={{ wordBreak: 'break-all' }}>- {url}</Text>
-      ))}
-    </Box>
   );
 }

--- a/src/components/UI/ImportExportPage/SessionImportRows.tsx
+++ b/src/components/UI/ImportExportPage/SessionImportRows.tsx
@@ -1,0 +1,225 @@
+import { Flex, Text, Box, Badge, Checkbox, Popover, Button } from '@radix-ui/themes';
+import { AlertTriangle, Eye } from 'lucide-react';
+import { getMessage } from '../../../utils/i18n';
+import {
+  formatSessionDateShort,
+  getSessionGroupLabel,
+  getSessionTabLabel,
+  countSessionTabs,
+} from '../../../utils/sessionUtils';
+import type { Session } from '../../../types/session';
+import type { ConflictingSession, SessionDiff, GroupDiff } from '../../../utils/sessionClassification';
+
+/* ─── SessionRow ─────────────────────────────────────────────────────────── */
+
+export interface SessionRowProps {
+  session: Session;
+  checkbox?: boolean;
+  checked?: boolean;
+  onToggle?: () => void;
+  dimmed?: boolean;
+  statusBadge?: string;
+}
+
+export function SessionRow({ session, checkbox, checked, onToggle, dimmed, statusBadge }: SessionRowProps) {
+  const tabCount = countSessionTabs(session);
+  const groupCount = session.groups.length;
+
+  return (
+    <Flex
+      align="center"
+      gap="3"
+      p="2"
+      style={{
+        borderRadius: 'var(--radius-2)',
+        backgroundColor: 'var(--gray-a2)',
+        opacity: dimmed ? 0.6 : 1,
+      }}
+    >
+      {checkbox && (
+        <Checkbox checked={checked} onCheckedChange={onToggle} aria-label={session.name} />
+      )}
+      <Flex direction="column" gap="1" style={{ flex: 1 }}>
+        <Text size="2" weight="medium">{session.name}</Text>
+        <Text size="1" color="gray">
+          {formatSessionDateShort(session.createdAt)} · {getSessionGroupLabel(groupCount)} · {getSessionTabLabel(tabCount)}
+        </Text>
+      </Flex>
+      {session.isPinned && (
+        <Badge color="indigo" variant="soft" size="1">{getMessage('pinnedBadge')}</Badge>
+      )}
+      {statusBadge && (
+        <Badge color="gray" variant="outline" size="1">{statusBadge}</Badge>
+      )}
+    </Flex>
+  );
+}
+
+/* ─── ConflictSessionRow ─────────────────────────────────────────────────── */
+
+export interface ConflictSessionRowProps {
+  conflict: ConflictingSession;
+}
+
+export function ConflictSessionRow({ conflict }: ConflictSessionRowProps) {
+  const session = conflict.imported;
+  const tabCount = countSessionTabs(session);
+  const groupCount = session.groups.length;
+
+  return (
+    <Flex
+      align="center"
+      gap="3"
+      p="2"
+      style={{
+        borderRadius: 'var(--radius-2)',
+        backgroundColor: 'var(--orange-a2)',
+      }}
+    >
+      <AlertTriangle size={16} style={{ color: 'var(--orange-9)', flexShrink: 0 }} aria-hidden="true" />
+      <Flex direction="column" gap="1" style={{ flex: 1 }}>
+        <Text size="2" weight="medium">{session.name}</Text>
+        <Text size="1" color="gray">
+          {formatSessionDateShort(session.createdAt)} · {getSessionGroupLabel(groupCount)} · {getSessionTabLabel(tabCount)}
+        </Text>
+      </Flex>
+      {session.isPinned && (
+        <Badge color="indigo" variant="soft" size="1">{getMessage('pinnedBadge')}</Badge>
+      )}
+      <Popover.Root>
+        <Popover.Trigger>
+          <Button variant="ghost" size="1" aria-label={getMessage('viewDiff')} title={getMessage('viewDiff')}>
+            <Eye size={14} aria-hidden="true" />
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content style={{ maxWidth: 380 }}>
+          <Text size="3" weight="bold" mb="2">
+            {getMessage('differences')} — {session.name}
+          </Text>
+          <SessionDiffView diff={conflict.diff} />
+        </Popover.Content>
+      </Popover.Root>
+    </Flex>
+  );
+}
+
+/* ─── SessionDiffView ────────────────────────────────────────────────────── */
+
+interface SessionDiffViewProps {
+  diff: SessionDiff;
+}
+
+export function SessionDiffView({ diff }: SessionDiffViewProps) {
+  const hasContent =
+    diff.isPinned !== undefined ||
+    diff.categoryId !== undefined ||
+    diff.groupsAdded.length > 0 ||
+    diff.groupsRemoved.length > 0 ||
+    diff.groupsChanged.length > 0 ||
+    diff.ungroupedTabsAdded.length > 0 ||
+    diff.ungroupedTabsRemoved.length > 0;
+
+  if (!hasContent) return null;
+
+  return (
+    <Flex direction="column" gap="3">
+      {diff.isPinned !== undefined && (
+        <Box>
+          <Text size="2" weight="medium" mb="1">isPinned</Text>
+          <Flex direction="column" gap="1">
+            <Flex align="center" gap="2">
+              <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
+              <Text size="1">{String(diff.isPinned.current)}</Text>
+            </Flex>
+            <Flex align="center" gap="2">
+              <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
+              <Text size="1">{String(diff.isPinned.imported)}</Text>
+            </Flex>
+          </Flex>
+        </Box>
+      )}
+
+      {diff.categoryId !== undefined && (
+        <Box>
+          <Text size="2" weight="medium" mb="1">categoryId</Text>
+          <Flex direction="column" gap="1">
+            <Flex align="center" gap="2">
+              <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
+              <Text size="1">{String(diff.categoryId.current ?? 'null')}</Text>
+            </Flex>
+            <Flex align="center" gap="2">
+              <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
+              <Text size="1">{String(diff.categoryId.imported ?? 'null')}</Text>
+            </Flex>
+          </Flex>
+        </Box>
+      )}
+
+      {diff.groupsAdded.length > 0 && (
+        <Box>
+          <Text size="2" weight="medium" mb="1">Groups added</Text>
+          {diff.groupsAdded.map(title => (
+            <Text key={title} size="1" color="green" as="p">{title}</Text>
+          ))}
+        </Box>
+      )}
+
+      {diff.groupsRemoved.length > 0 && (
+        <Box>
+          <Text size="2" weight="medium" mb="1">Groups removed</Text>
+          {diff.groupsRemoved.map(title => (
+            <Text key={title} size="1" color="red" as="p">{title}</Text>
+          ))}
+        </Box>
+      )}
+
+      {diff.groupsChanged.map(groupDiff => (
+        <GroupDiffView key={groupDiff.title} groupDiff={groupDiff} />
+      ))}
+
+      {(diff.ungroupedTabsAdded.length > 0 || diff.ungroupedTabsRemoved.length > 0) && (
+        <Box>
+          <Text size="2" weight="medium" mb="1">Ungrouped tabs</Text>
+          {diff.ungroupedTabsAdded.map(url => (
+            <Text key={url} size="1" color="green" as="p" style={{ wordBreak: 'break-all' }}>+ {url}</Text>
+          ))}
+          {diff.ungroupedTabsRemoved.map(url => (
+            <Text key={url} size="1" color="red" as="p" style={{ wordBreak: 'break-all' }}>- {url}</Text>
+          ))}
+        </Box>
+      )}
+    </Flex>
+  );
+}
+
+/* ─── GroupDiffView ──────────────────────────────────────────────────────── */
+
+interface GroupDiffViewProps {
+  groupDiff: GroupDiff;
+}
+
+function GroupDiffView({ groupDiff }: GroupDiffViewProps) {
+  return (
+    <Box>
+      <Text size="2" weight="medium" mb="1">Group: {groupDiff.title}</Text>
+      {groupDiff.colorChanged && (
+        <Flex direction="column" gap="1" mb="1">
+          <Flex align="center" gap="2">
+            <Badge color="red" variant="soft" size="1">{getMessage('currentValue')}</Badge>
+            <Text size="1">{groupDiff.colorChanged.current}</Text>
+          </Flex>
+          <Flex align="center" gap="2">
+            <Badge color="green" variant="soft" size="1">{getMessage('importedValue')}</Badge>
+            <Text size="1">{groupDiff.colorChanged.imported}</Text>
+          </Flex>
+        </Flex>
+      )}
+      {groupDiff.tabsAdded.map(url => (
+        <Text key={url} size="1" color="green" as="p" style={{ wordBreak: 'break-all' }}>+ {url}</Text>
+      ))}
+      {groupDiff.tabsRemoved.map(url => (
+        <Text key={url} size="1" color="red" as="p" style={{ wordBreak: 'break-all' }}>- {url}</Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/UI/OptionsLayout/OptionsFooter.tsx
+++ b/src/components/UI/OptionsLayout/OptionsFooter.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Flex, Text } from '@radix-ui/themes';
+import { Github } from 'lucide-react';
+import { browser } from 'wxt/browser';
+
+const GITHUB_URL = 'https://github.com/EspritVorace/smart-tab-organizer';
+
+function openGithub() {
+  browser.tabs.create({ url: GITHUB_URL });
+}
+
+function handleGithubKeyDown(e: React.KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    openGithub();
+  }
+}
+
+/** Expanded sidebar footer: avatar, username, GitHub icon. */
+export function OptionsFooter() {
+  return (
+    <Flex
+      align="center"
+      gap="3"
+      style={{
+        padding: '12px 16px',
+        cursor: 'pointer',
+        borderRadius: '4px',
+        transition: 'background-color 0.2s ease',
+      }}
+      onClick={openGithub}
+      onKeyDown={handleGithubKeyDown}
+      tabIndex={0}
+      role="button"
+      aria-label="Visiter le profil GitHub d'EspritVorace"
+      className="custom-footer-expanded"
+    >
+      <img
+        src="/icons/ev.png"
+        alt="EspritVorace"
+        style={{ width: '24px', height: '24px', borderRadius: '50%', flexShrink: 0 }}
+      />
+      <Flex align="center" gap="2">
+        <Text size="2" weight="medium" style={{ color: 'var(--gray-11)', textDecoration: 'none' }}>
+          EspritVorace
+        </Text>
+        <Github size={16} style={{ color: 'var(--gray-11)', flexShrink: 0 }} />
+      </Flex>
+    </Flex>
+  );
+}
+
+/** Collapsed sidebar footer: avatar only. */
+export function OptionsFooterCollapsed() {
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      style={{
+        padding: '12px',
+        cursor: 'pointer',
+        borderRadius: '4px',
+        transition: 'background-color 0.2s ease',
+      }}
+      onClick={openGithub}
+      onKeyDown={handleGithubKeyDown}
+      tabIndex={0}
+      role="button"
+      aria-label="Visiter le profil GitHub d'EspritVorace"
+      className="custom-footer-collapsed"
+    >
+      <img
+        src="/icons/ev.png"
+        alt="EspritVorace"
+        style={{ width: '24px', height: '24px', borderRadius: '50%' }}
+      />
+    </Flex>
+  );
+}

--- a/src/components/UI/OptionsLayout/OptionsHeader.tsx
+++ b/src/components/UI/OptionsLayout/OptionsHeader.tsx
@@ -1,0 +1,42 @@
+import { Flex, Text } from '@radix-ui/themes';
+import { ThemeToggle } from '../ThemeToggle/ThemeToggle';
+
+interface OptionsHeaderProps {
+  version: string;
+}
+
+/** Expanded sidebar header: logo, app name, version, theme toggle. */
+export function OptionsHeader({ version }: OptionsHeaderProps) {
+  return (
+    <Flex align="center" gap="3" style={{ width: '100%', paddingRight: '64px', position: 'relative' }}>
+      <img
+        src="/icons/icon48.png"
+        alt="SmartTab Organizer"
+        style={{ width: '32px', height: '32px', flexShrink: 0 }}
+      />
+      <Flex direction="column" gap="0" style={{ lineHeight: '1.2', flex: 1 }}>
+        <Flex align="center" gap="2">
+          <Text size="3" weight="bold" style={{ color: 'var(--gray-12)' }}>SmartTab</Text>
+          <Text size="1" style={{ color: 'var(--gray-11)' }}>(v{version})</Text>
+        </Flex>
+        <Text size="3" weight="bold" style={{ color: 'var(--gray-12)' }}>Organizer</Text>
+      </Flex>
+      <Flex align="center" style={{ position: 'absolute', right: '8px' }}>
+        <ThemeToggle />
+      </Flex>
+    </Flex>
+  );
+}
+
+/** Collapsed sidebar header: logo only. */
+export function OptionsHeaderCollapsed() {
+  return (
+    <Flex align="center" justify="center" style={{ width: '100%' }}>
+      <img
+        src="/icons/icon48.png"
+        alt="SmartTab Organizer"
+        style={{ width: '32px', height: '32px' }}
+      />
+    </Flex>
+  );
+}

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+
+interface DeepLinkState {
+  currentTab: string;
+  openSnapshotWizard: boolean;
+  snapshotGroupId: number | null;
+}
+
+const VALID_SECTIONS = ['rules', 'importexport', 'sessions', 'stats', 'settings'] as const;
+
+/**
+ * Handles hash-based deep linking for the options page.
+ * Parses the URL hash on mount and on every hashchange event.
+ */
+export function useDeepLinking(): DeepLinkState & {
+  setCurrentTab: (tab: string) => void;
+  setOpenSnapshotWizard: (open: boolean) => void;
+  setSnapshotGroupId: (id: number | null) => void;
+} {
+  const [currentTab, setCurrentTab] = useState<string>('rules');
+  const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
+  const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
+
+  useEffect(() => {
+    function handleHash() {
+      const hash = window.location.hash; // e.g. '#sessions?action=snapshot'
+      if (!hash.startsWith('#')) return;
+      const questionMark = hash.indexOf('?');
+      const section = questionMark === -1 ? hash.slice(1) : hash.slice(1, questionMark);
+      if (!(VALID_SECTIONS as readonly string[]).includes(section)) return;
+      setCurrentTab(section);
+      if (section === 'sessions' && questionMark !== -1) {
+        const params = new URLSearchParams(hash.slice(questionMark + 1));
+        if (params.get('action') === 'snapshot') {
+          setOpenSnapshotWizard(true);
+          const groupIdParam = params.get('groupId');
+          setSnapshotGroupId(groupIdParam ? parseInt(groupIdParam, 10) : null);
+        }
+      }
+    }
+
+    handleHash();
+    window.addEventListener('hashchange', handleHash);
+    return () => window.removeEventListener('hashchange', handleHash);
+  }, []);
+
+  return {
+    currentTab,
+    setCurrentTab,
+    openSnapshotWizard,
+    setOpenSnapshotWizard,
+    snapshotGroupId,
+    setSnapshotGroupId,
+  };
+}

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -1,23 +1,19 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import type { Statistics } from '../types/statistics.js';
 import { defaultStatistics } from '../types/statistics.js';
-import { logger } from '../utils/logger';
 import { statisticsItem } from '../utils/storageItems.js';
+import { useSyncedState } from './useSyncedState.js';
 
 export interface UseStatisticsReturn {
-  // État actuel
   statistics: Statistics | null;
   isLoaded: boolean;
 
-  // Setters pour chaque champ
   setTabGroupsCreatedCount: (value: number) => Promise<void>;
   setTabsDeduplicatedCount: (value: number) => Promise<void>;
 
-  // Callbacks de changement pour chaque champ
   onTabGroupsCreatedCountChange: (callback: (value: number) => void) => () => void;
   onTabsDeduplicatedCountChange: (callback: (value: number) => void) => () => void;
 
-  // Utilitaires
   updateStatistics: (updates: Partial<Statistics>) => Promise<void>;
   resetStatistics: () => Promise<void>;
   incrementTabGroupsCreated: () => Promise<void>;
@@ -25,153 +21,53 @@ export interface UseStatisticsReturn {
   reloadStatistics: () => Promise<void>;
 }
 
-function mergeWithDefaults(value: Statistics | null): Statistics {
-  return { ...defaultStatistics, ...value };
+function mergeWithDefaults(v: Statistics | null): Statistics {
+  return { ...defaultStatistics, ...v };
 }
 
 export function useStatistics(): UseStatisticsReturn {
-  const [statistics, setStatistics] = useState<Statistics | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [changeCallbacks, setChangeCallbacks] = useState<{
-    [K in keyof Statistics]?: Set<(value: Statistics[K]) => void>;
-  }>({});
+  const { value: statistics, isLoaded, update, reset, onFieldChange, reload } =
+    useSyncedState<Statistics>({
+      load: async () => mergeWithDefaults(await statisticsItem.getValue()),
 
-  // Ref pour éviter de réagir aux changements qu'on a nous-même déclenchés
-  const isLocalUpdate = useRef(false);
-  const changeCallbacksRef = useRef(changeCallbacks);
-  changeCallbacksRef.current = changeCallbacks;
+      // The statistics object is stored as a single item.
+      // Pass the full updated value to the watcher as a partial so the
+      // generic hook merges it into state (effectively replacing all fields).
+      watch: (onChanged) =>
+        statisticsItem.watch(v => onChanged(mergeWithDefaults(v))),
 
-  // Chargement initial
-  useEffect(() => {
-    statisticsItem.getValue()
-      .then(value => {
-        setStatistics(mergeWithDefaults(value));
-        setIsLoaded(true);
-      })
-      .catch(error => logger.error('Error loading statistics:', error));
-  }, []);
+      // Save the full current state (updates are already merged into `current`).
+      save: async (_updates, current) => {
+        await statisticsItem.setValue(current);
+      },
 
-  // Watcher pour les changements de storage
-  useEffect(() => {
-    return statisticsItem.watch((newValue) => {
-      if (isLocalUpdate.current) return;
-
-      const newStatistics = mergeWithDefaults(newValue);
-      setStatistics(prev => {
-        // Déclencher les callbacks pour les champs modifiés
-        if (prev) {
-          (Object.keys(newStatistics) as (keyof Statistics)[]).forEach(field => {
-            if (newStatistics[field] !== prev[field]) {
-              const callbacks = changeCallbacksRef.current[field];
-              if (callbacks) callbacks.forEach(cb => cb(newStatistics[field]));
-            }
-          });
-        }
-        return newStatistics;
-      });
+      defaults: defaultStatistics,
     });
-  }, []); // Pas de dépendances - le watcher reste stable
 
-  // Fonction générique pour mettre à jour un champ
-  const updateField = useCallback(async <K extends keyof Statistics>(
-    field: K,
-    value: Statistics[K]
-  ) => {
-    if (!statistics) return;
-    isLocalUpdate.current = true;
-    try {
-      const updatedStatistics = { ...statistics, [field]: value };
-      await statisticsItem.setValue(updatedStatistics);
-      setStatistics(updatedStatistics);
-    } finally {
-      setTimeout(() => { isLocalUpdate.current = false; }, 100);
-    }
-  }, [statistics]);
-
-  // Fonction générique pour enregistrer un callback de changement
-  const registerChangeCallback = useCallback(<K extends keyof Statistics>(
-    field: K,
-    callback: (value: Statistics[K]) => void
-  ) => {
-    setChangeCallbacks(prev => ({
-      ...prev,
-      [field]: new Set([...(prev[field] || []), callback])
-    }));
-    return () => {
-      setChangeCallbacks(prev => {
-        const newCallbacks = { ...prev };
-        if (newCallbacks[field]) {
-          newCallbacks[field]!.delete(callback);
-          if (newCallbacks[field]!.size === 0) delete newCallbacks[field];
-        }
-        return newCallbacks;
-      });
-    };
-  }, []);
-
-  // Fonction pour mettre à jour plusieurs champs
-  const updateStatistics = useCallback(async (updates: Partial<Statistics>) => {
-    if (!statistics) return;
-    isLocalUpdate.current = true;
-    try {
-      const updatedStatistics = { ...statistics, ...updates };
-      await statisticsItem.setValue(updatedStatistics);
-      setStatistics(updatedStatistics);
-    } finally {
-      setTimeout(() => { isLocalUpdate.current = false; }, 100);
-    }
-  }, [statistics]);
-
-  // Fonction pour reset les statistiques
-  const resetStatistics = useCallback(async () => {
-    isLocalUpdate.current = true;
-    try {
-      await statisticsItem.setValue(defaultStatistics);
-      setStatistics(defaultStatistics);
-    } finally {
-      setTimeout(() => { isLocalUpdate.current = false; }, 100);
-    }
-  }, []);
-
-  // Fonction pour incrémenter les groupes créés
   const incrementTabGroupsCreated = useCallback(async () => {
     if (!statistics) return;
-    await updateField('tabGroupsCreatedCount', statistics.tabGroupsCreatedCount + 1);
-  }, [statistics, updateField]);
+    await update({ tabGroupsCreatedCount: statistics.tabGroupsCreatedCount + 1 });
+  }, [statistics, update]);
 
-  // Fonction pour incrémenter les onglets dédupliqués
   const incrementTabsDeduplicated = useCallback(async () => {
     if (!statistics) return;
-    await updateField('tabsDeduplicatedCount', statistics.tabsDeduplicatedCount + 1);
-  }, [statistics, updateField]);
-
-  // Fonction pour recharger les statistiques
-  const reloadStatistics = useCallback(async () => {
-    try {
-      const value = await statisticsItem.getValue();
-      setStatistics(mergeWithDefaults(value));
-    } catch (error) {
-      logger.error('Error reloading statistics:', error);
-    }
-  }, []);
+    await update({ tabsDeduplicatedCount: statistics.tabsDeduplicatedCount + 1 });
+  }, [statistics, update]);
 
   return {
     statistics,
     isLoaded,
 
-    // Setters
-    setTabGroupsCreatedCount: (value) => updateField('tabGroupsCreatedCount', value),
-    setTabsDeduplicatedCount: (value) => updateField('tabsDeduplicatedCount', value),
+    setTabGroupsCreatedCount: (value) => update({ tabGroupsCreatedCount: value }),
+    setTabsDeduplicatedCount: (value) => update({ tabsDeduplicatedCount: value }),
 
-    // Change callbacks
-    onTabGroupsCreatedCountChange: (cb) => registerChangeCallback('tabGroupsCreatedCount', cb),
-    onTabsDeduplicatedCountChange: (cb) => registerChangeCallback('tabsDeduplicatedCount', cb),
+    onTabGroupsCreatedCountChange: (cb) => onFieldChange('tabGroupsCreatedCount', cb),
+    onTabsDeduplicatedCountChange: (cb) => onFieldChange('tabsDeduplicatedCount', cb),
 
-    // Utilitaires
-    updateStatistics,
-    resetStatistics,
+    updateStatistics: update,
+    resetStatistics: reset,
     incrementTabGroupsCreated,
     incrementTabsDeduplicated,
-    reloadStatistics
+    reloadStatistics: reload,
   };
 }

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -1,34 +1,32 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
 import { storage } from 'wxt/utils/storage';
 import type { SyncSettings, DomainRuleSettings } from '../types/syncSettings.js';
-import { logger } from '../utils/logger';
 import {
   globalGroupingEnabledItem,
   globalDeduplicationEnabledItem,
   domainRulesItem,
   notifyOnGroupingItem,
   notifyOnDeduplicationItem,
+  syncSettingsItemMap,
 } from '../utils/storageItems.js';
+import { useSyncedState } from './useSyncedState.js';
 
 export interface UseSyncedSettingsReturn {
-  // État actuel
   settings: SyncSettings | null;
   isLoaded: boolean;
 
-  // Setters pour chaque champ
   setGlobalGroupingEnabled: (value: boolean) => Promise<void>;
   setGlobalDeduplicationEnabled: (value: boolean) => Promise<void>;
   setDomainRules: (value: DomainRuleSettings) => Promise<void>;
 
-  // Callbacks de changement pour chaque champ
   onGlobalGroupingEnabledChange: (callback: (value: boolean) => void) => () => void;
   onGlobalDeduplicationEnabledChange: (callback: (value: boolean) => void) => () => void;
   onDomainRulesChange: (callback: (value: DomainRuleSettings) => void) => () => void;
 
-  // Utilitaires
   updateSettings: (updates: Partial<SyncSettings>) => Promise<void>;
   reloadSettings: () => Promise<void>;
 }
+
+// --- Storage helpers (module-level, stable references) ---
 
 async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
   const results = await storage.getItems([
@@ -47,135 +45,52 @@ async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
   };
 }
 
+/**
+ * Register one watcher per storage item.
+ * Each watcher fires `onChanged` with a single-field partial so the generic
+ * hook can merge it into state and invoke per-field callbacks.
+ */
+function watchSyncSettings(onChanged: (update: Partial<SyncSettings>) => void): () => void {
+  const unwatchers = (
+    Object.entries(syncSettingsItemMap) as [keyof SyncSettings, { watch: (cb: (v: any) => void) => () => void }][]
+  ).map(([field, item]) => item.watch((v) => onChanged({ [field]: v })));
+  return () => unwatchers.forEach(u => u());
+}
+
+/**
+ * Persist only the fields present in `updates` to their respective storage items.
+ */
+async function saveSettingsToStorage(updates: Partial<SyncSettings>): Promise<void> {
+  const items = (Object.entries(updates) as [keyof typeof syncSettingsItemMap, any][])
+    .filter(([key]) => key in syncSettingsItemMap)
+    .map(([key, value]) => ({ item: syncSettingsItemMap[key], value }));
+  if (items.length > 0) await storage.setItems(items);
+}
+
+// --- Hook ---
+
 export function useSyncedSettings(): UseSyncedSettingsReturn {
-  const [settings, setSettings] = useState<SyncSettings | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [changeCallbacks, setChangeCallbacks] = useState<{
-    [K in keyof SyncSettings]?: Set<(value: SyncSettings[K]) => void>;
-  }>({});
-
-  // Ref pour éviter de réagir aux changements qu'on a nous-même déclenchés
-  const isLocalUpdate = useRef(false);
-  // Ref pour les callbacks (évite les problèmes de closure)
-  const changeCallbacksRef = useRef(changeCallbacks);
-  changeCallbacksRef.current = changeCallbacks;
-
-  // Chargement initial
-  useEffect(() => {
-    loadSyncSettingsFromStorage()
-      .then(s => { setSettings(s); setIsLoaded(true); })
-      .catch(error => logger.error('Error loading settings:', error));
-  }, []);
-
-  // Watchers pour les changements de storage (provenant d'autres sources)
-  useEffect(() => {
-    function applyExternalChange<K extends keyof SyncSettings>(field: K, newValue: SyncSettings[K]) {
-      if (isLocalUpdate.current) return;
-      setSettings(prev => {
-        if (!prev) return prev;
-        const callbacks = changeCallbacksRef.current[field];
-        if (callbacks) callbacks.forEach(cb => cb(newValue));
-        return { ...prev, [field]: newValue };
-      });
-    }
-
-    const unwatchers = [
-      globalGroupingEnabledItem.watch(v => applyExternalChange('globalGroupingEnabled', v)),
-      globalDeduplicationEnabledItem.watch(v => applyExternalChange('globalDeduplicationEnabled', v)),
-      domainRulesItem.watch(v => applyExternalChange('domainRules', v)),
-      notifyOnGroupingItem.watch(v => applyExternalChange('notifyOnGrouping', v)),
-      notifyOnDeduplicationItem.watch(v => applyExternalChange('notifyOnDeduplication', v)),
-    ];
-
-    return () => unwatchers.forEach(u => u());
-  }, []); // Pas de dépendances - les watchers restent stables
-
-  // Fonction générique pour mettre à jour un champ
-  const updateField = useCallback(async <K extends keyof SyncSettings>(
-    field: K,
-    value: SyncSettings[K],
-    setValue: (v: SyncSettings[K]) => Promise<void>,
-  ) => {
-    isLocalUpdate.current = true;
-    try {
-      // Mettre à jour l'état local d'abord pour une UI réactive
-      setSettings(prev => prev ? { ...prev, [field]: value } : null);
-      // Puis persister dans le storage
-      await setValue(value);
-    } finally {
-      // Réactiver l'écoute des changements externes après un court délai
-      setTimeout(() => { isLocalUpdate.current = false; }, 100);
-    }
-  }, []);
-
-  // Fonction générique pour enregistrer un callback de changement
-  const registerChangeCallback = useCallback(<K extends keyof SyncSettings>(
-    field: K,
-    callback: (value: SyncSettings[K]) => void
-  ) => {
-    setChangeCallbacks(prev => ({
-      ...prev,
-      [field]: new Set([...(prev[field] || []), callback as any])
-    }));
-    return () => {
-      setChangeCallbacks(prev => {
-        const newCallbacks = { ...prev };
-        if (newCallbacks[field]) {
-          (newCallbacks[field] as Set<any>).delete(callback);
-          if (newCallbacks[field]!.size === 0) delete newCallbacks[field];
-        }
-        return newCallbacks;
-      });
-    };
-  }, []);
-
-  // Fonction pour mettre à jour plusieurs champs
-  const updateSettings = useCallback(async (updates: Partial<SyncSettings>) => {
-    isLocalUpdate.current = true;
-    try {
-      setSettings(prev => prev ? { ...prev, ...updates } : null);
-      const items: Parameters<typeof storage.setItems>[0] = [];
-      if ('globalGroupingEnabled' in updates)
-        items.push({ item: globalGroupingEnabledItem, value: updates.globalGroupingEnabled! });
-      if ('globalDeduplicationEnabled' in updates)
-        items.push({ item: globalDeduplicationEnabledItem, value: updates.globalDeduplicationEnabled! });
-      if ('domainRules' in updates)
-        items.push({ item: domainRulesItem, value: updates.domainRules! });
-      if ('notifyOnGrouping' in updates)
-        items.push({ item: notifyOnGroupingItem, value: updates.notifyOnGrouping! });
-      if ('notifyOnDeduplication' in updates)
-        items.push({ item: notifyOnDeduplicationItem, value: updates.notifyOnDeduplication! });
-      if (items.length > 0) await storage.setItems(items);
-    } finally {
-      setTimeout(() => { isLocalUpdate.current = false; }, 100);
-    }
-  }, []);
-
-  // Fonction pour recharger les settings
-  const reloadSettings = useCallback(async () => {
-    try {
-      setSettings(await loadSyncSettingsFromStorage());
-    } catch (error) {
-      logger.error('Error reloading settings:', error);
-    }
-  }, []);
+  const { value: settings, isLoaded, update, onFieldChange, reload } =
+    useSyncedState<SyncSettings>({
+      load: loadSyncSettingsFromStorage,
+      watch: watchSyncSettings,
+      // Only save changed fields; `current` is not needed here.
+      save: (updates) => saveSettingsToStorage(updates),
+    });
 
   return {
     settings,
     isLoaded,
 
-    // Setters
-    setGlobalGroupingEnabled: (v) => updateField('globalGroupingEnabled', v, globalGroupingEnabledItem.setValue),
-    setGlobalDeduplicationEnabled: (v) => updateField('globalDeduplicationEnabled', v, globalDeduplicationEnabledItem.setValue),
-    setDomainRules: (v) => updateField('domainRules', v, domainRulesItem.setValue),
+    setGlobalGroupingEnabled: (v) => update({ globalGroupingEnabled: v }),
+    setGlobalDeduplicationEnabled: (v) => update({ globalDeduplicationEnabled: v }),
+    setDomainRules: (v) => update({ domainRules: v }),
 
-    // Change callbacks
-    onGlobalGroupingEnabledChange: (cb) => registerChangeCallback('globalGroupingEnabled', cb),
-    onGlobalDeduplicationEnabledChange: (cb) => registerChangeCallback('globalDeduplicationEnabled', cb),
-    onDomainRulesChange: (cb) => registerChangeCallback('domainRules', cb),
+    onGlobalGroupingEnabledChange: (cb) => onFieldChange('globalGroupingEnabled', cb),
+    onGlobalDeduplicationEnabledChange: (cb) => onFieldChange('globalDeduplicationEnabled', cb),
+    onDomainRulesChange: (cb) => onFieldChange('domainRules', cb),
 
-    // Utilitaires
-    updateSettings,
-    reloadSettings
+    updateSettings: update,
+    reloadSettings: reload,
   };
 }

--- a/src/hooks/useSyncedState.ts
+++ b/src/hooks/useSyncedState.ts
@@ -1,0 +1,198 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { logger } from '../utils/logger';
+
+/**
+ * Configuration for useSyncedState.
+ *
+ * @template T - Shape of the state object (must be a plain object).
+ */
+export interface SyncedStateOptions<T extends object> {
+  /**
+   * Async function that loads the full initial state from storage.
+   * Called once on mount.
+   */
+  load: () => Promise<T>;
+
+  /**
+   * Register external-change watchers.
+   * The provided `onChanged` callback must be called with a *partial* object
+   * containing only the fields that changed. The hook merges it into state.
+   * Return a cleanup function (called on unmount).
+   */
+  watch: (onChanged: (update: Partial<T>) => void) => () => void;
+
+  /**
+   * Persist a partial update to storage.
+   * Receives both the changed fields (`updates`) and the full new state
+   * (`current`) so implementations can choose to save granularly or as a whole.
+   */
+  save: (updates: Partial<T>, current: T) => Promise<void>;
+
+  /**
+   * Optional defaults. When provided, `reset()` restores the state to these
+   * values. Omit to make `reset()` a no-op.
+   */
+  defaults?: T;
+}
+
+export interface SyncedStateReturn<T extends object> {
+  /** Current state, or null while the initial load is pending. */
+  value: T | null;
+  /** True once the initial load completed successfully. */
+  isLoaded: boolean;
+  /** Optimistically update state and persist to storage. */
+  update: (updates: Partial<T>) => Promise<void>;
+  /** Reset to defaults (no-op if no defaults were provided). */
+  reset: () => Promise<void>;
+  /**
+   * Register a callback for a specific field.
+   * Called when an *external* storage change updates that field.
+   * Returns an unregister function.
+   */
+  onFieldChange: <K extends keyof T>(field: K, cb: (value: T[K]) => void) => () => void;
+  /** Re-fetch the full state from storage and overwrite local state. */
+  reload: () => Promise<void>;
+}
+
+/**
+ * Generic hook for state that is persisted to browser storage and watched for
+ * changes made by other extension contexts (background, popup, options…).
+ *
+ * Handles:
+ * - Initial load
+ * - External-change watchers with per-field callbacks
+ * - Optimistic local writes (state updated before storage write completes)
+ * - isLocalUpdate guard to avoid reacting to own writes
+ */
+export function useSyncedState<T extends object>({
+  load,
+  watch: setupWatch,
+  save,
+  defaults,
+}: SyncedStateOptions<T>): SyncedStateReturn<T> {
+  // --- State ---
+  const [value, _setValue] = useState<T | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [changeCallbacks, setChangeCallbacks] = useState<{
+    [K in keyof T]?: Set<(v: T[K]) => void>;
+  }>({});
+
+  // --- Refs ---
+
+  // Synchronous mirror of `value` for reads in async callbacks (avoids stale closures).
+  const valueRef = useRef<T | null>(null);
+
+  // Prevents reacting to storage events triggered by our own writes.
+  const isLocalUpdate = useRef(false);
+
+  // Keeps callbacks accessible inside the stable watcher closure.
+  const changeCallbacksRef = useRef(changeCallbacks);
+  changeCallbacksRef.current = changeCallbacks;
+
+  // Option refs so effects only run once while still seeing the latest functions.
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const setupWatchRef = useRef(setupWatch);
+  setupWatchRef.current = setupWatch;
+
+  // --- Helpers ---
+
+  /** Update both the React state and the sync ref atomically. */
+  const setValue = useCallback((next: T | null) => {
+    valueRef.current = next;
+    _setValue(next);
+  }, []);
+
+  /**
+   * Wrap any storage write with the local-update guard.
+   * Sets the flag before writing, clears it after a short delay so the
+   * storage watcher has time to fire and be ignored.
+   */
+  const withLocalUpdate = useCallback(async (fn: () => Promise<void>) => {
+    isLocalUpdate.current = true;
+    try {
+      await fn();
+    } finally {
+      setTimeout(() => { isLocalUpdate.current = false; }, 100);
+    }
+  }, []);
+
+  // --- Effects ---
+
+  useEffect(() => {
+    loadRef.current()
+      .then(v => { setValue(v); setIsLoaded(true); })
+      .catch(error => logger.error('[useSyncedState] load error:', error));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    return setupWatchRef.current((update) => {
+      if (isLocalUpdate.current) return;
+      _setValue(prev => {
+        if (!prev) return prev;
+        const next = { ...prev, ...update };
+        valueRef.current = next;
+        // Fire per-field callbacks for fields that actually changed.
+        (Object.keys(update) as (keyof T)[]).forEach((field) => {
+          if ((update as T)[field] !== prev[field]) {
+            const cbs = changeCallbacksRef.current[field];
+            if (cbs) cbs.forEach(cb => cb(next[field] as T[typeof field]));
+          }
+        });
+        return next;
+      });
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // --- Public API ---
+
+  const update = useCallback(async (updates: Partial<T>) => {
+    const current = valueRef.current;
+    if (!current) return;
+    const newValue = { ...current, ...updates };
+    setValue(newValue);
+    await withLocalUpdate(async () => {
+      await saveRef.current(updates, newValue);
+    });
+  }, [setValue, withLocalUpdate]);
+
+  const reset = useCallback(async () => {
+    if (!defaults) return;
+    setValue(defaults);
+    await withLocalUpdate(async () => {
+      await saveRef.current(defaults as Partial<T>, defaults);
+    });
+  }, [defaults, setValue, withLocalUpdate]);
+
+  const onFieldChange = useCallback(<K extends keyof T>(
+    field: K,
+    callback: (value: T[K]) => void,
+  ) => {
+    setChangeCallbacks(prev => ({
+      ...prev,
+      [field]: new Set([...(prev[field] ?? []), callback as any]),
+    }));
+    return () => {
+      setChangeCallbacks(prev => {
+        const next = { ...prev };
+        if (next[field]) {
+          (next[field] as Set<any>).delete(callback);
+          if ((next[field] as Set<any>).size === 0) delete next[field];
+        }
+        return next;
+      });
+    };
+  }, []);
+
+  const reload = useCallback(async () => {
+    try {
+      setValue(await loadRef.current());
+    } catch (error) {
+      logger.error('[useSyncedState] reload error:', error);
+    }
+  }, [setValue]);
+
+  return { value, isLoaded, update, reset, onFieldChange, reload };
+}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -3,6 +3,7 @@ import { Button, Switch, Text, HoverCard, Box, Flex, Badge, Card, Checkbox, Icon
 import { Pencil, Trash2, Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, MoreHorizontal } from 'lucide-react';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { RuleWizardModal } from '../components/Core/DomainRule/RuleWizardModal';
+import { RuleDetailPopover } from '../components/Core/DomainRule/RuleDetailPopover';
 import { ImportWizard } from '../components/UI/ImportExportPage/ImportWizard';
 import { ConfirmDialog } from '../components/UI/ConfirmDialog/ConfirmDialog';
 import { getMessage } from '../utils/i18n';
@@ -22,40 +23,124 @@ interface DomainRulesPageProps {
   updateRules: (rules: DomainRuleSetting[]) => void;
 }
 
+/* ─── Local presentation components ──────────────────────────────────────── */
+
+interface BulkActionsBarProps {
+  selectedIds: Set<string>;
+  filteredRules: DomainRuleSetting[];
+  isAllSelected: boolean;
+  isIndeterminate: boolean;
+  onSelectAll: (checked: boolean) => void;
+  onBulkToggle: (ids: string[], enabled: boolean) => void;
+  onBulkDeleteRequest: (ids: string[]) => void;
+}
+
+function BulkActionsBar({
+  selectedIds, filteredRules, isAllSelected, isIndeterminate,
+  onSelectAll, onBulkToggle, onBulkDeleteRequest,
+}: BulkActionsBarProps) {
+  return (
+    <Flex align="center" gap="3" p="2" mb="4"
+      style={{ backgroundColor: 'var(--accent-a3)', borderRadius: 'var(--radius-2)' }}>
+      <Checkbox
+        checked={isAllSelected}
+        onCheckedChange={(checked) => onSelectAll(checked as boolean)}
+        {...(isIndeterminate && { 'data-indeterminate': true })}
+      />
+      <Text size="2" weight="medium">
+        {selectedIds.size === 1
+          ? getMessage('dataTableSelectedCountSingular')
+          : getMessage('dataTableSelectedCountPlural').replace('{count}', selectedIds.size.toString())
+        }
+      </Text>
+      <Separator orientation="vertical" />
+      <Flex gap="2">
+        <Button size="1" variant="solid" onClick={() => onBulkToggle(Array.from(selectedIds), true)}>
+          <Eye size={14} />
+          {getMessage('enableSelected')}
+        </Button>
+        <Button size="1" variant="soft" onClick={() => onBulkToggle(Array.from(selectedIds), false)}>
+          <EyeOff size={14} />
+          {getMessage('disableSelected')}
+        </Button>
+        <Button size="1" variant="soft" color="red"
+          onClick={() => onBulkDeleteRequest(Array.from(selectedIds))}>
+          <Trash2 size={14} />
+          {getMessage('deleteSelected')}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}
+
+interface RulesEmptyStateProps {
+  hasRules: boolean;
+  hasSearch: boolean;
+  onAddRule: () => void;
+  onImport: () => void;
+}
+
+function RulesEmptyState({ hasRules, hasSearch, onAddRule, onImport }: RulesEmptyStateProps) {
+  if (!hasRules && !hasSearch) {
+    return (
+      <Flex direction="column" align="center" justify="center" gap="3" style={{ minHeight: 200 }}>
+        <Shield size={40} style={{ color: 'var(--gray-8)' }} aria-hidden="true" />
+        <Text size="3" weight="medium" color="gray" align="center">
+          {getMessage('rulesEmptyTitle')}
+        </Text>
+        <Text size="2" color="gray" align="center" style={{ maxWidth: 340 }}>
+          {getMessage('rulesEmptyDescription')}
+        </Text>
+        <Flex gap="2">
+          <Button variant="soft" onClick={onAddRule}>
+            <Plus size={14} aria-hidden="true" />
+            {getMessage('addRule')}
+          </Button>
+          <Button variant="soft" onClick={onImport}>
+            <Upload size={14} aria-hidden="true" />
+            {getMessage('importRulesButton')}
+          </Button>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" align="center" justify="center" gap="2" style={{ minHeight: 120 }}>
+      <AlertCircle size={32} style={{ color: 'var(--gray-8)' }} aria-hidden="true" />
+      <Text color="gray">{getMessage('noRulesFound')}</Text>
+    </Flex>
+  );
+}
+
+/* ─── Page component ──────────────────────────────────────────────────────── */
+
 export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPageProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isImportOpen, setIsImportOpen] = useState(false);
   const [editingRule, setEditingRule] = useState<DomainRule | undefined>(undefined);
 
-  // Handlers - déclarés avant les useMemo
   const handleToggleEnabled = useCallback((ruleId: string, enabled: boolean) => {
-    const updatedRules = syncSettings.domainRules.map(rule =>
+    updateRules(syncSettings.domainRules.map(rule =>
       rule.id === ruleId ? { ...rule, enabled } : rule
-    );
-    updateRules(updatedRules);
+    ));
   }, [syncSettings.domainRules, updateRules]);
 
   const handleDeleteRule = useCallback((ruleId: string) => {
-    const updatedRules = syncSettings.domainRules.filter(rule => rule.id !== ruleId);
-    updateRules(updatedRules);
+    updateRules(syncSettings.domainRules.filter(rule => rule.id !== ruleId));
   }, [syncSettings.domainRules, updateRules]);
 
   const handleBulkToggle = useCallback((ruleIds: string[], enabled: boolean) => {
-    const updatedRules = syncSettings.domainRules.map(rule =>
+    updateRules(syncSettings.domainRules.map(rule =>
       ruleIds.includes(rule.id) ? { ...rule, enabled } : rule
-    );
-    updateRules(updatedRules);
+    ));
   }, [syncSettings.domainRules, updateRules]);
 
   const handleBulkDelete = useCallback((ruleIds: string[]) => {
-    const updatedRules = syncSettings.domainRules.filter(rule => !ruleIds.includes(rule.id));
-    updateRules(updatedRules);
+    updateRules(syncSettings.domainRules.filter(rule => !ruleIds.includes(rule.id)));
   }, [syncSettings.domainRules, updateRules]);
 
-  // Confirm dialog state
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
-
-  // Search & selection state
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
@@ -78,11 +163,7 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
   }, []);
 
   const handleSelectAll = useCallback((checked: boolean) => {
-    if (checked) {
-      setSelectedIds(new Set(filteredRules.map(r => r.id)));
-    } else {
-      setSelectedIds(new Set());
-    }
+    setSelectedIds(checked ? new Set(filteredRules.map(r => r.id)) : new Set());
   }, [filteredRules]);
 
   const isAllSelected = filteredRules.length > 0 && selectedIds.size === filteredRules.length;
@@ -94,7 +175,6 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     setIsModalOpen(true);
   }, []);
 
-  // Keyboard navigation for the card list
   const listRef = useRef<HTMLDivElement>(null);
 
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent, rule: DomainRuleSetting, index: number) => {
@@ -104,14 +184,12 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     switch (e.key) {
       case 'ArrowDown': {
         e.preventDefault();
-        const next = cards[index + 1];
-        next?.focus();
+        cards[index + 1]?.focus();
         break;
       }
       case 'ArrowUp': {
         e.preventDefault();
-        const prev = cards[index - 1];
-        prev?.focus();
+        cards[index - 1]?.focus();
         break;
       }
       case 'Home': {
@@ -125,7 +203,6 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
         break;
       }
       case ' ': {
-        // Only toggle selection if focus is on the card itself, not on a child interactive element
         const target = e.target as HTMLElement;
         if (target.getAttribute('role') === 'row') {
           e.preventDefault();
@@ -150,7 +227,7 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
         break;
       }
     }
-  }, [handleRowSelect, handleEditRule, handleDeleteRule, selectedIds]);
+  }, [handleRowSelect, handleEditRule, selectedIds]);
 
   const handleAddRule = () => {
     setEditingRule(undefined);
@@ -159,24 +236,15 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
 
   const handleSubmitRule = (rule: DomainRule) => {
     if (editingRule) {
-      // Édition - trouver la règle originale pour préserver enabled et badge
       const originalRule = syncSettings.domainRules.find(r => r.id === rule.id);
       const updatedRule: DomainRuleSetting = {
         ...rule,
         enabled: originalRule?.enabled ?? true,
-        badge: originalRule?.badge
+        badge: originalRule?.badge,
       };
-      const updatedRules = syncSettings.domainRules.map(r =>
-        r.id === rule.id ? updatedRule : r
-      );
-      updateRules(updatedRules);
+      updateRules(syncSettings.domainRules.map(r => r.id === rule.id ? updatedRule : r));
     } else {
-      // Création
-      const newRule: DomainRuleSetting = {
-        ...rule,
-        id: generateUUID(),
-        enabled: true
-      };
+      const newRule: DomainRuleSetting = { ...rule, id: generateUUID(), enabled: true };
       updateRules([...syncSettings.domainRules, newRule]);
     }
     setIsModalOpen(false);
@@ -192,7 +260,6 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     if (!deleteTarget) return;
     if (deleteTarget.type === 'single') {
       handleDeleteRule(deleteTarget.ruleId);
-      // Focus next or previous card after keyboard-initiated deletion
       if (deleteTarget.focusIndex != null) {
         const cards = listRef.current?.querySelectorAll<HTMLElement>('[role="row"]');
         if (cards) {
@@ -236,70 +303,25 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
               </Button>
             </Flex>
 
-            {/* Bulk Actions Bar */}
             {selectedIds.size > 0 && (
-              <Flex align="center" gap="3" p="2" mb="4" style={{ backgroundColor: 'var(--accent-a3)', borderRadius: 'var(--radius-2)' }}>
-                <Checkbox
-                  checked={isAllSelected}
-                  onCheckedChange={(checked) => handleSelectAll(checked as boolean)}
-                  {...(isIndeterminate && { 'data-indeterminate': true })}
-                />
-                <Text size="2" weight="medium">
-                  {selectedIds.size === 1
-                    ? getMessage('dataTableSelectedCountSingular')
-                    : getMessage('dataTableSelectedCountPlural').replace('{count}', selectedIds.size.toString())
-                  }
-                </Text>
-                <Separator orientation="vertical" />
-                <Flex gap="2">
-                  <Button size="1" variant="solid" onClick={() => handleBulkToggle(Array.from(selectedIds), true)}>
-                    <Eye size={14} />
-                    {getMessage('enableSelected')}
-                  </Button>
-                  <Button size="1" variant="soft" onClick={() => handleBulkToggle(Array.from(selectedIds), false)}>
-                    <EyeOff size={14} />
-                    {getMessage('disableSelected')}
-                  </Button>
-                  <Button size="1" variant="soft" color="red" onClick={() => {
-                    setDeleteTarget({ type: 'bulk', ruleIds: Array.from(selectedIds) });
-                  }}>
-                    <Trash2 size={14} />
-                    {getMessage('deleteSelected')}
-                  </Button>
-                </Flex>
-              </Flex>
+              <BulkActionsBar
+                selectedIds={selectedIds}
+                filteredRules={filteredRules}
+                isAllSelected={isAllSelected}
+                isIndeterminate={isIndeterminate}
+                onSelectAll={handleSelectAll}
+                onBulkToggle={handleBulkToggle}
+                onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', ruleIds: ids })}
+              />
             )}
 
-            {/* Card List */}
             {filteredRules.length === 0 ? (
-              syncSettings.domainRules.length === 0 && !searchTerm ? (
-                // True empty state — no rules at all
-                <Flex direction="column" align="center" justify="center" gap="3" style={{ minHeight: 200 }}>
-                  <Shield size={40} style={{ color: 'var(--gray-8)' }} aria-hidden="true" />
-                  <Text size="3" weight="medium" color="gray" align="center">
-                    {getMessage('rulesEmptyTitle')}
-                  </Text>
-                  <Text size="2" color="gray" align="center" style={{ maxWidth: 340 }}>
-                    {getMessage('rulesEmptyDescription')}
-                  </Text>
-                  <Flex gap="2">
-                    <Button variant="soft" onClick={handleAddRule}>
-                      <Plus size={14} aria-hidden="true" />
-                      {getMessage('addRule')}
-                    </Button>
-                    <Button variant="soft" onClick={() => setIsImportOpen(true)}>
-                      <Upload size={14} aria-hidden="true" />
-                      {getMessage('importRulesButton')}
-                    </Button>
-                  </Flex>
-                </Flex>
-              ) : (
-                // Search returned no results
-                <Flex direction="column" align="center" justify="center" gap="2" style={{ minHeight: 120 }}>
-                  <AlertCircle size={32} style={{ color: 'var(--gray-8)' }} aria-hidden="true" />
-                  <Text color="gray">{getMessage('noRulesFound')}</Text>
-                </Flex>
-              )
+              <RulesEmptyState
+                hasRules={syncSettings.domainRules.length > 0}
+                hasSearch={!!searchTerm}
+                onAddRule={handleAddRule}
+                onImport={() => setIsImportOpen(true)}
+              />
             ) : (
               <Flex direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
                 {filteredRules.map((rule, index) => (
@@ -344,70 +366,14 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                                   size="2"
                                   style={{ cursor: 'pointer', flexShrink: 0 }}
                                 >
-                                  {category ? `${category.emoji} ` : ''}<AccessibleHighlight text={rule.label} searchTerm={searchTerm} />
+                                  {category ? `${category.emoji} ` : ''}
+                                  <AccessibleHighlight text={rule.label} searchTerm={searchTerm} />
                                 </Badge>
                               );
                             })()}
                           </HoverCard.Trigger>
                           <HoverCard.Content size="2" style={{ maxWidth: 400 }}>
-                            <Flex direction="column" gap="3">
-                              <Flex justify="between" align="center" pb="2" style={{ borderBottom: '1px solid var(--gray-5)' }}>
-                                <Text size="3" weight="bold"><AccessibleHighlight text={rule.label} searchTerm={searchTerm} /></Text>
-                                <Badge color={rule.enabled ? 'green' : 'gray'} variant="soft">
-                                  {getMessage(rule.enabled ? 'enabled' : 'disabled')}
-                                </Badge>
-                              </Flex>
-                              <Box style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '8px 12px', alignItems: 'baseline' }}>
-                                <Text size="1" weight="bold" color="gray">{getMessage('domainFilter')}</Text>
-                                <Text size="2"><code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px' }}><AccessibleHighlight text={rule.domainFilter} searchTerm={searchTerm} /></code></Text>
-
-                                <Text size="1" weight="bold" color="gray">{getMessage('tabGroupColor')}</Text>
-                                <Flex align="center" gap="2">
-                                  {(() => {
-                                    const cat = getRuleCategory(rule.categoryId);
-                                    if (cat) {
-                                      return (
-                                        <>
-                                          <div style={{ width: '16px', height: '16px', backgroundColor: `var(--${getRadixColor(cat.color)}-9)`, borderRadius: '50%', border: '1px solid var(--gray-6)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '10px' }}>{cat.emoji}</div>
-                                          <Text size="2">{getMessage(cat.labelKey as any)}</Text>
-                                        </>
-                                      );
-                                    }
-                                    return <Text size="2" color="gray">{getMessage('categoryNone')}</Text>;
-                                  })()}
-                                </Flex>
-
-                                <Text size="1" weight="bold" color="gray">{getMessage('groupNameSource')}</Text>
-                                <Text size="2">{getMessage(`groupNameSource${rule.groupNameSource.split('_').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('')}`)}</Text>
-
-                                {rule.presetId && (
-                                  <>
-                                    <Text size="1" weight="bold" color="gray">{getMessage('presetLabel')}</Text>
-                                    <Text size="2">{rule.presetId}</Text>
-                                  </>
-                                )}
-                                {rule.titleParsingRegEx && (
-                                  <>
-                                    <Text size="1" weight="bold" color="gray">{getMessage('titleRegex')}</Text>
-                                    <Text size="2"><code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px', wordBreak: 'break-all' }}>{rule.titleParsingRegEx}</code></Text>
-                                  </>
-                                )}
-                                {rule.urlParsingRegEx && (
-                                  <>
-                                    <Text size="1" weight="bold" color="gray">{getMessage('urlRegex')}</Text>
-                                    <Text size="2"><code style={{ backgroundColor: 'var(--gray-3)', padding: '2px 6px', borderRadius: '4px', wordBreak: 'break-all' }}>{rule.urlParsingRegEx}</code></Text>
-                                  </>
-                                )}
-
-                                <Text size="1" weight="bold" color="gray">{getMessage('deduplicationMode')}</Text>
-                                <Text size="2">{getMessage(`${rule.deduplicationMatchMode}Match`)}</Text>
-
-                                <Text size="1" weight="bold" color="gray">{getMessage('deduplicationEnabled')}</Text>
-                                <Badge size="1" color={rule.deduplicationEnabled ? 'green' : 'red'} variant="soft">
-                                  {rule.deduplicationEnabled ? getMessage('yes') : getMessage('no')}
-                                </Badge>
-                              </Box>
-                            </Flex>
+                            <RuleDetailPopover rule={rule} searchTerm={searchTerm} />
                           </HoverCard.Content>
                         </HoverCard.Root>
 

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -1,5 +1,5 @@
 // options/options.ts
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { browser } from 'wxt/browser';
 import { Theme } from '@radix-ui/themes';
@@ -7,274 +7,61 @@ import { ThemeProvider } from 'next-themes';
 
 import { useSyncedSettings } from '../hooks/useSyncedSettings.js';
 import { useStatistics } from '../hooks/useStatistics.js';
-import { generateUUID, isValidDomain, isValidRegex } from '../utils/utils';
+import { useDeepLinking } from '../hooks/useDeepLinking.js';
 import { getMessage } from '../utils/i18n';
 const version = browser.runtime.getManifest().version;
 
 import { Sidebar } from '../components/UI/Sidebar/Sidebar';
 import type { SidebarItem } from '../components/UI/Sidebar/Sidebar';
-import { ThemeToggle } from '../components/UI/ThemeToggle/ThemeToggle';
-import { Flex, Text } from '@radix-ui/themes';
+import { OptionsHeader, OptionsHeaderCollapsed } from '../components/UI/OptionsLayout/OptionsHeader';
+import { OptionsFooter, OptionsFooterCollapsed } from '../components/UI/OptionsLayout/OptionsFooter';
+import { useState } from 'react';
 import { DomainRulesPage } from './DomainRulesPage';
 import { StatisticsPage } from './StatisticsPage';
 import { SettingsPage } from '../components/UI/SettingsPage/SettingsPage';
 import { ImportExportPage } from '../components/UI/ImportExportPage/ImportExportPage';
 import { ConfirmDialog } from '../components/UI/ConfirmDialog/ConfirmDialog';
-import { Shield, FileText, BarChart3, Settings, Github, Archive } from 'lucide-react';
+import { Shield, FileText, BarChart3, Settings, Archive } from 'lucide-react';
 import { FEATURE_BASE_COLORS } from '../utils/themeConstants';
 import { SessionsPage } from './SessionsPage';
-import type { SyncSettings, DomainRuleSettings } from '../types/syncSettings';
+import type { DomainRuleSettings } from '../types/syncSettings';
 
 (() => {
 
-// --- Fonctions Utilitaires ---
-interface TooltipProps {
-    textKey: string;
-    children: React.ReactNode;
-}
-
-function Tooltip({ textKey, children }: TooltipProps) {
-    return (
-        <div className="tooltip-container">
-            {children}
-            <span className="tooltip-text">{getMessage(textKey)}</span>
-        </div>
-    );
-}
-
-// --- Composant Principal ---
 function OptionsContent() {
     const { settings, updateSettings } = useSyncedSettings();
     const { statistics: stats, resetStatistics } = useStatistics();
-    const [currentTab, setCurrentTab] = useState<string>('rules');
-    
+    const {
+        currentTab, setCurrentTab,
+        openSnapshotWizard, setOpenSnapshotWizard,
+        snapshotGroupId, setSnapshotGroupId,
+    } = useDeepLinking();
+
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
     const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
-    const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
-    const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
-
-    // Deep linking: navigate to the right section on mount and on hash changes
-    // (hashchange fires when an existing tab's URL hash is updated externally)
-    useEffect(() => {
-        const validSections = ['rules', 'importexport', 'sessions', 'stats', 'settings'];
-
-        function handleHash() {
-            const hash = window.location.hash; // e.g. '#sessions?action=snapshot'
-            if (!hash.startsWith('#')) return;
-            const questionMark = hash.indexOf('?');
-            const section = questionMark === -1 ? hash.slice(1) : hash.slice(1, questionMark);
-            if (!validSections.includes(section)) return;
-            setCurrentTab(section);
-            if (section === 'sessions' && questionMark !== -1) {
-                const params = new URLSearchParams(hash.slice(questionMark + 1));
-                if (params.get('action') === 'snapshot') {
-                    setOpenSnapshotWizard(true);
-                    const groupIdParam = params.get('groupId');
-                    setSnapshotGroupId(groupIdParam ? parseInt(groupIdParam, 10) : null);
-                }
-            }
-        }
-
-        handleHash();
-        window.addEventListener('hashchange', handleHash);
-        return () => window.removeEventListener('hashchange', handleHash);
-    }, []);
-
-    // Storage handled by hooks
-
-    // --- Gestionnaires ---
-    const updateSetting = useCallback((key: keyof SyncSettings, value: any) => {
-        updateSettings({ [key]: value });
-    }, [updateSettings]);
 
     const updateRules = useCallback((newRules: DomainRuleSettings) => {
         updateSettings({ domainRules: newRules });
     }, [updateSettings]);
 
-    
-
-
-     const handleResetStats = useCallback(() => {
-         setResetConfirmOpen(true);
-    }, []);
+    const handleResetStats = useCallback(() => setResetConfirmOpen(true), []);
 
     const handleTabChange = useCallback((tab: string) => {
         window.location.hash = tab;
         setCurrentTab(tab);
-    }, []);
+    }, [setCurrentTab]);
 
-    // Sidebar items configuration with themed accent colors
     const sidebarItems: SidebarItem[] = [
-        {
-            id: 'rules',
-            label: getMessage('domainRulesTab'),
-            icon: Shield as any,
-            accentColor: FEATURE_BASE_COLORS.DOMAIN_RULES,
-        },
-        {
-            id: 'sessions',
-            label: getMessage('sessionsTab'),
-            icon: Archive as any,
-            accentColor: FEATURE_BASE_COLORS.SESSIONS,
-        },
-        {
-            id: 'importexport',
-            label: getMessage('importExportTab'),
-            icon: FileText as any,
-            accentColor: FEATURE_BASE_COLORS.IMPORT, // Utilise la couleur Import pour l'onglet combiné
-        },
-        {
-            id: 'stats',
-            label: getMessage('statisticsTab'),
-            icon: BarChart3 as any,
-            accentColor: FEATURE_BASE_COLORS.STATISTICS,
-        },
-        {
-            id: 'settings',
-            label: getMessage('settingsTab'),
-            icon: Settings as any,
-            accentColor: FEATURE_BASE_COLORS.SETTINGS,
-        },
+        { id: 'rules', label: getMessage('domainRulesTab'), icon: Shield as any, accentColor: FEATURE_BASE_COLORS.DOMAIN_RULES },
+        { id: 'sessions', label: getMessage('sessionsTab'), icon: Archive as any, accentColor: FEATURE_BASE_COLORS.SESSIONS },
+        { id: 'importexport', label: getMessage('importExportTab'), icon: FileText as any, accentColor: FEATURE_BASE_COLORS.IMPORT },
+        { id: 'stats', label: getMessage('statisticsTab'), icon: BarChart3 as any, accentColor: FEATURE_BASE_COLORS.STATISTICS },
+        { id: 'settings', label: getMessage('settingsTab'), icon: Settings as any, accentColor: FEATURE_BASE_COLORS.SETTINGS },
     ];
 
-
-    // --- Rendu ---
     if (!settings) {
         return <p>Chargement...</p>;
     }
-
-    // Contenu du header pour la sidebar
-    const headerContent = (
-        <Flex align="center" gap="3" style={{ width: '100%', paddingRight: '64px', position: 'relative' }}>
-            <img 
-                src="/icons/icon48.png" 
-                alt="SmartTab Organizer" 
-                style={{ 
-                    width: '32px', 
-                    height: '32px',
-                    flexShrink: 0
-                }} 
-            />
-            <Flex direction="column" gap="0" style={{ lineHeight: '1.2', flex: 1 }}>
-                <Flex align="center" gap="2">
-                    <Text size="3" weight="bold" style={{ color: 'var(--gray-12)' }}>
-                        SmartTab
-                    </Text>
-                    <Text size="1" style={{ color: 'var(--gray-11)' }}>
-                        (v{version})
-                    </Text>
-                </Flex>
-                <Text size="3" weight="bold" style={{ color: 'var(--gray-12)' }}>
-                    Organizer
-                </Text>
-            </Flex>
-            <Flex align="center" style={{ position: 'absolute', right: '8px' }}>
-                <ThemeToggle />
-            </Flex>
-        </Flex>
-    );
-
-    const headerCollapsedContent = (
-        <Flex align="center" justify="center" style={{ width: '100%' }}>
-            <img 
-                src="/icons/icon48.png" 
-                alt="SmartTab Organizer" 
-                style={{ 
-                    width: '32px', 
-                    height: '32px'
-                }} 
-            />
-        </Flex>
-    );
-
-    // Custom SidebarFooter content
-    const customFooterContent = (
-        <Flex 
-            align="center" 
-            gap="3" 
-            style={{ 
-                padding: '12px 16px',
-                cursor: 'pointer',
-                borderRadius: '4px',
-                transition: 'background-color 0.2s ease',
-            }}
-            onClick={() => browser.tabs.create({ url: 'https://github.com/EspritVorace/smart-tab-organizer' })}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    browser.tabs.create({ url: 'https://github.com/EspritVorace/smart-tab-organizer' });
-                }
-            }}
-            tabIndex={0}
-            role="button"
-            aria-label="Visiter le profil GitHub d'EspritVorace"
-            className="custom-footer-expanded"
-        >
-            <img 
-                src="/icons/ev.png" 
-                alt="EspritVorace" 
-                style={{ 
-                    width: '24px', 
-                    height: '24px',
-                    borderRadius: '50%',
-                    flexShrink: 0
-                }} 
-            />
-            <Flex align="center" gap="2">
-                <Text 
-                    size="2" 
-                    weight="medium" 
-                    style={{ 
-                        color: 'var(--gray-11)',
-                        textDecoration: 'none'
-                    }}
-                >
-                    EspritVorace
-                </Text>
-                <Github 
-                    size={16} 
-                    style={{ 
-                        color: 'var(--gray-11)',
-                        flexShrink: 0
-                    }} 
-                />
-            </Flex>
-        </Flex>
-    );
-
-    const customFooterCollapsedContent = (
-        <Flex 
-            align="center" 
-            justify="center" 
-            style={{ 
-                padding: '12px',
-                cursor: 'pointer',
-                borderRadius: '4px',
-                transition: 'background-color 0.2s ease',
-            }}
-            onClick={() => browser.tabs.create({ url: 'https://github.com/EspritVorace/smart-tab-organizer' })}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    browser.tabs.create({ url: 'https://github.com/EspritVorace/smart-tab-organizer' });
-                }
-            }}
-            tabIndex={0}
-            role="button"
-            aria-label="Visiter le profil GitHub d'EspritVorace"
-            className="custom-footer-collapsed"
-        >
-            <img 
-                src="/icons/ev.png" 
-                alt="EspritVorace" 
-                style={{ 
-                    width: '24px', 
-                    height: '24px',
-                    borderRadius: '50%'
-                }} 
-            />
-        </Flex>
-    );
 
     return (
         <div id="options-inner" style={{ display: 'flex', height: '100vh' }}>
@@ -284,11 +71,11 @@ function OptionsContent() {
                 activeItem={currentTab}
                 onItemClick={handleTabChange}
                 items={sidebarItems}
-                headerContent={headerContent}
-                headerCollapsedContent={headerCollapsedContent}
+                headerContent={<OptionsHeader version={version} />}
+                headerCollapsedContent={<OptionsHeaderCollapsed />}
                 showFooter={true}
-                footerContent={customFooterContent}
-                footerCollapsedContent={customFooterCollapsedContent}
+                footerContent={<OptionsFooter />}
+                footerCollapsedContent={<OptionsFooterCollapsed />}
             />
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
                 <main style={{ flex: 1, overflow: 'auto', padding: '20px' }}>
@@ -329,17 +116,11 @@ function OptionsContent() {
             />
         </div>
     );
-
 }
 
 function OptionsApp() {
     return (
-        <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-        >
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <Theme>
                 <OptionsContent />
             </Theme>

--- a/src/utils/presetUtils.ts
+++ b/src/utils/presetUtils.ts
@@ -55,3 +55,14 @@ export async function getPresetsForDomain(domain: string): Promise<Preset[]> {
 export function clearPresetsCache(): void {
   presetsCache = null;
 }
+
+/**
+ * Convert PresetCategory[] into the grouped-options format expected by
+ * SearchableSelect. Shared between ConfigEditModal and WizardStep2Config.
+ */
+export function presetsToSearchableGroups(categories: PresetCategory[]) {
+  return categories.map((cat) => ({
+    label: cat.name,
+    options: cat.presets.map((p) => ({ value: p.id, label: p.name })),
+  }));
+}

--- a/src/utils/sessionUtils.ts
+++ b/src/utils/sessionUtils.ts
@@ -2,6 +2,7 @@ import type { Session, SavedTab, SavedTabGroup } from '../types/session';
 import type { TabTreeData, TabItem, TabGroupItem } from '../components/Core/TabTree/tabTreeTypes';
 import { generateUUID } from './utils';
 import { foldAccents } from './stringUtils';
+import { getMessage } from './i18n';
 
 /**
  * Result of matching a session against a search term.
@@ -93,6 +94,32 @@ export function sessionToTabTreeData(session: Session): {
   });
 
   return { treeData: { ungroupedTabs, groups }, numericIdToSavedTabId };
+}
+
+/**
+ * Format an ISO date string to a short localized date (no time).
+ * Used in list views where space is limited (e.g. "Apr 5, 2026").
+ */
+export function formatSessionDateShort(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString(undefined, { dateStyle: 'medium' });
+  } catch {
+    return isoString;
+  }
+}
+
+/** Localized label for a group count (singular/plural). */
+export function getSessionGroupLabel(count: number): string {
+  return count === 1
+    ? getMessage('sessionGroupOne')
+    : getMessage('sessionGroupCount').replace('$1', String(count));
+}
+
+/** Localized label for a tab count (singular/plural). */
+export function getSessionTabLabel(count: number): string {
+  return count === 1
+    ? getMessage('sessionTabOne')
+    : getMessage('sessionTabCount').replace('$1', String(count));
 }
 
 /** Format an ISO date string to a localized readable string */

--- a/tests/useStatistics.test.ts
+++ b/tests/useStatistics.test.ts
@@ -275,7 +275,7 @@ describe('useStatistics', () => {
 
     expect(result.current.isLoaded).toBe(false);
     expect(result.current.statistics).toBe(null);
-    expect(consoleSpy).toHaveBeenCalledWith('[smart-tab-organizer]', 'Error loading statistics:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('[smart-tab-organizer]', '[useSyncedState] load error:', expect.any(Error));
 
     consoleSpy.mockRestore();
   });


### PR DESCRIPTION
- TabTreeEditor : extraction du hook useTabTreeEditor (état + handlers), TabEditRow, GroupEditRow et MoveTabDropdown dans leurs propres fichiers
- DomainRulesPage : extraction de RuleDetailPopover (60 LOC de JSX inline), BulkActionsBar et RulesEmptyState comme composants locaux
- ImportSessionsWizard : déplacement de SessionRow, ConflictSessionRow, SessionDiffView et GroupDiffView dans SessionImportRows.tsx partagé
- ExportSessionsWizard : suppression des formatters dupliqués (formatDate, getTabCount, getGroupLabel, getTabLabel)
- sessionUtils : ajout de formatSessionDateShort, getSessionGroupLabel, getSessionTabLabel — maintenant partagés entre Import et Export
- options.tsx : extraction de useDeepLinking (hook), OptionsHeader et OptionsFooter (composants expanded/collapsed) dans OptionsLayout/

0 régression — 367 tests passés, pnpm compile propre.

https://claude.ai/code/session_014GUAKwt1yTo123wJ8mzPUD