### PR TITLE
docs: améliore la stack technique et ajoute une section Contributing …

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -109,7 +109,48 @@ Para desarrollo con recarga automática: `pnpm dev` (Chrome) o `pnpm dev:firefox
 
 ## 🛠️ Stack Tecnológico
 
-WXT · React + TypeScript · Radix UI Themes · Zod · Vitest · Playwright
+| Capa | Tecnología |
+|---|---|
+| Framework de extensión | [WXT](https://wxt.dev/) |
+| Interfaz | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
+| Biblioteca de componentes | [Radix UI Themes](https://www.radix-ui.com/themes) + iconos [Lucide](https://lucide.dev/) |
+| Formularios & validación | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Temas | [next-themes](https://github.com/pacocoursey/next-themes) |
+| Tests unitarios | [Vitest](https://vitest.dev/) |
+| Tests E2E | [Playwright](https://playwright.dev/) |
+| Explorador de componentes | [Storybook](https://storybook.js.org/) |
+| Gestor de paquetes | [pnpm](https://pnpm.io/) |
+
+## 🤝 Contribuir
+
+¡Las contribuciones son bienvenidas! Aquí tienes cómo empezar:
+
+**Requisitos previos:** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+
+```bash
+git clone https://github.com/EspritVorace/smart-tab-organizer.git
+cd smart-tab-organizer
+pnpm install
+pnpm dev          # Chrome con recarga automática
+pnpm dev:firefox  # Firefox con recarga automática
+```
+
+**Tests**
+
+```bash
+pnpm test         # Tests unitarios (Vitest)
+pnpm test:e2e     # Tests end-to-end (Playwright)
+pnpm storybook    # Explorador de componentes (puerto 6006)
+```
+
+**Convenciones de código**
+
+- Usar `logger.debug()` de `src/utils/logger.ts` — nunca `console.log()`
+- Sin tipos `any` — usar tipos precisos o `unknown` con narrowing
+- Todo texto de UI mediante `getMessage()` de `src/utils/i18n.ts` — sin cadenas hardcodeadas
+- Accesibilidad mediante primitivas Radix UI; los iconos Lucide requieren `aria-hidden="true"`
+
+Por favor, abre un issue antes de enviar un pull request grande.
 
 ## 📜 Licencia
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -109,7 +109,48 @@ Pour le développement avec rechargement automatique : `pnpm dev` (Chrome) ou `p
 
 ## 🛠️ Stack Technique
 
-WXT · React + TypeScript · Radix UI Themes · Zod · Vitest · Playwright
+| Couche | Technologie |
+|---|---|
+| Framework d'extension | [WXT](https://wxt.dev/) |
+| Interface | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
+| Bibliothèque de composants | [Radix UI Themes](https://www.radix-ui.com/themes) + icônes [Lucide](https://lucide.dev/) |
+| Formulaires & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Thèmes | [next-themes](https://github.com/pacocoursey/next-themes) |
+| Tests unitaires | [Vitest](https://vitest.dev/) |
+| Tests E2E | [Playwright](https://playwright.dev/) |
+| Explorateur de composants | [Storybook](https://storybook.js.org/) |
+| Gestionnaire de paquets | [pnpm](https://pnpm.io/) |
+
+## 🤝 Contribuer
+
+Les contributions sont les bienvenues ! Voici comment démarrer :
+
+**Prérequis :** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+
+```bash
+git clone https://github.com/EspritVorace/smart-tab-organizer.git
+cd smart-tab-organizer
+pnpm install
+pnpm dev          # Chrome avec rechargement automatique
+pnpm dev:firefox  # Firefox avec rechargement automatique
+```
+
+**Tests**
+
+```bash
+pnpm test         # Tests unitaires (Vitest)
+pnpm test:e2e     # Tests end-to-end (Playwright)
+pnpm storybook    # Explorateur de composants (port 6006)
+```
+
+**Conventions de code**
+
+- Utiliser `logger.debug()` de `src/utils/logger.ts` — jamais `console.log()`
+- Pas de type `any` — utiliser des types précis ou `unknown` avec narrowing
+- Tout texte UI via `getMessage()` de `src/utils/i18n.ts` — pas de chaînes en dur
+- Accessibilité via les primitives Radix UI ; les icônes Lucide nécessitent `aria-hidden="true"`
+
+Merci d'ouvrir une issue avant de soumettre une pull request importante.
 
 ## 📜 Licence
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,48 @@ For development with auto-reload: `pnpm dev` (Chrome) or `pnpm dev:firefox`.
 
 ## 🛠️ Tech Stack
 
-WXT · React + TypeScript · Radix UI Themes · Zod · Vitest · Playwright
+| Layer | Technology |
+|---|---|
+| Extension framework | [WXT](https://wxt.dev/) |
+| UI | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
+| Component library | [Radix UI Themes](https://www.radix-ui.com/themes) + [Lucide](https://lucide.dev/) icons |
+| Forms & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Theming | [next-themes](https://github.com/pacocoursey/next-themes) |
+| Unit tests | [Vitest](https://vitest.dev/) |
+| E2E tests | [Playwright](https://playwright.dev/) |
+| Component explorer | [Storybook](https://storybook.js.org/) |
+| Package manager | [pnpm](https://pnpm.io/) |
+
+## 🤝 Contributing
+
+Contributions are welcome! Here's how to get started:
+
+**Prerequisites:** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+
+```bash
+git clone https://github.com/EspritVorace/smart-tab-organizer.git
+cd smart-tab-organizer
+pnpm install
+pnpm dev          # Chrome with auto-reload
+pnpm dev:firefox  # Firefox with auto-reload
+```
+
+**Tests**
+
+```bash
+pnpm test         # Unit tests (Vitest)
+pnpm test:e2e     # End-to-end tests (Playwright)
+pnpm storybook    # Component explorer (port 6006)
+```
+
+**Code conventions**
+
+- Use `logger.debug()` from `src/utils/logger.ts` — never `console.log()`
+- No `any` types — use precise types or narrow `unknown`
+- All UI text via `getMessage()` from `src/utils/i18n.ts` — no hardcoded strings
+- Accessibility via Radix UI primitives; Lucide icons need `aria-hidden="true"`
+
+Please open an issue before submitting a large pull request.
 
 ## 📜 License
 


### PR DESCRIPTION
…dans les 3 READMEs

- Stack technique : remplace la liste en ligne par un tableau avec liens vers les projets open source (WXT, React, TypeScript, Radix UI Themes, Lucide, React Hook Form, Zod, next-themes, Vitest, Playwright, Storybook, pnpm)
- Ajoute une section Contributing (EN/FR/ES) avec prérequis, commandes de dev/test et conventions de code essentielles

https://claude.ai/code/session_01T416CnJELb7kipYnGArnA1