### PR TITLE
fix: remove duplicate presetsToSearchableGroups from presetUtils

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -7,7 +7,8 @@ import { RegexPresetsCallouts } from '../../Form/themed-callouts';
 import { FormField, SearchableSelect } from '../../Form/FormFields';
 import { groupNameSourceOptions, type GroupNameSourceValue } from '../../../schemas/enums';
 import type { PresetCategory } from '../../../utils/presetUtils';
-import { getPresetById, presetsToSearchableGroups } from '../../../utils/presetUtils';
+import { getPresetById } from '../../../utils/presetUtils';
+import { presetsToSearchableGroups } from '../../../utils/presetsToSearchableGroups';
 import { logger } from '../../../utils/logger';
 import { ConfigModeSelector } from './ConfigModeSelector';
 

--- a/src/components/Core/DomainRule/WizardStep2Config.tsx
+++ b/src/components/Core/DomainRule/WizardStep2Config.tsx
@@ -8,7 +8,7 @@ import { FormField, SearchableSelect } from '../../Form/FormFields';
 import { groupNameSourceOptions, type GroupNameSourceValue } from '../../../schemas/enums';
 import type { DomainRule } from '../../../schemas/domainRule';
 import type { PresetCategory } from '../../../utils/presetUtils';
-import { presetsToSearchableGroups } from '../../../utils/presetUtils';
+import { presetsToSearchableGroups } from '../../../utils/presetsToSearchableGroups';
 import { ConfigModeSelector } from './ConfigModeSelector';
 
 interface WizardStep2ConfigProps {

--- a/src/utils/presetUtils.ts
+++ b/src/utils/presetUtils.ts
@@ -56,13 +56,3 @@ export function clearPresetsCache(): void {
   presetsCache = null;
 }
 
-/**
- * Convert PresetCategory[] into the grouped-options format expected by
- * SearchableSelect. Shared between ConfigEditModal and WizardStep2Config.
- */
-export function presetsToSearchableGroups(categories: PresetCategory[]) {
-  return categories.map((cat) => ({
-    label: cat.name,
-    options: cat.presets.map((p) => ({ value: p.id, label: p.name })),
-  }));
-}


### PR DESCRIPTION
The function was defined in both presetUtils.ts and the dedicated presetsToSearchableGroups.ts (added during refacto), causing pnpm duplicate import warnings. Removed the copy from presetUtils.ts and updated imports in ConfigEditModal and WizardStep2Config to use the canonical location.

https://claude.ai/code/session_01RPSA6EKpjV7Bj8HdfJN1Xk