### PR TITLE
Add DnD rule ordering & domain migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-toast": "^1.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
@@ -226,6 +235,28 @@ packages:
     resolution: {integrity: sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw==}
     engines: {node: '>= 0.10.4'}
     hasBin: true
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -4198,6 +4229,31 @@ snapshots:
       split: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.9.2':
     dependencies:

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -29,7 +29,7 @@
   "notificationDeduplicationMessage": { "message": "Duplicate tab closed: {title}" },
   "addRule": { "message": "Add Rule" },
   "domainFilter": { "message": "Domain Filter" },
-  "domainFilterPlaceholder": { "message": "e.g., *.atlassian.net" },
+  "domainFilterPlaceholder": { "message": "e.g., atlassian.net" },
   "titleRegex": { "message": "Title RegEx" },
   "urlRegex": { "message": "URL RegEx" },
   "deduplicationMode": { "message": "Deduplication Mode" },
@@ -82,7 +82,7 @@
   "lightMode": { "message": "Light" },
   "darkModeOption": { "message": "Dark" },
   "customRegex": { "message": "Custom RegEx..." },
-  "domainTooltip": { "message": "Enter domain (e.g., jira.com) or use *. for subdomains (e.g., *.jira.com)." },
+  "domainTooltip": { "message": "Enter a domain (e.g., jira.com). Subdomains are matched automatically. Use a RegEx for advanced patterns." },
   "regexTooltip": { "message": "Select a preset or enter a RegEx. The 1st capturing group ( ) will be the group name." },
   "dedupTooltip": { "message": "'Exact': Identical URL. 'Includes': New URL contained within an existing one." },
   "presetNameTooltip": { "message": "Name to identify this RegEx preset." },
@@ -424,5 +424,9 @@
   "editConfigAriaLabel": { "message": "Edit configuration" },
   "optionsSummaryDedupEnabled": { "message": "Deduplication enabled · {mode}" },
   "optionsSummaryDedupDisabled": { "message": "Deduplication disabled" },
-  "summaryModify": { "message": "Modify" }
+  "summaryModify": { "message": "Modify" },
+  "ruleMoveToFirst": { "message": "Move to top" },
+  "ruleMoveToLast": { "message": "Move to bottom" },
+  "ruleMoveToFirstOfDomain": { "message": "First of domain" },
+  "ruleMoveToLastOfDomain": { "message": "Last of domain" }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -29,7 +29,7 @@
   "notificationDeduplicationMessage": { "message": "Pestaña duplicada cerrada: {title}" },
   "addRule": { "message": "Añadir Regla" },
   "domainFilter": { "message": "Filtro Dominio" },
-  "domainFilterPlaceholder": { "message": "ej: *.atlassian.net" },
+  "domainFilterPlaceholder": { "message": "ej: atlassian.net" },
   "titleRegex": { "message": "RegEx Título" },
   "urlRegex": { "message": "RegEx URL" },
   "deduplicationMode": { "message": "Modo Deduplicación" },
@@ -82,7 +82,7 @@
   "lightMode": { "message": "Claro" },
   "darkModeOption": { "message": "Oscuro" },
   "customRegex": { "message": "RegEx Personalizada..." },
-  "domainTooltip": { "message": "Ingrese dominio (ej: jira.com) o use *. para subdominios (ej: *.jira.com)." },
+  "domainTooltip": { "message": "Ingrese un dominio (ej: jira.com). Los subdominios coinciden automáticamente. Use una RegEx para patrones avanzados." },
   "regexTooltip": { "message": "Seleccione preajuste o ingrese RegEx. El 1er grupo de captura ( ) será el nombre del grupo." },
   "dedupTooltip": { "message": "'Exacta': URL idéntica. 'Incluida': Nueva URL contenida en una existente." },
   "presetNameTooltip": { "message": "Nombre para identificar este preajuste RegEx." },
@@ -425,5 +425,9 @@
   "editConfigAriaLabel": { "message": "Editar configuración" },
   "optionsSummaryDedupEnabled": { "message": "Deduplicación activada · {mode}" },
   "optionsSummaryDedupDisabled": { "message": "Deduplicación desactivada" },
-  "summaryModify": { "message": "Modificar" }
+  "summaryModify": { "message": "Modificar" },
+  "ruleMoveToFirst": { "message": "Al principio" },
+  "ruleMoveToLast": { "message": "Al final" },
+  "ruleMoveToFirstOfDomain": { "message": "Primera del dominio" },
+  "ruleMoveToLastOfDomain": { "message": "Última del dominio" }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -29,7 +29,7 @@
   "notificationDeduplicationMessage": { "message": "Onglet doublon fermé : {title}" },
   "addRule": { "message": "Ajouter une Règle" },
   "domainFilter": { "message": "Filtre Domaine" },
-  "domainFilterPlaceholder": { "message": "ex: *.atlassian.net" },
+  "domainFilterPlaceholder": { "message": "ex: atlassian.net" },
   "titleRegex": { "message": "RegEx Titre" },
   "urlRegex": { "message": "RegEx URL" },
   "deduplicationMode": { "message": "Mode Déduplication" },
@@ -82,7 +82,7 @@
   "lightMode": { "message": "Clair" },
   "darkModeOption": { "message": "Sombre" },
   "customRegex": { "message": "RegEx Personnalisée..." },
-  "domainTooltip": { "message": "Entrez le domaine (ex: jira.com) ou utilisez *. pour les sous-domaines (ex: *.jira.com)." },
+  "domainTooltip": { "message": "Entrez un domaine (ex: jira.com). Les sous-domaines matchent automatiquement. Utilisez une RegEx pour des patterns avancés." },
   "regexTooltip": { "message": "Sélectionnez un préréglage ou entrez une RegEx. Le 1er groupe capturant ( ) sera le nom du groupe." },
   "dedupTooltip": { "message": "'Exacte': URL identique. 'Incluse': Nouvelle URL contenue dans une existante." },
   "presetNameTooltip": { "message": "Nom pour identifier ce préréglage RegEx." },
@@ -425,5 +425,9 @@
   "editConfigAriaLabel": { "message": "Modifier la configuration" },
   "optionsSummaryDedupEnabled": { "message": "Déduplication activée · {mode}" },
   "optionsSummaryDedupDisabled": { "message": "Déduplication désactivée" },
-  "summaryModify": { "message": "Modifier" }
+  "summaryModify": { "message": "Modifier" },
+  "ruleMoveToFirst": { "message": "En premier" },
+  "ruleMoveToLast": { "message": "En dernier" },
+  "ruleMoveToFirstOfDomain": { "message": "Première du domaine" },
+  "ruleMoveToLastOfDomain": { "message": "Dernière du domaine" }
 }

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -10,7 +10,10 @@ export async function getSettings(): Promise<SyncSettings> {
         groupingEnabled: typeof rule.groupingEnabled === 'boolean' ? rule.groupingEnabled : true,
         deduplicationMatchMode: rule.deduplicationMatchMode || 'exact',
         groupNameSource: rule.groupNameSource || 'title',
-        urlParsingRegEx: rule.urlParsingRegEx || ''
+        urlParsingRegEx: rule.urlParsingRegEx || '',
+        // Migrate legacy wildcard syntax: *.example.com → example.com
+        // Subdomains now match implicitly for plain domains
+        domainFilter: rule.domainFilter?.startsWith('*.') ? rule.domainFilter.slice(2) : rule.domainFilter,
     }));
     return settings;
 }

--- a/src/components/Core/DomainRule/DomainRuleCard.stories.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.stories.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Theme, Box, Flex } from '@radix-ui/themes';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { DomainRuleCard } from './DomainRuleCard';
+import type { DomainRuleSetting } from '../../../types/syncSettings';
+
+/* ── Mock data ──────────────────────────────────────────────────────────────── */
+
+const baseRule: DomainRuleSetting = {
+  id: 'rule-1',
+  domainFilter: 'github.com',
+  label: 'GitHub',
+  titleParsingRegEx: '',
+  urlParsingRegEx: '',
+  groupNameSource: 'title',
+  deduplicationMatchMode: 'exact',
+  deduplicationEnabled: true,
+  presetId: null,
+  categoryId: 'development',
+  enabled: true,
+};
+
+const noop = () => {};
+
+const defaultProps = {
+  rule: baseRule,
+  index: 0,
+  isSelected: false,
+  searchTerm: '',
+  isDragDisabled: false,
+  isDomainActionDisabled: false,
+  onSelect: noop,
+  onToggleEnabled: noop,
+  onEdit: noop,
+  onDeleteRequest: noop,
+  onMoveToFirst: noop,
+  onMoveToLast: noop,
+  onMoveToFirstOfDomain: noop,
+  onMoveToLastOfDomain: noop,
+  onKeyDown: noop,
+};
+
+/* ── Wrapper: DndContext required for useSortable ───────────────────────────── */
+
+function DndWrapper({ children }: { children: React.ReactNode }) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter}>
+      <SortableContext items={['rule-1']} strategy={verticalListSortingStrategy}>
+        {children}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+/* ── Meta ────────────────────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof DomainRuleCard> = {
+  title: 'Components/Core/DomainRule/DomainRuleCard',
+  component: DomainRuleCard,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <Theme>
+        <Box style={{ maxWidth: 680 }}>
+          <DndWrapper>
+            <Story />
+          </DndWrapper>
+        </Box>
+      </Theme>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ── Stories ─────────────────────────────────────────────────────────────────── */
+
+export const DomainRuleCardDefault: Story = {
+  args: defaultProps,
+};
+
+export const DomainRuleCardDisabled: Story = {
+  args: {
+    ...defaultProps,
+    rule: { ...baseRule, enabled: false },
+  },
+};
+
+export const DomainRuleCardSelected: Story = {
+  args: {
+    ...defaultProps,
+    isSelected: true,
+  },
+};
+
+export const DomainRuleCardDragDisabled: Story = {
+  name: 'DomainRuleCard — Drag Disabled (search active)',
+  args: {
+    ...defaultProps,
+    isDragDisabled: true,
+    searchTerm: 'git',
+  },
+};
+
+export const DomainRuleCardDomainActionsDisabled: Story = {
+  name: 'DomainRuleCard — Domain Actions Disabled (unique domain)',
+  args: {
+    ...defaultProps,
+    isDomainActionDisabled: true,
+  },
+};
+
+export const DomainRuleCardWithSearch: Story = {
+  name: 'DomainRuleCard — Search Highlight',
+  args: {
+    ...defaultProps,
+    searchTerm: 'git',
+    isDragDisabled: true,
+  },
+};
+
+export const DomainRuleCardListSortable: Story = {
+  name: 'DomainRuleCard — Sortable List (3 rules)',
+  render: () => {
+    const rules: DomainRuleSetting[] = [
+      { ...baseRule, id: 'rule-1', label: 'GitHub', domainFilter: 'github.com' },
+      { ...baseRule, id: 'rule-2', label: 'GitLab', domainFilter: 'gitlab.com', categoryId: null },
+      { ...baseRule, id: 'rule-3', label: 'Bitbucket', domainFilter: 'bitbucket.org', categoryId: null, enabled: false },
+    ];
+    const sensors = useSensors(
+      useSensor(PointerSensor),
+      useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+    return (
+      <Theme>
+        <Box style={{ maxWidth: 680 }}>
+          <DndContext sensors={sensors} collisionDetection={closestCenter}>
+            <SortableContext items={rules.map(r => r.id)} strategy={verticalListSortingStrategy}>
+              <Flex direction="column" gap="3">
+                {rules.map((rule, index) => (
+                  <DomainRuleCard
+                    key={rule.id}
+                    {...defaultProps}
+                    rule={rule}
+                    index={index}
+                    isDomainActionDisabled={false}
+                  />
+                ))}
+              </Flex>
+            </SortableContext>
+          </DndContext>
+        </Box>
+      </Theme>
+    );
+  },
+};

--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { Button, Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu, Box } from '@radix-ui/themes';
+import { Pencil, Trash2, MoreHorizontal, GripVertical } from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { RuleDetailPopover } from './RuleDetailPopover';
+import { AccessibleHighlight } from '../../UI/AccessibleHighlight/AccessibleHighlight';
+import { getMessage } from '../../../utils/i18n';
+import { getRadixColor } from '../../../utils/utils';
+import { getRuleCategory } from '../../../schemas/enums';
+import type { DomainRuleSetting } from '../../../types/syncSettings';
+
+export interface DomainRuleCardProps {
+  rule: DomainRuleSetting;
+  index: number;
+  isSelected: boolean;
+  searchTerm: string;
+  isDragDisabled: boolean;
+  isDomainActionDisabled: boolean;
+  onSelect: (id: string, checked: boolean) => void;
+  onToggleEnabled: (id: string, enabled: boolean) => void;
+  onEdit: (rule: DomainRuleSetting) => void;
+  onDeleteRequest: (ruleId: string, focusIndex: number) => void;
+  onMoveToFirst: (id: string) => void;
+  onMoveToLast: (id: string) => void;
+  onMoveToFirstOfDomain: (id: string) => void;
+  onMoveToLastOfDomain: (id: string) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+export function DomainRuleCard({
+  rule,
+  index,
+  isSelected,
+  searchTerm,
+  isDragDisabled,
+  isDomainActionDisabled,
+  onSelect,
+  onToggleEnabled,
+  onEdit,
+  onDeleteRequest,
+  onMoveToFirst,
+  onMoveToLast,
+  onMoveToFirstOfDomain,
+  onMoveToLastOfDomain,
+  onKeyDown,
+}: DomainRuleCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: rule.id, disabled: isDragDisabled });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : rule.enabled ? 1 : 0.6,
+    zIndex: isDragging ? 10 : undefined,
+    position: isDragging ? 'relative' : undefined,
+  };
+
+  const category = getRuleCategory(rule.categoryId);
+
+  return (
+    <Card
+      ref={setNodeRef}
+      data-testid={`rule-card-${rule.id}`}
+      variant="surface"
+      size="2"
+      role="row"
+      tabIndex={0}
+      aria-selected={isSelected}
+      aria-label={`${rule.label} — ${rule.domainFilter}`}
+      onKeyDown={onKeyDown}
+      style={style}
+    >
+      <Flex align="center" justify="between" gap="4">
+        {/* Drag handle */}
+        <Box
+          data-testid={`rule-card-${rule.id}-drag-handle`}
+          {...attributes}
+          {...listeners}
+          aria-disabled={isDragDisabled}
+          style={{
+            cursor: isDragDisabled ? 'not-allowed' : 'grab',
+            touchAction: 'none',
+            color: isDragDisabled ? 'var(--gray-6)' : 'var(--gray-9)',
+            flexShrink: 0,
+          }}
+        >
+          <GripVertical size={16} aria-hidden="true" />
+        </Box>
+
+        {/* Left: Selection + Toggle */}
+        <Flex align="center" gap="3" role="gridcell">
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={(checked) => onSelect(rule.id, checked as boolean)}
+          />
+          <Switch
+            size="1"
+            checked={rule.enabled}
+            onCheckedChange={(checked) => onToggleEnabled(rule.id, checked)}
+          />
+        </Flex>
+
+        {/* Center: Badge + Domain */}
+        <Flex align="center" gap="3" role="gridcell" style={{ flex: 1, minWidth: 0 }}>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Badge
+                color={(category ? getRadixColor(category.color) : 'gray') as any}
+                variant="solid"
+                size="2"
+                style={{ cursor: 'pointer', flexShrink: 0 }}
+              >
+                {category ? `${category.emoji} ` : ''}
+                <AccessibleHighlight text={rule.label} searchTerm={searchTerm} />
+              </Badge>
+            </HoverCard.Trigger>
+            <HoverCard.Content size="2" style={{ maxWidth: 400 }}>
+              <RuleDetailPopover rule={rule} searchTerm={searchTerm} />
+            </HoverCard.Content>
+          </HoverCard.Root>
+
+          <Text size="2" color="gray" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <AccessibleHighlight text={rule.domainFilter} searchTerm={searchTerm} />
+          </Text>
+        </Flex>
+
+        {/* Right: Actions */}
+        <Flex align="center" role="gridcell" style={{ flexShrink: 0 }}>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <IconButton
+                data-testid={`rule-card-${rule.id}-btn-dropdown`}
+                size="2"
+                variant="ghost"
+                color="gray"
+                aria-label={getMessage('ruleMoreActions')}
+              >
+                <MoreHorizontal size={16} aria-hidden="true" />
+              </IconButton>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-edit`}
+                onClick={() => onEdit(rule)}
+              >
+                <Pencil size={14} aria-hidden="true" />
+                {getMessage('edit')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-move-first`}
+                onClick={() => onMoveToFirst(rule.id)}
+              >
+                {getMessage('ruleMoveToFirst')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-move-last`}
+                onClick={() => onMoveToLast(rule.id)}
+              >
+                {getMessage('ruleMoveToLast')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-move-first-domain`}
+                disabled={isDomainActionDisabled}
+                onClick={() => !isDomainActionDisabled && onMoveToFirstOfDomain(rule.id)}
+              >
+                {getMessage('ruleMoveToFirstOfDomain')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-move-last-domain`}
+                disabled={isDomainActionDisabled}
+                onClick={() => !isDomainActionDisabled && onMoveToLastOfDomain(rule.id)}
+              >
+                {getMessage('ruleMoveToLastOfDomain')}
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item
+                data-testid={`rule-card-${rule.id}-menu-delete`}
+                color="red"
+                onClick={() => onDeleteRequest(rule.id, index)}
+              >
+                <Trash2 size={14} aria-hidden="true" />
+                {getMessage('delete')}
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -36,10 +36,25 @@ async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
     notifyOnGroupingItem,
     notifyOnDeduplicationItem,
   ]);
+
+  const rawRules = results[2].value as DomainRuleSettings;
+  // Migrate legacy wildcard syntax: *.example.com → example.com
+  const hasWildcards = rawRules?.some(r => r.domainFilter?.startsWith('*.'));
+  const domainRules = hasWildcards
+    ? rawRules.map(r => ({
+        ...r,
+        domainFilter: r.domainFilter?.startsWith('*.') ? r.domainFilter.slice(2) : r.domainFilter,
+      }))
+    : rawRules;
+  if (hasWildcards) {
+    // Persist the migrated rules so migration only runs once
+    await storage.setItems([{ item: domainRulesItem, value: domainRules }]);
+  }
+
   return {
     globalGroupingEnabled: results[0].value as boolean,
     globalDeduplicationEnabled: results[1].value as boolean,
-    domainRules: results[2].value as DomainRuleSettings,
+    domainRules,
     notifyOnGrouping: results[3].value as boolean,
     notifyOnDeduplication: results[4].value as boolean,
   };

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,16 +1,36 @@
 import React, { useState, useMemo, useCallback, useRef } from 'react';
-import { Button, Switch, Text, HoverCard, Box, Flex, Badge, Card, Checkbox, IconButton, TextField, Separator, DropdownMenu } from '@radix-ui/themes';
-import { Pencil, Trash2, Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, MoreHorizontal } from 'lucide-react';
+import { Button, Text, Flex, Box, Checkbox, IconButton, TextField, Separator } from '@radix-ui/themes';
+import { Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, Trash2 } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { RuleWizardModal } from '../components/Core/DomainRule/RuleWizardModal';
-import { RuleDetailPopover } from '../components/Core/DomainRule/RuleDetailPopover';
 import { ImportWizard } from '../components/UI/ImportExportPage/ImportWizard';
 import { ConfirmDialog } from '../components/UI/ConfirmDialog/ConfirmDialog';
 import { getMessage } from '../utils/i18n';
 import { foldAccents } from '../utils/stringUtils';
-import { AccessibleHighlight } from '../components/UI/AccessibleHighlight/AccessibleHighlight';
-import { generateUUID, getRadixColor } from '../utils/utils';
-import { getRuleCategory } from '../schemas/enums';
+import { generateUUID } from '../utils/utils';
+import { DomainRuleCard } from '../components/Core/DomainRule/DomainRuleCard';
+import {
+  moveToFirst,
+  moveToLast,
+  moveToFirstOfDomain,
+  moveToLastOfDomain,
+  getRulesForRootDomain,
+  applyDragReorder,
+} from '../utils/ruleOrderUtils';
 import type { SyncSettings, DomainRuleSetting } from '../types/syncSettings';
 import type { DomainRule } from '../schemas/domainRule';
 
@@ -140,9 +160,30 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     updateRules(syncSettings.domainRules.filter(rule => !ruleIds.includes(rule.id)));
   }, [syncSettings.domainRules, updateRules]);
 
+  const handleMoveToFirst = useCallback((ruleId: string) => {
+    updateRules(moveToFirst(syncSettings.domainRules, ruleId));
+  }, [syncSettings.domainRules, updateRules]);
+
+  const handleMoveToLast = useCallback((ruleId: string) => {
+    updateRules(moveToLast(syncSettings.domainRules, ruleId));
+  }, [syncSettings.domainRules, updateRules]);
+
+  const handleMoveToFirstOfDomain = useCallback((ruleId: string) => {
+    updateRules(moveToFirstOfDomain(syncSettings.domainRules, ruleId));
+  }, [syncSettings.domainRules, updateRules]);
+
+  const handleMoveToLastOfDomain = useCallback((ruleId: string) => {
+    updateRules(moveToLastOfDomain(syncSettings.domainRules, ruleId));
+  }, [syncSettings.domainRules, updateRules]);
+
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const filteredRules = useMemo(() => {
     if (!searchTerm) return syncSettings.domainRules;
@@ -174,6 +215,17 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     setEditingRule(domainRule);
     setIsModalOpen(true);
   }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    updateRules(applyDragReorder(
+      syncSettings.domainRules,
+      filteredRules.map(r => r.id),
+      String(active.id),
+      String(over.id),
+    ));
+  }, [syncSettings.domainRules, filteredRules, updateRules]);
 
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -324,97 +376,39 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                 onImport={() => setIsImportOpen(true)}
               />
             ) : (
-              <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
-                {filteredRules.map((rule, index) => (
-                  <Card
-                    key={rule.id}
-                    data-testid={`rule-card-${rule.id}`}
-                    variant="surface"
-                    size="2"
-                    role="row"
-                    tabIndex={0}
-                    aria-selected={selectedIds.has(rule.id)}
-                    aria-label={`${rule.label} — ${rule.domainFilter}`}
-                    onKeyDown={(e) => handleCardKeyDown(e, rule, index)}
-                    style={{
-                      opacity: rule.enabled ? 1 : 0.6,
-                      transition: 'opacity 0.2s, box-shadow 0.2s',
-                    }}
-                  >
-                    <Flex align="center" justify="between" gap="4">
-                      {/* Left: Selection + Toggle */}
-                      <Flex align="center" gap="3" role="gridcell">
-                        <Checkbox
-                          checked={selectedIds.has(rule.id)}
-                          onCheckedChange={(checked) => handleRowSelect(rule.id, checked as boolean)}
-                        />
-                        <Switch
-                          size="1"
-                          checked={rule.enabled}
-                          onCheckedChange={(checked) => handleToggleEnabled(rule.id, checked)}
-                        />
-                      </Flex>
-
-                      {/* Center: Badge + Domain */}
-                      <Flex align="center" gap="3" role="gridcell" style={{ flex: 1, minWidth: 0 }}>
-                        <HoverCard.Root>
-                          <HoverCard.Trigger>
-                            {(() => {
-                              const category = getRuleCategory(rule.categoryId);
-                              return (
-                                <Badge
-                                  color={(category ? getRadixColor(category.color) : 'gray') as any}
-                                  variant="solid"
-                                  size="2"
-                                  style={{ cursor: 'pointer', flexShrink: 0 }}
-                                >
-                                  {category ? `${category.emoji} ` : ''}
-                                  <AccessibleHighlight text={rule.label} searchTerm={searchTerm} />
-                                </Badge>
-                              );
-                            })()}
-                          </HoverCard.Trigger>
-                          <HoverCard.Content size="2" style={{ maxWidth: 400 }}>
-                            <RuleDetailPopover rule={rule} searchTerm={searchTerm} />
-                          </HoverCard.Content>
-                        </HoverCard.Root>
-
-                        <Text size="2" color="gray" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          <AccessibleHighlight text={rule.domainFilter} searchTerm={searchTerm} />
-                        </Text>
-                      </Flex>
-
-                      {/* Right: Actions */}
-                      <Flex align="center" role="gridcell" style={{ flexShrink: 0 }}>
-                        <DropdownMenu.Root>
-                          <DropdownMenu.Trigger>
-                            <IconButton
-                              data-testid={`rule-card-${rule.id}-btn-dropdown`}
-                              size="2"
-                              variant="ghost"
-                              color="gray"
-                              aria-label={getMessage('ruleMoreActions')}
-                            >
-                              <MoreHorizontal size={16} aria-hidden="true" />
-                            </IconButton>
-                          </DropdownMenu.Trigger>
-                          <DropdownMenu.Content>
-                            <DropdownMenu.Item onClick={() => handleEditRule(rule)}>
-                              <Pencil size={14} aria-hidden="true" />
-                              {getMessage('edit')}
-                            </DropdownMenu.Item>
-                            <DropdownMenu.Separator />
-                            <DropdownMenu.Item color="red" onClick={() => setDeleteTarget({ type: 'single', ruleId: rule.id })}>
-                              <Trash2 size={14} aria-hidden="true" />
-                              {getMessage('delete')}
-                            </DropdownMenu.Item>
-                          </DropdownMenu.Content>
-                        </DropdownMenu.Root>
-                      </Flex>
-                    </Flex>
-                  </Card>
-                ))}
-              </Flex>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={filteredRules.map(r => r.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
+                    {filteredRules.map((rule, index) => (
+                      <DomainRuleCard
+                        key={rule.id}
+                        rule={rule}
+                        index={index}
+                        isSelected={selectedIds.has(rule.id)}
+                        searchTerm={searchTerm}
+                        isDragDisabled={!!searchTerm}
+                        isDomainActionDisabled={getRulesForRootDomain(syncSettings.domainRules, rule.domainFilter).length <= 1}
+                        onSelect={handleRowSelect}
+                        onToggleEnabled={handleToggleEnabled}
+                        onEdit={handleEditRule}
+                        onDeleteRequest={(ruleId, focusIndex) => setDeleteTarget({ type: 'single', ruleId, focusIndex })}
+                        onMoveToFirst={handleMoveToFirst}
+                        onMoveToLast={handleMoveToLast}
+                        onMoveToFirstOfDomain={handleMoveToFirstOfDomain}
+                        onMoveToLastOfDomain={handleMoveToLastOfDomain}
+                        onKeyDown={(e) => handleCardKeyDown(e, rule, index)}
+                      />
+                    ))}
+                  </Flex>
+                </SortableContext>
+              </DndContext>
             )}
           </Box>
         )}

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -49,12 +49,9 @@ export const createDomainFilterValidator = () => {
   return z.string().min(1).refine((val) => {
     // D'abord vérifier si c'est un nom de domaine valide
     if (val === 'localhost') return true;
-    
-    // Vérifier les patterns de domaine avec wildcards (ex: *.example.com)
-    const wildcardDomainRegex = /^\*\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/;
-    if (wildcardDomainRegex.test(val)) return true;
-    
+
     // Vérifier les noms de domaine normaux (au moins 2 parties séparées par un point, pas de point final)
+    // Les wildcards (*.domain) ne sont plus acceptés — les sous-domaines matchent implicitement
     const domainRegex = /^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)+$/;
     // Vérifier qu'il ne se termine pas par un point
     if (val.endsWith('.')) return false;

--- a/src/utils/ruleOrderUtils.ts
+++ b/src/utils/ruleOrderUtils.ts
@@ -1,0 +1,137 @@
+import { arrayMove } from '@dnd-kit/sortable';
+import type { DomainRuleSetting } from '../types/syncSettings.js';
+
+/**
+ * Returns the "root domain" of a domainFilter for grouping purposes.
+ * - "sub.example.com" → "example.com" (last 2 segments)
+ * - "example.com" → "example.com"
+ * - "localhost" → "localhost"
+ * - regex patterns (contain regex metacharacters other than . and -) → "__regex__"
+ */
+export function getRootDomain(domainFilter: string): string {
+  if (!domainFilter) return '__empty__';
+  const trimmed = domainFilter.trim();
+  // Regex pattern: contains chars that are not valid in a plain domain
+  const hasRegexChars = /[*+?^${}()|[\]\\]/.test(trimmed);
+  if (hasRegexChars) return '__regex__';
+  if (trimmed === 'localhost') return 'localhost';
+  const parts = trimmed.split('.');
+  if (parts.length <= 2) return trimmed;
+  return parts.slice(-2).join('.');
+}
+
+/**
+ * Returns all rules sharing the same root domain as the given domainFilter.
+ */
+export function getRulesForRootDomain(
+  rules: DomainRuleSetting[],
+  domainFilter: string,
+): DomainRuleSetting[] {
+  const root = getRootDomain(domainFilter);
+  return rules.filter(r => getRootDomain(r.domainFilter) === root);
+}
+
+/**
+ * Moves the given rule to position 0 in the array.
+ */
+export function moveToFirst(
+  rules: DomainRuleSetting[],
+  ruleId: string,
+): DomainRuleSetting[] {
+  const idx = rules.findIndex(r => r.id === ruleId);
+  if (idx <= 0) return rules;
+  return arrayMove(rules, idx, 0);
+}
+
+/**
+ * Moves the given rule to the last position in the array.
+ */
+export function moveToLast(
+  rules: DomainRuleSetting[],
+  ruleId: string,
+): DomainRuleSetting[] {
+  const idx = rules.findIndex(r => r.id === ruleId);
+  if (idx < 0 || idx === rules.length - 1) return rules;
+  return arrayMove(rules, idx, rules.length - 1);
+}
+
+/**
+ * Moves the given rule to just before all other rules sharing the same root domain.
+ * Rules of other domains are not affected.
+ */
+export function moveToFirstOfDomain(
+  rules: DomainRuleSetting[],
+  ruleId: string,
+): DomainRuleSetting[] {
+  const ruleIdx = rules.findIndex(r => r.id === ruleId);
+  if (ruleIdx < 0) return rules;
+  const rule = rules[ruleIdx];
+  const root = getRootDomain(rule.domainFilter);
+
+  // Find index of the first rule in the array that shares the same root domain
+  const firstOfDomainIdx = rules.findIndex(r => getRootDomain(r.domainFilter) === root);
+  if (firstOfDomainIdx === ruleIdx) return rules; // already first
+  return arrayMove(rules, ruleIdx, firstOfDomainIdx);
+}
+
+/**
+ * Moves the given rule to just after all other rules sharing the same root domain.
+ * Rules of other domains are not affected.
+ */
+export function moveToLastOfDomain(
+  rules: DomainRuleSetting[],
+  ruleId: string,
+): DomainRuleSetting[] {
+  const ruleIdx = rules.findIndex(r => r.id === ruleId);
+  if (ruleIdx < 0) return rules;
+  const rule = rules[ruleIdx];
+  const root = getRootDomain(rule.domainFilter);
+
+  // Find index of the last rule in the array that shares the same root domain
+  let lastOfDomainIdx = -1;
+  for (let i = 0; i < rules.length; i++) {
+    if (getRootDomain(rules[i].domainFilter) === root) {
+      lastOfDomainIdx = i;
+    }
+  }
+  if (lastOfDomainIdx === ruleIdx) return rules; // already last
+  return arrayMove(rules, ruleIdx, lastOfDomainIdx);
+}
+
+/**
+ * Applies a drag-and-drop reorder: moves activeId to the position of overId
+ * within the filteredIds subset, then reconstructs the full allRules array.
+ *
+ * When DnD is only enabled with no active search filter,
+ * filteredIds === allRules.map(r => r.id), making this a simple arrayMove.
+ */
+export function applyDragReorder(
+  allRules: DomainRuleSetting[],
+  filteredIds: string[],
+  activeId: string,
+  overId: string,
+): DomainRuleSetting[] {
+  const activeIndex = filteredIds.indexOf(activeId);
+  const overIndex = filteredIds.indexOf(overId);
+  if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) return allRules;
+
+  const reorderedFilteredIds = arrayMove(filteredIds, activeIndex, overIndex);
+
+  // Rebuild full array: place filtered items in their new order,
+  // preserving non-filtered items at their original positions.
+  const filteredSet = new Set(filteredIds);
+  const result: DomainRuleSetting[] = [];
+  let filteredPointer = 0;
+  const ruleById = new Map(allRules.map(r => [r.id, r]));
+
+  for (const rule of allRules) {
+    if (filteredSet.has(rule.id)) {
+      result.push(ruleById.get(reorderedFilteredIds[filteredPointer])!);
+      filteredPointer++;
+    } else {
+      result.push(rule);
+    }
+  }
+
+  return result;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,10 +10,16 @@ export function generateUUID(): string {
 export function domainToRegex(domainFilter: string | null): RegExp | null {
   if (!domainFilter) return null;
   try {
-    let p = domainFilter.trim().replace(/\./g, '\\.').replace(/^\*\\\./, '([^.]+\\.)*');
+    const trimmed = domainFilter.trim();
+    // Defensive strip: handle legacy *.domain rules not yet migrated
+    const cleaned = trimmed.startsWith('*.') ? trimmed.slice(2) : trimmed;
+    // Plain domain: only letters, digits, dots and hyphens — not localhost
+    const isPlainDomain = cleaned !== 'localhost' && /^[a-zA-Z0-9][a-zA-Z0-9.\-]*$/.test(cleaned);
+    const escaped = cleaned.replace(/\./g, '\\.');
+    const p = isPlainDomain ? `([^.]+\\.)*${escaped}` : escaped;
     return new RegExp(`^https?:\\/\\/(${p})(\\/|$)`, 'i');
   } catch (e) {
-    logger.error("Err domainToRegex:", domainFilter, e);
+    logger.error('Err domainToRegex:', domainFilter, e);
     return null;
   }
 }
@@ -57,7 +63,8 @@ export function isValidRegex(regex: string): boolean {
 }
 
 export function isValidDomain(domain: string | null): boolean {
-  return domain ? /^(\*\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(domain.trim()) : false;
+  // Wildcards (*.domain) are no longer accepted — subdomains match implicitly
+  return domain ? /^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(domain.trim()) : false;
 }
 
 export function getRadixColor(groupColor: string): string {

--- a/tests/e2e/domain-rules-dnd.spec.ts
+++ b/tests/e2e/domain-rules-dnd.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * E2E tests for drag-and-drop reordering of domain rules.
+ * Covers: reorder via drag, drag handle disabled during search.
+ */
+import { test, expect } from './fixtures';
+import { goToDomainRulesSection } from './helpers/navigation';
+
+test.beforeEach(async ({ helpers }) => {
+  await helpers.clearDomainRules();
+});
+
+async function getDomainRuleLabels(helpers: any): Promise<string[]> {
+  const settings = await helpers.getSettings();
+  return (settings.domainRules as any[]).map((r: any) => r.label);
+}
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop reordering
+// ---------------------------------------------------------------------------
+test.describe('Drag-and-drop reordering', () => {
+  test('dragging a rule card reorders the list in storage', async ({ extensionContext, extensionId, helpers }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+    await helpers.addDomainRule({ label: 'Rule C', domainFilter: 'c.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    // Find drag handles for Rule A (first) and Rule C (last)
+    const ruleARow = page.getByRole('row', { name: /Rule A/i });
+    const ruleCRow = page.getByRole('row', { name: /Rule C/i });
+
+    const ruleAHandle = ruleARow.locator('[data-testid$="-drag-handle"]');
+    const ruleCHandle = ruleCRow.locator('[data-testid$="-drag-handle"]');
+
+    // Drag Rule A (index 0) to Rule C position (index 2)
+    await ruleAHandle.dragTo(ruleCHandle);
+    await page.waitForTimeout(500);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    // Rule A should now be after Rule B and Rule C
+    const ruleAIdx = labels.indexOf('Rule A');
+    const ruleBIdx = labels.indexOf('Rule B');
+    expect(ruleAIdx).toBeGreaterThan(ruleBIdx);
+  });
+
+  test('drag handle has aria-disabled="true" when search is active', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: 'github.com' });
+    await helpers.addDomainRule({ label: 'GitLab', domainFilter: 'gitlab.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    // Type in the search box to activate a filter
+    await page.getByTestId('page-rules-search').fill('git');
+    await page.waitForTimeout(200);
+
+    // All visible rule drag handles should be aria-disabled
+    const dragHandles = page.locator('[data-testid$="-drag-handle"]');
+    const count = await dragHandles.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      await expect(dragHandles.nth(i)).toHaveAttribute('aria-disabled', 'true');
+    }
+
+    await page.close();
+  });
+
+  test('drag handle does not have aria-disabled when no search filter', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: 'github.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    const dragHandle = page.locator('[data-testid$="-drag-handle"]').first();
+    await expect(dragHandle).not.toHaveAttribute('aria-disabled', 'true');
+
+    await page.close();
+  });
+});

--- a/tests/e2e/domain-rules-position-actions.spec.ts
+++ b/tests/e2e/domain-rules-position-actions.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * E2E tests for domain rule position actions in the "…" dropdown menu.
+ * Covers: Move to top, Move to bottom, First of domain, Last of domain.
+ */
+import { test, expect } from './fixtures';
+import { goToDomainRulesSection } from './helpers/navigation';
+
+test.beforeEach(async ({ helpers }) => {
+  await helpers.clearDomainRules();
+});
+
+async function getDomainRuleLabels(helpers: any): Promise<string[]> {
+  const settings = await helpers.getSettings();
+  return (settings.domainRules as any[]).map((r: any) => r.label);
+}
+
+// ---------------------------------------------------------------------------
+// Move to top
+// ---------------------------------------------------------------------------
+test.describe('Move to top', () => {
+  test('moves the last rule to the first position', async ({ extensionContext, extensionId, helpers }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+    await helpers.addDomainRule({ label: 'Rule C', domainFilter: 'c.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    // Open dropdown for Rule C (last) and click "Move to top"
+    await page.getByRole('row', { name: /Rule C/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /move to top/i }).click();
+    await page.waitForTimeout(300);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    expect(labels[0]).toBe('Rule C');
+    expect(labels).toContain('Rule A');
+    expect(labels).toContain('Rule B');
+  });
+
+  test('is a no-op when rule is already first', async ({ extensionContext, extensionId, helpers }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Rule A/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /move to top/i }).click();
+    await page.waitForTimeout(300);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    expect(labels[0]).toBe('Rule A');
+    expect(labels[1]).toBe('Rule B');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Move to bottom
+// ---------------------------------------------------------------------------
+test.describe('Move to bottom', () => {
+  test('moves the first rule to the last position', async ({ extensionContext, extensionId, helpers }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+    await helpers.addDomainRule({ label: 'Rule C', domainFilter: 'c.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Rule A/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /move to bottom/i }).click();
+    await page.waitForTimeout(300);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    expect(labels[labels.length - 1]).toBe('Rule A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First of domain / Last of domain
+// ---------------------------------------------------------------------------
+test.describe('First of domain / Last of domain', () => {
+  test('"First of domain" moves rule before the first rule of same root domain', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    // Order: GitHub, Example, Sub.Example, GitLab
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: 'github.com' });
+    await helpers.addDomainRule({ label: 'Example', domainFilter: 'example.com' });
+    await helpers.addDomainRule({ label: 'Sub Example', domainFilter: 'sub.example.com' });
+    await helpers.addDomainRule({ label: 'GitLab', domainFilter: 'gitlab.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    // Move "Sub Example" (root: example.com) to first of domain
+    // "Example" (also example.com) is at index 1, so Sub Example should move before it
+    await page.getByRole('row', { name: /Sub Example/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /first of domain/i }).click();
+    await page.waitForTimeout(300);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    const subExampleIdx = labels.indexOf('Sub Example');
+    const exampleIdx = labels.indexOf('Example');
+    expect(subExampleIdx).toBeLessThan(exampleIdx);
+    // Unrelated rules should remain
+    expect(labels).toContain('GitHub');
+    expect(labels).toContain('GitLab');
+  });
+
+  test('"Last of domain" moves rule after the last rule of same root domain', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Example', domainFilter: 'example.com' });
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: 'github.com' });
+    await helpers.addDomainRule({ label: 'Sub Example', domainFilter: 'sub.example.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    // Move "Example" (root: example.com) to last of domain
+    // "Sub Example" (also example.com) is at index 2, so Example should move after it
+    await page.getByRole('row', { name: /^Example$/i }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /last of domain/i }).click();
+    await page.waitForTimeout(300);
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    const exampleIdx = labels.indexOf('Example');
+    const subExampleIdx = labels.indexOf('Sub Example');
+    expect(exampleIdx).toBeGreaterThan(subExampleIdx);
+    expect(labels).toContain('GitHub');
+  });
+
+  test('"First of domain" and "Last of domain" are disabled for a unique-domain rule', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Solo', domainFilter: 'solo.com' });
+    await helpers.addDomainRule({ label: 'Other', domainFilter: 'other.org' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByRole('row', { name: /Solo/i }).getByLabel('More actions').click();
+
+    const firstOfDomainItem = page.getByRole('menuitem', { name: /first of domain/i });
+    const lastOfDomainItem = page.getByRole('menuitem', { name: /last of domain/i });
+
+    await expect(firstOfDomainItem).toHaveAttribute('data-disabled', 'true');
+    await expect(lastOfDomainItem).toHaveAttribute('data-disabled', 'true');
+
+    await page.close();
+  });
+});

--- a/tests/e2e/domain-rules-position-actions.spec.ts
+++ b/tests/e2e/domain-rules-position-actions.spec.ts
@@ -126,7 +126,7 @@ test.describe('First of domain / Last of domain', () => {
 
     // Move "Example" (root: example.com) to last of domain
     // "Sub Example" (also example.com) is at index 2, so Example should move after it
-    await page.getByRole('row', { name: /^Example$/i }).getByLabel('More actions').click();
+    await page.getByRole('row', { name: /Example/i }).first().getByLabel('More actions').click();
     await page.getByRole('menuitem', { name: /last of domain/i }).click();
     await page.waitForTimeout(300);
     await page.close();
@@ -154,8 +154,9 @@ test.describe('First of domain / Last of domain', () => {
     const firstOfDomainItem = page.getByRole('menuitem', { name: /first of domain/i });
     const lastOfDomainItem = page.getByRole('menuitem', { name: /last of domain/i });
 
-    await expect(firstOfDomainItem).toHaveAttribute('data-disabled', 'true');
-    await expect(lastOfDomainItem).toHaveAttribute('data-disabled', 'true');
+    // Radix UI DropdownMenu.Item sets data-disabled="" (empty string) when disabled
+    await expect(firstOfDomainItem).toHaveAttribute('data-disabled', '');
+    await expect(lastOfDomainItem).toHaveAttribute('data-disabled', '');
 
     await page.close();
   });

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -111,7 +111,7 @@ test.describe('Edit rule via dropdown', () => {
     extensionId,
     helpers,
   }) => {
-    await helpers.addDomainRule({ label: 'Notion', domainFilter: '*.notion.so' });
+    await helpers.addDomainRule({ label: 'Notion', domainFilter: 'notion.so' });
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
@@ -123,7 +123,7 @@ test.describe('Edit rule via dropdown', () => {
     await expect(dialog).toBeVisible();
     // In edit mode the identity zone has directly editable inputs (no wizard steps)
     await expect(dialog.locator('input[name="label"]')).toHaveValue('Notion');
-    await expect(dialog.locator('input[name="domainFilter"]')).toHaveValue('*.notion.so');
+    await expect(dialog.locator('input[name="domainFilter"]')).toHaveValue('notion.so');
     await page.close();
   });
 });

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -348,7 +348,7 @@ test.describe('Edit mode — Summary View', () => {
   test('edit opens on summary view (no wizard stepper)', async ({
     extensionContext, extensionId, helpers,
   }) => {
-    await helpers.addDomainRule({ label: 'Edit Me', domainFilter: '*.edit.com' });
+    await helpers.addDomainRule({ label: 'Edit Me', domainFilter: 'edit.com' });
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
@@ -362,7 +362,7 @@ test.describe('Edit mode — Summary View', () => {
     await expect(dialog.getByTestId('wizard-rule-stepper')).not.toBeAttached();
     // Identity fields visible and editable
     await expect(dialog.getByTestId('wizard-rule-field-label')).toHaveValue('Edit Me');
-    await expect(dialog.getByTestId('wizard-rule-field-domain')).toHaveValue('*.edit.com');
+    await expect(dialog.getByTestId('wizard-rule-field-domain')).toHaveValue('edit.com');
     await page.close();
   });
 

--- a/tests/grouping.test.ts
+++ b/tests/grouping.test.ts
@@ -132,9 +132,9 @@ describe('grouping', () => {
       expect(result?.label).toBe('Active Rule');
     });
 
-    it('devrait supporter les wildcards dans le domainFilter', () => {
+    it('devrait matcher les sous-domaines implicitement (plain domain)', () => {
       const rules: DomainRuleSetting[] = [
-        createMockRule({ domainFilter: '*.example.com' })
+        createMockRule({ domainFilter: 'example.com' })
       ];
 
       const result = findMatchingRule('https://sub.example.com/page', rules);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -12,10 +12,14 @@ test('domainToRegex with typical domain', () => {
   const regex = domainToRegex('example.com');
   assert.ok(regex instanceof RegExp);
   assert.ok(regex.test('https://example.com'));
-  assert.ok(!regex.test('https://sub.example.com'));
+  // Plain domains now match subdomains implicitly
+  assert.ok(regex.test('https://sub.example.com'));
+  assert.ok(regex.test('https://deep.sub.example.com'));
+  assert.ok(!regex.test('https://notexample.com'));
 });
 
-test('domainToRegex with wildcard domain', () => {
+test('domainToRegex legacy wildcard domain (defensive strip during migration)', () => {
+  // *.example.com stripped to example.com — same subdomain-matching behavior
   const regex = domainToRegex('*.example.com');
   assert.ok(regex instanceof RegExp);
   assert.ok(regex.test('https://sub.example.com'));
@@ -27,7 +31,12 @@ test('matchesDomain typical', () => {
   assert.strictEqual(matchesDomain('https://other.com', 'example.com'), false);
 });
 
-test('matchesDomain wildcard', () => {
+test('matchesDomain subdomain (plain domain matches subdomains implicitly)', () => {
+  assert.strictEqual(matchesDomain('https://a.example.com', 'example.com'), true);
+  assert.strictEqual(matchesDomain('https://example.com', 'example.com'), true);
+});
+
+test('matchesDomain legacy wildcard (defensive strip)', () => {
   assert.strictEqual(matchesDomain('https://a.example.com', '*.example.com'), true);
   assert.strictEqual(matchesDomain('https://example.com', '*.example.com'), true);
 });
@@ -75,7 +84,10 @@ test('isValidRegex edge cases', () => {
 
 test('isValidDomain edge cases', () => {
   assert.strictEqual(isValidDomain('example.com'), true);
-  assert.strictEqual(isValidDomain('*.example.com'), true);
+  assert.strictEqual(isValidDomain('sub.example.com'), true);
+  // Wildcards are no longer accepted — subdomains match implicitly
+  assert.strictEqual(isValidDomain('*.example.com'), false);
   assert.strictEqual(isValidDomain('example'), false);
   assert.strictEqual(isValidDomain(''), false);
+  assert.strictEqual(isValidDomain(null), false);
 });

--- a/tests/utils/ruleOrderUtils.test.ts
+++ b/tests/utils/ruleOrderUtils.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRootDomain,
+  getRulesForRootDomain,
+  moveToFirst,
+  moveToLast,
+  moveToFirstOfDomain,
+  moveToLastOfDomain,
+  applyDragReorder,
+} from '../../src/utils/ruleOrderUtils';
+import type { DomainRuleSetting } from '../../src/types/syncSettings';
+
+/* ── Helpers ──────────────────────────────────────────────────────────────── */
+
+const makeRule = (id: string, domainFilter: string): DomainRuleSetting => ({
+  id,
+  domainFilter,
+  label: `Rule ${id}`,
+  titleParsingRegEx: '',
+  urlParsingRegEx: '',
+  groupNameSource: 'title',
+  deduplicationMatchMode: 'exact',
+  deduplicationEnabled: true,
+  presetId: null,
+  enabled: true,
+});
+
+/* ── getRootDomain ─────────────────────────────────────────────────────────── */
+
+describe('getRootDomain', () => {
+  it('returns domain as-is when it has 2 segments', () => {
+    expect(getRootDomain('example.com')).toBe('example.com');
+  });
+
+  it('returns last 2 segments for a subdomain', () => {
+    expect(getRootDomain('sub.example.com')).toBe('example.com');
+  });
+
+  it('returns last 2 segments for a deep subdomain', () => {
+    expect(getRootDomain('a.b.c.example.com')).toBe('example.com');
+  });
+
+  it('returns "localhost" for localhost', () => {
+    expect(getRootDomain('localhost')).toBe('localhost');
+  });
+
+  it('returns "__regex__" for patterns with regex metacharacters', () => {
+    expect(getRootDomain('[a-z]+\\.example\\.com')).toBe('__regex__');
+    expect(getRootDomain('example\\.')).toBe('__regex__');
+    expect(getRootDomain('foo.*')).toBe('__regex__');
+  });
+
+  it('returns "__empty__" for empty string', () => {
+    expect(getRootDomain('')).toBe('__empty__');
+  });
+});
+
+/* ── getRulesForRootDomain ────────────────────────────────────────────────── */
+
+describe('getRulesForRootDomain', () => {
+  const rules = [
+    makeRule('a', 'example.com'),
+    makeRule('b', 'sub.example.com'),
+    makeRule('c', 'github.com'),
+    makeRule('d', 'api.github.com'),
+  ];
+
+  it('groups example.com and sub.example.com together', () => {
+    const result = getRulesForRootDomain(rules, 'example.com');
+    expect(result.map(r => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('groups github.com and api.github.com together', () => {
+    const result = getRulesForRootDomain(rules, 'api.github.com');
+    expect(result.map(r => r.id)).toEqual(['c', 'd']);
+  });
+
+  it('returns only one rule when domain is unique', () => {
+    const result = getRulesForRootDomain([makeRule('x', 'unique.org')], 'unique.org');
+    expect(result).toHaveLength(1);
+  });
+});
+
+/* ── moveToFirst ──────────────────────────────────────────────────────────── */
+
+describe('moveToFirst', () => {
+  const rules = ['a', 'b', 'c', 'd'].map(id => makeRule(id, 'example.com'));
+
+  it('moves a rule from last to first', () => {
+    expect(moveToFirst(rules, 'd').map(r => r.id)).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  it('moves a rule from middle to first', () => {
+    expect(moveToFirst(rules, 'b').map(r => r.id)).toEqual(['b', 'a', 'c', 'd']);
+  });
+
+  it('is a no-op when rule is already first', () => {
+    const result = moveToFirst(rules, 'a');
+    expect(result.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('is a no-op for unknown id', () => {
+    const result = moveToFirst(rules, 'unknown');
+    expect(result.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+/* ── moveToLast ───────────────────────────────────────────────────────────── */
+
+describe('moveToLast', () => {
+  const rules = ['a', 'b', 'c', 'd'].map(id => makeRule(id, 'example.com'));
+
+  it('moves a rule from first to last', () => {
+    expect(moveToLast(rules, 'a').map(r => r.id)).toEqual(['b', 'c', 'd', 'a']);
+  });
+
+  it('moves a rule from middle to last', () => {
+    expect(moveToLast(rules, 'b').map(r => r.id)).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  it('is a no-op when rule is already last', () => {
+    const result = moveToLast(rules, 'd');
+    expect(result.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('is a no-op for unknown id', () => {
+    const result = moveToLast(rules, 'unknown');
+    expect(result.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+/* ── moveToFirstOfDomain ──────────────────────────────────────────────────── */
+
+describe('moveToFirstOfDomain', () => {
+  it('moves rule to just before the first rule of same root domain', () => {
+    const rules = [
+      makeRule('gh1', 'github.com'),
+      makeRule('ex1', 'example.com'),
+      makeRule('ex2', 'sub.example.com'),
+      makeRule('gh2', 'api.github.com'),
+    ];
+    // Move gh2 (api.github.com → root: github.com) to first of its domain (gh1 at index 0)
+    expect(moveToFirstOfDomain(rules, 'gh2').map(r => r.id)).toEqual(['gh2', 'gh1', 'ex1', 'ex2']);
+  });
+
+  it('is a no-op when rule is already first of its domain', () => {
+    const rules = [
+      makeRule('ex1', 'example.com'),
+      makeRule('ex2', 'sub.example.com'),
+      makeRule('gh1', 'github.com'),
+    ];
+    const result = moveToFirstOfDomain(rules, 'ex1');
+    expect(result.map(r => r.id)).toEqual(['ex1', 'ex2', 'gh1']);
+  });
+
+  it('handles non-contiguous rules of same domain', () => {
+    const rules = [
+      makeRule('ex1', 'example.com'),
+      makeRule('gh1', 'github.com'),
+      makeRule('ex2', 'sub.example.com'),
+    ];
+    // Move ex2 to first of domain (example.com). ex1 is at index 0.
+    expect(moveToFirstOfDomain(rules, 'ex2').map(r => r.id)).toEqual(['ex2', 'ex1', 'gh1']);
+  });
+});
+
+/* ── moveToLastOfDomain ───────────────────────────────────────────────────── */
+
+describe('moveToLastOfDomain', () => {
+  it('moves rule to just after the last rule of same root domain', () => {
+    const rules = [
+      makeRule('ex1', 'example.com'),
+      makeRule('ex2', 'sub.example.com'),
+      makeRule('gh1', 'github.com'),
+      makeRule('gh2', 'api.github.com'),
+    ];
+    // Move ex1 (root: example.com) to last of domain (ex2 at index 1)
+    expect(moveToLastOfDomain(rules, 'ex1').map(r => r.id)).toEqual(['ex2', 'ex1', 'gh1', 'gh2']);
+  });
+
+  it('is a no-op when rule is already last of its domain', () => {
+    const rules = [
+      makeRule('ex1', 'example.com'),
+      makeRule('ex2', 'sub.example.com'),
+      makeRule('gh1', 'github.com'),
+    ];
+    const result = moveToLastOfDomain(rules, 'ex2');
+    expect(result.map(r => r.id)).toEqual(['ex1', 'ex2', 'gh1']);
+  });
+
+  it('handles non-contiguous rules of same domain', () => {
+    const rules = [
+      makeRule('ex1', 'example.com'),
+      makeRule('gh1', 'github.com'),
+      makeRule('ex2', 'sub.example.com'),
+    ];
+    // Move ex1 to last of domain (ex2 at index 2)
+    expect(moveToLastOfDomain(rules, 'ex1').map(r => r.id)).toEqual(['gh1', 'ex2', 'ex1']);
+  });
+});
+
+/* ── applyDragReorder ─────────────────────────────────────────────────────── */
+
+describe('applyDragReorder', () => {
+  const rules = ['a', 'b', 'c', 'd'].map(id => makeRule(id, 'example.com'));
+
+  it('moves element from index 2 to index 0 in full list', () => {
+    const filteredIds = ['a', 'b', 'c', 'd'];
+    const result = applyDragReorder(rules, filteredIds, 'c', 'a');
+    expect(result.map(r => r.id)).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('moves element from index 0 to last in full list', () => {
+    const filteredIds = ['a', 'b', 'c', 'd'];
+    const result = applyDragReorder(rules, filteredIds, 'a', 'd');
+    expect(result.map(r => r.id)).toEqual(['b', 'c', 'd', 'a']);
+  });
+
+  it('is a no-op when activeId === overId', () => {
+    const filteredIds = ['a', 'b', 'c', 'd'];
+    const result = applyDragReorder(rules, filteredIds, 'b', 'b');
+    expect(result.map(r => r.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('preserves non-filtered rules at their original positions', () => {
+    // Only 'a' and 'c' are visible (filtered); 'b' and 'd' are hidden
+    const filteredIds = ['a', 'c'];
+    const result = applyDragReorder(rules, filteredIds, 'c', 'a');
+    // 'b' stays at index 1, 'd' stays at index 3; 'a' and 'c' swap
+    expect(result.map(r => r.id)).toEqual(['c', 'b', 'a', 'd']);
+  });
+});


### PR DESCRIPTION
Introduce drag-and-drop ordering for domain rules using dnd-kit and new UI pieces. Adds @dnd-kit dependencies, a DomainRuleCard component with Storybook stories, and integrates sortable DnD into DomainRulesPage (including keyboard sensors and search-disabled dragging). Implements ruleOrderUtils (root-domain grouping, moveToFirst/Last/FirstOfDomain/LastOfDomain, applyDragReorder) and wire up position actions in the page. Migrate legacy wildcard domain filters (strip leading "*.") in storage/load paths so subdomains match implicitly, and update validation and domainToRegex/isValidDomain to disallow wildcard syntax. Also add i18n keys for move actions and include end-to-end tests covering DnD and position actions.