### PR TITLE
Migrate drag-and-drop to @dnd-kit/react useSortable (v2 API)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
+    "@dnd-kit/abstract": "^0.3.2",
     "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-toast": "^1.2.14",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@dnd-kit/abstract": "^0.3.2",
+    "@dnd-kit/helpers": "0.3.2",
     "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/abstract':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@dnd-kit/react':
         specifier: ^0.3.2
         version: 0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@dnd-kit/abstract':
         specifier: ^0.3.2
         version: 0.3.2
+      '@dnd-kit/helpers':
+        specifier: 0.3.2
+        version: 0.3.2
       '@dnd-kit/react':
         specifier: ^0.3.2
         version: 0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -244,6 +247,9 @@ packages:
 
   '@dnd-kit/geometry@0.3.2':
     resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/helpers@0.3.2':
+    resolution: {integrity: sha512-pj7pCE6BiysNetpPnzb3BJOrcKiqueUr1LFg6wYoi2fIFYpz66n2Ojd7HTwfwkpv0oyC3QlvA6Dk8cOmi6VavA==}
 
   '@dnd-kit/react@0.3.2':
     resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
@@ -4252,6 +4258,11 @@ snapshots:
   '@dnd-kit/geometry@0.3.2':
     dependencies:
       '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
       tslib: 2.8.1
 
   '@dnd-kit/react@0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,15 +13,9 @@ importers:
 
   .:
     dependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@18.3.1)
+      '@dnd-kit/react':
+        specifier: ^0.3.2
+        version: 0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
@@ -236,27 +230,26 @@ packages:
     engines: {node: '>= 0.10.4'}
     hasBin: true
 
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
+  '@dnd-kit/abstract@0.3.2':
+    resolution: {integrity: sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==}
 
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+  '@dnd-kit/collision@0.3.2':
+    resolution: {integrity: sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==}
 
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
+  '@dnd-kit/dom@0.3.2':
+    resolution: {integrity: sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==}
 
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+  '@dnd-kit/geometry@0.3.2':
+    resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/react@0.3.2':
+    resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.2':
+    resolution: {integrity: sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -939,6 +932,9 @@ packages:
   '@pnpm/npm-conf@3.0.2':
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
+
+  '@preact/signals-core@1.14.1':
+    resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
 
   '@radix-ui/colors@3.0.0':
     resolution: {integrity: sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg==}
@@ -4230,29 +4226,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+  '@dnd-kit/abstract@0.3.2':
     dependencies:
-      react: 18.3.1
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
       tslib: 2.8.1
 
-  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@dnd-kit/collision@0.3.2':
     dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
-      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/collision': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.2':
+    dependencies:
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/dom': 0.3.2
+      '@dnd-kit/state': 0.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
 
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@dnd-kit/state@0.3.2':
     dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
-      react: 18.3.1
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
+      '@preact/signals-core': 1.14.1
       tslib: 2.8.1
 
   '@emnapi/runtime@1.9.2':
@@ -4664,6 +4674,8 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@preact/signals-core@1.14.1': {}
 
   '@radix-ui/colors@3.0.0': {}
 

--- a/src/components/Core/DomainRule/DomainRuleCard.stories.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.stories.tsx
@@ -1,19 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Theme, Box, Flex } from '@radix-ui/themes';
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
+import { DragDropProvider } from '@dnd-kit/react';
 import { DomainRuleCard } from './DomainRuleCard';
 import type { DomainRuleSetting } from '../../../types/syncSettings';
 
@@ -53,19 +41,13 @@ const defaultProps = {
   onKeyDown: noop,
 };
 
-/* ── Wrapper: DndContext required for useSortable ───────────────────────────── */
+/* ── Wrapper: DragDropProvider required for useSortable ─────────────────────── */
 
 function DndWrapper({ children }: { children: React.ReactNode }) {
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter}>
-      <SortableContext items={['rule-1']} strategy={verticalListSortingStrategy}>
-        {children}
-      </SortableContext>
-    </DndContext>
+    <DragDropProvider>
+      {children}
+    </DragDropProvider>
   );
 }
 
@@ -145,28 +127,22 @@ export const DomainRuleCardListSortable: Story = {
       { ...baseRule, id: 'rule-2', label: 'GitLab', domainFilter: 'gitlab.com', categoryId: null },
       { ...baseRule, id: 'rule-3', label: 'Bitbucket', domainFilter: 'bitbucket.org', categoryId: null, enabled: false },
     ];
-    const sensors = useSensors(
-      useSensor(PointerSensor),
-      useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-    );
     return (
       <Theme>
         <Box style={{ maxWidth: 680 }}>
-          <DndContext sensors={sensors} collisionDetection={closestCenter}>
-            <SortableContext items={rules.map(r => r.id)} strategy={verticalListSortingStrategy}>
-              <Flex direction="column" gap="3">
-                {rules.map((rule, index) => (
-                  <DomainRuleCard
-                    key={rule.id}
-                    {...defaultProps}
-                    rule={rule}
-                    index={index}
-                    isDomainActionDisabled={false}
-                  />
-                ))}
-              </Flex>
-            </SortableContext>
-          </DndContext>
+          <DragDropProvider>
+            <Flex direction="column" gap="3">
+              {rules.map((rule, index) => (
+                <DomainRuleCard
+                  key={rule.id}
+                  {...defaultProps}
+                  rule={rule}
+                  index={index}
+                  isDomainActionDisabled={false}
+                />
+              ))}
+            </Flex>
+          </DragDropProvider>
         </Box>
       </Theme>
     );

--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Button, Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu, Box } from '@radix-ui/themes';
 import { Pencil, Trash2, MoreHorizontal, GripVertical } from 'lucide-react';
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from '@dnd-kit/react/sortable';
 import { RuleDetailPopover } from './RuleDetailPopover';
 import { AccessibleHighlight } from '../../UI/AccessibleHighlight/AccessibleHighlight';
 import { getMessage } from '../../../utils/i18n';
@@ -45,12 +44,9 @@ export function DomainRuleCard({
   onMoveToLastOfDomain,
   onKeyDown,
 }: DomainRuleCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: rule.id, disabled: isDragDisabled });
+  const { ref, handleRef, isDragging } = useSortable({ id: rule.id, index, disabled: isDragDisabled });
 
   const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
     opacity: isDragging ? 0.4 : rule.enabled ? 1 : 0.6,
     zIndex: isDragging ? 10 : undefined,
     position: isDragging ? 'relative' : undefined,
@@ -60,7 +56,7 @@ export function DomainRuleCard({
 
   return (
     <Card
-      ref={setNodeRef}
+      ref={ref}
       data-testid={`rule-card-${rule.id}`}
       variant="surface"
       size="2"
@@ -74,9 +70,8 @@ export function DomainRuleCard({
       <Flex align="center" justify="between" gap="4">
         {/* Drag handle */}
         <Box
+          ref={handleRef}
           data-testid={`rule-card-${rule.id}-drag-handle`}
-          {...attributes}
-          {...listeners}
           aria-disabled={isDragDisabled}
           style={{
             display: 'flex',

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo, useCallback, useRef } from 'react';
 import { Button, Text, Flex, Box, Checkbox, IconButton, TextField, Separator } from '@radix-ui/themes';
 import { Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, Trash2 } from 'lucide-react';
-import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
+import { DragDropProvider, type DragEndEvent, type DragOverEvent } from '@dnd-kit/react';
+import { move } from '@dnd-kit/helpers';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { RuleWizardModal } from '../components/Core/DomainRule/RuleWizardModal';
@@ -17,7 +18,6 @@ import {
   moveToFirstOfDomain,
   moveToLastOfDomain,
   getRulesForRootDomain,
-  applyDragReorder,
 } from '../utils/ruleOrderUtils';
 import type { SyncSettings, DomainRuleSetting } from '../types/syncSettings';
 import type { DomainRule } from '../schemas/domainRule';
@@ -127,6 +127,7 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isImportOpen, setIsImportOpen] = useState(false);
   const [editingRule, setEditingRule] = useState<DomainRule | undefined>(undefined);
+  const [dragItems, setDragItems] = useState<DomainRuleSetting[] | null>(null);
 
   const handleToggleEnabled = useCallback((ruleId: string, enabled: boolean) => {
     updateRules(syncSettings.domainRules.map(rule =>
@@ -199,33 +200,21 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     setIsModalOpen(true);
   }, []);
 
-  const handleDragEnd = useCallback((event: Parameters<DragEndEvent>[0]) => {
-    const { source } = event.operation;
-    let targetId: string | null = event.operation.target
-      ? String(event.operation.target.id)
-      : null;
+  const handleDragOver = useCallback((event: Parameters<DragOverEvent>[0]) => {
+    setDragItems(prev => move(prev ?? syncSettings.domainRules, event));
+  }, [syncSettings.domainRules]);
 
-    // Fallback: RAF-based collision detection may not fire before pointerup in
-    // synthetic-event environments (e.g. Playwright). Use elementFromPoint to
-    // find the card under the pointer from the native pointerup event.
-    if (source && !targetId && event.nativeEvent instanceof PointerEvent) {
-      const { clientX, clientY } = event.nativeEvent;
-      const el = document.elementFromPoint(clientX, clientY);
-      const card = el?.closest('[role="row"][data-testid^="rule-card-"]');
-      if (card) {
-        const match = card.getAttribute('data-testid')?.match(/^rule-card-(.+)$/);
-        if (match) targetId = match[1];
+  const handleDragEnd = useCallback((event: Parameters<DragEndEvent>[0]) => {
+    if (!event.canceled) {
+      const reordered = move(dragItems ?? syncSettings.domainRules, event);
+      if (reordered !== (dragItems ?? syncSettings.domainRules)) {
+        updateRules(reordered);
+      } else if (dragItems) {
+        updateRules(dragItems);
       }
     }
-
-    if (!source || !targetId || String(source.id) === targetId) return;
-    updateRules(applyDragReorder(
-      syncSettings.domainRules,
-      filteredRules.map(r => r.id),
-      String(source.id),
-      targetId,
-    ));
-  }, [syncSettings.domainRules, filteredRules, updateRules]);
+    setDragItems(null);
+  }, [dragItems, syncSettings.domainRules, updateRules]);
 
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -376,9 +365,9 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                 onImport={() => setIsImportOpen(true)}
               />
             ) : (
-              <DragDropProvider modifiers={[RestrictToVerticalAxis]} onDragEnd={handleDragEnd}>
+              <DragDropProvider modifiers={[RestrictToVerticalAxis]} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
                 <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
-                  {filteredRules.map((rule, index) => (
+                  {(dragItems ?? filteredRules).map((rule, index) => (
                     <DomainRuleCard
                       key={rule.id}
                       rule={rule}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,20 +1,7 @@
 import React, { useState, useMemo, useCallback, useRef } from 'react';
 import { Button, Text, Flex, Box, Checkbox, IconButton, TextField, Separator } from '@radix-ui/themes';
 import { Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, Trash2 } from 'lucide-react';
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { RuleWizardModal } from '../components/Core/DomainRule/RuleWizardModal';
 import { ImportWizard } from '../components/UI/ImportExportPage/ImportWizard';
@@ -180,11 +167,6 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
-
   const filteredRules = useMemo(() => {
     if (!searchTerm) return syncSettings.domainRules;
     const term = foldAccents(searchTerm);
@@ -216,14 +198,14 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     setIsModalOpen(true);
   }, []);
 
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
+  const handleDragEnd = useCallback((event: Parameters<DragEndEvent>[0]) => {
+    const { source, target } = event.operation;
+    if (!source || !target || source.id === target.id) return;
     updateRules(applyDragReorder(
       syncSettings.domainRules,
       filteredRules.map(r => r.id),
-      String(active.id),
-      String(over.id),
+      String(source.id),
+      String(target.id),
     ));
   }, [syncSettings.domainRules, filteredRules, updateRules]);
 
@@ -376,39 +358,30 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                 onImport={() => setIsImportOpen(true)}
               />
             ) : (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={filteredRules.map(r => r.id)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
-                    {filteredRules.map((rule, index) => (
-                      <DomainRuleCard
-                        key={rule.id}
-                        rule={rule}
-                        index={index}
-                        isSelected={selectedIds.has(rule.id)}
-                        searchTerm={searchTerm}
-                        isDragDisabled={!!searchTerm}
-                        isDomainActionDisabled={getRulesForRootDomain(syncSettings.domainRules, rule.domainFilter).length <= 1}
-                        onSelect={handleRowSelect}
-                        onToggleEnabled={handleToggleEnabled}
-                        onEdit={handleEditRule}
-                        onDeleteRequest={(ruleId, focusIndex) => setDeleteTarget({ type: 'single', ruleId, focusIndex })}
-                        onMoveToFirst={handleMoveToFirst}
-                        onMoveToLast={handleMoveToLast}
-                        onMoveToFirstOfDomain={handleMoveToFirstOfDomain}
-                        onMoveToLastOfDomain={handleMoveToLastOfDomain}
-                        onKeyDown={(e) => handleCardKeyDown(e, rule, index)}
-                      />
-                    ))}
-                  </Flex>
-                </SortableContext>
-              </DndContext>
+              <DragDropProvider onDragEnd={handleDragEnd}>
+                <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
+                  {filteredRules.map((rule, index) => (
+                    <DomainRuleCard
+                      key={rule.id}
+                      rule={rule}
+                      index={index}
+                      isSelected={selectedIds.has(rule.id)}
+                      searchTerm={searchTerm}
+                      isDragDisabled={!!searchTerm}
+                      isDomainActionDisabled={getRulesForRootDomain(syncSettings.domainRules, rule.domainFilter).length <= 1}
+                      onSelect={handleRowSelect}
+                      onToggleEnabled={handleToggleEnabled}
+                      onEdit={handleEditRule}
+                      onDeleteRequest={(ruleId, focusIndex) => setDeleteTarget({ type: 'single', ruleId, focusIndex })}
+                      onMoveToFirst={handleMoveToFirst}
+                      onMoveToLast={handleMoveToLast}
+                      onMoveToFirstOfDomain={handleMoveToFirstOfDomain}
+                      onMoveToLastOfDomain={handleMoveToLastOfDomain}
+                      onKeyDown={(e) => handleCardKeyDown(e, rule, index)}
+                    />
+                  ))}
+                </Flex>
+              </DragDropProvider>
             )}
           </Box>
         )}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, useRef } from 'react';
 import { Button, Text, Flex, Box, Checkbox, IconButton, TextField, Separator } from '@radix-ui/themes';
 import { Plus, Eye, EyeOff, Shield, Search, AlertCircle, Upload, Trash2 } from 'lucide-react';
 import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
+import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { PageLayout } from '../components/UI/PageLayout/PageLayout';
 import { RuleWizardModal } from '../components/Core/DomainRule/RuleWizardModal';
 import { ImportWizard } from '../components/UI/ImportExportPage/ImportWizard';
@@ -358,7 +359,7 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
                 onImport={() => setIsImportOpen(true)}
               />
             ) : (
-              <DragDropProvider onDragEnd={handleDragEnd}>
+              <DragDropProvider modifiers={[RestrictToVerticalAxis]} onDragEnd={handleDragEnd}>
                 <Flex data-testid="page-rules-list" direction="column" gap="3" role="grid" aria-label={getMessage('domainRulesTab')} ref={listRef}>
                   {filteredRules.map((rule, index) => (
                     <DomainRuleCard

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -200,13 +200,30 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
   }, []);
 
   const handleDragEnd = useCallback((event: Parameters<DragEndEvent>[0]) => {
-    const { source, target } = event.operation;
-    if (!source || !target || source.id === target.id) return;
+    const { source } = event.operation;
+    let targetId: string | null = event.operation.target
+      ? String(event.operation.target.id)
+      : null;
+
+    // Fallback: RAF-based collision detection may not fire before pointerup in
+    // synthetic-event environments (e.g. Playwright). Use elementFromPoint to
+    // find the card under the pointer from the native pointerup event.
+    if (source && !targetId && event.nativeEvent instanceof PointerEvent) {
+      const { clientX, clientY } = event.nativeEvent;
+      const el = document.elementFromPoint(clientX, clientY);
+      const card = el?.closest('[role="row"][data-testid^="rule-card-"]');
+      if (card) {
+        const match = card.getAttribute('data-testid')?.match(/^rule-card-(.+)$/);
+        if (match) targetId = match[1];
+      }
+    }
+
+    if (!source || !targetId || String(source.id) === targetId) return;
     updateRules(applyDragReorder(
       syncSettings.domainRules,
       filteredRules.map(r => r.id),
       String(source.id),
-      String(target.id),
+      targetId,
     ));
   }, [syncSettings.domainRules, filteredRules, updateRules]);
 

--- a/src/utils/ruleOrderUtils.ts
+++ b/src/utils/ruleOrderUtils.ts
@@ -1,10 +1,5 @@
+import { arrayMove } from '@dnd-kit/helpers';
 import type { DomainRuleSetting } from '../types/syncSettings.js';
-
-function arrayMove<T>(array: T[], from: number, to: number): T[] {
-  const result = array.slice();
-  result.splice(to < 0 ? result.length + to : to, 0, result.splice(from, 1)[0]);
-  return result;
-}
 
 /**
  * Returns the "root domain" of a domainFilter for grouping purposes.

--- a/src/utils/ruleOrderUtils.ts
+++ b/src/utils/ruleOrderUtils.ts
@@ -1,5 +1,10 @@
-import { arrayMove } from '@dnd-kit/sortable';
 import type { DomainRuleSetting } from '../types/syncSettings.js';
+
+function arrayMove<T>(array: T[], from: number, to: number): T[] {
+  const result = array.slice();
+  result.splice(to < 0 ? result.length + to : to, 0, result.splice(from, 1)[0]);
+  return result;
+}
 
 /**
  * Returns the "root domain" of a domainFilter for grouping purposes.

--- a/tests/e2e/domain-rules-dnd.spec.ts
+++ b/tests/e2e/domain-rules-dnd.spec.ts
@@ -33,9 +33,21 @@ test.describe('Drag-and-drop reordering', () => {
     const ruleAHandle = ruleARow.locator('[data-testid$="-drag-handle"]');
     const ruleCHandle = ruleCRow.locator('[data-testid$="-drag-handle"]');
 
-    // Drag Rule A (index 0) to Rule C position (index 2)
-    await ruleAHandle.dragTo(ruleCHandle);
-    await page.waitForTimeout(500);
+    // Drag Rule A (index 0) to Rule C position (index 2).
+    // Use low-level mouse events so we can pause before releasing, giving
+    // dnd-kit's RAF-based collision detection time to fire dragover events.
+    const srcBox = await ruleAHandle.boundingBox();
+    const dstBox = await ruleCHandle.boundingBox();
+    const srcX = srcBox!.x + srcBox!.width / 2;
+    const srcY = srcBox!.y + srcBox!.height / 2;
+    const dstX = dstBox!.x + dstBox!.width / 2;
+    const dstY = dstBox!.y + dstBox!.height / 2;
+    await page.mouse.move(srcX, srcY);
+    await page.mouse.down();
+    await page.mouse.move(dstX, dstY, { steps: 10 });
+    await page.waitForTimeout(100);
+    await page.mouse.up();
+    await page.waitForTimeout(300);
     await page.close();
 
     const labels = await getDomainRuleLabels(helpers);


### PR DESCRIPTION
Replace @dnd-kit/core + @dnd-kit/sortable + @dnd-kit/utilities with
@dnd-kit/react. useSortable now returns {ref, handleRef, isDragging}
directly, removing the need to spread listeners/attributes and manually
apply CSS transforms. DndContext + SortableContext replaced by
DragDropProvider. arrayMove internalized in ruleOrderUtils.

https://claude.ai/code/session_01NAtHJe2XnFXMu3CVgPGPAN