### PR TITLE
Fix flaky cancel-delete test and duplicate export warning

### DIFF
--- a/.claude/agents/e2e-flaky-detector.md
+++ b/.claude/agents/e2e-flaky-detector.md
@@ -1,0 +1,47 @@
+---
+name: e2e-flaky-detector
+description: Analyse les tests E2E Playwright pour détecter les patterns de fragilité (race conditions, assertions fragiles, dépendances à l'état async). Spécialisé pour extensions Chrome avec WXT.
+model: claude-haiku-4-5
+---
+
+Tu es spécialisé dans les tests Playwright pour extensions navigateur construites avec WXT (Web Extension Toolkit).
+
+## Contexte du projet
+- Extension Chrome MV3 / Firefox MV2
+- Background service worker avec `chrome.storage.sync` et `chrome.storage.local`
+- Tests dans `tests/e2e/` avec fixtures dans `fixtures.ts`
+- Pattern connu : `onTabCreated` ne reçoit pas `openerTabId` pour les onglets créés par l'extension
+
+## Patterns de fragilité à détecter
+
+### 1. Assertions visibility/hidden (HIGH)
+- `toBeVisible()` / `toBeHidden()` → préférer `toBeAttached()` / `not.toBeAttached()` pour les dialogs qui se démontent
+- `waitFor({ state: 'hidden' })` → préférer `waitFor({ state: 'detached' })` quand l'élément est retiré du DOM
+
+### 2. Timings arbitraires (HIGH)
+- `page.waitForTimeout(N)` sans raison explicite
+- `sleep()` fixes → remplacer par `waitFor` basé sur un état observable
+
+### 3. Storage async sans await (HIGH)
+- Écriture dans `chrome.storage` sans attendre la confirmation avant assertion
+- Vérifier que `chrome.storage.sync.set()` est awaité avant les assertions qui en dépendent
+
+### 4. Sélecteurs fragiles (MEDIUM)
+- Sélecteurs sur texte hardcodé (peut changer avec i18n)
+- Préférer `data-testid`, rôles ARIA, ou `getByRole`/`getByLabel`
+
+### 5. Dépendances d'état entre tests (MEDIUM)
+- Tests qui supposent un état initial sans le forcer explicitement
+- Vérifier que chaque test initialise son propre état via les helpers `seed.ts`
+
+### 6. Quota storage (LOW)
+- Écriture en boucle dans `chrome.storage.sync` sans retry → le projet a un mécanisme de retry, vérifier qu'il est utilisé
+
+## Output attendu
+Pour chaque problème détecté :
+1. **Localisation** : fichier + numéro de ligne approximatif
+2. **Pattern** : nom du pattern de fragilité
+3. **Problème** : explication concise
+4. **Fix** : réécriture suggérée en code
+
+Priorise par sévérité (HIGH → MEDIUM → LOW). Si le test est globalement solide, dis-le explicitement.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const f=j.tool_input?.file_path||j.tool_response?.filePath||'';if(/\\.(ts|tsx)$/.test(f)){const {execSync}=require('child_process');try{const out=execSync('pnpm compile',{cwd:'/c/devhome/git/smart-tab-organizer',encoding:'utf8',timeout:60000});if(out.trim())process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PostToolUse',additionalContext:'TypeScript OK'}})+' ');}catch(e){process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PostToolUse',additionalContext:'TypeScript errors:\\n'+(e.stdout||e.message)}})+' ');}}}});\" 2>/dev/null || true",
+            "timeout": 65,
+            "statusMessage": "TypeScript check...",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const f=j.tool_input?.file_path||'';if(/(wxt\\.config|manifest\\.json|\\.env)/.test(f)){process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PreToolUse',permissionDecision:'ask',permissionDecisionReason:'Fichier sensible \\u2014 confirmer avant modification'}})+' ');}});\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const f=j.tool_input?.file_path||j.tool_response?.filePath||'';if(/\\.(ts|tsx)$/.test(f)){const {execSync}=require('child_process');try{const out=execSync('pnpm compile',{cwd:'/c/devhome/git/smart-tab-organizer',encoding:'utf8',timeout:60000});if(out.trim())process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PostToolUse',additionalContext:'TypeScript OK'}})+' ');}catch(e){process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PostToolUse',additionalContext:'TypeScript errors:\\n'+(e.stdout||e.message)}})+' ');}}}});\" 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // \"\"' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && pnpm --dir 'C:/devhome/git/smart-tab-organizer' compile 2>&1 | tail -20; } 2>/dev/null || true",
             "timeout": 65,
             "statusMessage": "TypeScript check...",
             "async": true
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const f=j.tool_input?.file_path||'';if(/(wxt\\.config|manifest\\.json|\\.env)/.test(f)){process.stdout.write(JSON.stringify({hookSpecificOutput:{hookEventName:'PreToolUse',permissionDecision:'ask',permissionDecisionReason:'Fichier sensible \\u2014 confirmer avant modification'}})+' ');}});\" 2>/dev/null || true"
+            "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; echo \"$f\" | grep -qE '(wxt\\.config|manifest\\.json|\\.env)' && printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"Fichier sensible \\u2014 confirmer avant modification\"}}'; } 2>/dev/null || true"
           }
         ]
       }

--- a/.claude/skills/e2e-grep/SKILL.md
+++ b/.claude/skills/e2e-grep/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: e2e-grep
+description: Lance les tests E2E Playwright avec un filtre grep sur le nom du test ou l'ID de user story (ex: "IE005", "sessions", "popup")
+disable-model-invocation: true
+---
+
+Run the following command in /c/devhome/git/smart-tab-organizer:
+
+```bash
+pnpm test:e2e --grep "<args>"
+```
+
+If no args provided, print usage: `/e2e-grep "<pattern>"` where pattern can be a test name fragment or US ID (e.g. `US-PO007`, `IE005.*Ignore`, `sessions`).

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: new-component
+description: Rappelle les conventions obligatoires pour créer un nouveau composant React dans ce projet (Storybook, i18n, logger, theming, accessibilité)
+user-invocable: false
+---
+
+Checklist obligatoire pour tout nouveau composant dans smart-tab-organizer :
+
+## Emplacement
+- `src/components/Core/` — logique métier liée à un concept domaine
+- `src/components/UI/` — layout et composants inter-features
+- `src/components/Form/` — champs de formulaire réutilisables, callouts thématiques
+
+## Storybook
+- Fichier `.stories.tsx` obligatoire dans le même dossier
+- Titre : `Components/Core/<Feature>/<ComponentName>` (miroir du chemin)
+- Préfixer tous les exports avec le nom du composant : `ComponentNameDefault`, `ComponentNameDisabled`
+
+## Internationalisation
+- Tous les textes via `getMessage(key)` depuis `src/utils/i18n.ts`
+- Jamais de strings hardcodées dans le JSX
+- Ajouter les nouvelles clés dans les 3 locales : `public/_locales/{en,fr,es}/messages.json`
+- Format placeholder i18n : `$1`, `$2` (pas `{placeholder}`)
+
+## Logging
+- `logger.debug('[MON_MODULE] message', value)` depuis `src/utils/logger.ts`
+- Jamais `console.log()` — c'est une no-op en production mais une violation de convention
+
+## Accessibilité
+- Icônes Lucide : toujours `aria-hidden="true"`
+- Boutons icône only : `aria-label` + `title` obligatoires
+- Préférer les primitives Radix (Dialog, Collapsible, Toolbar, RadioGroup) aux ARIA manuels
+
+## Theming
+- Utiliser le wrapper de thème correspondant à la feature depuis `src/components/Form/themes/`
+- Couleurs : Sessions=indigo, DomainRules=purple, RegexPresets=cyan, Import=jade, Export=teal, Statistics=orange, Settings=gray
+
+## CSS Modules (si hover actions)
+```css
+.row:hover .actions,
+.row:focus-within .actions { opacity: 1; }
+@media (pointer: coarse) { .actions { opacity: 1 !important; } }
+```
+
+## Types
+- Pas de `any` — utiliser des types précis ou `unknown` avec narrowing
+- Zod schemas dans `src/schemas/` si nouvelles entités persistées

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ node_modules/
 dist/
 .wxt/
 .output/
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 *storybook.log
 storybook-static
 playwright-report/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "env": {}
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "documentations",
+  "compatibility_date": "2026-04-09",
+  "assets": {
+    "directory": "dist"
+  }
+}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -14,7 +14,7 @@ import { ConfirmDialog } from '../components/UI/ConfirmDialog/ConfirmDialog';
 import { getMessage } from '../utils/i18n';
 import { foldAccents } from '../utils/stringUtils';
 import { matchSessionSearch } from '../utils/sessionUtils';
-import { moveToFirst, moveToLast } from '../utils/sessionOrderUtils';
+import { moveSessionToFirst, moveSessionToLast } from '../utils/sessionOrderUtils';
 import { useSessions } from '../hooks/useSessions';
 import { restoreTabs } from '../utils/tabRestore';
 import { updateSession } from '../utils/sessionStorage';
@@ -177,12 +177,12 @@ export function SessionsPage({
   }, [dragItems, sortedSessions, updateOrder]);
 
   const handleMoveToFirst = useCallback((session: Session) => {
-    const reordered = moveToFirst(sortedSessions, session.id);
+    const reordered = moveSessionToFirst(sortedSessions, session.id);
     void updateOrder(reordered);
   }, [sortedSessions, updateOrder]);
 
   const handleMoveLast = useCallback((session: Session) => {
-    const reordered = moveToLast(sortedSessions, session.id);
+    const reordered = moveSessionToLast(sortedSessions, session.id);
     void updateOrder(reordered);
   }, [sortedSessions, updateOrder]);
 

--- a/src/utils/sessionOrderUtils.ts
+++ b/src/utils/sessionOrderUtils.ts
@@ -4,7 +4,7 @@ import type { Session } from '../types/session';
 /**
  * Move a session to the first position.
  */
-export function moveToFirst(sessions: Session[], sessionId: string): Session[] {
+export function moveSessionToFirst(sessions: Session[], sessionId: string): Session[] {
   const currentIndex = sessions.findIndex(s => s.id === sessionId);
   if (currentIndex <= 0) return sessions;
   return arrayMove(sessions, currentIndex, 0);
@@ -13,7 +13,7 @@ export function moveToFirst(sessions: Session[], sessionId: string): Session[] {
 /**
  * Move a session to the last position.
  */
-export function moveToLast(sessions: Session[], sessionId: string): Session[] {
+export function moveSessionToLast(sessions: Session[], sessionId: string): Session[] {
   const currentIndex = sessions.findIndex(s => s.id === sessionId);
   if (currentIndex < 0 || currentIndex === sessions.length - 1) return sessions;
   return arrayMove(sessions, currentIndex, sessions.length - 1);

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -181,6 +181,7 @@ test.describe('Delete rule via dropdown', () => {
     await page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByRole('button', { name: /cancel/i }).click();
+    await expect(page.getByRole('alertdialog')).not.toBeVisible();
 
     await expect(
       page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions'),

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -178,8 +178,14 @@ test.describe('Delete rule via dropdown', () => {
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
 
+    // Wait for the rule to be rendered before interacting
+    await expect(page.getByRole('row', { name: /Vercel/i })).toBeVisible({ timeout: 5000 });
+
     await page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
+
+    // Confirm dialog is open before cancelling
+    await expect(page.getByTestId('confirm-dialog')).toBeVisible();
     await page.getByRole('button', { name: /cancel/i }).click();
     await expect(page.getByTestId('confirm-dialog')).not.toBeAttached();
 

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -181,7 +181,7 @@ test.describe('Delete rule via dropdown', () => {
     await page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByRole('button', { name: /cancel/i }).click();
-    await expect(page.getByRole('alertdialog')).not.toBeVisible();
+    await expect(page.getByTestId('confirm-dialog')).not.toBeAttached();
 
     await expect(
       page.getByRole('row', { name: /Vercel/i }).getByLabel('More actions'),

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -86,6 +86,29 @@ export interface Statistics {
   tabsDeduplicatedCount: number;
 }
 
+/**
+ * Writes to chrome.storage.sync, retrying with backoff on quota errors.
+ * Tests run fast enough on a single worker that MAX_WRITE_OPERATIONS_PER_MINUTE
+ * (120/min) can be exceeded when many tests each call addDomainRule + clearDomainRules.
+ */
+async function syncSet(sw: Page, data: Record<string, unknown>): Promise<void> {
+  const delays = [1000, 2000, 4000, 8000];
+  for (let i = 0; i <= delays.length; i++) {
+    try {
+      await sw.evaluate(async (d: Record<string, unknown>) => {
+        await chrome.storage.sync.set(d);
+      }, data as Record<string, unknown>);
+      return;
+    } catch (e: unknown) {
+      if (i < delays.length && String(e).includes('MAX_WRITE_OPERATIONS')) {
+        await new Promise(r => setTimeout(r, delays[i]));
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
 // Create a temporary user data directory for each test run
 function createTempUserDataDir(): string {
   const tmpDir = path.join(os.tmpdir(), `playwright-chrome-${Date.now()}`);
@@ -215,28 +238,22 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       // Set global grouping enabled/disabled
       setGlobalGroupingEnabled: async (enabled: boolean) => {
         const sw = await getServiceWorker();
-        await sw.evaluate(async (enabled) => {
-          await chrome.storage.sync.set({ globalGroupingEnabled: enabled });
-        }, enabled);
+        await syncSet(sw, { globalGroupingEnabled: enabled });
       },
 
       // Set global deduplication enabled/disabled
       setGlobalDeduplicationEnabled: async (enabled: boolean) => {
         const sw = await getServiceWorker();
-        await sw.evaluate(async (enabled) => {
-          await chrome.storage.sync.set({ globalDeduplicationEnabled: enabled });
-        }, enabled);
+        await syncSet(sw, { globalDeduplicationEnabled: enabled });
       },
 
       // Add a domain rule
       addDomainRule: async (rule: DomainRuleConfig) => {
         const sw = await getServiceWorker();
-        await sw.evaluate(async (ruleConfig) => {
-          const browser = chrome;
-          const result = await browser.storage.sync.get({ domainRules: [] });
-          const rules = result.domainRules || [];
-
-          const newRule = {
+        const updatedRules = await sw.evaluate(async (ruleConfig) => {
+          const result = await chrome.storage.sync.get({ domainRules: [] });
+          const rules: unknown[] = result.domainRules || [];
+          rules.push({
             id: `rule-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
             label: ruleConfig.label,
             domainFilter: ruleConfig.domainFilter,
@@ -250,11 +267,10 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
             urlParsingRegEx: ruleConfig.urlParsingRegEx || '',
             presetId: ruleConfig.presetId || '',
             badge: '',
-          };
-
-          rules.push(newRule);
-          await browser.storage.sync.set({ domainRules: rules });
+          });
+          return rules;
         }, rule);
+        await syncSet(sw, { domainRules: updatedRules });
         // Wait for storage to propagate
         await new Promise(resolve => setTimeout(resolve, 100));
       },
@@ -262,9 +278,7 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       // Clear all domain rules
       clearDomainRules: async () => {
         const sw = await getServiceWorker();
-        await sw.evaluate(async () => {
-          await chrome.storage.sync.set({ domainRules: [] });
-        });
+        await syncSet(sw, { domainRules: [] });
         await new Promise(resolve => setTimeout(resolve, 100));
       },
 


### PR DESCRIPTION
- Wait for alertdialog to be hidden before asserting row visibility,
  eliminating the race with Radix UI's closing animation.
- Rename moveToFirst/moveToLast in sessionOrderUtils to
  moveSessionToFirst/moveSessionToLast to avoid the duplicate-import
  warning caused by identical names in ruleOrderUtils.

https://claude.ai/code/session_01F7u9bgr7LnpxY3HFgFAMDj