### PR TITLE
fix(docs): add wrangler.jsonc to prevent interactive setup on Cloudflare deploy

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "documentations",
+  "compatibility_date": "2026-04-09",
+  "assets": {
+    "directory": "dist"
+  }
+}


### PR DESCRIPTION
Without this file, `npx wrangler deploy` triggers the auto-configuration
wizard which attempts `astro add cloudflare` and fails with
"Missing file or directory: public/.assetsignore".

The static Starlight site needs only an assets-directory config — no
worker script or Cloudflare adapter required.

https://claude.ai/code/session_01JsDvRYewitKejB6hFhn9NM