### PR TITLE
feat: persist and restore collapsed/expanded state of tab groups in sessions

### DIFF
--- a/src/components/Core/TabTree/useTabTreeEditor.ts
+++ b/src/components/Core/TabTree/useTabTreeEditor.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { getMessage } from '../../../utils/i18n';
 import type { Session, SavedTab, SavedTabGroup } from '../../../types/session';
 import type { ChromeGroupColor } from './tabTreeTypes';
@@ -10,7 +10,7 @@ export type AlertDialogState =
 
 export function useTabTreeEditor(session: Session, onSessionChange: (updated: Session) => void) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => new Set(session.groups.map((g) => g.id))
+    () => new Set(session.groups.filter((g) => !g.collapsed).map((g) => g.id))
   );
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
   const [editUrl, setEditUrl] = useState('');
@@ -19,17 +19,22 @@ export function useTabTreeEditor(session: Session, onSessionChange: (updated: Se
   const [urlError, setUrlError] = useState<string | null>(null);
   const [alertDialog, setAlertDialog] = useState<AlertDialogState>(null);
 
-  // Auto-expand newly added groups
+  // Track known group IDs so we only auto-expand genuinely new groups,
+  // not groups that were intentionally initialized as collapsed.
+  const knownGroupIds = useRef<Set<string>>(new Set(session.groups.map((g) => g.id)));
+
+  // Auto-expand newly added groups (not groups collapsed at init)
   useEffect(() => {
     setExpandedGroups((prev) => {
       const next = new Set(prev);
       let changed = false;
       for (const group of session.groups) {
-        if (!next.has(group.id)) {
+        if (!knownGroupIds.current.has(group.id)) {
           next.add(group.id);
           changed = true;
         }
       }
+      knownGroupIds.current = new Set(session.groups.map((g) => g.id));
       return changed ? next : prev;
     });
   }, [session.groups]);
@@ -39,11 +44,21 @@ export function useTabTreeEditor(session: Session, onSessionChange: (updated: Se
   const toggleGroup = useCallback((groupId: string) => {
     setExpandedGroups((prev) => {
       const next = new Set(prev);
-      if (next.has(groupId)) next.delete(groupId);
+      const wasExpanded = next.has(groupId);
+      if (wasExpanded) next.delete(groupId);
       else next.add(groupId);
+
+      onSessionChange({
+        ...session,
+        groups: session.groups.map((g) =>
+          g.id === groupId ? { ...g, collapsed: wasExpanded } : g
+        ),
+        updatedAt: new Date().toISOString(),
+      });
+
       return next;
     });
-  }, []);
+  }, [session, onSessionChange]);
 
   function openTabEdit(tab: SavedTab) {
     setEditingItemId(tab.id);

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -19,6 +19,7 @@ const savedTabGroupSchema = z.object({
   title: z.string(),
   color: chromeGroupColorSchema,
   tabs: z.array(savedTabSchema),
+  collapsed: z.boolean().optional(),
 });
 
 export const sessionSchema = z.object({

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -16,6 +16,8 @@ export interface SavedTabGroup {
   title: string;
   color: ChromeGroupColor;
   tabs: SavedTab[];
+  /** Whether the group was collapsed in Chrome when captured */
+  collapsed?: boolean;
 }
 
 /** A complete saved session snapshot */

--- a/src/utils/tabCapture.ts
+++ b/src/utils/tabCapture.ts
@@ -77,6 +77,7 @@ export async function captureCurrentTabs(): Promise<CaptureResult> {
           title: group.title || '',
           color: normalizeColor(group.color),
           tabs: [],
+          collapsed: group.collapsed || false,
         },
         treeGroup: {
           id: treeGroupId,

--- a/src/utils/tabRestore.ts
+++ b/src/utils/tabRestore.ts
@@ -97,7 +97,7 @@ async function restoreInNewWindow(
     if (tabIds.length > 0) {
       try {
         const groupId = await (browser.tabs as any).group({ tabIds, createProperties: { windowId } });
-        await (browser.tabGroups as any).update(groupId, { title: group.title, color: group.color });
+        await (browser.tabGroups as any).update(groupId, { title: group.title, color: group.color, collapsed: group.collapsed ?? false });
         result.groupsCreated++;
       } catch (e) {
         result.errors.push(`Failed to create group: ${group.title}`);
@@ -221,6 +221,7 @@ async function restoreInCurrentWindow(
         await (browser.tabGroups as any).update(groupId, {
           title: group.title,
           color: group.color,
+          collapsed: group.collapsed ?? false,
         });
         result.groupsCreated++;
       } catch (e) {

--- a/tests/e2e/helpers/seed.ts
+++ b/tests/e2e/helpers/seed.ts
@@ -13,6 +13,7 @@ export interface TestSavedTabGroup {
   title: string;
   color: string;
   tabs: TestSavedTab[];
+  collapsed?: boolean;
 }
 
 export interface TestSession {

--- a/tests/e2e/session-editor.spec.ts
+++ b/tests/e2e/session-editor.spec.ts
@@ -442,3 +442,85 @@ test.describe('[US-E02] Delete group', () => {
     await page.close();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Collapsed/expanded group state (US-S018)
+// ---------------------------------------------------------------------------
+test.describe('[US-S018] Collapsed group state in editor', () => {
+  test('a group with collapsed: true is displayed collapsed (tabs not visible)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createTestSession({ name: 'Collapsed Test' });
+    session.groups[0].collapsed = true;
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    // Group header should be visible
+    await expect(dialog.getByText('Work', { exact: true })).toBeVisible();
+    // Tabs inside the collapsed group should NOT be visible
+    await expect(dialog.getByText('Example', { exact: true })).not.toBeVisible();
+    await expect(dialog.getByText('Google', { exact: true })).not.toBeVisible();
+    await page.close();
+  });
+
+  test('a group without collapsed field is displayed expanded (tabs visible)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createTestSession({ name: 'Expanded Test' });
+    // No collapsed field set (default behavior)
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Work', { exact: true })).toBeVisible();
+    // Tabs inside the expanded group should be visible
+    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
+    await page.close();
+  });
+
+  test('toggling collapse then saving persists collapsed: true in storage', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createTestSession({ name: 'Toggle Test' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    // Tabs should be visible (group starts expanded)
+    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
+
+    // Click the expand/collapse toggle on the group row
+    await dialog.getByRole('button', { name: /collapse group/i }).click();
+
+    // Tabs should now be hidden
+    await expect(dialog.getByText('Example', { exact: true })).not.toBeVisible();
+
+    // Save
+    await page.getByTestId('dialog-session-edit-btn-save').click();
+    await expect(dialog).not.toBeVisible();
+
+    // Verify storage
+    const sessions = await getSessionsFromStorage(extensionContext);
+    expect(sessions[0].groups[0].collapsed).toBe(true);
+    await page.close();
+  });
+});

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -524,3 +524,27 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
     await page.close();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Restore with collapsed groups (US-S017)
+// ---------------------------------------------------------------------------
+test.describe('[US-S017] Restore with collapsed group state', () => {
+  test('restoring a session with a collapsed group succeeds without error', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createTestSession({ name: 'Collapsed Group Session' });
+    session.groups[0].collapsed = true;
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('menuitem', { name: /current window/i }).click();
+
+    // Restore should show success message
+    await expect(page.getByText(/tab.*opened/i)).toBeVisible({ timeout: 5000 });
+    await page.close();
+  });
+});

--- a/tests/hooks/useTabTreeEditor.test.ts
+++ b/tests/hooks/useTabTreeEditor.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTabTreeEditor } from '../../src/components/Core/TabTree/useTabTreeEditor';
+import type { Session, SavedTab, SavedTabGroup } from '../../src/types/session';
+
+vi.mock('../../src/utils/i18n.js', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+function tab(id: string, url = `https://${id}.com`): SavedTab {
+  return { id, title: id, url };
+}
+
+function group(
+  id: string,
+  tabs: SavedTab[],
+  collapsed?: boolean,
+): SavedTabGroup {
+  return { id, title: id, color: 'blue', tabs, ...(collapsed !== undefined ? { collapsed } : {}) };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    name: 'Test Session',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    groups: overrides.groups ?? [],
+    ungroupedTabs: overrides.ungroupedTabs ?? [],
+    isPinned: false,
+    categoryId: null,
+    ...overrides,
+  };
+}
+
+describe('useTabTreeEditor — collapsed state initialization [US-S018]', () => {
+  it('initializes a group with collapsed: true as collapsed (absent from expandedGroups)', () => {
+    const session = makeSession({
+      groups: [group('g1', [tab('a')], true)],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    expect(result.current.expandedGroups.has('g1')).toBe(false);
+  });
+
+  it('initializes a group with collapsed: false as expanded (present in expandedGroups)', () => {
+    const session = makeSession({
+      groups: [group('g1', [tab('a')], false)],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    expect(result.current.expandedGroups.has('g1')).toBe(true);
+  });
+
+  it('initializes a group without collapsed field as expanded (backward compat)', () => {
+    const session = makeSession({
+      groups: [group('g1', [tab('a')])],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    expect(result.current.expandedGroups.has('g1')).toBe(true);
+  });
+
+  it('handles mixed collapsed/expanded groups correctly', () => {
+    const session = makeSession({
+      groups: [
+        group('expanded', [tab('a')], false),
+        group('collapsed', [tab('b')], true),
+        group('default', [tab('c')]),
+      ],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    expect(result.current.expandedGroups.has('expanded')).toBe(true);
+    expect(result.current.expandedGroups.has('collapsed')).toBe(false);
+    expect(result.current.expandedGroups.has('default')).toBe(true);
+  });
+});
+
+describe('useTabTreeEditor — toggleGroup persists collapsed state [US-S018]', () => {
+  it('collapsing an expanded group calls onSessionChange with collapsed: true', () => {
+    const session = makeSession({
+      groups: [group('g1', [tab('a')], false)],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    // g1 starts expanded
+    expect(result.current.expandedGroups.has('g1')).toBe(true);
+
+    act(() => result.current.toggleGroup('g1'));
+
+    // g1 is now collapsed in local state
+    expect(result.current.expandedGroups.has('g1')).toBe(false);
+
+    // onSessionChange was called with collapsed: true
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updatedSession = onChange.mock.calls[0][0] as Session;
+    expect(updatedSession.groups[0].collapsed).toBe(true);
+  });
+
+  it('expanding a collapsed group calls onSessionChange with collapsed: false', () => {
+    const session = makeSession({
+      groups: [group('g1', [tab('a')], true)],
+    });
+    const onChange = vi.fn();
+
+    const { result } = renderHook(() => useTabTreeEditor(session, onChange));
+
+    // g1 starts collapsed
+    expect(result.current.expandedGroups.has('g1')).toBe(false);
+
+    act(() => result.current.toggleGroup('g1'));
+
+    // g1 is now expanded in local state
+    expect(result.current.expandedGroups.has('g1')).toBe(true);
+
+    // onSessionChange was called with collapsed: false
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updatedSession = onChange.mock.calls[0][0] as Session;
+    expect(updatedSession.groups[0].collapsed).toBe(false);
+  });
+});

--- a/tests/schemas/session.test.ts
+++ b/tests/schemas/session.test.ts
@@ -5,12 +5,12 @@ vi.mock('../../src/utils/i18n.js', () => ({
   getMessage: vi.fn((key: string) => key),
 }));
 
-const makeSession = (id: string, name: string) => ({
+const makeSession = (id: string, name: string, groups: Record<string, unknown>[] = []) => ({
   id,
   name,
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
-  groups: [],
+  groups,
   ungroupedTabs: [],
   isPinned: false,
   categoryId: null,
@@ -73,5 +73,33 @@ describe('createSessionSchemaWithUniqueness', () => {
     const schema = createSessionSchemaWithUniqueness(existing, 'a');
     const result = schema.safeParse(makeSession('a', 'Personal'));
     expect(result.success).toBe(false);
+  });
+});
+
+describe('savedTabGroupSchema — collapsed field [US-S016]', () => {
+  const makeGroup = (collapsed?: boolean) => ({
+    id: 'group-1',
+    title: 'Work',
+    color: 'blue',
+    tabs: [{ id: 'tab-1', title: 'Example', url: 'https://example.com' }],
+    ...(collapsed !== undefined ? { collapsed } : {}),
+  });
+
+  it('accepte un groupe avec collapsed: true', () => {
+    const schema = createSessionSchemaWithUniqueness([]);
+    const result = schema.safeParse(makeSession('s1', 'Session', [makeGroup(true)]));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte un groupe avec collapsed: false', () => {
+    const schema = createSessionSchemaWithUniqueness([]);
+    const result = schema.safeParse(makeSession('s1', 'Session', [makeGroup(false)]));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte un groupe sans champ collapsed (retro-compatibilite)', () => {
+    const schema = createSessionSchemaWithUniqueness([]);
+    const result = schema.safeParse(makeSession('s1', 'Session', [makeGroup()]));
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/tabCapture.test.ts
+++ b/tests/tabCapture.test.ts
@@ -146,6 +146,42 @@ describe('captureCurrentTabs', () => {
     expect(result.ungroupedTabs).toHaveLength(1);
   });
 
+  it('captures collapsed: true when Chrome group is collapsed [US-S016]', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'blue', collapsed: true });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].collapsed).toBe(true);
+  });
+
+  it('captures collapsed: false when Chrome group is expanded [US-S016]', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'blue', collapsed: false });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].collapsed).toBe(false);
+  });
+
+  it('defaults collapsed to false when Chrome group has no collapsed property [US-S016]', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'blue' });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].collapsed).toBe(false);
+  });
+
   it('excludes Firefox extension Options page from captured tabs', async () => {
     // Regression: moz-extension:// URLs were previously kept, so the Options
     // page itself showed up in the snapshot wizard and got auto-selected.

--- a/tests/tabRestore.test.ts
+++ b/tests/tabRestore.test.ts
@@ -43,8 +43,8 @@ function makeTab(url: string, title = 'Tab'): SavedTab {
   return { id: `saved-${url}`, title, url };
 }
 
-function makeGroup(title: string, tabs: SavedTab[], color: 'blue' | 'red' = 'blue'): SavedTabGroup {
-  return { id: `group-${title}`, title, color, tabs };
+function makeGroup(title: string, tabs: SavedTab[], color: 'blue' | 'red' = 'blue', collapsed?: boolean): SavedTabGroup {
+  return { id: `group-${title}`, title, color, tabs, ...(collapsed !== undefined ? { collapsed } : {}) };
 }
 
 beforeEach(() => {
@@ -96,7 +96,7 @@ describe('restoreTabs — new window', () => {
     const groupCall = mockTabsGroup.mock.calls[0][0];
     expect(groupCall.tabIds).toHaveLength(2);
     expect(groupCall.tabIds).toContain(1); // reused firstTabId
-    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, { title: 'Work', color: 'blue' });
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, { title: 'Work', color: 'blue', collapsed: false });
     expect(result.groupsCreated).toBe(1);
     expect(result.tabsCreated).toBe(2);
   });
@@ -120,6 +120,38 @@ describe('restoreTabs — new window', () => {
     expect(result.tabsCreated).toBe(2); // seeded a.com + successful b.com
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('https://c.com');
+  });
+
+  it('passes collapsed: true to tabGroups.update when group has collapsed: true [US-S017]', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    await restoreTabs({
+      tabs: [],
+      groups: [makeGroup('Work', [makeTab('https://a.com')], 'blue', true)],
+      target: 'new',
+    });
+
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, {
+      title: 'Work',
+      color: 'blue',
+      collapsed: true,
+    });
+  });
+
+  it('passes collapsed: false to tabGroups.update when group has no collapsed field [US-S017]', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    await restoreTabs({
+      tabs: [],
+      groups: [makeGroup('Work', [makeTab('https://a.com')], 'blue')],
+      target: 'new',
+    });
+
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, {
+      title: 'Work',
+      color: 'blue',
+      collapsed: false,
+    });
   });
 
   it('returns an error when windows.create does not yield an id', async () => {
@@ -200,9 +232,26 @@ describe('restoreTabs — current window', () => {
     expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, {
       title: 'Research',
       color: 'blue',
+      collapsed: false,
     });
     expect(result.groupsCreated).toBe(1);
     expect(result.tabsCreated).toBe(2);
+  });
+
+  it('passes collapsed state to tabGroups.update in current window [US-S017]', async () => {
+    const group = makeGroup('Research', [makeTab('https://r1.com')], 'red', true);
+
+    await restoreTabs({
+      tabs: [],
+      groups: [group],
+      target: 'current',
+    });
+
+    expect(mockTabGroupsUpdate).toHaveBeenCalledWith(100, {
+      title: 'Research',
+      color: 'red',
+      collapsed: true,
+    });
   });
 
   it('skips a group entirely when groupAction is "skip"', async () => {

--- a/user-stories/US-S-sessions.md
+++ b/user-stories/US-S-sessions.md
@@ -101,3 +101,47 @@
 - [ ] Après la restauration, le dialogue se ferme automatiquement.
 - [ ] Une notification système apparaît avec le titre « Session restored » et un message indiquant le nombre d'onglets ouverts et de doublons ignorés (ex. « 5 tab(s) opened, 2 duplicate(s) skipped »).
 - [ ] Si des erreurs surviennent lors de la restauration, une notification d'erreur est affichée à la place.
+
+---
+
+## US-S016 : Capture de l'etat replie/deplie des groupes d'onglets
+
+**En tant qu'** utilisateur qui prend un snapshot de ses onglets,
+**je veux** que l'etat replie ou deplie de chaque groupe d'onglets Chrome soit enregistre automatiquement,
+**afin que** le snapshot reflète fidelement l'agencement de ma fenetre au moment de la sauvegarde.
+
+### Criteres d'acceptation
+
+- [ ] Lorsqu'un groupe Chrome est replie au moment du snapshot, la session enregistree contient `collapsed: true` pour ce groupe.
+- [ ] Lorsqu'un groupe Chrome est deplie au moment du snapshot, la session enregistree contient `collapsed: false` pour ce groupe.
+- [ ] Les sessions existantes sans champ `collapsed` continuent de fonctionner normalement (retro-compatibilite) : elles sont traitees comme si tous les groupes etaient deplies.
+
+---
+
+## US-S017 : Restauration de l'etat replie/deplie des groupes d'onglets
+
+**En tant qu'** utilisateur qui restaure une session,
+**je veux** que les groupes d'onglets soient recrees avec leur etat replie ou deplie d'origine,
+**afin de** retrouver exactement l'agencement que j'avais sauvegarde.
+
+### Criteres d'acceptation
+
+- [ ] Lors de la restauration dans une nouvelle fenetre, un groupe marque `collapsed: true` est cree replie dans Chrome.
+- [ ] Lors de la restauration dans la fenetre courante (creation d'un nouveau groupe), le groupe respecte l'etat `collapsed` sauvegarde.
+- [ ] Lors d'une fusion (merge) dans un groupe existant, l'etat replie/deplie du groupe existant n'est pas modifie.
+- [ ] Les sessions sans champ `collapsed` restaurent les groupes en etat deplie (comportement par defaut).
+
+---
+
+## US-S018 : Edition de l'etat replie/deplie dans l'editeur de session
+
+**En tant qu'** utilisateur qui edite une session,
+**je veux** que l'editeur affiche les groupes selon leur etat replie/deplie sauvegarde et que les modifications de cet etat soient persistees a la sauvegarde,
+**afin de** pouvoir ajuster l'agencement des groupes avant une restauration.
+
+### Criteres d'acceptation
+
+- [ ] A l'ouverture de l'editeur, un groupe avec `collapsed: true` est affiche replie (ses onglets enfants ne sont pas visibles).
+- [ ] A l'ouverture de l'editeur, un groupe sans champ `collapsed` ou avec `collapsed: false` est affiche deplie (ses onglets enfants sont visibles).
+- [ ] Replier ou deplier un groupe dans l'editeur est considere comme une modification (le bouton « Save » devient activable).
+- [ ] Apres sauvegarde, la valeur `collapsed` de chaque groupe est mise a jour dans le stockage.


### PR DESCRIPTION
Capture the collapsed state from Chrome tab groups when saving sessions,
restore it when recreating groups, and reflect it in the session editor.
The field is optional for backward compatibility with existing sessions.

User stories: US-S016, US-S017, US-S018
Unit tests: schema validation, tabCapture, tabRestore, useTabTreeEditor
E2E tests: session-editor collapsed state, sessions restore regression

https://claude.ai/code/session_01EDPGDzPnF2qrPG1qrbbSJH