### PR TITLE
docs: align CLAUDE.md, READMEs and user stories with current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,16 @@ pnpm compile              # TypeScript check only
 
 # Tests
 pnpm test                     # Vitest unit tests
-pnpm test:watch / test:ui # Watch / Vitest UI
-pnpm test:e2e             # build + Playwright E2E
-pnpm test:e2e:ui          # build + Playwright with UI
-pnpm test:e2e:headed      # build + Playwright headed
+pnpm test:watch / test:ui     # Watch / Vitest UI
+pnpm test:coverage            # Vitest + coverage report
+pnpm test:e2e                 # build + Playwright E2E
+pnpm test:e2e:ui              # build + Playwright with UI
+pnpm test:e2e:headed          # build + Playwright headed
 
 # Docs
-pnpm storybook            # port 6006
+pnpm storybook                            # Storybook (port 6006)
+pnpm docs:dev / docs:build / docs:preview # Astro Starlight (port 4321)
+pnpm screenshots                          # Deterministic multi-locale/theme screenshots
 ```
 
 ## Architecture
@@ -32,7 +35,7 @@ pnpm storybook            # port 6006
 - `src/entrypoints/popup.html` / `options.html`
 
 ### Background Modules (`src/background/`)
-`index.ts` · `grouping.ts` · `deduplication.ts` · `event-handlers.ts` · `messaging.ts` · `settings.ts` · `profileSync.ts` (auto-sync alarm + draft persistence)
+`index.ts` · `grouping.ts` · `deduplication.ts` · `event-handlers.ts` · `messaging.ts` · `settings.ts`
 
 ### Storage
 | Backend | Contents |
@@ -41,12 +44,12 @@ pnpm storybook            # port 6006
 | `browser.storage.local` | Sessions, UI prefs (e.g. `popupStatsCollapsed`), help prefs |
 | `browser.storage.session` | Profile–window map, sync drafts, editing guard |
 
-`useSyncedSettings` hook uses refs to prevent race conditions.
+`useSyncedSettings` hook uses refs to prevent race conditions. `useSyncedState` unifies synchronized storage access for settings and statistics.
 
 ### Schemas & Types
-- `src/schemas/` — Zod schemas: `domainRule`, `enums`, `importExport`, `session`
+- `src/schemas/` — Zod schemas: `common`, `domainRule`, `enums`, `importExport`, `session`, `index`
 - `src/schemas/importExport.ts` — relaxed schema (no form-level refinements) for import validation
-- `src/types/` — TS types extending Zod-inferred types (e.g. `DomainRuleSetting` adds `enabled`, `badge`)
+- `src/types/` — TS types extending Zod-inferred types (e.g. `DomainRuleSetting` adds `enabled`, `badge`), plus `messages.ts` (inter-component message types)
 
 ### Static Data
 - `public/data/presets.json` — regex presets (read-only, loaded at runtime)
@@ -58,31 +61,36 @@ pnpm storybook            # port 6006
 src/
   background/      # Background service worker modules
   components/
-    Core/          # DomainRule/ · RegexPreset/ · Session/ · Statistics/ · TabTree/
-    UI/            # Header/ · PopupHeader/ · PopupToolbar/ · PopupProfilesList/
-                   # PageLayout/ · Sidebar/ · ImportExportPage/ · SessionWizards/
-                   # SettingsPage/ · SettingsToggles/ · WizardStepper/ · SplitButton/
-                   # ConfirmDialog/ · StatusBadge/ · ThemeToggle/ · Combobox/ · DataTable/
+    Core/          # DomainRule/ · Session/ · Statistics/ · TabTree/
+    UI/            # AccessibleHighlight/ · Header/ · PopupHeader/ · PopupToolbar/
+                   # PopupProfilesList/ · PageLayout/ · Sidebar/ · ImportExportPage/
+                   # SessionWizards/ · SettingsPage/ · SettingsToggles/ · WizardStepper/
+                   # SplitButton/ · ConfirmDialog/ · StatusBadge/ · ThemeToggle/
+                   # Combobox/ · DataTable/ · OptionsLayout/
     Form/          # FormFields/ · themed-callouts/ · themes/
-  hooks/           # useSyncedSettings · useStatistics · useSessions · useSessionEditor · useModal · useClipboard
-  pages/           # DomainRulesPage · SessionsPage · StatisticsPage · options.tsx · popup.jsx
+  hooks/           # useSyncedState · useSyncedSettings · useStatistics · useSessions
+                   # useSessionEditor · useModal · useDeepLinking
+  pages/           # DomainRulesPage · SessionsPage · StatisticsPage · options.tsx · popup.tsx
   schemas/         # Zod schemas
   types/           # TS types
-  utils/           # i18n · sessionStorage · sessionUtils · tabCapture · tabRestore
-                   # profileWindowMap · conflictDetection · importClassification
-                   # themeConstants · settingsUtils · statisticsUtils · notifications · …
+  utils/           # i18n · logger · sessionStorage · sessionUtils · tabCapture · tabRestore
+                   # conflictDetection · deduplicationSkip · importClassification
+                   # sessionClassification · sessionOrderUtils · ruleOrderUtils
+                   # presetsToSearchableGroups · nameUtils · stringUtils · migration
+                   # storageItems · sessionsHelpPrefs · settingsUtils · statisticsUtils
+                   # themeConstants · notifications · utils
   styles/          # radix-themes.css (custom focus for non-Radix markup only)
 tests/             # Vitest unit tests
 tests/e2e/         # Playwright E2E tests
 ```
 
 ### Features
-1. **Automatic Grouping** — domain rules + regex presets (middle-click / right-click new tab)
-2. **Deduplication** — exact URL / hostname+path / hostname / includes modes
-3. **Rule Management** — CRUD for domain rules; built-in & custom regex presets
-4. **Import/Export Wizard** — Zod-validated JSON, rule classification (new/conflicting/identical), conflict resolution
-5. **Statistics** — grouping & dedup counters
-6. **Sessions & Profiles** — snapshots of open tabs; pinned profiles with icon, auto-sync, window exclusivity; restore wizard with conflict resolution; interactive session editor
+1. **Automatic Grouping** : domain rules + regex presets (middle-click / right-click new tab)
+2. **Deduplication** : exact URL / hostname+path / hostname / includes modes
+3. **Rule Management** : CRUD for domain rules; built-in & custom regex presets; drag-and-drop reordering
+4. **Import/Export Wizard** : Zod-validated JSON for rules and sessions; rule/session classification (new/conflicting/identical); conflict resolution; optional note field
+5. **Statistics** : grouping & dedup counters
+6. **Sessions & Profiles** : snapshots of open tabs with optional note; pinned profiles with icon, auto-sync, window exclusivity; restore wizard with conflict resolution; interactive session editor; collapsed/expanded group state persistence; drag-and-drop session reordering; session card with HoverCard metadata and inline rename
 
 ### Feature Themes (`src/utils/themeConstants.ts`)
 `DOMAIN_RULES` purple · `REGEX_PRESETS` cyan · `IMPORT` jade · `EXPORT` teal · `STATISTICS` orange · `SETTINGS` gray · `SESSIONS` indigo
@@ -134,7 +142,7 @@ identifier et résoudre les zones floues de la user story concernée.
 
 ### Processus
 
-1. Lire la ou les US concernées dans `user_stories/`.
+1. Lire la ou les US concernées dans `user-stories/`.
 2. Lister les points ambigus ou non couverts : cas limites, comportements
    implicites, interactions avec des features existantes, impact sur les
    schemas Zod ou les types.

--- a/README-es.md
+++ b/README-es.md
@@ -40,7 +40,7 @@ Clic central o clic derecho → «Abrir en una pestaña nueva» en un sitio conf
 - Preajustes integrados para Jira, GitLab, GitHub, Trello y más
 
 <p align="center">
-  <img src="doc/readme/gifs/regroup.gif" alt="Vídeo de agrupación automática">
+  <img src="assets/readme/gifs/regroup.gif" alt="Vídeo de agrupación automática">
 </p>
 
 ### 🔁 Deduplicación
@@ -49,7 +49,7 @@ Abrir una página que ya está abierta reactiva y recarga la pestaña existente 
 La sensibilidad de coincidencia es configurable por regla: URL exacta, nombre de host + ruta, nombre de host o «includes».
 
 <p align="center">
-  <img src="doc/readme/gifs/dedup.gif" alt="Vídeo de deduplicación">
+  <img src="assets/readme/gifs/dedup.gif" alt="Vídeo de deduplicación">
 </p>
 
 
@@ -61,6 +61,8 @@ Guarda un snapshot con nombre de tus pestañas y grupos abiertos, y restáuralos
 - **Asistente de restauración** — elige qué pestañas recuperar, la ventana de destino y resuelve conflictos de grupos antes de aplicar
 - **Búsqueda profunda** — encuentra pestañas y grupos por nombre en todas tus sesiones guardadas
 - **Editor de sesión** — reorganiza, renombra y elimina pestañas y grupos sin necesidad de restaurar
+- **Notas de sesión** — anota tus sesiones con texto libre
+- **Drag-and-drop** — reordena tus sesiones arrastrando
 
 <p align="center">
   <img src="doc/readme/es-dark-sessions-list.png" alt="Lista de sesiones">
@@ -114,6 +116,7 @@ Para desarrollo con recarga automática: `pnpm dev` (Chrome) o `pnpm dev:firefox
 | Interfaz | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
 | Biblioteca de componentes | [Radix UI Themes](https://www.radix-ui.com/themes) + iconos [Lucide](https://lucide.dev/) |
 | Formularios & validación | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
 | Temas | [next-themes](https://github.com/pacocoursey/next-themes) |
 | Tests unitarios | [Vitest](https://vitest.dev/) |
 | Tests E2E | [Playwright](https://playwright.dev/) |

--- a/README-fr.md
+++ b/README-fr.md
@@ -40,7 +40,7 @@ Clic molette ou clic droit → « Ouvrir dans un nouvel onglet » sur un site co
 - Préréglages intégrés pour Jira, GitLab, GitHub, Trello et plus encore
 
 <p align="center">
-  <img src="doc/readme/gifs/regroup.gif" alt="Vidéo de regroupement automatique">
+  <img src="assets/readme/gifs/regroup.gif" alt="Vidéo de regroupement automatique">
 </p>
 
 ### 🔁 Déduplication
@@ -49,7 +49,7 @@ Ouvrir une page déjà ouverte remet l'onglet existant au premier plan et le rec
 La sensibilité de correspondance est configurable par règle : URL exacte, nom d'hôte + chemin, nom d'hôte ou « includes ».
 
 <p align="center">
-  <img src="doc/readme/gifs/dedup.gif" alt="Vidéo de déduplication">
+  <img src="assets/readme/gifs/dedup.gif" alt="Vidéo de déduplication">
 </p>
 
 
@@ -61,6 +61,8 @@ Sauvegardez un snapshot nommé de vos onglets et groupes ouverts, et restaurez-l
 - **Assistant de restauration** — choisissez les onglets à récupérer, la fenêtre cible, et résolvez les conflits de groupes avant d'appliquer
 - **Recherche profonde** — retrouvez onglets et groupes par nom dans toutes vos sessions sauvegardées
 - **Éditeur de session** — réorganisez, renommez et supprimez onglets et groupes sans avoir à restaurer
+- **Notes de session** — annotez vos sessions avec du texte libre
+- **Drag-and-drop** — réordonnez vos sessions par glisser-déposer
 
 <p align="center">
   <img src="doc/readme/fr-dark-sessions-list.png" alt="Liste des sessions">
@@ -114,6 +116,7 @@ Pour le développement avec rechargement automatique : `pnpm dev` (Chrome) ou `p
 | Interface | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
 | Bibliothèque de composants | [Radix UI Themes](https://www.radix-ui.com/themes) + icônes [Lucide](https://lucide.dev/) |
 | Formulaires & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
 | Thèmes | [next-themes](https://github.com/pacocoursey/next-themes) |
 | Tests unitaires | [Vitest](https://vitest.dev/) |
 | Tests E2E | [Playwright](https://playwright.dev/) |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Middle-click or right-click → "Open in new tab" on a configured site and the t
 - Built-in presets for Jira, GitLab, GitHub, Trello and more
 
 <p align="center">
-  <img src="doc/readme/gifs/regroup.gif" alt="Automatic Regroupment video">
+  <img src="assets/readme/gifs/regroup.gif" alt="Automatic Regroupment video">
 </p>
 
 ### 🔁 Deduplication
@@ -49,7 +49,7 @@ Opening a page that's already open refocuses and reloads the existing tab instea
 Matching sensitivity is configurable per rule: exact URL, hostname + path, hostname, or "includes".
 
 <p align="center">
-  <img src="doc/readme/gifs/dedup.gif" alt="Deduplication video">
+  <img src="assets/readme/gifs/dedup.gif" alt="Deduplication video">
 </p>
 
 
@@ -61,6 +61,8 @@ Save a named snapshot of your open tabs and groups, restore them whenever you ne
 - **Restore wizard** — pick which tabs to bring back, choose the target window, resolve group conflicts before applying
 - **Deep search** — find tabs and groups by name across all your saved sessions
 - **Session editor** — reorganize, rename and delete tabs and groups without restoring first
+- **Session notes** — annotate any session with free-form text
+- **Drag-and-drop** — reorder your sessions list by dragging
 
 <p align="center">
   <img src="doc/readme/en-dark-sessions-list.png" alt="Sessions list">
@@ -114,6 +116,7 @@ For development with auto-reload: `pnpm dev` (Chrome) or `pnpm dev:firefox`.
 | UI | [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
 | Component library | [Radix UI Themes](https://www.radix-ui.com/themes) + [Lucide](https://lucide.dev/) icons |
 | Forms & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
+| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
 | Theming | [next-themes](https://github.com/pacocoursey/next-themes) |
 | Unit tests | [Vitest](https://vitest.dev/) |
 | E2E tests | [Playwright](https://playwright.dev/) |

--- a/user-stories/US-IE-import-export.md
+++ b/user-stories/US-IE-import-export.md
@@ -153,3 +153,47 @@
 - [ ] Après un export réussi (fichier ou presse-papiers), le dialogue se ferme automatiquement.
 - [ ] Une notification système apparaît avec le titre « Rules exported ».
 - [ ] Le JSON exporté est formaté avec une indentation de 2 espaces.
+
+---
+
+## US-IE010 : Note optionnelle a l'export (regles et sessions)
+
+**En tant qu'** utilisateur qui exporte des regles ou des sessions,
+**je veux** pouvoir ajouter une note libre au fichier d'export,
+**afin de** documenter le contenu ou le contexte de l'export pour le destinataire.
+
+### Criteres d'acceptation
+
+- [ ] Le wizard d'export (regles et sessions) expose un champ `TextArea` (Radix, redimensionnable verticalement) labellise **"Note"**.
+- [ ] Le champ est optionnel : laisser le champ vide n'affecte pas l'export.
+- [ ] Si une note est saisie, le JSON exporte contient un champ `note` a la racine de l'objet (ex. `{ "note": "...", "rules": [...] }`).
+- [ ] Si le champ est vide, le champ `note` n'apparait pas dans le JSON exporte.
+
+---
+
+## US-IE011 : Affichage de la note a l'import (regles et sessions)
+
+**En tant qu'** utilisateur qui importe un fichier JSON contenant une note,
+**je veux** voir la note de l'auteur affichee dans le wizard d'import,
+**afin de** comprendre le contexte du fichier avant de valider l'import.
+
+### Criteres d'acceptation
+
+- [ ] Si le JSON importe contient un champ `note` a la racine, celle-ci est affichee dans un callout gris au-dessus de la liste de classification (etape 2 du wizard).
+- [ ] Si le JSON ne contient pas de champ `note`, aucun callout n'est affiche.
+- [ ] La note est affichee en lecture seule (pas de champ editable).
+
+---
+
+## US-IE012 : Format enveloppe pour l'export de sessions
+
+**En tant qu'** utilisateur,
+**je veux** que l'export de sessions utilise un format enveloppe (`{ note?, sessions: [...] }`),
+**afin que** le fichier puisse contenir des metadonnees (comme la note) en plus des sessions.
+
+### Criteres d'acceptation
+
+- [ ] L'export de sessions produit un objet JSON `{ sessions: [...] }` (et non un tableau brut).
+- [ ] Si une note est redigee, elle est incluse : `{ note: "...", sessions: [...] }`.
+- [ ] A l'import, le wizard accepte les deux formats : le nouveau format enveloppe et l'ancien format (tableau brut `[...]`) pour la retro-compatibilite.
+- [ ] Le schema Zod `importSessionsDataSchema` valide les deux formats.

--- a/user-stories/US-S-DND.md
+++ b/user-stories/US-S-DND.md
@@ -1,0 +1,85 @@
+# US-S-DND : Reordering des sessions par drag-and-drop
+
+## Contexte
+
+La liste des sessions est affichee dans un ordre fixe.
+L'utilisateur ne peut pas reorganiser ses sessions pour mettre les plus
+utilisees en tete, ce qui oblige a faire defiler la liste.
+
+Ajouter un champ `position` aux sessions et un systeme de drag-and-drop
+permet de personnaliser l'ordre d'affichage.
+
+---
+
+## User Stories
+
+### US-S-DND-01 : Reordonner les sessions par glisser-deposer
+
+**En tant qu'** utilisateur sur la page Sessions,
+**je veux** pouvoir deplacer une session dans la liste par drag-and-drop,
+**afin de** choisir l'ordre d'affichage selon mes preferences.
+
+**Criteres d'acceptance :**
+- Chaque carte de session affiche un handle de drag (icone `GripVertical`)
+  sur le bord gauche.
+- Le curseur passe en `grab` au survol du handle, puis `grabbing` pendant
+  le drag.
+- Pendant le drag, la carte deplacee est visuellement attenuee
+  (opacite reduite).
+- Au relachement, la carte prend sa nouvelle position et la liste se
+  reorganise immediatement (reordering optimiste).
+- L'ordre resultant est persiste dans `browser.storage.local` via le
+  champ `position` de chaque session.
+- La persistance utilise une operation batch unique pour eviter les
+  race conditions.
+
+---
+
+### US-S-DND-02 : Deplacer une session en premiere position
+
+**En tant qu'** utilisateur,
+**je veux** pouvoir envoyer une session en premiere position via le menu
+d'actions,
+**afin de** la placer rapidement en tete de liste sans drag long.
+
+**Criteres d'acceptance :**
+- Le menu d'actions (icone `...`) de chaque carte propose l'option
+  "Move to first".
+- Au clic, la session se deplace en premiere position dans la liste.
+- L'option est desactivee si la session est deja en premiere position.
+- L'option est desactivee pendant un drag en cours.
+
+---
+
+### US-S-DND-03 : Deplacer une session en derniere position
+
+**En tant qu'** utilisateur,
+**je veux** pouvoir envoyer une session en derniere position via le menu
+d'actions,
+**afin de** la releguer en fin de liste rapidement.
+
+**Criteres d'acceptance :**
+- Le menu d'actions de chaque carte propose l'option "Move to last".
+- Au clic, la session se deplace en derniere position dans la liste.
+- L'option est desactivee si la session est deja en derniere position.
+- L'option est desactivee pendant un drag en cours.
+
+---
+
+## Implementation technique
+
+| Aspect | Detail |
+|---|---|
+| Librairie DnD | `@dnd-kit/react` (API v2 : `useSortable`) |
+| Champ de tri | `session.position` (`z.number().optional()`) |
+| Utilitaire de reordering | `src/utils/sessionOrderUtils.ts` : `moveSessionToFirst`, `moveSessionToLast` |
+| Persistance | `src/utils/sessionStorage.ts` : operation batch pour reassigner les positions |
+| Reordering optimiste | La liste React est mise a jour avant la fin de la persistance |
+
+---
+
+## Hors perimetre
+
+- Reordering entre categories de sessions (pas de categories pour les sessions).
+- Reordering des onglets dans une session (couvert par l'editeur de session).
+- Reordering via raccourci clavier (clavier non couvert par `@dnd-kit` dans cette version).

--- a/user-stories/US-S-sessions.md
+++ b/user-stories/US-S-sessions.md
@@ -145,3 +145,30 @@
 - [ ] A l'ouverture de l'editeur, un groupe sans champ `collapsed` ou avec `collapsed: false` est affiche deplie (ses onglets enfants sont visibles).
 - [ ] Replier ou deplier un groupe dans l'editeur est considere comme une modification (le bouton « Save » devient activable).
 - [ ] Apres sauvegarde, la valeur `collapsed` de chaque groupe est mise a jour dans le stockage.
+
+---
+
+## US-S019 : Carte de session redessinee (HoverCard et rename inline)
+
+**En tant qu'** utilisateur sur la page Sessions,
+**je veux** consulter les metadonnees d'une session (dates de creation et de modification, note) et renommer une session directement sur sa carte,
+**afin de** acceder aux informations utiles sans ouvrir l'editeur et de renommer rapidement une session.
+
+### Criteres d'acceptation
+
+**HoverCard metadonnees :**
+- [ ] Le nom de la session dans la carte est un declencheur de HoverCard (Radix `HoverCard.Root`).
+- [ ] Au survol, le HoverCard affiche : nom de la session, date de creation, date de derniere modification.
+- [ ] Si la session a une note, celle-ci est egalement affichee dans le HoverCard.
+- [ ] Le HoverCard ne bloque pas les interactions avec la carte (il se ferme au deplacement du curseur).
+
+**Rename inline :**
+- [ ] Un bouton crayon (icone `Pencil`) est affiche entre le nom de la session et le badge de categorie.
+- [ ] Au clic sur le crayon, le nom de la session devient un champ de texte editable.
+- [ ] Le champ est confirme par la touche Entree ou par un bouton de validation (icone `Check`).
+- [ ] Le champ est annule par la touche Echap ou par un bouton d'annulation (icone `X`).
+- [ ] Un nom duplique (insensible a la casse) affiche un message d'erreur sous le champ.
+- [ ] Un nom vide n'est pas accepte.
+
+**Menu d'actions consolide :**
+- [ ] Le menu d'actions (`...`) regroupe toutes les actions : restauration (fenetre courante, nouvelle fenetre, personnalisee), edition, deplacer en premier/dernier (cf. US-S-DND), epingler/desepingler, supprimer.


### PR DESCRIPTION
CLAUDE.md: remove references to deleted files (profileSync.ts,
useClipboard, RegexPreset/, profileWindowMap), add missing entries
(useSyncedState, useDeepLinking, AccessibleHighlight/, OptionsLayout/,
24 utils, schemas common/index, type messages), fix popup.jsx to
popup.tsx, user_stories/ to user-stories/, add test:coverage and
docs:* commands, update Features list with sessions notes, DnD,
collapsed state and import/export notes.

READMEs (EN/FR/ES): fix broken GIF links (doc/readme/gifs/ to
assets/readme/gifs/), add session notes and drag-and-drop features,
add @dnd-kit to tech stack.

User stories: create US-S-DND.md for session drag-and-drop reordering,
add US-S019 (card redesign with HoverCard and inline rename) to
US-S-sessions.md, add US-IE010 to IE012 (import/export note field
and wrapped sessions format) to US-IE-import-export.md.

https://claude.ai/code/session_01CeaqvNEncjvzQPwKQQcnEZ