### PR TITLE
Keep pinned sessions in storage order

### DIFF
--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -39,9 +39,7 @@ export function PopupProfilesList() {
 
   useEffect(() => {
     loadSessions().then((all) => {
-      const pinned = all
-        .filter((s) => s.isPinned)
-        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      const pinned = all.filter((s) => s.isPinned);
       setPinnedSessions(pinned);
     });
   }, []);

--- a/tests/components/PopupProfilesList.test.tsx
+++ b/tests/components/PopupProfilesList.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { Session } from '../../src/types/session';
+
+// Mock i18n
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => {
+    const messages: Record<string, string> = {
+      popupPinnedSessionsLabel: 'Pinned sessions',
+      sessionRestoreCurrentWindow: 'Restore in current window',
+      sessionRestoreNewWindow: 'Restore in new window',
+    };
+    return messages[key] || key;
+  }),
+}));
+
+// Mock sessionStorage
+vi.mock('../../src/utils/sessionStorage', () => ({
+  loadSessions: vi.fn(),
+}));
+
+// Mock tabRestore
+vi.mock('../../src/utils/tabRestore', () => ({
+  restoreTabs: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock getRuleCategory
+vi.mock('../../src/schemas/enums', () => ({
+  getRuleCategory: vi.fn(() => null),
+}));
+
+// Mock chromeGroupColors
+vi.mock('../../src/utils/tabTreeUtils', () => ({
+  chromeGroupColors: {},
+}));
+
+// Import after mocks
+import { PopupProfilesList } from '../../src/components/UI/PopupProfilesList/PopupProfilesList';
+import * as sessionStorageModule from '../../src/utils/sessionStorage';
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <Theme>{children}</Theme>
+);
+
+describe('PopupProfilesList', () => {
+  let mockLoadSessions: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadSessions = vi.mocked(sessionStorageModule.loadSessions);
+  });
+
+  it('should not render when no pinned sessions exist', async () => {
+    mockLoadSessions.mockResolvedValue([]);
+
+    const { container } = render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>
+    );
+
+    // Wait for loadSessions to be called and state to update
+    await waitFor(() => {
+      expect(mockLoadSessions).toHaveBeenCalled();
+    });
+
+    // PopupProfilesList returns null, so no pinned sessions section should be rendered
+    const pinnedSectionLabel = container.querySelector('[class*="Separator"]');
+    // The label "Pinned sessions" should not be visible
+    expect(screen.queryByText('Pinned sessions')).not.toBeInTheDocument();
+  });
+
+  it('should display pinned sessions in storage order, not sorted by updatedAt', async () => {
+    const sessions: Session[] = [
+      {
+        id: '1',
+        isPinned: true,
+        updatedAt: '2026-04-10T00:00:00Z',
+        name: 'Old Pinned',
+        createdAt: '2026-04-10T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+      {
+        id: '2',
+        isPinned: true,
+        updatedAt: '2026-04-01T00:00:00Z',
+        name: 'Newer Pinned',
+        createdAt: '2026-04-01T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+      {
+        id: '3',
+        isPinned: false,
+        updatedAt: '2026-04-20T00:00:00Z',
+        name: 'Unpinned',
+        createdAt: '2026-04-20T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+    ];
+
+    mockLoadSessions.mockResolvedValue(sessions);
+
+    render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>
+    );
+
+    // Wait for loadSessions to resolve and component to render
+    await waitFor(() => {
+      expect(mockLoadSessions).toHaveBeenCalled();
+    });
+
+    // Get pinned session items
+    await waitFor(() => {
+      expect(screen.getByText('Old Pinned')).toBeInTheDocument();
+    });
+
+    const pinnedItems = screen.getAllByTestId(/^popup-profile-item-/);
+
+    // Should show only pinned sessions (1 and 2, not 3)
+    expect(pinnedItems).toHaveLength(2);
+
+    // Order should be storage order (1, 2), not by updatedAt (2, 1)
+    expect(pinnedItems[0]).toHaveAttribute('data-testid', 'popup-profile-item-1');
+    expect(pinnedItems[1]).toHaveAttribute('data-testid', 'popup-profile-item-2');
+
+    // Verify session names
+    expect(screen.getByText('Old Pinned')).toBeInTheDocument();
+    expect(screen.getByText('Newer Pinned')).toBeInTheDocument();
+    expect(screen.queryByText('Unpinned')).not.toBeInTheDocument();
+  });
+
+  it('should not apply any sorting to pinned sessions', async () => {
+    const sessions: Session[] = [
+      {
+        id: 'p3',
+        isPinned: true,
+        updatedAt: '2026-04-01T00:00:00Z',
+        name: 'Third (oldest)',
+        createdAt: '2026-04-01T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+      {
+        id: 'p1',
+        isPinned: true,
+        updatedAt: '2026-04-30T00:00:00Z',
+        name: 'First (newest)',
+        createdAt: '2026-04-30T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+      {
+        id: 'p2',
+        isPinned: true,
+        updatedAt: '2026-04-15T00:00:00Z',
+        name: 'Second (middle)',
+        createdAt: '2026-04-15T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+    ];
+
+    mockLoadSessions.mockResolvedValue(sessions);
+
+    render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Third (oldest)')).toBeInTheDocument();
+    });
+
+    const pinnedItems = screen.getAllByTestId(/^popup-profile-item-/);
+
+    // Order should be exactly as in storage (p3, p1, p2), not sorted by updatedAt
+    expect(pinnedItems).toHaveLength(3);
+    expect(pinnedItems[0]).toHaveAttribute('data-testid', 'popup-profile-item-p3');
+    expect(pinnedItems[1]).toHaveAttribute('data-testid', 'popup-profile-item-p1');
+    expect(pinnedItems[2]).toHaveAttribute('data-testid', 'popup-profile-item-p2');
+
+    // If it were sorted by updatedAt desc, order would be p1, p2, p3
+    // But we want the storage order: p3, p1, p2
+    expect(screen.getByText('Third (oldest)')).toBeInTheDocument();
+    expect(screen.getByText('First (newest)')).toBeInTheDocument();
+    expect(screen.getByText('Second (middle)')).toBeInTheDocument();
+  });
+
+  it('should display pinned sessions label when pinned sessions exist', async () => {
+    const sessions: Session[] = [
+      {
+        id: '1',
+        isPinned: true,
+        updatedAt: '2026-04-10T00:00:00Z',
+        name: 'Pinned Session',
+        createdAt: '2026-04-10T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+    ];
+
+    mockLoadSessions.mockResolvedValue(sessions);
+
+    render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Pinned sessions')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/e2e/popup-pinned-sessions-order.spec.ts
+++ b/tests/e2e/popup-pinned-sessions-order.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * E2E tests for popup pinned sessions order.
+ * Verifies that pinned sessions in the popup respect the storage order
+ * (which can be manually reordered via drag-drop in SessionsPage).
+ */
+import { test, expect } from './fixtures';
+import { goToPopup, goToSessionsSection } from './helpers/navigation';
+import {
+  seedSessions,
+  clearSessions,
+  clearHelpPrefs,
+  createPinnedSession,
+} from './helpers/seed';
+
+test.beforeEach(async ({ extensionContext }) => {
+  await clearSessions(extensionContext);
+  await clearHelpPrefs(extensionContext);
+});
+
+test.describe('[US-PIN-ORDER] Popup pinned sessions order', () => {
+  test('popup displays pinned sessions in storage order (not by updatedAt)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    // Create 3 pinned sessions with timestamps in reverse order
+    // to verify they're NOT sorted by updatedAt
+    const now = new Date();
+    const p1 = createPinnedSession({
+      name: 'Pinned A (oldest)',
+      updatedAt: new Date(now.getTime() - 10000).toISOString(),
+    });
+    const p2 = createPinnedSession({
+      name: 'Pinned B (newest)',
+      updatedAt: new Date(now.getTime()).toISOString(),
+    });
+    const p3 = createPinnedSession({
+      name: 'Pinned C (middle)',
+      updatedAt: new Date(now.getTime() - 5000).toISOString(),
+    });
+
+    // Seed in storage order: p1, p2, p3
+    await seedSessions(extensionContext, [p1, p2, p3]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    // Get pinned sessions by their text in the popup
+    // Order should be storage order (p1, p2, p3), NOT sorted by updatedAt (p2, p3, p1)
+    const pinnedA = page.getByText('Pinned A (oldest)');
+    const pinnedB = page.getByText('Pinned B (newest)');
+    const pinnedC = page.getByText('Pinned C (middle)');
+
+    // All should be visible
+    await expect(pinnedA).toBeVisible();
+    await expect(pinnedB).toBeVisible();
+    await expect(pinnedC).toBeVisible();
+
+    // Get bounding boxes to determine visual order (top to bottom)
+    const boxA = await pinnedA.boundingBox();
+    const boxB = await pinnedB.boundingBox();
+    const boxC = await pinnedC.boundingBox();
+
+    if (boxA && boxB && boxC) {
+      // Verify order by Y position (top = earlier, bottom = later)
+      expect(boxA.y).toBeLessThan(boxB.y); // A before B
+      expect(boxB.y).toBeLessThan(boxC.y); // B before C
+    }
+
+    await page.close();
+  });
+
+  test('popup respects custom storage order from multiple pinned sessions', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    // Create 3 pinned sessions and seed them in a custom order
+    const p1 = createPinnedSession({ name: 'Middle Session' });
+    const p2 = createPinnedSession({ name: 'Last Session' });
+    const p3 = createPinnedSession({ name: 'First Session' });
+
+    // Seed in custom order: Middle, Last, First (not sorted alphabetically or by date)
+    await seedSessions(extensionContext, [p1, p2, p3]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    // Get pinned sessions by their text
+    const middle = page.getByText('Middle Session', { exact: true });
+    const last = page.getByText('Last Session', { exact: true });
+    const first = page.getByText('First Session', { exact: true });
+
+    // All should be visible
+    await expect(middle).toBeVisible();
+    await expect(last).toBeVisible();
+    await expect(first).toBeVisible();
+
+    // Verify order by bounding box (visual top-to-bottom order)
+    const boxMiddle = await middle.boundingBox();
+    const boxLast = await last.boundingBox();
+    const boxFirst = await first.boundingBox();
+
+    if (boxMiddle && boxLast && boxFirst) {
+      // Order should be storage order (Middle, Last, First), not alphabetical
+      expect(boxMiddle.y).toBeLessThan(boxLast.y); // Middle before Last
+      expect(boxLast.y).toBeLessThan(boxFirst.y); // Last before First
+    }
+
+    await page.close();
+  });
+
+  test('unpinned sessions should not appear in popup pinned list', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    // Create 2 pinned + 1 unpinned
+    const p1 = createPinnedSession({ name: 'Pinned 1' });
+    const p2 = createPinnedSession({ name: 'Pinned 2' });
+    const u1 = { ...p1, isPinned: false, name: 'Unpinned 1' };
+
+    await seedSessions(extensionContext, [p1, u1, p2]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    // Should show pinned sessions label
+    await expect(page.getByText('Pinned sessions')).toBeVisible();
+
+    // Should show pinned sessions
+    await expect(page.getByText('Pinned 1', { exact: true })).toBeVisible();
+    await expect(page.getByText('Pinned 2', { exact: true })).toBeVisible();
+
+    // Verify unpinned session is NOT in the popup
+    await expect(page.getByText('Unpinned 1')).not.toBeVisible();
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
Stop sorting pinned sessions by updatedAt when loading them so the popup preserves the storage (manual) order. Update PopupProfilesList to simply filter pinned sessions without reordering. Add unit tests (tests/components/PopupProfilesList.test.tsx) and E2E tests (tests/e2e/popup-pinned-sessions-order.spec.ts) to verify that only pinned sessions are shown, the pinned label appears when appropriate, and the displayed order matches storage order rather than being sorted by updatedAt.