### PR TITLE
Add docs for grouping, deduplication, naming

### DIFF
--- a/docs/src/content/docs/concepts/deduplication.mdx
+++ b/docs/src/content/docs/concepts/deduplication.mdx
@@ -1,6 +1,68 @@
 ---
 title: Modes de déduplication
-description: Les quatre modes de détection des onglets en doublon (URL exacte, chemin, domaine, sous-chaîne) illustrés par des exemples concrets.
+description: Les deux modes de détection des onglets en doublon (URL exacte et sous-chaîne) illustrés par des exemples concrets.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside } from '@astrojs/starlight/components';
+
+La déduplication évite d'accumuler plusieurs onglets pointant vers la même page. Quand vous ouvrez un lien déjà ouvert dans votre navigateur, SmartTab Organizer ferme le nouvel onglet et remet le focus sur l'onglet existant.
+
+## Conditions pour qu'une déduplication se déclenche
+
+Comme pour le groupement, trois conditions doivent être réunies :
+
+1. Le **toggle de déduplication global** est activé (popup ou page Paramètres).
+2. Une **règle de domaine** correspond au domaine de l'onglet ouvert.
+3. Cette règle a son option **Déduplication** activée.
+
+Un domaine sans règle correspondante utilise le paramètre global. Si la règle d'un domaine désactive la déduplication, les doublons sont conservés même si le toggle global est activé.
+
+<Aside type="caution">
+Les URL avec des schémas spéciaux (`chrome:`, `chrome-extension:`, `about:`) sont ignorées par la déduplication.
+</Aside>
+
+## Les deux modes de correspondance
+
+### URL exacte
+
+Deux onglets sont considérés comme doublons uniquement si leurs URL sont identiques au caractère près : même protocole, même domaine, même chemin, même paramètres de requête et même fragment.
+
+| URL existante | Nouvel onglet | Résultat |
+|---|---|---|
+| `https://example.com/page?lang=fr` | `https://example.com/page?lang=fr` | Doublon, fermé |
+| `https://example.com/page?lang=fr` | `https://example.com/page?lang=en` | Distinct, conservé |
+| `https://example.com/page#section1` | `https://example.com/page#section1` | Doublon, fermé |
+| `https://example.com/page#section1` | `https://example.com/page#section2` | Distinct, conservé |
+
+Ce mode est adapté aux sites où les paramètres d'URL ont une signification fonctionnelle (filtres, langues, identifiants).
+
+### Sous-chaîne (includes)
+
+Deux onglets sont considérés comme doublons si l'URL de l'un est contenue dans l'URL de l'autre.
+
+| URL existante | Nouvel onglet | Résultat |
+|---|---|---|
+| `https://example.com/products/item/123` | `https://example.com/products/item` | Doublon, fermé |
+| `https://example.com/products` | `https://example.com/about` | Distinct, conservé |
+
+Ce mode est adapté aux sites où naviguer en profondeur dans une section ne doit pas créer de doublons par rapport à la page parente.
+
+## Notification et bouton Annuler
+
+Quand le paramètre **Notifier lors d'une déduplication** est activé dans les Paramètres, une notification native du navigateur apparait après chaque fermeture de doublon. Elle indique le titre de l'onglet fermé et propose un bouton **Annuler**.
+
+Cliquer sur **Annuler** rouvre l'onglet fermé dans la même fenêtre et le rend actif. Pour éviter qu'il soit immédiatement refermé à nouveau, sa déduplication est suspendue pendant 10 secondes. La notification se ferme automatiquement après 5 secondes si vous n'interagissez pas.
+
+Ce paramètre est indépendant du paramètre équivalent pour le groupement : vous pouvez activer les notifications uniquement pour la déduplication, uniquement pour le groupement, pour les deux, ou pour aucun.
+
+## Activer et désactiver la déduplication
+
+Le comportement est identique au groupement : un toggle global prévaut sur les réglages individuels par règle, et chaque règle peut désactiver la déduplication indépendamment du global.
+
+---
+
+## Voir aussi
+
+- [Comment fonctionne le groupement](/concepts/groupement) : le mécanisme parallèle pour organiser les onglets en groupes
+- [Paramètres](/fonctionnalites/parametres) : configurer les notifications de déduplication et de groupement
+- [Créer une règle](/fonctionnalites/regles/creer-une-regle) : choisir le mode de déduplication lors de la configuration d'une règle

--- a/docs/src/content/docs/concepts/groupement.mdx
+++ b/docs/src/content/docs/concepts/groupement.mdx
@@ -3,4 +3,68 @@ title: Comment fonctionne le groupement
 description: Comprendre le mécanisme de groupement automatique des onglets, du clic milieu jusqu'au groupe Chrome.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside } from '@astrojs/starlight/components';
+
+Le groupement automatique est la fonctionnalité centrale de SmartTab Organizer. Quand vous ouvrez un lien depuis un onglet parent, l'extension détecte l'action, consulte vos règles de domaine, et place le nouvel onglet dans un groupe Chrome coloré sans aucune intervention manuelle.
+
+## Comment le groupement se déclenche
+
+SmartTab Organizer surveille deux types d'événements de navigation :
+
+**Clic du milieu** sur un lien. Le content script mémorise l'URL cible au moment du clic. Quand le nouvel onglet s'ouvre, le service worker retrouve cette entrée et crée le groupe.
+
+**Clic droit puis "Ouvrir dans un nouvel onglet"**. Le content script intervient de la même façon au moment du clic droit sur le lien. Le mécanisme est ensuite identique.
+
+<Aside type="caution">
+Les onglets ouverts depuis la barre d'adresse ou par un raccourci clavier ne déclenchent pas le groupement automatique. Les URL avec des schémas spéciaux (`chrome:`, `chrome-extension:`, `about:`) sont également ignorées.
+</Aside>
+
+## Conditions pour qu'un groupe soit créé
+
+Trois conditions doivent être réunies simultanément :
+
+1. Le **toggle de groupement global** est activé (popup ou page Paramètres).
+2. Une **règle de domaine** correspond au domaine de l'onglet qui vient d'être ouvert.
+3. Cette règle a son option **Groupement** activée.
+
+Si l'une de ces conditions n'est pas remplie, l'onglet s'ouvre normalement sans être groupé.
+
+## Rejoindre un groupe existant ou en créer un nouveau
+
+Quand plusieurs onglets enfants sont ouverts successivement depuis le même onglet parent, ils rejoignent tous le même groupe Chrome. Aucun groupe supplémentaire n'est créé. Le compteur de statistiques "Groupes créés" ne s'incrémente qu'à la création d'un nouveau groupe, pas quand un onglet rejoint un groupe existant.
+
+Si un second onglet parent distinct déclenche une règle, un nouveau groupe séparé est créé.
+
+## Priorité entre plusieurs règles
+
+Quand plusieurs règles correspondent au même domaine, la règle placée le plus haut dans votre liste est appliquée en priorité. Vous pouvez réordonner vos règles par glisser-deposer dans la page Règles de domaine pour ajuster cette priorité.
+
+## Couleur du groupe
+
+La couleur du groupe est héritée de la catégorie associée à la règle. Si aucune catégorie n'est définie, Chrome assigne sa couleur par défaut.
+
+## Comment le groupe est nommé
+
+Le nom affiché sur le groupe Chrome dépend du **mode de nommage** configuré dans la règle. Trois modes sont proposés lors de la création d'une règle :
+
+**Preset** : l'extension extrait automatiquement un nom depuis le titre ou l'URL de l'onglet parent, en s'appuyant sur les expressions régulières du preset sélectionné. C'est le choix recommandé pour les sites courants.
+
+**Demander** : le nom du groupe vous est demandé à chaque ouverture d'onglet. Si vous annulez l'invite, les onglets sont immédiatement dégroupés.
+
+**Manuel** : vous choisissez vous-même la stratégie d'extraction parmi les options disponibles. Pour le détail de chaque stratégie et leur comportement en cas d'échec, consultez la page [Sources de nom de groupe](/concepts/sources-nom-groupe).
+
+## Activer et désactiver le groupement
+
+Le groupement se contrôle à deux niveaux indépendants :
+
+**Niveau global** : le toggle "Groupement" dans la popup ou la page Paramètres active ou désactive le groupement pour toutes les règles simultanément.
+
+**Niveau règle** : chaque règle possède un toggle individuel dans la liste des règles. Désactiver une règle l'exclut du traitement sans la supprimer. Le toggle global prévaut sur les réglages individuels.
+
+---
+
+## Voir aussi
+
+- [Sources de nom de groupe](/concepts/sources-nom-groupe) : détail des 8 modes de nommage et leurs comportements de repli
+- [Créer une règle](/fonctionnalites/regles/creer-une-regle) : guide pas-à-pas de l'assistant de création
+- [Modes de déduplication](/concepts/deduplication) : éviter les doublons en complément du groupement

--- a/docs/src/content/docs/concepts/sessions-epinglees.mdx
+++ b/docs/src/content/docs/concepts/sessions-epinglees.mdx
@@ -1,6 +1,30 @@
 ---
 title: Sessions épinglées
-description: Ce que sont les sessions épinglées, leur cas d'usage et comment les associer à une fenêtre de navigateur.
+description: Ce que sont les sessions épinglées, leur cas d'usage et comment les distinguer des sessions ordinaires.
 ---
 
-{/* TODO: contenu à rédiger */}
+Une session épinglée est une session que vous avez promue au rang de favoris. Elle se distingue des sessions ordinaires à la fois par son emplacement dans l'interface et par les actions rapides qu'elle rend accessibles.
+
+## Sessions ordinaires et sessions épinglées
+
+Toutes les sessions sauvegardées dans SmartTab Organizer apparaissent dans la page Sessions. Les sessions ordinaires s'accumulent dans la section basse de cette page et servent principalement à retrouver un contexte de travail passé.
+
+Une **session épinglée** est une session que vous avez choisie de mettre en avant. Elle apparait dans une section dédiée en haut de la page Sessions, séparée des sessions ordinaires. Elle est aussi listée directement dans la popup, ce qui permet de la restaurer en un clic sans ouvrir la page Options.
+
+L'épinglage ne modifie pas le contenu de la session : les onglets et groupes sauvegardés restent identiques. C'est uniquement le statut et l'emplacement dans l'interface qui changent.
+
+## Cas d'usage typiques
+
+Les sessions épinglées conviennent aux contextes de travail auxquels vous revenez régulièrement : un projet client, un environnement de développement, une veille thématique. Plutôt que de chercher la bonne session dans une longue liste, vous la retrouvez immédiatement dans la popup.
+
+Les sessions ordinaires conviennent mieux aux captures ponctuelles : sauvegarder l'état de votre navigateur avant de tout fermer, archiver une recherche en cours, ou conserver un contexte avant une interruption.
+
+## Catégorie
+
+Chaque session épinglée peut être associée à une catégorie. Ce sont les mêmes catégories que celles utilisées pour les règles de domaine : elles apportent une couleur et un emoji qui s'affichent dans la popup à côté du nom de la session. Cela permet de distinguer visuellement vos sessions épinglées d'un coup d'oeil quand vous en avez plusieurs.
+
+## Voir aussi
+
+- [Épingler une session](/fonctionnalites/sessions/sessions-epinglees) : comment épingler, désépingler et associer une catégorie
+- [Vue d'ensemble des sessions](/fonctionnalites/sessions/vue-ensemble) : la liste des sessions et ses fonctionnalités
+- [Popup](/fonctionnalites/popup) : accéder aux sessions épinglées depuis la popup

--- a/docs/src/content/docs/concepts/sources-nom-groupe.mdx
+++ b/docs/src/content/docs/concepts/sources-nom-groupe.mdx
@@ -1,6 +1,87 @@
 ---
 title: Sources de nom de groupe
-description: Comment SmartTab Organizer détermine le nom d'un groupe à partir du titre de l'onglet, du domaine, du chemin URL ou d'une valeur personnalisée.
+description: Comment SmartTab Organizer détermine le nom d'un groupe à partir du titre de l'onglet, de l'URL ou d'une valeur personnalisée, et comportement de chaque mode en cas d'échec.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside } from '@astrojs/starlight/components';
+
+Quand SmartTab Organizer crée un groupe Chrome, il lui attribue un nom. Ce nom est déterminé par le **mode de nommage** configuré dans la règle de domaine. Certains modes extraient le nom depuis le contenu de l'onglet, d'autres demandent votre avis.
+
+## Le principe d'extraction par regex
+
+Les modes qui extraient un nom depuis l'onglet parent utilisent une expression régulière. L'extension applique cette regex au titre de la page ou à son URL, et retient le contenu du **premier groupe de capture** `(...)`.
+
+Par exemple, la regex `^([^·]+)` appliquée au titre `PROJ-42 · Mon projet Jira` retourne `PROJ-42`.
+
+Une regex syntaxiquement invalide est ignorée sans faire planter l'extension. La tentative passe à l'étape suivante dans la chaîne de repli du mode concerné.
+
+## Comment le mode est choisi
+
+Lors de la création ou de l'édition d'une règle, trois segments sont proposés : **Preset**, **Demander** et **Manuel**.
+
+**Preset** délègue entièrement le choix du mode au preset sélectionné. Chaque preset embarque un mode de nommage recommandé adapté au site visé. Ce mode peut être n'importe lequel des modes disponibles (Titre, URL, Intelligent, Intelligent + Label ou Intelligent + Demander). C'est l'approche recommandée pour les sites courants car le preset configure aussi les regex automatiquement.
+
+**Demander** fixe le mode à "Demander" : une invite de saisie apparait à chaque création de groupe.
+
+**Manuel** vous laisse choisir explicitement le mode parmi les cinq options disponibles, et saisir vous-même les expressions régulières si nécessaire.
+
+## Les modes de nommage
+
+### Demander
+
+Une invite de saisie apparait à chaque création de groupe. Le label de la règle est proposé comme valeur par défaut.
+
+Si vous validez avec un nom, le groupe est renommé avec ce nom. Si vous annulez l'invite, les onglets qui venaient d'être regroupés sont immédiatement dégroupés.
+
+### Titre
+
+L'extension tente d'extraire le nom depuis le **titre de la page** parente. En cas d'échec, elle tente l'extraction depuis l'**URL**.
+
+Si les deux extractions échouent, l'onglet n'est **pas groupé**.
+
+<Aside type="caution">
+En mode Titre (et en mode URL ci-dessous), l'absence de correspondance regex empêche totalement le groupage. Vérifiez vos expressions régulières avant d'enregistrer la règle.
+</Aside>
+
+### URL
+
+L'extension tente d'extraire le nom depuis l'**URL** de l'onglet parent. En cas d'échec, elle tente l'extraction depuis le **titre**.
+
+Si les deux extractions échouent, l'onglet n'est **pas groupé**.
+
+### Intelligent
+
+L'extension tente l'extraction depuis le titre puis depuis l'URL, en utilisant les regex du preset sélectionné.
+
+Si les deux extractions échouent, l'onglet n'est **pas groupé**.
+
+### Intelligent + Label
+
+Même stratégie d'extraction que le mode Intelligent. En cas d'échec, le **label de la règle** est utilisé comme nom de repli.
+
+Ce mode garantit qu'un groupe est toujours créé, même quand la regex ne correspond pas.
+
+### Intelligent + Demander
+
+Même stratégie d'extraction que le mode Intelligent. En cas d'échec, une invite de saisie est présentée, comme en mode Demander. Si vous annulez l'invite, les onglets sont dégroupés.
+
+Ce mode combine l'extraction automatique et la saisie manuelle comme filet de sécurité.
+
+## Tableau de synthèse
+
+| Mode | Étape 1 | Étape 2 | Étape 3 |
+|---|---|---|---|
+| Demander | Invite utilisateur | Dégroupage si annulation | |
+| Titre | Extraction titre | Extraction URL | Pas de groupage |
+| URL | Extraction URL | Extraction titre | Pas de groupage |
+| Intelligent | Extraction titre (preset) | Extraction URL (preset) | Pas de groupage |
+| Intelligent + Label | Extraction titre (preset) | Extraction URL (preset) | Label de la règle |
+| Intelligent + Demander | Extraction titre (preset) | Extraction URL (preset) | Invite utilisateur, dégroupage si annulation |
+
+---
+
+## Voir aussi
+
+- [Comment fonctionne le groupement](/concepts/groupement) : conditions de déclenchement et comportement général
+- [Presets regex](/fonctionnalites/regles/presets-regex) : utiliser les patterns intégrés pour configurer automatiquement le mode et les regex
+- [Liste des presets](/annexes/presets-regex) : tableau de référence des 50 presets disponibles

--- a/docs/src/content/docs/fonctionnalites/popup.mdx
+++ b/docs/src/content/docs/fonctionnalites/popup.mdx
@@ -14,11 +14,6 @@ import popupContentDark from '../../../assets/screenshots/fr-dark-popup-content.
 La popup s'ouvre en cliquant sur l'icône de l'extension dans la barre d'outils du navigateur.
 Elle donne un aperçu rapide de l'activité de groupement et de déduplication, et permet d'accéder aux pages de configuration.
 
-## Vue d'ensemble
-
-<ThemeImage lightSrc={popupOverviewLight} darkSrc={popupOverviewDark} alt="Vue d'ensemble de la popup SmartTab Organizer" />
-
-## Contenu
 
 <ThemeImage lightSrc={popupContentLight} darkSrc={popupContentDark} alt="Contenu détaillé de la popup avec statistiques et accès rapide" />
 

--- a/docs/src/content/docs/introduction/pourquoi.mdx
+++ b/docs/src/content/docs/introduction/pourquoi.mdx
@@ -3,4 +3,14 @@ title: Pourquoi cette extension ?
 description: Comprendre le problème que résout SmartTab Organizer et les cas d'usage qu'il couvre.
 ---
 
-{/* TODO: contenu à rédiger */}
+Il y a des soirs où l'on retrouve son navigateur dans un état lamentable, rempli d'onglets dont on ne sait plus lesquels sont encore utiles. On aimerait tout garder, tout le temps, mais ce n'est pas toujours possible.
+
+C'est pour cela que j'ai cherché une extension capable de classer automatiquement mes onglets dans des groupes aux noms cohérents, et de sauvegarder mes sessions de travail.
+Le problème : la plupart des solutions existantes reposent sur l'IA, et je n'ai aucune envie de donner accès à mon historique de navigation à un service tiers. Ma vie privée compte, et les projets de mon entreprise aussi.
+
+C'est une certaine ironie que ce soit justement l'IA qui m'ait permis de construire cette extension. Mais je ne l'utilise pas dans l'extension elle-même : aucune donnée ne quitte votre navigateur.
+
+Je m'en sers au quotidien, et j'espère qu'elle vous sera utile aussi.
+
+SmartTab Organizer regroupe automatiquement vos onglets selon des règles que vous définissez, évite les doublons, et vous permet de sauvegarder et restaurer vos espaces de travail sous forme de sessions nommées. Tout se passe localement, dans votre navigateur.
+


### PR DESCRIPTION
Flesh out several documentation pages: detailed guides for automatic grouping (triggering, priorities, naming, colors), deduplication (modes, conditions, notifications and undo), group-name sources (modes, regex behavior and fallbacks), pinned sessions (differences, use cases, categories) and a personal introduction. Also remove an outdated "Vue d'ensemble" image from the popup page. Includes examples, cautions and "Voir aussi" links to related pages.