### PR TITLE
Speed up unit tests via render mutualization and file parallelism

### DIFF
--- a/tests/components/FormFields.test.tsx
+++ b/tests/components/FormFields.test.tsx
@@ -12,7 +12,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('Form Components', () => {
   describe('FieldLabel', () => {
-    it('devrait afficher le label', () => {
+    it('affiche le label sans astérisque par défaut', () => {
       render(
         <TestWrapper>
           <FieldLabel>Mon Label</FieldLabel>
@@ -20,6 +20,7 @@ describe('Form Components', () => {
       );
 
       expect(screen.getByText('Mon Label')).toBeInTheDocument();
+      expect(screen.queryByText('*')).not.toBeInTheDocument();
     });
 
     it('devrait afficher un astérisque rouge si required', () => {
@@ -31,16 +32,6 @@ describe('Form Components', () => {
 
       expect(screen.getByText('Champ requis')).toBeInTheDocument();
       expect(screen.getByText('*')).toBeInTheDocument();
-    });
-
-    it('ne devrait pas afficher d\'astérisque par défaut', () => {
-      render(
-        <TestWrapper>
-          <FieldLabel>Champ optionnel</FieldLabel>
-        </TestWrapper>
-      );
-
-      expect(screen.queryByText('*')).not.toBeInTheDocument();
     });
   });
 

--- a/tests/components/SessionCard.stories.test.tsx
+++ b/tests/components/SessionCard.stories.test.tsx
@@ -13,79 +13,37 @@ const existingSessions = [
 
 describe('SessionCard (portable stories)', () => {
   describe('SessionCardDefault', () => {
-    it('renders the session name', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      expect(screen.getByTestId('session-card-session-1-name')).toBeInTheDocument();
-    });
-
-    it('displays the tab count summary', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      // 5 tabs total (2 Frontend + 2 Backend + 1 ungrouped)
-      expect(screen.getByText(/5 tabs/)).toBeInTheDocument();
-    });
-
-    it('displays the group count summary', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      // 2 groups (Frontend + Backend APIs)
-      expect(screen.getByText(/2 groups/)).toBeInTheDocument();
-    });
-
-    it('shows the pin button with "Pin" label', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      expect(screen.getByRole('button', { name: 'Pin' })).toBeInTheDocument();
-    });
-
-    it('shows the rename button', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      expect(screen.getByRole('button', { name: 'Rename' })).toBeInTheDocument();
-    });
-
-    it('shows the more actions menu button', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      expect(
-        screen.getByRole('button', { name: 'More actions' }),
-      ).toBeInTheDocument();
-    });
-
-    it('renders group color dots', () => {
+    it('renders session metadata (name, tab/group counts, color dots)', () => {
       const { container } = render(
         <SessionCardDefault existingSessions={existingSessions as any} />,
       );
 
-      // 2 groups = 2 color dots
+      expect(screen.getByTestId('session-card-session-1-name')).toBeInTheDocument();
+      // 5 tabs total (2 Frontend + 2 Backend + 1 ungrouped)
+      expect(screen.getByText(/5 tabs/)).toBeInTheDocument();
+      // 2 groups (Frontend + Backend APIs)
+      expect(screen.getByText(/2 groups/)).toBeInTheDocument();
+
+      // 2 groups = 2 color dots (8px circles with borderRadius 50%)
       const dots = container.querySelectorAll('span[aria-hidden="true"]');
-      // Filter for the small color dots (8px circles)
       const colorDots = Array.from(dots).filter(
         (el) => (el as HTMLElement).style.borderRadius === '50%',
       );
       expect(colorDots).toHaveLength(2);
     });
 
-    it('preview is collapsed by default', () => {
+    it('renders action buttons and collapsed preview', () => {
       render(
         <SessionCardDefault existingSessions={existingSessions as any} />,
       );
 
+      expect(screen.getByRole('button', { name: 'Pin' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Rename' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'More actions' }),
+      ).toBeInTheDocument();
+
       const toggle = screen.getByTestId('session-card-session-1-preview-toggle');
-      // Collapsible is closed: the content should not be visible
       expect(toggle.closest('[data-state]')?.getAttribute('data-state')).toBe(
         'closed',
       );

--- a/tests/components/Statistics.test.tsx
+++ b/tests/components/Statistics.test.tsx
@@ -30,7 +30,7 @@ describe('Statistics', () => {
     vi.clearAllMocks();
   });
 
-  it('devrait afficher le titre Statistiques', () => {
+  it('devrait afficher le titre Statistiques et les compteurs à zéro par défaut', () => {
     render(
       <TestWrapper>
         <Statistics stats={{ tabGroupsCreatedCount: 0, tabsDeduplicatedCount: 0 }} onReset={mockOnReset} />
@@ -38,19 +38,10 @@ describe('Statistics', () => {
     );
 
     expect(screen.getByText('Statistiques')).toBeInTheDocument();
-  });
-
-  it('devrait afficher les compteurs à zéro par défaut', () => {
-    render(
-      <TestWrapper>
-        <Statistics stats={{ tabGroupsCreatedCount: 0, tabsDeduplicatedCount: 0 }} onReset={mockOnReset} />
-      </TestWrapper>
-    );
-
     expect(screen.getAllByText('0')).toHaveLength(2);
   });
 
-  it('devrait afficher les valeurs des statistiques', () => {
+  it('devrait afficher les valeurs des statistiques et un bouton reset accessible', () => {
     render(
       <TestWrapper>
         <Statistics
@@ -62,6 +53,11 @@ describe('Statistics', () => {
 
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
+
+    // Bouton reset exposé (a11y : aria-label + title)
+    const resetButton = screen.getByRole('button', { name: /réinitialiser/i });
+    expect(resetButton).toHaveAttribute('aria-label', 'Réinitialiser les statistiques');
+    expect(resetButton).toHaveAttribute('title', 'Réinitialiser les statistiques');
   });
 
   it('devrait utiliser le singulier pour 1', () => {
@@ -148,18 +144,4 @@ describe('Statistics', () => {
     expect(screen.getAllByText('0')).toHaveLength(2);
   });
 
-  it('devrait avoir un bouton reset accessible', () => {
-    render(
-      <TestWrapper>
-        <Statistics
-          stats={{ tabGroupsCreatedCount: 5, tabsDeduplicatedCount: 10 }}
-          onReset={mockOnReset}
-        />
-      </TestWrapper>
-    );
-
-    const resetButton = screen.getByRole('button');
-    expect(resetButton).toHaveAttribute('aria-label', 'Réinitialiser les statistiques');
-    expect(resetButton).toHaveAttribute('title', 'Réinitialiser les statistiques');
-  });
 });

--- a/tests/components/TabTree.test.tsx
+++ b/tests/components/TabTree.test.tsx
@@ -65,7 +65,7 @@ describe('TabTree', () => {
   });
 
   describe('rendering', () => {
-    it('devrait afficher les noms des groupes', () => {
+    it('affiche groupes, onglets, domaines et compteur d\'enfants', () => {
       render(
         <TestWrapper>
           <TabTree
@@ -76,52 +76,16 @@ describe('TabTree', () => {
         </TestWrapper>
       );
 
+      // Group name
       expect(screen.getByText('Jira Tickets')).toBeInTheDocument();
-    });
-
-    it('devrait afficher les titres des onglets', () => {
-      render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
+      // Tab titles
       expect(screen.getByText('PROJ-123 - Fix bug')).toBeInTheDocument();
       expect(screen.getByText('PROJ-456 - Add feature')).toBeInTheDocument();
       expect(screen.getByText('Claude.ai')).toBeInTheDocument();
-    });
-
-    it('devrait afficher les domaines des onglets', () => {
-      render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
-      // Two Jira tabs share the same domain
+      // Domains (two Jira tabs share the same domain)
       expect(screen.getAllByText('jira.company.com')).toHaveLength(2);
       expect(screen.getByText('claude.ai')).toBeInTheDocument();
-    });
-
-    it('devrait afficher le nombre d\'enfants du groupe', () => {
-      render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
+      // Group children count
       expect(screen.getByText('(2)')).toBeInTheDocument();
     });
 
@@ -226,7 +190,7 @@ describe('TabTree', () => {
   });
 
   describe('accessibility', () => {
-    it('devrait avoir un rôle tree sur le conteneur', () => {
+    it('expose les rôles ARIA tree/treeitem et les aria-labels groupes/onglets', () => {
       const { container } = render(
         <TestWrapper>
           <TabTree
@@ -237,49 +201,14 @@ describe('TabTree', () => {
         </TestWrapper>
       );
 
+      // Tree container role
       expect(container.querySelector('[role="tree"]')).toBeInTheDocument();
-    });
-
-    it('devrait avoir des rôles treeitem sur les nœuds', () => {
-      const { container } = render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
+      // Treeitem roles on nodes
       const treeitems = container.querySelectorAll('[role="treeitem"]');
       expect(treeitems.length).toBeGreaterThan(0);
-    });
-
-    it('devrait avoir des aria-label sur les checkboxes des groupes', () => {
-      render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
+      // Group checkbox aria-label
       expect(screen.getByLabelText('Select group Jira Tickets')).toBeInTheDocument();
-    });
-
-    it('devrait avoir des aria-label sur les checkboxes des onglets', () => {
-      render(
-        <TestWrapper>
-          <TabTree
-            data={createSampleData()}
-            selectedTabIds={new Set()}
-            onSelectionChange={mockOnSelectionChange}
-          />
-        </TestWrapper>
-      );
-
+      // Tab checkbox aria-labels
       expect(screen.getByLabelText('Select tab PROJ-123 - Fix bug')).toBeInTheDocument();
       expect(screen.getByLabelText('Select tab Claude.ai')).toBeInTheDocument();
     });

--- a/tests/components/UIComponents.test.tsx
+++ b/tests/components/UIComponents.test.tsx
@@ -89,7 +89,7 @@ describe('UI Components', () => {
   });
 
   describe('SettingsToggles', () => {
-    it('devrait afficher les deux toggles', () => {
+    it('affiche les deux toggles en état désactivé', () => {
       render(
         <TestWrapper>
           <SettingsToggles
@@ -99,8 +99,14 @@ describe('UI Components', () => {
         </TestWrapper>
       );
 
+      // Labels
       expect(screen.getByText('Activer le groupage')).toBeInTheDocument();
       expect(screen.getByText('Activer la déduplication')).toBeInTheDocument();
+
+      // State reflected on switches
+      const switches = screen.getAllByRole('switch');
+      expect(switches[0]).toHaveAttribute('data-state', 'unchecked');
+      expect(switches[1]).toHaveAttribute('data-state', 'unchecked');
     });
 
     it('devrait afficher un skeleton en mode loading', () => {
@@ -168,21 +174,6 @@ describe('UI Components', () => {
       const switches = screen.getAllByRole('switch');
       expect(switches[0]).toHaveAttribute('data-state', 'checked');
       expect(switches[1]).toHaveAttribute('data-state', 'checked');
-    });
-
-    it('devrait refléter l\'état désactivé des toggles', () => {
-      render(
-        <TestWrapper>
-          <SettingsToggles
-            globalGroupingEnabled={false}
-            globalDeduplicationEnabled={false}
-          />
-        </TestWrapper>
-      );
-
-      const switches = screen.getAllByRole('switch');
-      expect(switches[0]).toHaveAttribute('data-state', 'unchecked');
-      expect(switches[1]).toHaveAttribute('data-state', 'unchecked');
     });
   });
 });

--- a/vitest.simple.config.ts
+++ b/vitest.simple.config.ts
@@ -24,8 +24,9 @@ export default defineConfig({
     ],
     exclude: [],
     setupFiles: ['./tests/setup.ts', './tests/setup-ui.ts', './tests/setup-storybook.ts'],
-    // Désactiver le parallélisme pour éviter les conflits de state
-    fileParallelism: false,
+    // Le parallélisme au niveau fichier est sûr : chaque worker Vitest a son
+    // propre contexte de modules, donc fakeBrowser et i18n sont isolés par worker.
+    fileParallelism: true,
     reporters: [
       'default',
       ['vitest-ctrf-json-reporter', { outputDir: 'ctrf', outputFile: 'unit-ctrf-report.json' }],


### PR DESCRIPTION
Before: 404.60s Vitest duration (6m46s wall), 748 tests.
After: 57.96s Vitest duration (58s wall), 732 tests. ~7x faster.

The bulk of the gain comes from enabling fileParallelism: true in
vitest.simple.config.ts. Each Vitest worker has its own module
context, so fakeBrowser and i18n setup stay isolated per worker,
and the comment claiming state conflicts was stale.

On top of that, the 5 heaviest test files re-mounted the same
component many times for a single assertion. Folded these into
shared-DOM multi-assertion tests where props were identical, while
keeping interaction tests and prop-variant tests isolated:

- SessionCard.stories.test.tsx: 8 SessionCardDefault renders → 2
- TabTree.test.tsx: 5 rendering + 4 a11y renders → 2
- UIComponents.test.tsx: merged 2 duplicate toggle-disabled renders
- Statistics.test.tsx: merged title+zero-counters and values+reset-a11y
- FormFields.test.tsx: merged FieldLabel default and no-asterisk

https://claude.ai/code/session_01RXKG6xNo5NXRXcBycniE1s