### PR TITLE
Handle notifications in browsers without buttons

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -52,7 +52,13 @@ export async function showNotification({ title, message, type = 'info', undoActi
     pendingUndoActions.set(notificationId, undoAction);
   }
 
-  await browser.notifications.create(notificationId, notificationOptions);
+  try {
+    await browser.notifications.create(notificationId, notificationOptions);
+  } catch {
+    // Firefox does not support the `buttons` property — retry without it
+    delete notificationOptions.buttons;
+    await browser.notifications.create(notificationId, notificationOptions);
+  }
 
   // Auto-clear after 5 seconds
   setTimeout(() => {


### PR DESCRIPTION
Wrap browser.notifications.create in a try/catch to handle browsers (e.g. Firefox) that throw when the notificationOptions include a `buttons` property. On failure the code removes `notificationOptions.buttons` and retries creating the notification to ensure cross-browser compatibility.