### PR TITLE
feat: use in-page toasts for user-triggered options actions

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -201,6 +201,8 @@
   "dataTableSelectedCountPlural": { "message": "{count} selected" },
   "dataTableActions": { "message": "Actions" },
   "undoAction": { "message": "Undo" },
+  "toastCloseLabel": { "message": "Close" },
+  "toastViewportLabel": { "message": "Notifications" },
 
   "exportRulesTitle": { "message": "Export Rules" },
   "exportRulesDescription": { "message": "Select domain rules to save as a JSON file or copy to clipboard" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -201,6 +201,8 @@
   "dataTableSelectedCountPlural": { "message": "{count} seleccionados" },
   "dataTableActions": { "message": "Acciones" },
   "undoAction": { "message": "Deshacer" },
+  "toastCloseLabel": { "message": "Cerrar" },
+  "toastViewportLabel": { "message": "Notificaciones" },
 
   "exportRulesTitle": { "message": "Exportar reglas" },
   "exportRulesDescription": { "message": "Seleccione las reglas de dominio para guardar como archivo JSON o copiar al portapapeles" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -201,6 +201,8 @@
   "dataTableSelectedCountPlural": { "message": "{count} sélectionnés" },
   "dataTableActions": { "message": "Actions" },
   "undoAction": { "message": "Annuler" },
+  "toastCloseLabel": { "message": "Fermer" },
+  "toastViewportLabel": { "message": "Notifications" },
 
   "exportRulesTitle": { "message": "Exporter des règles" },
   "exportRulesDescription": { "message": "Sélectionnez les règles de domaine à sauvegarder dans un fichier JSON ou copier dans le presse-papiers" },

--- a/src/components/UI/ImportExportWizards/Export/useExportActions.ts
+++ b/src/components/UI/ImportExportWizards/Export/useExportActions.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { getMessage } from '@/utils/i18n';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSuccessToast } from '@/utils/toast';
 
 export interface ExportActionsConfig {
   /** Filename suggested when the native Save As dialog opens. */
@@ -45,7 +45,7 @@ export function useExportActions(config: ExportActionsConfig): ExportActions {
   const { filename, notifyTitleKey, notifyMessage, selected, buildJson, onFinish } = config;
 
   const notify = useCallback(() => {
-    showSuccessNotification(
+    showSuccessToast(
       getMessage(notifyTitleKey),
       resolveMessage(notifyMessage, selected.length),
     );

--- a/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
@@ -5,7 +5,7 @@ import {
 import { Upload } from 'lucide-react';
 import { SessionsTheme } from '@/components/Form/themes';
 import { getMessage } from '@/utils/i18n';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSuccessToast } from '@/utils/toast';
 import { sessionsArraySchema } from '@/schemas/session';
 import { importSessionsDataSchema } from '@/schemas/importExport';
 import {
@@ -118,7 +118,7 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
     await saveSessions(updatedSessions);
     onOpenChange(false);
-    showSuccessNotification(
+    showSuccessToast(
       getMessage('importSessionsNotificationTitle'),
       getMessage('importSessionsNotificationMessage', [String(added), String(overwritten)]),
     );

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Dialog, Flex, Separator } from '@radix-ui/themes';
 import { FileUp } from 'lucide-react';
 import { ImportTheme } from '@/components/Form/themes';
 import { getMessage } from '@/utils/i18n';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSuccessToast } from '@/utils/toast';
 import { importDataSchema } from '@/schemas/importExport';
 import { classifyImportedRules } from '@/utils/importClassification';
 import { generateUUID } from '@/utils/utils';
@@ -100,7 +100,7 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
 
     onImport(updatedRules);
     onOpenChange(false);
-    showSuccessNotification(
+    showSuccessToast(
       getMessage('importNotificationTitle'),
       getMessage('importNotificationMessage', [String(added), String(overwritten)]),
     );

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -5,7 +5,7 @@ import { SessionsTheme } from '@/components/Form/themes';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
 import { ConflictResolutionStep } from './ConflictResolutionStep';
 import { getMessage } from '@/utils/i18n';
-import { showSuccessNotification, showNotification } from '@/utils/notifications';
+import { showSuccessToast, showErrorToast } from '@/utils/toast';
 import { sessionToTabTreeData } from '@/utils/sessionUtils';
 import {
   analyzeConflicts,
@@ -116,13 +116,12 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
       onOpenChange(false);
 
       if (result.errors.length > 0) {
-        showNotification({
-          title: getMessage('restoreNotificationTitle'),
-          message: getMessage('restoreNotificationError', [String(result.errors.length)]),
-          type: 'error',
-        });
+        showErrorToast(
+          getMessage('restoreNotificationTitle'),
+          getMessage('restoreNotificationError', [String(result.errors.length)]),
+        );
       } else {
-        showSuccessNotification(
+        showSuccessToast(
           getMessage('restoreNotificationTitle'),
           getMessage('restoreNotificationMessage', [
             String(result.tabsCreated),

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -8,7 +8,7 @@ import { SessionsTheme } from '@/components/Form/themes';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
 import { CategoryPicker } from '@/components/Core/DomainRule/CategoryPicker';
 import { getMessage } from '@/utils/i18n';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSuccessToast } from '@/utils/toast';
 import { captureCurrentTabs } from '@/utils/tabCapture';
 import { createSessionFromSelection, formatSessionDate } from '@/utils/sessionUtils';
 import type { Session, SavedTab, SavedTabGroup } from '@/types/session';
@@ -117,7 +117,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
       );
       await onSave(session);
       onOpenChange(false);
-      showSuccessNotification(
+      showSuccessToast(
         getMessage('snapshotNotificationTitle'),
         getMessage('sessionNotificationMessage', [trimmed]),
       );

--- a/src/components/UI/Toaster/Toaster.css
+++ b/src/components/UI/Toaster/Toaster.css
@@ -1,0 +1,86 @@
+.sto-toast-viewport {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 360px;
+  max-width: calc(100vw - 32px);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  z-index: 2147483647;
+  outline: none;
+}
+
+.sto-toast-root {
+  background: var(--color-panel-solid);
+  border: 1px solid var(--gray-a5);
+  border-radius: var(--radius-3);
+  box-shadow: var(--shadow-5);
+  overflow: hidden;
+}
+
+.sto-toast-root[data-variant='success'] {
+  border-left: 3px solid var(--green-9);
+}
+
+.sto-toast-root[data-variant='error'] {
+  border-left: 3px solid var(--red-9);
+}
+
+.sto-toast-root[data-variant='info'] {
+  border-left: 3px solid var(--gray-9);
+}
+
+.sto-toast-root[data-state='open'] {
+  animation: sto-toast-slide-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.sto-toast-root[data-state='closed'] {
+  animation: sto-toast-fade-out 160ms ease-in forwards;
+}
+
+.sto-toast-root[data-swipe='move'] {
+  transform: translateX(var(--radix-toast-swipe-move-x));
+}
+
+.sto-toast-root[data-swipe='cancel'] {
+  transform: translateX(0);
+  transition: transform 160ms ease-out;
+}
+
+.sto-toast-root[data-swipe='end'] {
+  animation: sto-toast-swipe-out 160ms ease-out forwards;
+}
+
+@keyframes sto-toast-slide-in {
+  from {
+    transform: translateX(calc(100% + 16px));
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes sto-toast-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+}
+
+@keyframes sto-toast-swipe-out {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+  to {
+    transform: translateX(calc(100% + 16px));
+  }
+}

--- a/src/components/UI/Toaster/Toaster.stories.tsx
+++ b/src/components/UI/Toaster/Toaster.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { Button, Flex } from '@radix-ui/themes';
+
+import { Toaster } from './Toaster';
+import { showErrorToast, showInfoToast, showSuccessToast } from '@/utils/toast';
+
+function ToasterPlayground({ autoFire }: { autoFire?: 'success' | 'error' | 'info' | 'stacked' }) {
+  useEffect(() => {
+    if (!autoFire) return;
+    const timer = window.setTimeout(() => {
+      if (autoFire === 'success') {
+        showSuccessToast('Rules exported', 'Your rules are in the downloads folder.');
+      } else if (autoFire === 'error') {
+        showErrorToast('Restore failed', '2 tabs could not be reopened.');
+      } else if (autoFire === 'info') {
+        showInfoToast('Snapshot saved', 'Session "Morning work" stored.');
+      } else if (autoFire === 'stacked') {
+        showSuccessToast('Rules imported', '3 new rules added.');
+        window.setTimeout(() => showSuccessToast('Session exported', 'Copied to clipboard.'), 200);
+        window.setTimeout(() => showErrorToast('Restore failed', '1 tab conflict.'), 400);
+      }
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, [autoFire]);
+
+  return (
+    <Flex direction="column" gap="3" p="4" style={{ minHeight: 300 }}>
+      <Button onClick={() => showSuccessToast('Success', 'Operation completed.')}>Fire success toast</Button>
+      <Button color="red" onClick={() => showErrorToast('Error', 'Something went wrong.')}>
+        Fire error toast
+      </Button>
+      <Button variant="soft" onClick={() => showInfoToast('Info', 'Just so you know.')}>
+        Fire info toast
+      </Button>
+      <Toaster />
+    </Flex>
+  );
+}
+
+const meta: Meta<typeof ToasterPlayground> = {
+  title: 'Components/UI/Toaster',
+  component: ToasterPlayground,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ToasterPlayground>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ToasterSuccess: Story = {
+  name: 'Success',
+  args: { autoFire: 'success' },
+};
+
+export const ToasterError: Story = {
+  name: 'Error',
+  args: { autoFire: 'error' },
+};
+
+export const ToasterInfo: Story = {
+  name: 'Info',
+  args: { autoFire: 'info' },
+};
+
+export const ToasterStacked: Story = {
+  name: 'Stacked',
+  args: { autoFire: 'stacked' },
+};

--- a/src/components/UI/Toaster/Toaster.tsx
+++ b/src/components/UI/Toaster/Toaster.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import * as Toast from '@radix-ui/react-toast';
+import { Box, Flex, IconButton, Text } from '@radix-ui/themes';
+import { CheckCircle2, AlertCircle, Info, X } from 'lucide-react';
+
+import { getMessage } from '@/utils/i18n';
+import { subscribeToToasts, type ToastPayload, type ToastVariant } from '@/utils/toast';
+import './Toaster.css';
+
+const TOAST_DURATION_MS = 6000;
+
+interface ActiveToast extends ToastPayload {
+  open: boolean;
+}
+
+const VARIANT_ACCENT: Record<ToastVariant, 'green' | 'red' | 'gray'> = {
+  success: 'green',
+  error: 'red',
+  info: 'gray',
+};
+
+function VariantIcon({ variant }: { variant: ToastVariant }) {
+  const color = `var(--${VARIANT_ACCENT[variant]}-10)`;
+  const commonProps = { size: 18, color, 'aria-hidden': true } as const;
+  if (variant === 'success') return <CheckCircle2 {...commonProps} />;
+  if (variant === 'error') return <AlertCircle {...commonProps} />;
+  return <Info {...commonProps} />;
+}
+
+export function Toaster() {
+  const [toasts, setToasts] = useState<ActiveToast[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToToasts((payload) => {
+      setToasts((prev) => [...prev, { ...payload, open: true }]);
+    });
+    return unsubscribe;
+  }, []);
+
+  const handleOpenChange = useCallback((id: string, open: boolean) => {
+    if (open) return;
+    setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, open: false } : t)));
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 200);
+  }, []);
+
+  return (
+    <Toast.Provider swipeDirection="right" duration={TOAST_DURATION_MS} label={getMessage('toastViewportLabel')}>
+      {toasts.map((toast) => {
+        const accent = VARIANT_ACCENT[toast.variant];
+        return (
+          <Toast.Root
+            key={toast.id}
+            open={toast.open}
+            onOpenChange={(open) => handleOpenChange(toast.id, open)}
+            duration={TOAST_DURATION_MS}
+            className="sto-toast-root"
+            data-variant={toast.variant}
+            data-testid={`toast-${toast.variant}`}
+          >
+            <Flex gap="3" align="start" p="3">
+              <Box pt="1">
+                <VariantIcon variant={toast.variant} />
+              </Box>
+              <Flex direction="column" gap="1" style={{ flex: 1, minWidth: 0 }}>
+                <Toast.Title asChild>
+                  <Text as="div" weight="bold" size="2" style={{ color: `var(--${accent}-12)` }}>
+                    {toast.title}
+                  </Text>
+                </Toast.Title>
+                <Toast.Description asChild>
+                  <Text as="div" size="2" color="gray">
+                    {toast.message}
+                  </Text>
+                </Toast.Description>
+              </Flex>
+              <Toast.Close asChild>
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  aria-label={getMessage('toastCloseLabel')}
+                  title={getMessage('toastCloseLabel')}
+                  data-testid="toast-btn-close"
+                >
+                  <X size={14} aria-hidden="true" />
+                </IconButton>
+              </Toast.Close>
+            </Flex>
+          </Toast.Root>
+        );
+      })}
+      <Toast.Viewport className="sto-toast-viewport" data-testid="toast-viewport" />
+    </Toast.Provider>
+  );
+}

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -24,6 +24,7 @@ import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { Shield, FileText, BarChart3, Settings, Archive } from 'lucide-react';
 import { FEATURE_BASE_COLORS } from '@/utils/themeConstants';
 import { SessionsPage } from './SessionsPage';
+import { Toaster } from '@/components/UI/Toaster/Toaster';
 import type { DomainRuleSettings } from '@/types/syncSettings';
 
 (() => {
@@ -123,6 +124,7 @@ function OptionsApp() {
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <Theme>
                 <OptionsContent />
+                <Toaster />
             </Theme>
         </ThemeProvider>
     );

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,45 @@
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface ToastPayload {
+  id: string;
+  variant: ToastVariant;
+  title: string;
+  message: string;
+}
+
+type ToastListener = (payload: ToastPayload) => void;
+
+const listeners = new Set<ToastListener>();
+let counter = 0;
+
+function nextId(): string {
+  counter += 1;
+  return `toast-${Date.now()}-${counter}`;
+}
+
+function emit(variant: ToastVariant, title: string, message: string): string {
+  const payload: ToastPayload = { id: nextId(), variant, title, message };
+  for (const listener of listeners) {
+    listener(payload);
+  }
+  return payload.id;
+}
+
+export function subscribeToToasts(listener: ToastListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function showSuccessToast(title: string, message: string): string {
+  return emit('success', title, message);
+}
+
+export function showErrorToast(title: string, message: string): string {
+  return emit('error', title, message);
+}
+
+export function showInfoToast(title: string, message: string): string {
+  return emit('info', title, message);
+}

--- a/tests/components/Toaster.stories.test.tsx
+++ b/tests/components/Toaster.stories.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/Toaster/Toaster.stories';
+
+const {
+  ToasterSuccess,
+  ToasterError,
+  ToasterInfo,
+  ToasterStacked,
+} = composeStories(stories);
+
+describe('Toaster (portable stories)', () => {
+  it('renders a success toast with export message', async () => {
+    render(<ToasterSuccess />);
+    expect(await screen.findByText('Rules exported')).toBeInTheDocument();
+    expect(screen.getByTestId('toast-success')).toBeInTheDocument();
+  });
+
+  it('renders an error toast for restore failures', async () => {
+    render(<ToasterError />);
+    expect(await screen.findByText('Restore failed')).toBeInTheDocument();
+    expect(screen.getByTestId('toast-error')).toBeInTheDocument();
+  });
+
+  it('renders an info toast', async () => {
+    render(<ToasterInfo />);
+    expect(await screen.findByText('Snapshot saved')).toBeInTheDocument();
+    expect(screen.getByTestId('toast-info')).toBeInTheDocument();
+  });
+
+  it('stacks multiple toasts of different variants', async () => {
+    render(<ToasterStacked />);
+    expect(await screen.findByText('Rules imported')).toBeInTheDocument();
+    expect(await screen.findByText('Session exported')).toBeInTheDocument();
+    expect(await screen.findByText('Restore failed')).toBeInTheDocument();
+    expect(screen.getAllByTestId('toast-success')).toHaveLength(2);
+    expect(screen.getAllByTestId('toast-error')).toHaveLength(1);
+  });
+});

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -71,7 +71,7 @@ function makeRuleJson(label: string, domainFilter: string): string {
 }
 
 async function submitTextImport(page: any, json: string): Promise<void> {
-  await page.getByRole('button', { name: /^import$/i }).click();
+  await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 5000 });
   await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -8,6 +8,10 @@
  *
  * Native notifications remain the channel for background events (grouping,
  * deduplication) -- tested separately in tests/e2e/notifications.spec.ts.
+ *
+ * The import rules flow (Text mode paste + Next + Import) is the simplest
+ * user trigger that produces a toast without needing any browser permission
+ * (clipboard, filesystem...). We use it to assert toast behaviour.
  */
 
 import { test, expect } from './fixtures';
@@ -27,11 +31,11 @@ async function goToImportExportSection(page: any, extensionId: string): Promise<
   await page.waitForTimeout(300);
 }
 
-async function seedDomainRules(extensionContext: any, rules: any[]): Promise<void> {
+async function clearDomainRules(extensionContext: any): Promise<void> {
   const sw = extensionContext.serviceWorkers()[0];
-  await sw.evaluate(async (r: any[]) => {
-    await chrome.storage.sync.set({ domainRules: r });
-  }, rules);
+  await sw.evaluate(async () => {
+    await chrome.storage.sync.set({ domainRules: [] });
+  });
   await new Promise((r) => setTimeout(r, 200));
 }
 
@@ -45,50 +49,58 @@ async function getSmartTabNotificationIds(extensionContext: any): Promise<string
   return all.filter((id) => id.startsWith('smarttab-'));
 }
 
-test.describe('Options page toasts', () => {
-  test('export to clipboard shows an in-page toast and no native notification', async ({
-    extensionContext,
-    extensionId,
-  }) => {
-    await seedDomainRules(extensionContext, [
+function makeRuleJson(label: string, domainFilter: string): string {
+  return JSON.stringify({
+    domainRules: [
       {
-        id: 'toast-rule-1',
-        label: 'Toast Test Rule',
-        domainFilter: 'toast-test.com',
+        id: `toast-${Date.now()}`,
+        label,
+        domainFilter,
         enabled: true,
-        groupingEnabled: true,
         deduplicationEnabled: false,
         deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
-        color: '',
+        groupNameSource: 'title',
+        presetId: null,
+        color: 'blue',
         titleParsingRegEx: '',
         urlParsingRegEx: '',
         badge: '',
       },
-    ]);
+    ],
+  });
+}
 
+async function submitTextImport(page: any, json: string): Promise<void> {
+  await page.getByRole('button', { name: /^import$/i }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+  await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
+  await dialog.locator('textarea').fill(json);
+  await page.waitForTimeout(300);
+  await dialog.getByRole('button', { name: /next/i }).click();
+  await page.waitForTimeout(300);
+  await dialog.getByRole('button', { name: /^import$/i }).click();
+}
+
+test.describe('Options page toasts', () => {
+  test.beforeEach(async ({ extensionContext }) => {
+    await clearDomainRules(extensionContext);
+  });
+
+  test('rule import shows an in-page toast and no native notification', async ({
+    extensionContext,
+    extensionId,
+  }) => {
     const page = await extensionContext.newPage();
-    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write']);
-
     await goToImportExportSection(page, extensionId);
 
     const notifBefore = await getSmartTabNotificationIds(extensionContext);
 
-    // Open export wizard
-    await page.getByRole('button', { name: /^export$/i }).click();
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await submitTextImport(page, makeRuleJson('Toast Rule', 'toast-visible.com'));
 
-    // Open the split-button dropdown and choose Clipboard
-    await dialog.getByRole('button', { name: /export.*option|chevron/i }).click();
-    await page.getByRole('menuitem', { name: /clipboard/i }).click();
-
-    // In-page toast should appear
     const toast = page.getByTestId('toast-success');
     await expect(toast).toBeVisible({ timeout: 3000 });
-    await expect(toast).toContainText(/export/i);
 
-    // No new native notification
     const notifAfter = await getSmartTabNotificationIds(extensionContext);
     expect(notifAfter).toEqual(notifBefore);
 
@@ -99,33 +111,10 @@ test.describe('Options page toasts', () => {
     extensionContext,
     extensionId,
   }) => {
-    await seedDomainRules(extensionContext, [
-      {
-        id: 'toast-rule-2',
-        label: 'Toast Close Rule',
-        domainFilter: 'toast-close.com',
-        enabled: true,
-        groupingEnabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'label',
-        color: '',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      },
-    ]);
-
     const page = await extensionContext.newPage();
-    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write']);
-
     await goToImportExportSection(page, extensionId);
 
-    await page.getByRole('button', { name: /^export$/i }).click();
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible({ timeout: 5000 });
-    await dialog.getByRole('button', { name: /export.*option|chevron/i }).click();
-    await page.getByRole('menuitem', { name: /clipboard/i }).click();
+    await submitTextImport(page, makeRuleJson('Toast Close Rule', 'toast-close.com'));
 
     const toast = page.getByTestId('toast-success');
     await expect(toast).toBeVisible({ timeout: 3000 });

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * E2E Tests for in-page toasts (Options page)
+ *
+ * When an action is triggered from the Options page (import/export of rules,
+ * import/export of sessions, snapshot, restore), user feedback is shown via
+ * an in-page toast (<Toaster /> in src/components/UI/Toaster/) instead of a
+ * native browser notification.
+ *
+ * Native notifications remain the channel for background events (grouping,
+ * deduplication) -- tested separately in tests/e2e/notifications.spec.ts.
+ */
+
+import { test, expect } from './fixtures';
+
+async function goToImportExportSection(page: any, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => {
+      const body = document.body.textContent ?? '';
+      return !body.includes('Chargement') && body.length > 50;
+    },
+    null,
+    { timeout: 10_000 },
+  );
+  await page.getByRole('button', { name: /import.*export/i }).click();
+  await page.waitForTimeout(300);
+}
+
+async function seedDomainRules(extensionContext: any, rules: any[]): Promise<void> {
+  const sw = extensionContext.serviceWorkers()[0];
+  await sw.evaluate(async (r: any[]) => {
+    await chrome.storage.sync.set({ domainRules: r });
+  }, rules);
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+async function getSmartTabNotificationIds(extensionContext: any): Promise<string[]> {
+  const sw = extensionContext.serviceWorkers()[0];
+  const all: string[] = await sw.evaluate(async () => {
+    return await new Promise<string[]>((resolve) => {
+      chrome.notifications.getAll((n) => resolve(Object.keys(n ?? {})));
+    });
+  });
+  return all.filter((id) => id.startsWith('smarttab-'));
+}
+
+test.describe('Options page toasts', () => {
+  test('export to clipboard shows an in-page toast and no native notification', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    await seedDomainRules(extensionContext, [
+      {
+        id: 'toast-rule-1',
+        label: 'Toast Test Rule',
+        domainFilter: 'toast-test.com',
+        enabled: true,
+        groupingEnabled: true,
+        deduplicationEnabled: false,
+        deduplicationMatchMode: 'exact',
+        groupNameSource: 'label',
+        color: '',
+        titleParsingRegEx: '',
+        urlParsingRegEx: '',
+        badge: '',
+      },
+    ]);
+
+    const page = await extensionContext.newPage();
+    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write'], {
+      origin: `chrome-extension://${extensionId}`,
+    });
+
+    await goToImportExportSection(page, extensionId);
+
+    const notifBefore = await getSmartTabNotificationIds(extensionContext);
+
+    // Open export wizard
+    await page.getByRole('button', { name: /^export$/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Open the split-button dropdown and choose Clipboard
+    await dialog.getByRole('button', { name: /export.*option|chevron/i }).click();
+    await page.getByRole('menuitem', { name: /clipboard/i }).click();
+
+    // In-page toast should appear
+    const toast = page.getByTestId('toast-success');
+    await expect(toast).toBeVisible({ timeout: 3000 });
+    await expect(toast).toContainText(/export/i);
+
+    // No new native notification
+    const notifAfter = await getSmartTabNotificationIds(extensionContext);
+    expect(notifAfter).toEqual(notifBefore);
+
+    await page.close();
+  });
+
+  test('closing a toast removes it from the viewport', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    await seedDomainRules(extensionContext, [
+      {
+        id: 'toast-rule-2',
+        label: 'Toast Close Rule',
+        domainFilter: 'toast-close.com',
+        enabled: true,
+        groupingEnabled: true,
+        deduplicationEnabled: false,
+        deduplicationMatchMode: 'exact',
+        groupNameSource: 'label',
+        color: '',
+        titleParsingRegEx: '',
+        urlParsingRegEx: '',
+        badge: '',
+      },
+    ]);
+
+    const page = await extensionContext.newPage();
+    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write'], {
+      origin: `chrome-extension://${extensionId}`,
+    });
+
+    await goToImportExportSection(page, extensionId);
+
+    await page.getByRole('button', { name: /^export$/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole('button', { name: /export.*option|chevron/i }).click();
+    await page.getByRole('menuitem', { name: /clipboard/i }).click();
+
+    const toast = page.getByTestId('toast-success');
+    await expect(toast).toBeVisible({ timeout: 3000 });
+
+    await page.getByTestId('toast-btn-close').first().click();
+    await expect(toast).toBeHidden({ timeout: 2000 });
+
+    await page.close();
+  });
+});

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -68,9 +68,7 @@ test.describe('Options page toasts', () => {
     ]);
 
     const page = await extensionContext.newPage();
-    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write'], {
-      origin: `chrome-extension://${extensionId}`,
-    });
+    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write']);
 
     await goToImportExportSection(page, extensionId);
 
@@ -119,9 +117,7 @@ test.describe('Options page toasts', () => {
     ]);
 
     const page = await extensionContext.newPage();
-    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write'], {
-      origin: `chrome-extension://${extensionId}`,
-    });
+    await extensionContext.grantPermissions(['clipboard-read', 'clipboard-write']);
 
     await goToImportExportSection(page, extensionId);
 

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -79,7 +79,7 @@ async function submitTextImport(page: any, json: string): Promise<void> {
   await page.waitForTimeout(300);
   await dialog.getByRole('button', { name: /next/i }).click();
   await page.waitForTimeout(300);
-  await dialog.getByRole('button', { name: /^import$/i }).click();
+  await dialog.getByRole('button', { name: /confirm.*import/i }).click();
 }
 
 test.describe('Options page toasts', () => {

--- a/tests/toast.test.ts
+++ b/tests/toast.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  showSuccessToast,
+  showErrorToast,
+  showInfoToast,
+  subscribeToToasts,
+  type ToastPayload,
+} from '../src/utils/toast';
+
+describe('toast emitter', () => {
+  it('emits a success payload with the provided title and message', () => {
+    const received: ToastPayload[] = [];
+    const unsubscribe = subscribeToToasts((p) => received.push(p));
+
+    const id = showSuccessToast('Done', 'All good');
+
+    unsubscribe();
+    expect(received).toHaveLength(1);
+    expect(received[0].id).toBe(id);
+    expect(received[0].variant).toBe('success');
+    expect(received[0].title).toBe('Done');
+    expect(received[0].message).toBe('All good');
+  });
+
+  it('emits error and info variants with the correct tag', () => {
+    const received: ToastPayload[] = [];
+    const unsubscribe = subscribeToToasts((p) => received.push(p));
+
+    showErrorToast('Oops', 'Something failed');
+    showInfoToast('FYI', 'Heads up');
+
+    unsubscribe();
+    expect(received.map((p) => p.variant)).toEqual(['error', 'info']);
+  });
+
+  it('returns an unsubscribe function that stops further delivery', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToToasts(listener);
+
+    showSuccessToast('A', 'a');
+    unsubscribe();
+    showSuccessToast('B', 'b');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('assigns unique ids even for toasts emitted within the same tick', () => {
+    const received: ToastPayload[] = [];
+    const unsubscribe = subscribeToToasts((p) => received.push(p));
+
+    showSuccessToast('A', 'a');
+    showSuccessToast('B', 'b');
+    showSuccessToast('C', 'c');
+
+    unsubscribe();
+    const ids = received.map((p) => p.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('broadcasts to multiple subscribers in insertion order', () => {
+    const calls: string[] = [];
+    const unsub1 = subscribeToToasts(() => calls.push('l1'));
+    const unsub2 = subscribeToToasts(() => calls.push('l2'));
+
+    showSuccessToast('x', 'y');
+
+    unsub1();
+    unsub2();
+    expect(calls).toEqual(['l1', 'l2']);
+  });
+});


### PR DESCRIPTION
Replace system notifications with Radix Toast (@radix-ui/react-toast) for
actions launched from the Options page (import/export of rules, import/export
of sessions, snapshot, restore). Background events (grouping, deduplication)
continue to use native browser notifications since they happen outside a page
controlled by the extension.

- Add src/utils/toast.ts: module-level emitter with showSuccessToast,
  showErrorToast, showInfoToast (API symmetrical to showSuccessNotification).
- Add src/components/UI/Toaster: Radix Toast Provider/Viewport mounted at
  OptionsApp root, bottom-right, 6 s auto-dismiss, variant-accented card.
- Swap calls in ImportWizard, ExportWizard, ImportSessionsWizard,
  ExportSessionsWizard, SnapshotWizard, RestoreWizard.
- Add i18n keys toastCloseLabel and toastViewportLabel for EN/FR/ES.
- Storybook story with Success / Error / Info / Stacked variants.
- Unit tests for the emitter and the Toaster component.
- E2E spec asserting toast visibility plus absence of native notification.

https://claude.ai/code/session_015p8CT3zadScSq1GvB86rui