### PR TITLE
Replace icon library with emojis and improve accessibility

### DIFF
--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Box, Button, Card, Flex, Text } from '@radix-ui/themes';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { browser } from 'wxt/browser';
-import { ChevronDown, ExternalLink, Pin } from 'lucide-react';
+import { ChevronDown, ExternalLink, Pin, Play } from 'lucide-react';
 import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
@@ -190,7 +190,8 @@ export function PopupProfilesList() {
                 {session.name}
               </Text>
               <SplitButton
-                label="▶"
+                label={<Play size={12} aria-hidden="true" fill="currentColor" />}
+                primaryAriaLabel={getMessage('sessionRestoreCurrentWindow')}
                 onClick={() => handleRestore(session, 'current')}
                 size="1"
                 variant="soft"

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Button, DropdownMenu, Flex, Text } from '@radix-ui/themes';
-import { Camera, ChevronDown, RotateCcw, Wand2 } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
@@ -29,6 +29,14 @@ const actionButtonStyle: React.CSSProperties = {
   gap: 4,
   paddingTop: 10,
   paddingBottom: 10,
+};
+
+const actionEmojiStyle: React.CSSProperties = {
+  fontSize: 18,
+  lineHeight: 1,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 };
 
 export function PopupToolbar() {
@@ -77,7 +85,9 @@ export function PopupToolbar() {
                 borderBottomRightRadius: 0,
               }}
             >
-              <Camera size={17} aria-hidden="true" />
+              <span aria-hidden="true" style={actionEmojiStyle}>
+                📸
+              </span>
               <Text as="span" size="1">
                 {getMessage('popupSave')}
               </Text>
@@ -130,7 +140,9 @@ export function PopupToolbar() {
             title={saveDisabledHint}
             style={actionButtonStyle}
           >
-            <Camera size={17} aria-hidden="true" />
+            <span aria-hidden="true" style={actionEmojiStyle}>
+              📸
+            </span>
             <Text as="span" size="1">
               {getMessage('popupSave')}
             </Text>
@@ -145,7 +157,9 @@ export function PopupToolbar() {
           aria-label={getMessage('popupRestoreSession')}
           style={actionButtonStyle}
         >
-          <RotateCcw size={17} aria-hidden="true" />
+          <span aria-hidden="true" style={actionEmojiStyle}>
+            🔄
+          </span>
           <Text as="span" size="1">
             {getMessage('popupRestore')}
           </Text>
@@ -160,7 +174,9 @@ export function PopupToolbar() {
           title={getMessage('organizeAllTabs')}
           style={actionButtonStyle}
         >
-          <Wand2 size={17} aria-hidden="true" />
+          <span aria-hidden="true" style={actionEmojiStyle}>
+            🪄
+          </span>
           <Text as="span" size="1">
             {isOrganizing ? getMessage('organizingTabs') : getMessage('organizeAllTabs')}
           </Text>

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -29,6 +29,7 @@ const actionButtonStyle: React.CSSProperties = {
   gap: 4,
   paddingTop: 10,
   paddingBottom: 10,
+  borderRadius: 'var(--radius-5)',
 };
 
 const actionEmojiStyle: React.CSSProperties = {
@@ -68,7 +69,7 @@ export function PopupToolbar() {
       p="1"
       style={{
         background: 'var(--gray-a3)',
-        borderRadius: 'var(--radius-3)',
+        borderRadius: 'var(--radius-5)',
       }}
     >
       <Flex gap="1">
@@ -101,6 +102,8 @@ export function PopupToolbar() {
                   style={{
                     borderTopLeftRadius: 0,
                     borderBottomLeftRadius: 0,
+                    borderTopRightRadius: 'var(--radius-5)',
+                    borderBottomRightRadius: 'var(--radius-5)',
                     paddingLeft: 4,
                     paddingRight: 4,
                     minWidth: 20,

--- a/src/components/UI/SplitButton/SplitButton.tsx
+++ b/src/components/UI/SplitButton/SplitButton.tsx
@@ -13,8 +13,8 @@ export interface SplitButtonMenuItem {
 }
 
 export interface SplitButtonProps {
-  /** Label of the primary button */
-  label: string;
+  /** Label of the primary button. Accepts text or any ReactNode (e.g. icon) */
+  label: React.ReactNode;
   /** Action on primary button click */
   onClick: () => void;
   /** Dropdown menu items */
@@ -27,6 +27,8 @@ export interface SplitButtonProps {
   disabled?: boolean;
   /** Aria-label for the chevron dropdown trigger */
   ariaLabel?: string;
+  /** Aria-label for the primary button. Required when label is not textual */
+  primaryAriaLabel?: string;
   /** data-testid forwarded to the primary button */
   'data-testid'?: string;
 }
@@ -39,6 +41,7 @@ export function SplitButton({
   size = '2',
   disabled = false,
   ariaLabel,
+  primaryAriaLabel,
   'data-testid': testId,
 }: SplitButtonProps) {
   return (
@@ -49,6 +52,7 @@ export function SplitButton({
         size={size}
         onClick={onClick}
         disabled={disabled}
+        aria-label={typeof label === 'string' ? undefined : primaryAriaLabel}
         style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
       >
         {label}


### PR DESCRIPTION
## Summary
This PR replaces lucide-react icons with emojis in the PopupToolbar component and improves accessibility across UI components by adding proper ARIA labels and enhancing the SplitButton component to support non-textual labels.

## Key Changes

- **PopupToolbar**: Replaced lucide-react icons (Camera, RotateCcw, Wand2) with emoji equivalents (📸, 🔄, 🪄) for a more playful UI
- **Icon styling**: Added `actionEmojiStyle` to properly style emoji icons with consistent sizing and alignment
- **Accessibility improvements**:
  - Added `primaryAriaLabel` prop to SplitButton for cases where the label is not textual
  - Updated SplitButton to accept `React.ReactNode` for label instead of just strings
  - Added proper `aria-label` handling in SplitButton's primary button
- **PopupProfilesList**: Updated the session restore button to use a Play icon with proper ARIA attributes and added descriptive aria-label via the new `primaryAriaLabel` prop
- **Visual refinements**: Updated border-radius values to use `var(--radius-5)` for consistency and improved dropdown button styling

## Implementation Details

- Emojis are wrapped in `<span>` elements with `aria-hidden="true"` to prevent screen reader duplication
- The SplitButton component now intelligently applies aria-label only when the label is not a plain string
- All icon replacements maintain the same visual hierarchy and size consistency

https://claude.ai/code/session_01A9hcN76efYiioEeBnZma1S