### PR TITLE
chore(claude): add SessionStart hook to run pnpm install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,19 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm install --frozen-lockfile",
+            "timeout": 300,
+            "statusMessage": "Installing dependencies..."
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Garantit que les dépendances sont présentes avant la première édition d'un fichier, ce qui évite que le hook PostToolUse ESLint échoue sur une session fraîche (conteneur web sans node_modules).

https://claude.ai/code/session_011cnedWMqTNQUFkegxTPkni