### PR TITLE
Extract TextFieldWithCategory component for reuse

### DIFF
--- a/src/components/Core/DomainRule/EditSummaryView.tsx
+++ b/src/components/Core/DomainRule/EditSummaryView.tsx
@@ -4,8 +4,8 @@ import { ChevronDown, ChevronRight, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { Controller, type Control, type FieldErrors } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
-import { CategoryPicker } from './CategoryPicker';
 import { FormField } from '@/components/Form/FormFields';
+import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { ConfigEditModal, type ConfigEditValues } from './ConfigEditModal';
 import { WizardStep3Options } from './WizardStep3Options';
 import { getRuleCategory, groupNameSourceOptions, deduplicationMatchModeOptions } from '@/schemas/enums';
@@ -79,29 +79,31 @@ export function EditSummaryView({
             required={true}
             error={errors.label}
           >
-            <Flex align="center" gap="2" style={{ marginTop: '4px' }}>
-              <Box style={{ flex: 1 }}>
-                <Controller
-                  name="label"
-                  control={control}
-                  render={({ field }) => (
-                    <TextField.Root
-                      {...field}
-                      name="label"
-                      data-testid="wizard-rule-field-label"
-                      placeholder={getMessage('labelPlaceholder')}
-                    />
-                  )}
-                />
-              </Box>
+            <div style={{ marginTop: '4px' }}>
               <Controller
-                name="categoryId"
+                name="label"
                 control={control}
-                render={({ field }) => (
-                  <CategoryPicker value={field.value as any} onChange={field.onChange} />
+                render={({ field: labelField }) => (
+                  <Controller
+                    name="categoryId"
+                    control={control}
+                    render={({ field: catField }) => (
+                      <TextFieldWithCategory
+                        ref={labelField.ref}
+                        name={labelField.name}
+                        value={labelField.value ?? ''}
+                        onChange={labelField.onChange}
+                        onBlur={labelField.onBlur}
+                        data-testid="wizard-rule-field-label"
+                        placeholder={getMessage('labelPlaceholder')}
+                        categoryId={catField.value as any}
+                        onCategoryChange={catField.onChange}
+                      />
+                    )}
+                  />
                 )}
               />
-            </Flex>
+            </div>
           </FormField>
 
           <FormField

--- a/src/components/Core/DomainRule/EditSummaryView.tsx
+++ b/src/components/Core/DomainRule/EditSummaryView.tsx
@@ -80,13 +80,6 @@ export function EditSummaryView({
             error={errors.label}
           >
             <Flex align="center" gap="2" style={{ marginTop: '4px' }}>
-              <Controller
-                name="categoryId"
-                control={control}
-                render={({ field }) => (
-                  <CategoryPicker value={field.value as any} onChange={field.onChange} />
-                )}
-              />
               <Box style={{ flex: 1 }}>
                 <Controller
                   name="label"
@@ -101,6 +94,13 @@ export function EditSummaryView({
                   )}
                 />
               </Box>
+              <Controller
+                name="categoryId"
+                control={control}
+                render={({ field }) => (
+                  <CategoryPicker value={field.value as any} onChange={field.onChange} />
+                )}
+              />
             </Flex>
           </FormField>
 

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -1,8 +1,8 @@
-import { Box, Flex, TextField } from '@radix-ui/themes';
+import { Flex, TextField } from '@radix-ui/themes';
 import { Controller, type Control, type FieldErrors } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
-import { CategoryPicker } from './CategoryPicker';
 import { FormField } from '@/components/Form/FormFields';
+import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import type { DomainRule } from '@/schemas/domainRule';
 
 interface WizardStep1IdentityProps {
@@ -19,29 +19,31 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
         required={true}
         error={errors.label}
       >
-        <Flex align="center" gap="2" style={{ marginTop: '4px' }}>
-          <Box style={{ flex: 1 }}>
-            <Controller
-              name="label"
-              control={control}
-              render={({ field }) => (
-                <TextField.Root
-                  {...field}
-                  data-testid="wizard-rule-field-label"
-                  name="label"
-                  placeholder={getMessage('labelPlaceholder')}
-                />
-              )}
-            />
-          </Box>
+        <div style={{ marginTop: '4px' }}>
           <Controller
-            name="categoryId"
+            name="label"
             control={control}
-            render={({ field }) => (
-              <CategoryPicker value={field.value as any} onChange={field.onChange} />
+            render={({ field: labelField }) => (
+              <Controller
+                name="categoryId"
+                control={control}
+                render={({ field: catField }) => (
+                  <TextFieldWithCategory
+                    ref={labelField.ref}
+                    name={labelField.name}
+                    value={labelField.value ?? ''}
+                    onChange={labelField.onChange}
+                    onBlur={labelField.onBlur}
+                    data-testid="wizard-rule-field-label"
+                    placeholder={getMessage('labelPlaceholder')}
+                    categoryId={catField.value as any}
+                    onCategoryChange={catField.onChange}
+                  />
+                )}
+              />
             )}
           />
-        </Flex>
+        </div>
       </FormField>
 
       {/* Domain Filter */}

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -20,13 +20,6 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
         error={errors.label}
       >
         <Flex align="center" gap="2" style={{ marginTop: '4px' }}>
-          <Controller
-            name="categoryId"
-            control={control}
-            render={({ field }) => (
-              <CategoryPicker value={field.value as any} onChange={field.onChange} />
-            )}
-          />
           <Box style={{ flex: 1 }}>
             <Controller
               name="label"
@@ -41,6 +34,13 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
               )}
             />
           </Box>
+          <Controller
+            name="categoryId"
+            control={control}
+            render={({ field }) => (
+              <CategoryPicker value={field.value as any} onChange={field.onChange} />
+            )}
+          />
         </Flex>
       </FormField>
 

--- a/src/components/Core/Session/SessionEditDialog.tsx
+++ b/src/components/Core/Session/SessionEditDialog.tsx
@@ -169,7 +169,6 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
               {getMessage('sessionEditorNameLabel')}
             </Text>
             <Flex align="center" gap="2">
-              <CategoryPicker value={categoryId as any} onChange={setCategoryId} />
               <Box style={{ flex: 1 }}>
                 <TextField.Root
                   data-testid="dialog-session-edit-field-name"
@@ -189,6 +188,7 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
                   </Text>
                 )}
               </Box>
+              <CategoryPicker value={categoryId as any} onChange={setCategoryId} />
             </Flex>
           </Box>
 

--- a/src/components/Core/Session/SessionEditDialog.tsx
+++ b/src/components/Core/Session/SessionEditDialog.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Flex,
   Text,
-  TextField,
   TextArea,
   Button,
   Separator,
@@ -15,7 +14,7 @@ import { Pencil, X } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { SessionsTheme } from '@/components/Form/themes';
 import { TabTreeEditor } from '@/components/Core/TabTree/TabTreeEditor';
-import { CategoryPicker } from '@/components/Core/DomainRule/CategoryPicker';
+import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { useSessionEditor } from '@/hooks/useSessionEditor';
 import { countSessionTabs } from '@/utils/sessionUtils';
 import type { Session } from '@/types/session';
@@ -168,28 +167,23 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
             >
               {getMessage('sessionEditorNameLabel')}
             </Text>
-            <Flex align="center" gap="2">
-              <Box style={{ flex: 1 }}>
-                <TextField.Root
-                  data-testid="dialog-session-edit-field-name"
-                  id="session-edit-name"
-                  value={editor.editedSession.name}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    editor.updateSessionName(e.target.value);
-                    setSaveNameError(null);
-                  }}
-                  size="2"
-                  style={{ width: '100%' }}
-                  aria-label={getMessage('sessionEditorNameLabel')}
-                />
-                {saveNameError && (
-                  <Text size="1" color="red" style={{ marginTop: 2 }}>
-                    {saveNameError}
-                  </Text>
-                )}
-              </Box>
-              <CategoryPicker value={categoryId as any} onChange={setCategoryId} />
-            </Flex>
+            <TextFieldWithCategory
+              id="session-edit-name"
+              data-testid="dialog-session-edit-field-name"
+              value={editor.editedSession.name}
+              onChange={(nextValue) => {
+                editor.updateSessionName(nextValue);
+                setSaveNameError(null);
+              }}
+              aria-label={getMessage('sessionEditorNameLabel')}
+              categoryId={categoryId as any}
+              onCategoryChange={setCategoryId}
+            />
+            {saveNameError && (
+              <Text size="1" color="red" style={{ marginTop: 2 }}>
+                {saveNameError}
+              </Text>
+            )}
           </Box>
 
           <Separator size="4" mb="3" />

--- a/src/components/Form/FormFields/TextFieldWithCategory.stories.tsx
+++ b/src/components/Form/FormFields/TextFieldWithCategory.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Box } from '@radix-ui/themes';
+import { TextFieldWithCategory } from './TextFieldWithCategory';
+import type { RuleCategoryId } from '@/schemas/enums';
+
+const meta: Meta<typeof TextFieldWithCategory> = {
+  title: 'Components/Form/FormFields/TextFieldWithCategory',
+  component: TextFieldWithCategory,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <Box style={{ width: 400 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledExample({
+  initialValue = '',
+  initialCategoryId = null as RuleCategoryId | null,
+  ...rest
+}: {
+  initialValue?: string;
+  initialCategoryId?: RuleCategoryId | null;
+  placeholder?: string;
+  maxLength?: number;
+  'aria-label'?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const [categoryId, setCategoryId] = useState<RuleCategoryId | null>(initialCategoryId);
+  return (
+    <TextFieldWithCategory
+      value={value}
+      onChange={setValue}
+      categoryId={categoryId}
+      onCategoryChange={setCategoryId}
+      {...rest}
+    />
+  );
+}
+
+export const TextFieldWithCategoryDefault: Story = {
+  render: () => <ControlledExample placeholder="Enter a label..." aria-label="Label" />,
+};
+
+export const TextFieldWithCategoryFilled: Story = {
+  render: () => (
+    <ControlledExample
+      initialValue="My work session"
+      initialCategoryId={'productivity' as RuleCategoryId}
+      aria-label="Label"
+    />
+  ),
+};
+
+export const TextFieldWithCategoryWithMaxLength: Story = {
+  render: () => (
+    <ControlledExample
+      initialValue="A quite long session name example"
+      maxLength={100}
+      aria-label="Label"
+    />
+  ),
+};

--- a/src/components/Form/FormFields/TextFieldWithCategory.tsx
+++ b/src/components/Form/FormFields/TextFieldWithCategory.tsx
@@ -1,0 +1,61 @@
+import { forwardRef } from 'react';
+import { Box, Flex, TextField } from '@radix-ui/themes';
+import { CategoryPicker } from '@/components/Core/DomainRule/CategoryPicker';
+import type { RuleCategoryId } from '@/schemas/enums';
+
+export interface TextFieldWithCategoryProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  maxLength?: number;
+  id?: string;
+  name?: string;
+  'data-testid'?: string;
+  'aria-label'?: string;
+  disabled?: boolean;
+  categoryId: RuleCategoryId | null | undefined;
+  onCategoryChange: (id: RuleCategoryId | null) => void;
+}
+
+export const TextFieldWithCategory = forwardRef<HTMLInputElement, TextFieldWithCategoryProps>(
+  function TextFieldWithCategory(
+    {
+      value,
+      onChange,
+      onBlur,
+      placeholder,
+      maxLength,
+      id,
+      name,
+      'data-testid': dataTestId,
+      'aria-label': ariaLabel,
+      disabled,
+      categoryId,
+      onCategoryChange,
+    },
+    ref,
+  ) {
+    return (
+      <Flex align="center" gap="2">
+        <Box style={{ flex: 1 }}>
+          <TextField.Root
+            ref={ref}
+            id={id}
+            name={name}
+            value={value}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+            onBlur={onBlur}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            data-testid={dataTestId}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            style={{ width: '100%' }}
+          />
+        </Box>
+        <CategoryPicker value={categoryId} onChange={onCategoryChange} />
+      </Flex>
+    );
+  },
+);

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
-  Dialog, Flex, Button, Text, Box, TextField,
+  Dialog, Flex, Button, Text,
   TextArea, Callout,
 } from '@radix-ui/themes';
 import { Camera, AlertCircle } from 'lucide-react';
 import { SessionsTheme } from '@/components/Form/themes';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
-import { CategoryPicker } from '@/components/Core/DomainRule/CategoryPicker';
+import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { WizardModal } from '@/components/UI/WizardModal';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast } from '@/utils/toast';
@@ -153,22 +153,16 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
               <Text size="2" weight="medium">
                 {getMessage('sessionNameLabel')}
               </Text>
-              <Flex align="center" gap="2">
-                <CategoryPicker value={categoryId as any} onChange={setCategoryId} />
-                <Box style={{ flex: 1 }}>
-                  <TextField.Root
-                    data-testid="wizard-snapshot-field-name"
-                    value={sessionName}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setSessionName(e.target.value)
-                    }
-                    placeholder={getMessage('sessionNamePlaceholder')}
-                    maxLength={100}
-                    aria-label={getMessage('sessionNameLabel')}
-                    style={{ width: '100%' }}
-                  />
-                </Box>
-              </Flex>
+              <TextFieldWithCategory
+                data-testid="wizard-snapshot-field-name"
+                value={sessionName}
+                onChange={setSessionName}
+                placeholder={getMessage('sessionNamePlaceholder')}
+                maxLength={100}
+                aria-label={getMessage('sessionNameLabel')}
+                categoryId={categoryId as any}
+                onCategoryChange={setCategoryId}
+              />
             </Flex>
 
             <Text size="2" weight="medium">


### PR DESCRIPTION
## Summary
This PR introduces a new reusable `TextFieldWithCategory` component that combines a text input field with a category picker. This component is extracted from repeated patterns across multiple forms and replaces those patterns in four different locations.

## Key Changes
- **New Component**: Created `TextFieldWithCategory` component in `src/components/Form/FormFields/` with full TypeScript support and ref forwarding
- **Storybook Stories**: Added comprehensive Storybook stories demonstrating default, filled, and max-length variants
- **Refactored Components**: Updated four components to use the new composite component:
  - `WizardStep1Identity`: Simplified label and category picker layout
  - `EditSummaryView`: Simplified label and category picker layout
  - `SessionEditDialog`: Replaced separate TextField and CategoryPicker with unified component
  - `SnapshotWizard`: Replaced separate TextField and CategoryPicker with unified component

## Implementation Details
- The component uses Radix UI's `Flex` and `TextField` primitives for consistent styling
- Supports all standard text input props (placeholder, maxLength, disabled, aria-label, etc.)
- Integrates `CategoryPicker` component alongside the text field
- Properly handles React Hook Form integration through ref forwarding and controlled component pattern
- Maintains accessibility with proper aria-label support
- Reduces code duplication and improves maintainability across the codebase

https://claude.ai/code/session_012LAYyHFeiRApSdkxHKPbds