### PR TITLE
Extract dialog header logic into reusable DialogShell component

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -1,9 +1,9 @@
-import { Button, Dialog, Flex, ScrollArea } from '@radix-ui/themes';
-import { X } from 'lucide-react';
+import { Button, Flex, ScrollArea } from '@radix-ui/themes';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { DomainRulesTheme } from '@/components/Form/themes';
+import { DialogShell } from '@/components/UI/DialogShell';
 import { type GroupNameSourceValue } from '@/schemas/enums';
 import { createRegexValidator } from '@/schemas/common';
 import type { PresetCategory } from '@/utils/presetUtils';
@@ -106,56 +106,46 @@ export function ConfigEditModal({
 
   return (
     <DomainRulesTheme>
-      <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-        <Dialog.Content style={{ maxWidth: 480 }}>
-          <Dialog.Title>{getMessage('editConfigTitle')}</Dialog.Title>
-          <Dialog.Description style={{ display: 'none' }}>
-            {getMessage('editConfigTitle')}
-          </Dialog.Description>
-
-          <ScrollArea type="auto" scrollbars="vertical" style={{ maxHeight: '55vh' }}>
-            <Flex direction="column" gap="4" mt="4" pr="3">
-              <DomainRuleConfigForm
-                idPrefix="edit"
-                configMode={configMode}
-                onConfigModeChange={setConfigMode}
-                presetId={presetId}
-                onPresetChange={handlePresetChange}
-                presetCategories={presetCategories}
-                isLoadingPresets={isLoadingPresets}
-                groupNameSource={groupNameSource}
-                onGroupNameSourceChange={setGroupNameSource}
-                titleParsingRegEx={titleParsingRegEx}
-                onTitleParsingRegExChange={setTitleParsingRegEx}
-                titleParsingRegExError={titleRegexError}
-                urlParsingRegEx={urlParsingRegEx}
-                onUrlParsingRegExChange={setUrlParsingRegEx}
-                urlParsingRegExError={urlRegexError}
-              />
-            </Flex>
-          </ScrollArea>
-
-          <Flex gap="3" justify="end" mt="4">
-            <Button variant="soft" color="gray" onClick={onClose}>
-              {getMessage('cancel')}
-            </Button>
-            <Button onClick={handleApply} disabled={hasRegexError}>
-              {getMessage('apply')}
-            </Button>
+      <DialogShell
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        title={getMessage('editConfigTitle')}
+        description={getMessage('editConfigTitle')}
+        hideDescription
+        maxWidth={480}
+        showHeaderSeparator={false}
+      >
+        <ScrollArea type="auto" scrollbars="vertical" style={{ maxHeight: '55vh' }}>
+          <Flex direction="column" gap="4" mt="4" pr="3">
+            <DomainRuleConfigForm
+              idPrefix="edit"
+              configMode={configMode}
+              onConfigModeChange={setConfigMode}
+              presetId={presetId}
+              onPresetChange={handlePresetChange}
+              presetCategories={presetCategories}
+              isLoadingPresets={isLoadingPresets}
+              groupNameSource={groupNameSource}
+              onGroupNameSourceChange={setGroupNameSource}
+              titleParsingRegEx={titleParsingRegEx}
+              onTitleParsingRegExChange={setTitleParsingRegEx}
+              titleParsingRegExError={titleRegexError}
+              urlParsingRegEx={urlParsingRegEx}
+              onUrlParsingRegExChange={setUrlParsingRegEx}
+              urlParsingRegExError={urlRegexError}
+            />
           </Flex>
+        </ScrollArea>
 
-          <Dialog.Close>
-            <Button
-              variant="ghost"
-              size="1"
-              aria-label={getMessage('cancel')}
-              style={{ position: 'absolute', top: '16px', right: '16px' }}
-            >
-              <X size={16} aria-hidden="true" />
-            </Button>
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Root>
+        <Flex gap="3" justify="end" mt="4">
+          <Button variant="soft" color="gray" onClick={onClose}>
+            {getMessage('cancel')}
+          </Button>
+          <Button onClick={handleApply} disabled={hasRegexError}>
+            {getMessage('apply')}
+          </Button>
+        </Flex>
+      </DialogShell>
     </DomainRulesTheme>
   );
 }

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Dialog, Flex } from '@radix-ui/themes';
-import { Edit2, Plus, X } from 'lucide-react';
+import { Edit2, Plus } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -380,6 +380,9 @@ export function RuleWizardModal({
         open={isOpen}
         onOpenChange={handleOpenChange}
         data-testid="wizard-rule"
+        icon={isEditing ? Edit2 : Plus}
+        title={title}
+        description={description}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[name="label"]');
@@ -387,12 +390,6 @@ export function RuleWizardModal({
         }}
       >
         <form onSubmit={handleSubmit(handleFormSubmit)} style={{ display: 'contents' }}>
-          <WizardModal.Header
-            icon={isEditing ? Edit2 : Plus}
-            title={title}
-            description={description}
-          />
-
           {/* aria-live region for step announcements */}
           <div
             role="status"
@@ -503,18 +500,6 @@ export function RuleWizardModal({
             )}
           </WizardModal.Footer>
         </form>
-
-        {/* Close (X) button */}
-        <Dialog.Close>
-          <Button
-            variant="ghost"
-            size="1"
-            aria-label={getMessage('cancel')}
-            style={{ position: 'absolute', top: '16px', right: '16px' }}
-          >
-            <X size={16} aria-hidden="true" />
-          </Button>
-        </Dialog.Close>
       </WizardModal>
     </DomainRulesTheme>
   );

--- a/src/components/Core/Session/SessionEditDialog.tsx
+++ b/src/components/Core/Session/SessionEditDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import {
-  Dialog,
   AlertDialog,
   Box,
   Flex,
@@ -8,11 +7,11 @@ import {
   TextArea,
   Button,
   Separator,
-  IconButton,
 } from '@radix-ui/themes';
-import { Pencil, X } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { SessionsTheme } from '@/components/Form/themes';
+import { DialogShell } from '@/components/UI/DialogShell';
 import { TabTreeEditor } from '@/components/Core/TabTree/TabTreeEditor';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { useSessionEditor } from '@/hooks/useSessionEditor';
@@ -118,132 +117,112 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
 
   return (
     <SessionsTheme>
-      <Dialog.Root
+      <DialogShell
         open={open}
         onOpenChange={(isOpen) => {
           if (!isOpen) handleCancel();
           else onOpenChange(true);
         }}
+        data-testid="dialog-session-edit"
+        maxWidth="600px"
+        title={getMessage('sessionEditorTitle')}
+        icon={Pencil}
+        showHeaderSeparator={false}
+        onInteractOutside={interceptClose}
+        onEscapeKeyDown={interceptClose}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('#session-edit-name');
+          input?.focus();
+        }}
       >
-        <Dialog.Content
-          data-testid="dialog-session-edit"
-          maxWidth="600px"
-          onInteractOutside={interceptClose}
-          onEscapeKeyDown={interceptClose}
-          onOpenAutoFocus={(e) => {
-            e.preventDefault();
-            const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('#session-edit-name');
-            input?.focus();
-          }}
-        >
-          {/* Title row */}
-          <Flex justify="between" align="center" mb="4">
-            <Dialog.Title mb="0">
-              <Flex align="center" gap="2">
-                <Pencil size={16} aria-hidden="true" />
-                {getMessage('sessionEditorTitle')}
-              </Flex>
-            </Dialog.Title>
-            <Dialog.Close>
-              <IconButton
-                size="1"
-                variant="ghost"
-                color="gray"
-                aria-label={getMessage('close')}
-              >
-                <X size={16} aria-hidden="true" />
-              </IconButton>
-            </Dialog.Close>
-          </Flex>
-
-          {/* Session name + category inline */}
-          <Box mb="4">
-            <Text
-              as="label"
-              size="2"
-              weight="medium"
-              htmlFor="session-edit-name"
-              style={{ display: 'block', marginBottom: 'var(--space-1)' }}
-            >
-              {getMessage('sessionEditorNameLabel')}
-            </Text>
-            <TextFieldWithCategory
-              id="session-edit-name"
-              data-testid="dialog-session-edit-field-name"
-              value={editor.editedSession.name}
-              onChange={(nextValue) => {
-                editor.updateSessionName(nextValue);
-                setSaveNameError(null);
-              }}
-              aria-label={getMessage('sessionEditorNameLabel')}
-              categoryId={categoryId as any}
-              onCategoryChange={setCategoryId}
-            />
-            {saveNameError && (
-              <Text size="1" color="red" style={{ marginTop: 2 }}>
-                {saveNameError}
-              </Text>
-            )}
-          </Box>
-
-          <Separator size="4" mb="3" />
-
-          {/* Editable tab tree */}
-          <TabTreeEditor
-            session={editor.editedSession}
-            onSessionChange={editor.applySessionUpdate}
-            maxHeight={360}
+        {/* Session name + category inline */}
+        <Box mb="4" mt="4">
+          <Text
+            as="label"
+            size="2"
+            weight="medium"
+            htmlFor="session-edit-name"
+            style={{ display: 'block', marginBottom: 'var(--space-1)' }}
+          >
+            {getMessage('sessionEditorNameLabel')}
+          </Text>
+          <TextFieldWithCategory
+            id="session-edit-name"
+            data-testid="dialog-session-edit-field-name"
+            value={editor.editedSession.name}
+            onChange={(nextValue) => {
+              editor.updateSessionName(nextValue);
+              setSaveNameError(null);
+            }}
+            aria-label={getMessage('sessionEditorNameLabel')}
+            categoryId={categoryId as any}
+            onCategoryChange={setCategoryId}
           />
-
-          {/* Note */}
-          <Box mt="3">
-            <Text
-              as="label"
-              size="2"
-              weight="medium"
-              htmlFor="session-edit-note"
-              style={{ display: 'block', marginBottom: 'var(--space-1)' }}
-            >
-              {getMessage('sessionNoteLabel')}
+          {saveNameError && (
+            <Text size="1" color="red" style={{ marginTop: 2 }}>
+              {saveNameError}
             </Text>
-            <TextArea
-              id="session-edit-note"
-              value={editor.editedSession.note ?? ''}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                editor.updateSessionNote(e.target.value)
-              }
-              placeholder={getMessage('sessionNotePlaceholder')}
-              resize="vertical"
-              rows={3}
-            />
-          </Box>
+          )}
+        </Box>
 
-          {/* Summary */}
-          <Box mt="3">
-            <Text size="1" color="gray">
-              {getPluralMessage(tabCount, 'sessionTabOne', 'sessionTabCount')}
-              {' · '}
-              {getPluralMessage(groupCount, 'sessionGroupOne', 'sessionGroupCount')}
-            </Text>
-          </Box>
+        <Separator size="4" mb="3" />
 
-          {/* Footer buttons */}
-          <Flex gap="2" justify="end" mt="4">
-            <Button
-              data-testid="dialog-session-edit-btn-cancel"
-              variant="soft"
-              color="gray"
-              onClick={handleCancel}
-              disabled={isSaving}
-            >
-              {getMessage('cancel')}
-            </Button>
-            <Button data-testid="dialog-session-edit-btn-save" onClick={handleSave} disabled={isSaving}>
-              {isSaving ? getMessage('loadingText') : getMessage('save')}
-            </Button>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
+        {/* Editable tab tree */}
+        <TabTreeEditor
+          session={editor.editedSession}
+          onSessionChange={editor.applySessionUpdate}
+          maxHeight={360}
+        />
+
+        {/* Note */}
+        <Box mt="3">
+          <Text
+            as="label"
+            size="2"
+            weight="medium"
+            htmlFor="session-edit-note"
+            style={{ display: 'block', marginBottom: 'var(--space-1)' }}
+          >
+            {getMessage('sessionNoteLabel')}
+          </Text>
+          <TextArea
+            id="session-edit-note"
+            value={editor.editedSession.note ?? ''}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              editor.updateSessionNote(e.target.value)
+            }
+            placeholder={getMessage('sessionNotePlaceholder')}
+            resize="vertical"
+            rows={3}
+          />
+        </Box>
+
+        {/* Summary */}
+        <Box mt="3">
+          <Text size="1" color="gray">
+            {getPluralMessage(tabCount, 'sessionTabOne', 'sessionTabCount')}
+            {' · '}
+            {getPluralMessage(groupCount, 'sessionGroupOne', 'sessionGroupCount')}
+          </Text>
+        </Box>
+
+        {/* Footer buttons */}
+        <Flex gap="2" justify="end" mt="4">
+          <Button
+            data-testid="dialog-session-edit-btn-cancel"
+            variant="soft"
+            color="gray"
+            onClick={handleCancel}
+            disabled={isSaving}
+          >
+            {getMessage('cancel')}
+          </Button>
+          <Button data-testid="dialog-session-edit-btn-save" onClick={handleSave} disabled={isSaving}>
+            {isSaving ? getMessage('loadingText') : getMessage('save')}
+          </Button>
+        </Flex>
+      </DialogShell>
 
       {/* Unsaved changes confirmation */}
       <AlertDialog.Root open={showUnsavedAlert} onOpenChange={setShowUnsavedAlert}>

--- a/src/components/UI/DialogShell/DialogShell.tsx
+++ b/src/components/UI/DialogShell/DialogShell.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Dialog, Flex, IconButton, Separator } from '@radix-ui/themes';
+import { X, type LucideIcon } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+
+type DialogContentProps = React.ComponentProps<typeof Dialog.Content>;
+
+interface DialogShellProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  icon?: LucideIcon;
+  description?: string;
+  /** When true, render description for screen readers only. */
+  hideDescription?: boolean;
+  children: React.ReactNode;
+
+  maxWidth?: number | string;
+  minHeight?: number | string;
+  maxHeight?: number | string;
+  /** Extra styles merged into Dialog.Content. Sizing props above take precedence. */
+  contentStyle?: React.CSSProperties;
+
+  /** Blocks outside click and pointer-down-outside from closing the dialog. */
+  preventOutsideClose?: boolean;
+  onInteractOutside?: DialogContentProps['onInteractOutside'];
+  onEscapeKeyDown?: DialogContentProps['onEscapeKeyDown'];
+  onPointerDownOutside?: DialogContentProps['onPointerDownOutside'];
+  onOpenAutoFocus?: DialogContentProps['onOpenAutoFocus'];
+
+  /** Render a separator below the header. Default true. */
+  showHeaderSeparator?: boolean;
+  'data-testid'?: string;
+}
+
+const closeButtonStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 16,
+  right: 16,
+};
+
+export function DialogShell({
+  open,
+  onOpenChange,
+  title,
+  icon: Icon,
+  description,
+  hideDescription = false,
+  children,
+  maxWidth,
+  minHeight,
+  maxHeight,
+  contentStyle,
+  preventOutsideClose = false,
+  onInteractOutside,
+  onEscapeKeyDown,
+  onPointerDownOutside,
+  onOpenAutoFocus,
+  showHeaderSeparator = true,
+  'data-testid': dataTestId,
+}: DialogShellProps) {
+  const mergedStyle: React.CSSProperties = {
+    ...contentStyle,
+    ...(maxWidth !== undefined ? { maxWidth } : null),
+    ...(minHeight !== undefined ? { minHeight } : null),
+    ...(maxHeight !== undefined ? { maxHeight } : null),
+  };
+
+  const resolvedInteractOutside =
+    onInteractOutside ?? (preventOutsideClose ? (event) => event.preventDefault() : undefined);
+  const resolvedPointerDownOutside =
+    onPointerDownOutside ?? (preventOutsideClose ? (event) => event.preventDefault() : undefined);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content
+        data-testid={dataTestId}
+        style={mergedStyle}
+        onInteractOutside={resolvedInteractOutside}
+        onPointerDownOutside={resolvedPointerDownOutside}
+        onEscapeKeyDown={onEscapeKeyDown}
+        onOpenAutoFocus={onOpenAutoFocus}
+      >
+        <div style={{ flexShrink: 0 }}>
+          <Dialog.Title>
+            <Flex align="center" gap="2">
+              {Icon && <Icon size={18} aria-hidden="true" />}
+              {title}
+            </Flex>
+          </Dialog.Title>
+          {description !== undefined && (
+            <Dialog.Description
+              size="2"
+              color="gray"
+              style={hideDescription ? { display: 'none' } : undefined}
+            >
+              {description}
+            </Dialog.Description>
+          )}
+          {showHeaderSeparator && <Separator size="4" mt="3" style={{ opacity: 0.3 }} />}
+        </div>
+
+        <Dialog.Close>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            aria-label={getMessage('close')}
+            title={getMessage('close')}
+            style={closeButtonStyle}
+          >
+            <X size={16} aria-hidden="true" />
+          </IconButton>
+        </Dialog.Close>
+
+        {children}
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/components/UI/DialogShell/index.ts
+++ b/src/components/UI/DialogShell/index.ts
@@ -1,0 +1,1 @@
+export { DialogShell } from './DialogShell';

--- a/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
@@ -84,13 +84,13 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
 
   return (
     <SessionsTheme>
-      <WizardModal open={open} onOpenChange={onOpenChange}>
-        <WizardModal.Header
-          icon={FileDown}
-          title={getMessage('exportSessionsTitle')}
-          description={getMessage('exportSessionsDescription')}
-        />
-
+      <WizardModal
+        open={open}
+        onOpenChange={onOpenChange}
+        icon={FileDown}
+        title={getMessage('exportSessionsTitle')}
+        description={getMessage('exportSessionsDescription')}
+      >
         <WizardModal.Body>
           <Box>
             <ExportNoteField value={exportNote} onChange={setExportNote} />

--- a/src/components/UI/ImportExportWizards/ExportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizard.tsx
@@ -56,13 +56,13 @@ export function ExportWizard({ open, onOpenChange, rules }: ExportWizardProps) {
 
   return (
     <ExportTheme>
-      <WizardModal open={open} onOpenChange={onOpenChange}>
-        <WizardModal.Header
-          icon={FileDown}
-          title={getMessage('exportRulesTitle')}
-          description={getMessage('exportRulesDescription')}
-        />
-
+      <WizardModal
+        open={open}
+        onOpenChange={onOpenChange}
+        icon={FileDown}
+        title={getMessage('exportRulesTitle')}
+        description={getMessage('exportRulesDescription')}
+      >
         <WizardModal.Body>
           <Box>
             <ExportNoteField value={exportNote} onChange={setExportNote} />

--- a/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
@@ -132,13 +132,13 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
   return (
     <SessionsTheme>
-      <WizardModal open={open} onOpenChange={onOpenChange}>
-        <WizardModal.Header
-          icon={Upload}
-          title={getMessage('importSessionsTitle')}
-          description={getMessage(STEP_DESCRIPTION_KEYS[step])}
-        />
-
+      <WizardModal
+        open={open}
+        onOpenChange={onOpenChange}
+        icon={Upload}
+        title={getMessage('importSessionsTitle')}
+        description={getMessage(STEP_DESCRIPTION_KEYS[step])}
+      >
         <WizardModal.Body>
           {step === 0 && (
             <SourceStep

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -114,13 +114,13 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
 
   return (
     <ImportTheme>
-      <WizardModal open={open} onOpenChange={onOpenChange}>
-        <WizardModal.Header
-          icon={FileUp}
-          title={getMessage('importRulesTitle')}
-          description={getMessage(STEP_DESCRIPTION_KEYS[step])}
-        />
-
+      <WizardModal
+        open={open}
+        onOpenChange={onOpenChange}
+        icon={FileUp}
+        title={getMessage('importRulesTitle')}
+        description={getMessage(STEP_DESCRIPTION_KEYS[step])}
+      >
         <WizardModal.Body>
           {step === 0 && (
             <SourceStep

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -195,13 +195,10 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
         open={open}
         onOpenChange={onOpenChange}
         data-testid="wizard-restore"
+        icon={RotateCcw}
+        title={getMessage('restoreTitle', [session.name])}
+        description={getMessage(STEP_DESCRIPTION_KEYS[step])}
       >
-        <WizardModal.Header
-          icon={RotateCcw}
-          title={getMessage('restoreTitle', [session.name])}
-          description={getMessage(STEP_DESCRIPTION_KEYS[step])}
-        />
-
         <WizardModal.Body>
           {step === 0 && (
             <Box data-testid="wizard-restore-step-0">

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -135,18 +135,15 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
         open={open}
         onOpenChange={onOpenChange}
         data-testid="wizard-snapshot"
+        icon={Camera}
+        title={getMessage('snapshotTitle')}
+        description={getMessage('snapshotDescription')}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[aria-label]');
           input?.focus();
         }}
       >
-        <WizardModal.Header
-          icon={Camera}
-          title={getMessage('snapshotTitle')}
-          description={getMessage('snapshotDescription')}
-        />
-
         <WizardModal.Body>
           <Flex direction="column" gap="3">
             <Flex direction="column" gap="1">

--- a/src/components/UI/WizardModal/WizardModal.stories.tsx
+++ b/src/components/UI/WizardModal/WizardModal.stories.tsx
@@ -26,12 +26,13 @@ type Story = StoryObj<typeof meta>;
 function MinimalDemo() {
   const [open, setOpen] = useState(true);
   return (
-    <WizardModal open={open} onOpenChange={setOpen}>
-      <WizardModal.Header
-        icon={FileUp}
-        title="Import data"
-        description="Paste your JSON or import a file to get started."
-      />
+    <WizardModal
+      open={open}
+      onOpenChange={setOpen}
+      icon={FileUp}
+      title="Import data"
+      description="Paste your JSON or import a file to get started."
+    >
       <WizardModal.Body>
         <Text size="2">Body content goes here.</Text>
       </WizardModal.Body>
@@ -61,12 +62,13 @@ function SteppedDemo() {
     { label: 'Summary' },
   ];
   return (
-    <WizardModal open={open} onOpenChange={setOpen}>
-      <WizardModal.Header
-        icon={Plus}
-        title="Create rule"
-        description={descriptions[step]}
-      />
+    <WizardModal
+      open={open}
+      onOpenChange={setOpen}
+      icon={Plus}
+      title="Create rule"
+      description={descriptions[step]}
+    >
       <WizardStepper steps={labels} currentStep={step} disableFutureNavigation />
       <WizardModal.Body>
         <Flex direction="column" gap="2">

--- a/src/components/UI/WizardModal/WizardModal.tsx
+++ b/src/components/UI/WizardModal/WizardModal.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
-import { Dialog, Flex, Separator } from '@radix-ui/themes';
+import { Flex, Separator } from '@radix-ui/themes';
 import type { LucideIcon } from 'lucide-react';
+import { DialogShell } from '@/components/UI/DialogShell';
 
 interface WizardModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  title: string;
+  icon?: LucideIcon;
+  description?: string;
+  /** When true, render description for screen readers only. */
+  hideDescription?: boolean;
   children: React.ReactNode;
   'data-testid'?: string;
   /** Forwarded to Dialog.Content (e.g. to pre-focus an input on open). */
-  onOpenAutoFocus?: (event: Event) => void;
+  onOpenAutoFocus?: React.ComponentProps<typeof DialogShell>['onOpenAutoFocus'];
 }
 
-const contentStyle: React.CSSProperties = {
-  maxWidth: 600,
-  minHeight: 'min(480px, 80vh)',
-  maxHeight: '80vh',
+const wizardContentStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
@@ -24,53 +27,32 @@ const contentStyle: React.CSSProperties = {
 function WizardModalRoot({
   open,
   onOpenChange,
+  title,
+  icon,
+  description,
+  hideDescription,
   children,
   'data-testid': dataTestId,
   onOpenAutoFocus,
 }: WizardModalProps) {
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content
-        data-testid={dataTestId}
-        style={contentStyle}
-        onOpenAutoFocus={onOpenAutoFocus}
-        onPointerDownOutside={(e) => e.preventDefault()}
-        onInteractOutside={(e) => e.preventDefault()}
-      >
-        {children}
-      </Dialog.Content>
-    </Dialog.Root>
-  );
-}
-
-interface HeaderProps {
-  icon?: LucideIcon;
-  title: string;
-  description?: string;
-  /** When provided, the description is rendered but visually hidden (accessibility only). */
-  hideDescription?: boolean;
-}
-
-function Header({ icon: Icon, title, description, hideDescription = false }: HeaderProps) {
-  return (
-    <div style={{ flexShrink: 0 }}>
-      <Dialog.Title>
-        <Flex align="center" gap="2">
-          {Icon && <Icon size={18} aria-hidden="true" />}
-          {title}
-        </Flex>
-      </Dialog.Title>
-      {description !== undefined && (
-        <Dialog.Description
-          size="2"
-          color="gray"
-          style={hideDescription ? { display: 'none' } : undefined}
-        >
-          {description}
-        </Dialog.Description>
-      )}
-      <Separator size="4" mt="3" style={{ opacity: 0.3 }} />
-    </div>
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      icon={icon}
+      description={description}
+      hideDescription={hideDescription}
+      data-testid={dataTestId}
+      onOpenAutoFocus={onOpenAutoFocus}
+      preventOutsideClose
+      maxWidth={600}
+      minHeight="min(480px, 80vh)"
+      maxHeight="80vh"
+      contentStyle={wizardContentStyle}
+    >
+      {children}
+    </DialogShell>
   );
 }
 
@@ -110,7 +92,6 @@ function Footer({ children }: FooterProps) {
 }
 
 export const WizardModal = Object.assign(WizardModalRoot, {
-  Header,
   Body,
   Footer,
 });


### PR DESCRIPTION
## Summary
This PR introduces a new `DialogShell` component that encapsulates common dialog header patterns (title, icon, description, close button) and applies it across multiple dialog-based components in the codebase. This reduces code duplication and ensures consistent dialog styling and behavior.

## Key Changes

- **New `DialogShell` component** (`src/components/UI/DialogShell/DialogShell.tsx`):
  - Wraps `Dialog.Root` and `Dialog.Content` with standardized header layout
  - Accepts `title`, `icon`, `description`, and `hideDescription` props
  - Includes built-in close button with proper positioning and accessibility
  - Supports customizable sizing (`maxWidth`, `minHeight`, `maxHeight`)
  - Provides `preventOutsideClose` option to block outside interactions
  - Renders optional header separator with configurable visibility

- **Updated `SessionEditDialog`**:
  - Replaced manual `Dialog.Root`/`Dialog.Content` with `DialogShell`
  - Removed manual header construction (title, icon, close button)
  - Simplified component structure by ~20 lines

- **Updated `ConfigEditModal`**:
  - Replaced `Dialog` implementation with `DialogShell`
  - Removed manual close button and header elements
  - Cleaner, more declarative API

- **Refactored `WizardModal`**:
  - Replaced internal `Dialog.Root`/`Dialog.Content` with `DialogShell`
  - Moved `Header` component logic into `DialogShell` props
  - Removed `WizardModal.Header` export (header now configured via root props)
  - Updated all wizard implementations to pass `title`, `icon`, `description` to root component

- **Updated all wizard consumers**:
  - `RuleWizardModal`, `ExportSessionsWizard`, `ExportWizard`, `ImportSessionsWizard`, `ImportWizard`, `RestoreWizard`, `SnapshotWizard`
  - Changed from `<WizardModal.Header ... />` child component to props on `<WizardModal ... />`
  - Removed manual close button implementations

## Implementation Details

- `DialogShell` handles all common dialog header concerns: icon rendering, title display, optional description, and close button positioning
- The component supports both preventing outside interactions (`preventOutsideClose`) and custom handlers (`onInteractOutside`, `onEscapeKeyDown`)
- Header separator opacity is reduced (0.3) for subtle visual separation
- All sizing and styling props are merged with proper precedence
- Maintains full accessibility with proper ARIA labels and semantic HTML

https://claude.ai/code/session_011imKSRmWNBz22g58DH42BR