### PR TITLE
Extract SessionRestoreButton component and add restore deep-linking

### DIFF
--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -8,7 +8,7 @@ import {
 import {
   MoreHorizontal, Pencil, Trash2, Check, X,
   Pin, PinOff, ChevronDown, ChevronRight,
-  Monitor, Square, Wrench, GripVertical,
+  GripVertical,
 } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { countSessionTabs, formatSessionDate } from '@/utils/sessionUtils';
@@ -17,6 +17,7 @@ import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { getRuleCategory } from '@/schemas/enums';
 import { getRadixColor } from '@/utils/utils';
 import { SessionPreviewTree } from './SessionPreviewTree';
+import { SessionRestoreButton } from './SessionRestoreButton/SessionRestoreButton';
 import type { Session } from '@/types/session';
 
 interface SessionCardProps {
@@ -310,6 +311,17 @@ export function SessionCard({
             )}
           </Flex>
 
+          {/* Restore split button */}
+          {!isRenaming && (
+            <SessionRestoreButton
+              session={session}
+              onRestoreCurrentWindow={onRestoreCurrentWindow}
+              onRestoreNewWindow={onRestoreNewWindow}
+              onCustomize={onRestore}
+              data-testid={`session-card-${session.id}-btn-restore`}
+            />
+          )}
+
           {/* More menu */}
           {!isRenaming && (
             <DropdownMenu.Root>
@@ -330,7 +342,7 @@ export function SessionCard({
                   {getMessage('sessionEdit')}
                 </DropdownMenu.Item>
 
-                <DropdownMenu.Separator />
+                {(onMoveToFirst || onMoveLast) && <DropdownMenu.Separator />}
 
                 {onMoveToFirst && (
                   <DropdownMenu.Item onClick={onMoveToFirst} disabled={isDragDisabled}>
@@ -342,21 +354,6 @@ export function SessionCard({
                     {getMessage('sessionMoveLast')}
                   </DropdownMenu.Item>
                 )}
-
-                <DropdownMenu.Separator />
-
-                <DropdownMenu.Item onClick={() => onRestoreCurrentWindow(session)}>
-                  <Monitor size={14} aria-hidden="true" />
-                  {getMessage('sessionRestoreCurrentWindow')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item onClick={() => onRestoreNewWindow(session)}>
-                  <Square size={14} aria-hidden="true" />
-                  {getMessage('sessionRestoreNewWindow')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item onClick={() => onRestore(session)}>
-                  <Wrench size={14} aria-hidden="true" />
-                  {getMessage('sessionRestoreCustomize')}
-                </DropdownMenu.Item>
 
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item color="red" onClick={() => onDelete(session)}>

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.stories.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Theme } from '@radix-ui/themes';
+import { SessionRestoreButton } from './SessionRestoreButton';
+import type { Session } from '@/types/session';
+
+const baseSession: Session = {
+  id: 'session-1',
+  name: 'Work Sprint',
+  createdAt: '2025-03-20T09:00:00.000Z',
+  updatedAt: '2025-03-28T17:30:00.000Z',
+  isPinned: false,
+  categoryId: null,
+  groups: [],
+  ungroupedTabs: [],
+};
+
+const noop = () => {};
+
+const meta: Meta<typeof SessionRestoreButton> = {
+  title: 'Components/Core/Session/SessionRestoreButton',
+  component: SessionRestoreButton,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <Theme>
+        <Box style={{ padding: 16 }}>
+          <Story />
+        </Box>
+      </Theme>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SessionRestoreButtonDefault: Story = {
+  args: {
+    session: baseSession,
+    onRestoreCurrentWindow: noop,
+    onRestoreNewWindow: noop,
+    onCustomize: noop,
+  },
+};
+
+export const SessionRestoreButtonSolid: Story = {
+  args: {
+    ...SessionRestoreButtonDefault.args,
+    variant: 'solid',
+  },
+};
+
+export const SessionRestoreButtonOutline: Story = {
+  args: {
+    ...SessionRestoreButtonDefault.args,
+    variant: 'outline',
+  },
+};

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Monitor, Play, Square, Wrench } from 'lucide-react';
+import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
+import { getMessage } from '@/utils/i18n';
+import type { Session } from '@/types/session';
+
+export interface SessionRestoreButtonProps {
+  session: Session;
+  onRestoreCurrentWindow: (session: Session) => void;
+  onRestoreNewWindow: (session: Session) => void;
+  onCustomize: (session: Session) => void;
+  size?: '1' | '2' | '3';
+  variant?: 'solid' | 'soft' | 'outline';
+  'data-testid'?: string;
+}
+
+export function SessionRestoreButton({
+  session,
+  onRestoreCurrentWindow,
+  onRestoreNewWindow,
+  onCustomize,
+  size = '1',
+  variant = 'soft',
+  'data-testid': testId,
+}: SessionRestoreButtonProps) {
+  return (
+    <SplitButton
+      data-testid={testId}
+      label={<Play size={12} aria-hidden="true" fill="currentColor" />}
+      primaryAriaLabel={getMessage('sessionRestoreCurrentWindow')}
+      onClick={() => onRestoreCurrentWindow(session)}
+      size={size}
+      variant={variant}
+      menuItems={[
+        {
+          label: getMessage('sessionRestoreCurrentWindow'),
+          icon: <Monitor size={14} aria-hidden="true" />,
+          onClick: () => onRestoreCurrentWindow(session),
+        },
+        {
+          label: getMessage('sessionRestoreNewWindow'),
+          icon: <Square size={14} aria-hidden="true" />,
+          onClick: () => onRestoreNewWindow(session),
+        },
+        {
+          label: getMessage('sessionRestoreCustomize'),
+          icon: <Wrench size={14} aria-hidden="true" />,
+          onClick: () => onCustomize(session),
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Box, Button, Card, Flex, Text } from '@radix-ui/themes';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { browser } from 'wxt/browser';
-import { ChevronDown, ExternalLink, Pin, Play } from 'lucide-react';
-import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
+import { ChevronDown, ExternalLink, Pin } from 'lucide-react';
+import { SessionRestoreButton } from '@/components/Core/Session/SessionRestoreButton/SessionRestoreButton';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
 import { restoreSessionTabs } from '@/utils/tabRestore';
@@ -54,8 +54,8 @@ function getCategoryIcon(categoryId: string | null | undefined): React.ReactNode
   );
 }
 
-async function openSessionsPage() {
-  const url = browser.runtime.getURL('/options.html') + '#sessions';
+async function openSessionsPage(hashSuffix = '') {
+  const url = browser.runtime.getURL('/options.html') + '#sessions' + hashSuffix;
   const tabs = await browser.tabs.query({ url: browser.runtime.getURL('/options.html') });
   if (tabs.length > 0 && tabs[0].id != null) {
     await browser.tabs.update(tabs[0].id, { active: true, url });
@@ -66,6 +66,10 @@ async function openSessionsPage() {
     await browser.tabs.create({ url });
   }
   window.close();
+}
+
+async function openCustomizeRestore(session: Session) {
+  await openSessionsPage(`?action=restore&sessionId=${encodeURIComponent(session.id)}`);
 }
 
 export function PopupProfilesList() {
@@ -189,22 +193,12 @@ export function PopupProfilesList() {
               >
                 {session.name}
               </Text>
-              <SplitButton
-                label={<Play size={12} aria-hidden="true" fill="currentColor" />}
-                primaryAriaLabel={getMessage('sessionRestoreCurrentWindow')}
-                onClick={() => handleRestore(session, 'current')}
-                size="1"
-                variant="soft"
-                menuItems={[
-                  {
-                    label: getMessage('sessionRestoreCurrentWindow'),
-                    onClick: () => handleRestore(session, 'current'),
-                  },
-                  {
-                    label: getMessage('sessionRestoreNewWindow'),
-                    onClick: () => handleRestore(session, 'new'),
-                  },
-                ]}
+              <SessionRestoreButton
+                session={session}
+                onRestoreCurrentWindow={(s) => handleRestore(s, 'current')}
+                onRestoreNewWindow={(s) => handleRestore(s, 'new')}
+                onCustomize={(s) => { void openCustomizeRestore(s); }}
+                data-testid={`popup-profile-btn-restore-${session.id}`}
               />
             </Flex>
           </Card>

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -4,6 +4,7 @@ interface DeepLinkState {
   currentTab: string;
   openSnapshotWizard: boolean;
   snapshotGroupId: number | null;
+  restoreSessionId: string | null;
 }
 
 const VALID_SECTIONS = ['rules', 'importexport', 'sessions', 'stats', 'settings'] as const;
@@ -16,10 +17,12 @@ export function useDeepLinking(): DeepLinkState & {
   setCurrentTab: (tab: string) => void;
   setOpenSnapshotWizard: (open: boolean) => void;
   setSnapshotGroupId: (id: number | null) => void;
+  setRestoreSessionId: (id: string | null) => void;
 } {
   const [currentTab, setCurrentTab] = useState<string>('rules');
   const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
   const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
+  const [restoreSessionId, setRestoreSessionId] = useState<string | null>(null);
 
   useEffect(() => {
     function handleHash() {
@@ -31,10 +34,14 @@ export function useDeepLinking(): DeepLinkState & {
       setCurrentTab(section);
       if (section === 'sessions' && questionMark !== -1) {
         const params = new URLSearchParams(hash.slice(questionMark + 1));
-        if (params.get('action') === 'snapshot') {
+        const action = params.get('action');
+        if (action === 'snapshot') {
           setOpenSnapshotWizard(true);
           const groupIdParam = params.get('groupId');
           setSnapshotGroupId(groupIdParam ? parseInt(groupIdParam, 10) : null);
+        } else if (action === 'restore') {
+          const sid = params.get('sessionId');
+          if (sid) setRestoreSessionId(sid);
         }
       }
     }
@@ -51,5 +58,7 @@ export function useDeepLinking(): DeepLinkState & {
     setOpenSnapshotWizard,
     snapshotGroupId,
     setSnapshotGroupId,
+    restoreSessionId,
+    setRestoreSessionId,
   };
 }

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -34,6 +34,10 @@ interface SessionsPageProps {
   snapshotGroupId?: number | null;
   /** Called when the snapshot wizard closes to reset the group context. */
   onSnapshotGroupIdChange?: (id: number | null) => void;
+  /** Session id for which a deep-link requests the restore wizard to open. */
+  restoreSessionId?: string | null;
+  /** Called to clear the restore deep-link once consumed. */
+  onRestoreSessionIdChange?: (id: string | null) => void;
 }
 
 function SectionHeader({ icon: Icon, titleKey, count }: { icon: LucideIcon; titleKey: string; count: number }) {
@@ -240,6 +244,8 @@ export function SessionsPage({
   onSnapshotWizardOpenChange,
   snapshotGroupId,
   onSnapshotGroupIdChange,
+  restoreSessionId,
+  onRestoreSessionIdChange,
 }: SessionsPageProps) {
   const { sessions, isLoaded, createSession, renameSession, removeSession, reload, updateOrder } = useSessions();
   // Internal open state; initialized from external prop so the wizard opens immediately on mount.
@@ -263,6 +269,17 @@ export function SessionsPage({
   const [deleteTarget, setDeleteTarget] = useState<Session | null>(null);
   const [quickRestoreMessage, setQuickRestoreMessage] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+
+  // Deep-link: open the RestoreWizard when a sessionId has been provided via
+  // URL hash (e.g. from the popup's customize restore action).
+  useEffect(() => {
+    if (!restoreSessionId || !isLoaded) return;
+    const found = sessions.find((s) => s.id === restoreSessionId);
+    if (found) {
+      setRestoreSession(found);
+      onRestoreSessionIdChange?.(null);
+    }
+  }, [restoreSessionId, isLoaded, sessions, onRestoreSessionIdChange]);
 
   // Order: use storage order directly (reorderSessions saves them in the correct order)
   const sortedSessions = sessions;

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -36,6 +36,7 @@ function OptionsContent() {
         currentTab, setCurrentTab,
         openSnapshotWizard, setOpenSnapshotWizard,
         snapshotGroupId, setSnapshotGroupId,
+        restoreSessionId, setRestoreSessionId,
     } = useDeepLinking();
 
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
@@ -98,6 +99,8 @@ function OptionsContent() {
                             onSnapshotWizardOpenChange={setOpenSnapshotWizard}
                             snapshotGroupId={snapshotGroupId}
                             onSnapshotGroupIdChange={setSnapshotGroupId}
+                            restoreSessionId={restoreSessionId}
+                            onRestoreSessionIdChange={setRestoreSessionId}
                         />
                     )}
                     {currentTab === 'stats' && (

--- a/tests/components/PopupProfilesList.test.tsx
+++ b/tests/components/PopupProfilesList.test.tsx
@@ -10,6 +10,8 @@ vi.mock('../../src/utils/i18n', () => ({
       popupPinnedSessionsLabel: 'Pinned sessions',
       sessionRestoreCurrentWindow: 'Restore in current window',
       sessionRestoreNewWindow: 'Restore in new window',
+      sessionRestoreCustomize: 'Customized restoration',
+      sessionRestoreOptions: 'Restore options',
       popupPinnedEmptyHint: 'Pin a session for one-click access from here.',
       popupGoToSessions: 'Manage sessions',
       popupPinnedEmptyToggleAria: 'Toggle pinned sessions hint',
@@ -264,6 +266,37 @@ describe('PopupProfilesList', () => {
     await waitFor(() => {
       expect(mockSetValue).toHaveBeenCalledWith(true);
     });
+  });
+
+  it('renders a SessionRestoreButton (split button) on each pinned session', async () => {
+    const sessions: Session[] = [
+      {
+        id: 'p-restore',
+        isPinned: true,
+        updatedAt: '2026-04-10T00:00:00Z',
+        name: 'Restorable Profile',
+        createdAt: '2026-04-10T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+    ];
+
+    mockLoadSessions.mockResolvedValue(sessions);
+
+    render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Restorable Profile')).toBeInTheDocument();
+    });
+
+    // Primary restore button (left half of the split button)
+    expect(screen.getByRole('button', { name: /Restore in current window/i })).toBeInTheDocument();
+    // Chevron dropdown trigger (right half) — exposes the 3 options (asserted in e2e)
+    expect(screen.getByRole('button', { name: /Restore options/i })).toBeInTheDocument();
   });
 
   it('should display pinned sessions label when pinned sessions exist', async () => {

--- a/tests/components/SessionRestoreButton.test.tsx
+++ b/tests/components/SessionRestoreButton.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { Session } from '../../src/types/session';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => {
+    const messages: Record<string, string> = {
+      sessionRestoreCurrentWindow: 'Restore in current window',
+      sessionRestoreNewWindow: 'Restore in new window',
+      sessionRestoreCustomize: 'Customized restoration',
+      sessionRestoreOptions: 'Restore options',
+    };
+    return messages[key] || key;
+  }),
+}));
+
+import { SessionRestoreButton } from '../../src/components/Core/Session/SessionRestoreButton/SessionRestoreButton';
+
+const session: Session = {
+  id: 's-1',
+  name: 'Sample',
+  createdAt: '2025-03-20T09:00:00.000Z',
+  updatedAt: '2025-03-28T17:30:00.000Z',
+  isPinned: false,
+  categoryId: null,
+  groups: [],
+  ungroupedTabs: [],
+};
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <Theme>{children}</Theme>
+);
+
+// Radix DropdownMenu does not open with fireEvent.click under happy-dom; the
+// menu item behavior (3 options, customize callback, etc.) is covered by the
+// Playwright E2E specs in tests/e2e/sessions.spec.ts and tests/e2e/popup.spec.ts.
+describe('SessionRestoreButton', () => {
+  let onRestoreCurrentWindow: ReturnType<typeof vi.fn>;
+  let onRestoreNewWindow: ReturnType<typeof vi.fn>;
+  let onCustomize: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onRestoreCurrentWindow = vi.fn();
+    onRestoreNewWindow = vi.fn();
+    onCustomize = vi.fn();
+  });
+
+  it('primary click calls onRestoreCurrentWindow with the session', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onCustomize={onCustomize}
+          data-testid="restore-btn"
+        />
+      </TestWrapper>,
+    );
+
+    const primary = screen.getByRole('button', { name: /Restore in current window/i });
+    fireEvent.click(primary);
+
+    expect(onRestoreCurrentWindow).toHaveBeenCalledWith(session);
+    expect(onRestoreNewWindow).not.toHaveBeenCalled();
+    expect(onCustomize).not.toHaveBeenCalled();
+  });
+
+  it('renders the dropdown trigger with the expected aria-label', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onCustomize={onCustomize}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole('button', { name: /Restore options/i })).toBeInTheDocument();
+  });
+});

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -163,7 +163,7 @@ test.describe('[US-PO02] Pinned sessions list', () => {
     await page.close();
   });
 
-  test('pinned session row dropdown offers current window and new window options', async ({
+  test('pinned session row dropdown offers current window, new window and customized restoration', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -177,6 +177,7 @@ test.describe('[US-PO02] Pinned sessions list', () => {
 
     await expect(page.getByRole('menuitem', { name: /current window/i })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: /new window/i })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: /customized restoration/i })).toBeVisible();
     await page.close();
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -383,14 +383,14 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     await page.close();
   });
 
-  test('More actions menu contains quick restore options [US-S011]', async ({ extensionContext, extensionId }) => {
+  test('Restore split button exposes the 3 restore options [US-S011]', async ({ extensionContext, extensionId }) => {
     const session = createTestSession({ name: 'Restorable' });
     await seedSessions(extensionContext, [session]);
 
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
 
     await expect(page.getByRole('menuitem', { name: /current window/i })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: /new window/i })).toBeVisible();
@@ -408,7 +408,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /current window/i }).click();
 
     await expect(page.getByText(/tab.*opened/i)).toBeVisible({ timeout: 5000 });
@@ -422,7 +422,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /customized restoration/i }).click();
 
     await expect(page.getByRole('dialog')).toBeVisible();
@@ -440,7 +440,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
 
     const pagesBefore = extensionContext.pages().length;
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /new window/i }).click();
 
     // Session has 3 tabs — at least one new page should be created
@@ -464,7 +464,7 @@ test.describe('[US-S04] Restore in current window', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /customized restoration/i }).click();
 
     const dialog = page.getByRole('dialog');
@@ -487,7 +487,7 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /customized restoration/i }).click();
 
     const dialog = page.getByRole('dialog');
@@ -511,7 +511,7 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /customized restoration/i }).click();
 
     const dialog = page.getByRole('dialog');
@@ -538,7 +538,7 @@ test.describe('[US-S017] Restore with collapsed group state', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByRole('menuitem', { name: /current window/i }).click();
 
     // Restore should show success message

--- a/tests/hooks/useDeepLinking.test.ts
+++ b/tests/hooks/useDeepLinking.test.ts
@@ -127,6 +127,36 @@ describe('useDeepLinking — hashchange listener', () => {
   });
 });
 
+describe('useDeepLinking — restore deep link', () => {
+  it('exposes restoreSessionId when hash is #sessions?action=restore&sessionId=abc', () => {
+    window.location.hash = '#sessions?action=restore&sessionId=abc';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('sessions');
+    expect(result.current.restoreSessionId).toBe('abc');
+    expect(result.current.openSnapshotWizard).toBe(false);
+  });
+
+  it('does not set restoreSessionId when sessionId is missing', () => {
+    window.location.hash = '#sessions?action=restore';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.restoreSessionId).toBeNull();
+  });
+
+  it('reacts to a restore hashchange after mount', () => {
+    const { result } = renderHook(() => useDeepLinking());
+    act(() => setHash('#sessions?action=restore&sessionId=s-42'));
+    expect(result.current.restoreSessionId).toBe('s-42');
+  });
+
+  it('exposes setRestoreSessionId to clear the deep-link', () => {
+    window.location.hash = '#sessions?action=restore&sessionId=s-1';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.restoreSessionId).toBe('s-1');
+    act(() => result.current.setRestoreSessionId(null));
+    expect(result.current.restoreSessionId).toBeNull();
+  });
+});
+
 describe('useDeepLinking — setters', () => {
   it('exposes setCurrentTab to override the tab manually', () => {
     const { result } = renderHook(() => useDeepLinking());


### PR DESCRIPTION
## Summary
This PR extracts the session restore functionality into a dedicated `SessionRestoreButton` component and adds support for deep-linking to the restore wizard from the popup. The restore button is now a reusable split button that offers three restore options: current window, new window, and customized restoration.

## Key Changes

- **New `SessionRestoreButton` component**: Created a dedicated, reusable split button component (`src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx`) that encapsulates all session restore actions with three menu options (current window, new window, customized restoration).

- **Refactored `SessionCard`**: Moved restore options from the "More actions" dropdown menu into the new `SessionRestoreButton` component, simplifying the menu and improving UX by making restore actions more prominent.

- **Updated `PopupProfilesList`**: Replaced inline split button logic with the new `SessionRestoreButton` component and added support for opening the customize restore wizard via deep-linking.

- **Deep-linking support**: 
  - Extended `useDeepLinking` hook to parse and expose `restoreSessionId` from URL hash parameters (`#sessions?action=restore&sessionId=...`)
  - Updated `SessionsPage` to automatically open the restore wizard when a `restoreSessionId` is provided via deep-link
  - Modified `openSessionsPage` utility to accept hash suffixes for constructing deep-links

- **Test coverage**: Added comprehensive unit tests for `SessionRestoreButton` and updated existing tests to verify the new deep-linking functionality and component integration.

- **Storybook stories**: Added stories for `SessionRestoreButton` with different variants (solid, soft, outline).

## Implementation Details

- The `SessionRestoreButton` uses the existing `SplitButton` component with a play icon as the primary action (restore in current window) and a dropdown menu exposing all three restore options.
- The customize restore action now navigates to the sessions page with a deep-link that automatically opens the restore wizard for the selected session.
- E2E tests were updated to reflect the new UI structure (clicking the restore options dropdown instead of the "More actions" menu).

https://claude.ai/code/session_01HYXAGWP5QhgdVYt5UXKGPF