### PR TITLE
Fix react-hooks/exhaustive-deps ESLint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,11 +68,6 @@ const TODO_DISABLED_VITEST = {
   'vitest/no-conditional-expect': 'off',
 };
 
-const TODO_DISABLED_HOOKS = {
-  // TODO(eslint): 4 warnings à vérifier
-  'react-hooks/exhaustive-deps': 'off',
-};
-
 export default tseslint.config(
   {
     ignores: [
@@ -101,12 +96,12 @@ export default tseslint.config(
       // Interdit les imports remontants (../...) dans src/ : utiliser l'alias @/.
       // Auto-fixable avec `pnpm lint:fix`.
       'local/prefer-alias-imports': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
     },
   },
 
   {
     rules: {
-      ...TODO_DISABLED_HOOKS,
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_',

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -123,6 +123,7 @@ export function RuleWizardModal({
 
   const groupNameSource = watch('groupNameSource');
   const deduplicationEnabled = watch('deduplicationEnabled');
+  const watchedPresetId = watch('presetId');
 
   // Load presets when modal opens
   useEffect(() => {
@@ -136,12 +137,11 @@ export function RuleWizardModal({
 
   // Update preset name when presetId changes
   useEffect(() => {
-    const presetId = getValues('presetId');
-    if (!presetId) { setPresetName(null); return; }
-    getPresetById(presetId)
+    if (!watchedPresetId) { setPresetName(null); return; }
+    getPresetById(watchedPresetId)
       .then((p) => setPresetName(p?.name ?? null))
       .catch(() => setPresetName(null));
-  }, [watch('presetId')]);
+  }, [watchedPresetId]);
 
   // Reset form and wizard state when modal opens/rule changes
   useEffect(() => {

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -156,7 +156,7 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
     } finally {
       setIsRestoring(false);
     }
-  }, [session, getSelectedData, target]);
+  }, [session, getSelectedData, target, onOpenChange]);
 
   // Step 0 button: analyze conflicts (if current window), then restore or show conflict step
   const handleRestoreOrNext = useCallback(async () => {

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -85,7 +85,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
       .catch(() => {
         setIsCapturing(false);
       });
-  }, [open]);
+  }, [open, initialGroupId]);
 
   // Derive selected SavedTab UUIDs from selected numeric IDs
   const selectedSavedTabIds = useMemo(() => {
@@ -128,7 +128,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
     } finally {
       setIsSaving(false);
     }
-  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, note, onSave, existingSessions]);
+  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, note, onSave, onOpenChange, existingSessions]);
 
   return (
     <SessionsTheme>

--- a/src/hooks/useSyncedState.ts
+++ b/src/hooks/useSyncedState.ts
@@ -125,7 +125,7 @@ export function useSyncedState<T extends object>({
     loadRef.current()
       .then(v => { setValue(v); setIsLoaded(true); })
       .catch(error => logger.error('[useSyncedState] load error:', error));
-  }, []);
+  }, [setValue]);
 
   useEffect(() => {
     return setupWatchRef.current((update) => {

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -281,7 +281,7 @@ export function SessionsPage({
   // future mount doesn't re-open the wizard unexpectedly.
   useEffect(() => {
     return () => onSnapshotWizardOpenChange?.(false);
-  }, []);
+  }, [onSnapshotWizardOpenChange]);
 
   const [restoreSession, setRestoreSession] = useState<Session | null>(null);
   const [editTarget, setEditTarget] = useState<Session | null>(null);


### PR DESCRIPTION
## Summary
This PR addresses ESLint `react-hooks/exhaustive-deps` warnings by fixing missing dependencies in useEffect hooks throughout the codebase. The ESLint rule is now enabled as a warning (previously disabled) to catch these issues going forward.

## Key Changes

- **RuleWizardModal.tsx**: Fixed dependency issue by using `watch('presetId')` directly in the dependency array instead of calling `getValues()` inside the effect. Introduced `watchedPresetId` variable to properly track preset ID changes.

- **SnapshotWizard.tsx**: Added missing `initialGroupId` dependency to the effect that initializes the wizard state.

- **RestoreWizard.tsx**: Added missing `onOpenChange` callback dependency to the restore handler effect.

- **useSyncedState.ts**: Added missing `setValue` dependency to the initialization effect.

- **SessionsPage.tsx**: Added missing `onSnapshotWizardOpenChange` callback dependency to the cleanup effect.

- **eslint.config.js**: Enabled `react-hooks/exhaustive-deps` as a warning rule (changed from disabled) and removed the `TODO_DISABLED_HOOKS` configuration object.

## Implementation Details

The fixes follow React hooks best practices by ensuring all external values used within useEffect hooks are included in their dependency arrays. This prevents potential bugs from stale closures and ensures effects run when their dependencies actually change.

https://claude.ai/code/session_01PJCc2MMsuYSSSosYvfE1Vo