### PR TITLE
Fix Playwright hook ordering and remove ESLint rule overrides

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,12 +54,6 @@ const localPlugin = {
 };
 
 
-const TODO_DISABLED_PLAYWRIGHT = {
-  // TODO(eslint): 5 occurrences
-  'playwright/no-conditional-expect': 'off',
-  // TODO(eslint): 2 occurrences, réordonner les hooks
-  'playwright/prefer-hooks-in-order': 'off',
-};
 
 const TODO_DISABLED_VITEST = {
   // API inexistante dans vitest 2.x
@@ -134,9 +128,5 @@ export default tseslint.config(
   {
     files: ['tests/e2e/**/*.spec.ts', 'tests/e2e/helpers/**/*.ts'],
     ...playwright.configs['flat/recommended'],
-  },
-  {
-    files: ['tests/e2e/**/*.spec.ts', 'tests/e2e/helpers/**/*.ts'],
-    rules: TODO_DISABLED_PLAYWRIGHT,
   },
 );

--- a/tests/e2e/grouping.spec.ts
+++ b/tests/e2e/grouping.spec.ts
@@ -71,11 +71,6 @@ test.describe('Tab Grouping', () => {
     await new Promise<void>(resolve => localServer.listen(FAKE_PORT, resolve));
   });
 
-  test.afterAll(async () => {
-    localServer.closeAllConnections();
-    await new Promise<void>(resolve => localServer.close(() => resolve()));
-  });
-
   test.beforeEach(async ({ helpers }) => {
     // Clean up any tabs/groups left by the previous test before configuring state
     await helpers.closeAllTestTabs();
@@ -84,6 +79,11 @@ test.describe('Tab Grouping', () => {
     await helpers.setGlobalGroupingEnabled(true);
     await helpers.setGlobalDeduplicationEnabled(false);
     await helpers.resetStatistics();
+  });
+
+  test.afterAll(async () => {
+    localServer.closeAllConnections();
+    await new Promise<void>(resolve => localServer.close(() => resolve()));
   });
 
   // ── 1. Global Settings ────────────────────────────────────────────────────

--- a/tests/e2e/naming.spec.ts
+++ b/tests/e2e/naming.spec.ts
@@ -37,11 +37,6 @@ test.describe('Group Naming Modes', () => {
     await new Promise<void>(resolve => localServer.listen(FAKE_PORT, resolve));
   });
 
-  test.afterAll(async () => {
-    localServer.closeAllConnections();
-    await new Promise<void>(resolve => localServer.close(() => resolve()));
-  });
-
   test.beforeEach(async ({ helpers }) => {
     await helpers.closeAllTestTabs();
     await helpers.clearAllTabGroups();
@@ -49,6 +44,11 @@ test.describe('Group Naming Modes', () => {
     await helpers.setGlobalGroupingEnabled(true);
     await helpers.setGlobalDeduplicationEnabled(false);
     await helpers.resetStatistics();
+  });
+
+  test.afterAll(async () => {
+    localServer.closeAllConnections();
+    await new Promise<void>(resolve => localServer.close(() => resolve()));
   });
 
   // ── US-G011: manual mode ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR reorganizes Playwright test hooks to follow the correct execution order and removes unnecessary ESLint rule overrides that were previously disabled.

## Key Changes
- **ESLint Configuration**: Removed the `TODO_DISABLED_PLAYWRIGHT` configuration object and its associated rule overrides for `playwright/no-conditional-expect` and `playwright/prefer-hooks-in-order`, allowing these rules to be enforced
- **Test Hook Ordering**: Reorganized `test.afterAll()` hooks to execute after `test.beforeEach()` hooks in both `grouping.spec.ts` and `naming.spec.ts`, following Playwright's recommended hook execution order (beforeAll → beforeEach → afterEach → afterAll)

## Implementation Details
The changes ensure that:
1. Playwright hooks are now ordered correctly according to best practices, with cleanup (`afterAll`) happening after setup (`beforeEach`)
2. ESLint rules for Playwright are no longer suppressed, improving code quality checks and preventing conditional expects and hook ordering issues
3. The test files now comply with the `playwright/prefer-hooks-in-order` rule without needing to disable it

https://claude.ai/code/session_01Qzr16xBo9L3NeBVF2w2sPw