### PR TITLE
Add custom toHaveBeenCalledExactlyOnceWith matcher for Vitest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,12 +61,7 @@ const TODO_DISABLED_PLAYWRIGHT = {
   'playwright/prefer-hooks-in-order': 'off',
 };
 
-const TODO_DISABLED_VITEST = {
-  // API inexistante dans vitest 2.x
-  'vitest/prefer-called-exactly-once-with': 'off',
-  // TODO(eslint): 2 occurrences
-  'vitest/no-conditional-expect': 'off',
-};
+const TODO_DISABLED_VITEST = {};
 
 export default tseslint.config(
   {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -75,8 +75,7 @@ describe('getPluralMessage', () => {
     const result = getPluralMessage(1, 'oneTab', 'manyTabs');
 
     expect(result).toBe('1 tab');
-    expect(mockGetMessage).toHaveBeenCalledOnce();
-    expect(mockGetMessage).toHaveBeenCalledWith('oneTab', undefined);
+    expect(mockGetMessage).toHaveBeenCalledExactlyOnceWith('oneTab', undefined);
   });
 
   it('uses the plural key when count > 1 and passes count as substitution', () => {

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -123,8 +123,7 @@ describe('executeNotificationUndoById', () => {
     const result = await executeNotificationUndoById(id);
 
     expect(result).toBe(true);
-    expect(mockTabsUngroup).toHaveBeenCalledOnce();
-    expect(mockTabsUngroup).toHaveBeenCalledWith([10, 11, 12]);
+    expect(mockTabsUngroup).toHaveBeenCalledExactlyOnceWith([10, 11, 12]);
 
     const all = (await fakeBrowser.notifications.getAll()) as Record<string, any>;
     expect(all[id]).toBeUndefined();

--- a/tests/schemas/session.test.ts
+++ b/tests/schemas/session.test.ts
@@ -37,11 +37,9 @@ describe('createSessionSchemaWithUniqueness', () => {
     const schema = createSessionSchemaWithUniqueness(existing);
     const result = schema.safeParse(makeSession('new-id', 'Work'));
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const nameError = result.error.issues.find(i => i.path.includes('name'));
-      expect(nameError).toBeDefined();
-      expect(nameError?.message).toBe('errorSessionNameUnique');
-    }
+    const nameError = result.error?.issues.find(i => i.path.includes('name'));
+    expect(nameError).toBeDefined();
+    expect(nameError?.message).toBe('errorSessionNameUnique');
   });
 
   it('rejette un nom identique en casse différente (case-insensitive)', () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,4 @@
-import { vi, beforeEach } from 'vitest';
+import { vi, beforeEach, expect } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
 
 // Expose fakeBrowser as global browser/chrome (mirrors extensionApiMock)
@@ -9,3 +9,34 @@ vi.stubGlobal('chrome', fakeBrowser);
 beforeEach(() => {
   fakeBrowser.reset();
 });
+
+// toHaveBeenCalledExactlyOnceWith n'existe pas dans vitest 2.x
+expect.extend({
+  toHaveBeenCalledExactlyOnceWith(
+    received: { mock: { calls: unknown[][] } },
+    ...expected: unknown[]
+  ) {
+    const calls = received.mock.calls;
+    if (calls.length !== 1) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected mock to be called exactly once, but was called ${calls.length} time(s).`,
+      };
+    }
+    const pass = this.equals(calls[0], expected);
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected mock not to be called exactly once with ${JSON.stringify(expected)}.`
+          : `Expected mock to be called with ${JSON.stringify(expected)}, but received ${JSON.stringify(calls[0])}.`,
+    };
+  },
+});
+
+declare module 'vitest' {
+  interface Assertion {
+    toHaveBeenCalledExactlyOnceWith(...args: unknown[]): void;
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a custom Vitest matcher `toHaveBeenCalledExactlyOnceWith` to replace the non-existent API in Vitest 2.x, and refactors existing tests to use this new matcher while removing unnecessary conditional checks.

## Key Changes
- **tests/setup.ts**: Added custom `expect.extend()` implementation of `toHaveBeenCalledExactlyOnceWith` matcher with proper TypeScript declarations for Vitest's Assertion interface
- **tests/i18n.test.ts**: Replaced separate `toHaveBeenCalledOnce()` and `toHaveBeenCalledWith()` calls with single `toHaveBeenCalledExactlyOnceWith()` call
- **tests/notifications.test.ts**: Replaced separate `toHaveBeenCalledOnce()` and `toHaveBeenCalledWith()` calls with single `toHaveBeenCalledExactlyOnceWith()` call
- **tests/schemas/session.test.ts**: Removed unnecessary conditional type guard (`if (!result.success)`) by using optional chaining on `result.error?.issues`
- **eslint.config.js**: Removed ESLint rule disables for `vitest/prefer-called-exactly-once-with` and `vitest/no-conditional-expect` as they are now addressed

## Implementation Details
The custom matcher validates that a mock function was called exactly once and with the expected arguments, returning appropriate pass/fail messages for both positive and negative assertions. This provides a more concise and readable API compared to chaining multiple separate assertions.

https://claude.ai/code/session_01REgDkqtyuNHhr9JnNvosUD