### PR TITLE
Migrate settings storage from sync to local

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,16 +35,15 @@ pnpm screenshots                          # Deterministic multi-locale/theme scr
 - `src/entrypoints/popup.html` / `options.html`
 
 ### Background Modules (`src/background/`)
-`index.ts` · `grouping.ts` · `deduplication.ts` · `event-handlers.ts` · `messaging.ts` · `settings.ts` · `organize.ts`
+`index.ts` · `grouping.ts` · `deduplication.ts` · `event-handlers.ts` · `messaging.ts` · `migration.ts` · `settings.ts` · `organize.ts`
 
 ### Storage
 | Backend | Contents |
 |---|---|
-| `browser.storage.sync` | Domain rules, grouping/dedup toggles, notification prefs |
-| `browser.storage.local` | Sessions, UI prefs (e.g. `popupStatsCollapsed`), help prefs |
-| `browser.storage.session` | Profile–window map, sync drafts, editing guard |
+| `browser.storage.local` | Domain rules, grouping/dedup toggles, notification prefs, sessions, UI prefs (e.g. `popupStatsCollapsed`), help prefs |
+| `browser.storage.session` | Profile-window map, session drafts, editing guard |
 
-`useSyncedSettings` hook uses refs to prevent race conditions. `useSyncedState` unifies synchronized storage access for settings and statistics.
+`useSettings` hook uses refs to prevent race conditions. `useStorageState` unifies storage access for settings and statistics.
 
 ### Schemas & Types
 - `src/schemas/` — Zod schemas: `common`, `domainRule`, `enums`, `importExport`, `session`
@@ -68,7 +67,7 @@ src/
                    # SplitButton/ · ConfirmDialog/ · StatusBadge/ · ThemeToggle/
                    # DataTable/ · OptionsLayout/
     Form/          # FormFields/ · themes/
-  hooks/           # useSyncedState · useSyncedSettings · useStatistics · useSessions
+  hooks/           # useStorageState · useSettings · useStatistics · useSessions
                    # useSessionEditor · useDeepLinking
   pages/           # DomainRulesPage · SessionsPage · StatisticsPage · ImportExportPage · options.tsx · popup.tsx
   schemas/         # Zod schemas
@@ -90,7 +89,7 @@ tests/e2e/         # Playwright E2E tests
 3. **Rule Management** : CRUD for domain rules; built-in & custom regex presets; drag-and-drop reordering
 4. **Import/Export Wizard** : Zod-validated JSON for rules and sessions; rule/session classification (new/conflicting/identical); conflict resolution; optional note field
 5. **Statistics** : grouping & dedup counters
-6. **Sessions & Profiles** : snapshots of open tabs with optional note; pinned profiles with icon, auto-sync, window exclusivity; restore wizard with conflict resolution; interactive session editor; collapsed/expanded group state persistence; drag-and-drop session reordering; session card with HoverCard metadata and inline rename
+6. **Sessions & Profiles** : snapshots of open tabs with optional note; pinned profiles with icon, window exclusivity; restore wizard with conflict resolution; interactive session editor; collapsed/expanded group state persistence; drag-and-drop session reordering; session card with HoverCard metadata and inline rename
 
 ### Theming
 Accent unique `indigo` (défaut Radix Themes). `src/utils/themeConstants.ts` garde les constantes par feature pour compat mais toutes pointent désormais sur `indigo`. Préférer les tokens Radix (`var(--accent-a3)`, `var(--gray-a2)`, etc.) aux couleurs hardcodées. Les wrappers dans `src/components/Form/themes/` restent en place mais n'appliquent plus d'accent différencié.
@@ -154,7 +153,7 @@ identifier et résoudre les zones floues de la user story concernée.
 ### Ne pas sauter cette étape si
 
 - La US référence une entité dont les champs ne sont pas tous explicites.
-- La US interagit avec `chrome.storage.sync` ou `browser.storage.local`.
+- La US interagit avec `browser.storage.local` ou `browser.storage.session`.
 - La US introduit un nouveau composant UI sans préciser le comportement
   responsive, les états vides, ou les états d'erreur.
 - La US touche au système i18n (nouvelles clés à ajouter dans les 3 locales).

--- a/migration-storage-local-audit.md
+++ b/migration-storage-local-audit.md
@@ -1,0 +1,280 @@
+# Audit : migration `storage.sync` vers `storage.local`
+
+## 1.1 Inventaire des acces a `storage.sync`
+
+### Acces directs a `browser.storage.sync`
+
+| Fichier | Ligne | Type d'acces | Donnee | Frequence |
+|---|---|---|---|---|
+| `src/utils/migration.ts` | 50 | Lecture | Cle `domainRules` (detection fresh install) | Init (onInstalled) |
+| `src/utils/migration.ts` | 88 | Lecture | Cle `statistics` dans `storage.local` (controle) | Init (onInstalled) |
+
+### Acces via WXT storage items (prefixe `sync:`)
+
+Ces acces n'appelent pas `browser.storage.sync` directement mais utilisent `storage.defineItem('sync:...')` de WXT, qui route vers `storage.sync` en interne.
+
+| Fichier | Role | Frequence |
+|---|---|---|
+| `src/utils/storageItems.ts` | Definition des 7 items `sync:*` et de la map `syncSettingsItemMap` | Declaration statique |
+| `src/utils/settingsUtils.ts` | `getSyncSettings`, `setSyncSettings`, `updateSyncSettings`, `watchSyncSettings`, `watchSyncSettingsField` | Init + user action + background |
+| `src/hooks/useSyncedSettings.ts` | `loadSyncSettingsFromStorage`, `watchSyncSettings`, `saveSettingsToStorage` | Runtime (React) |
+
+### Hooks qui encapsulent l'acces
+
+| Hook | Fichier | Role |
+|---|---|---|
+| `useSyncedSettings` | `src/hooks/useSyncedSettings.ts` | Charge, surveille et ecrit les settings (sync) |
+| `useSyncedState<T>` | `src/hooks/useSyncedState.ts` | Generique : load/watch/save, utilise par `useSyncedSettings` et `useStatistics` |
+
+`useStatistics` (via `useSyncedState`) lit et ecrit `local:statistics` uniquement : pas impacte.
+
+### Listeners `storage.onChanged`
+
+| Fichier | Filtre | Usage |
+|---|---|---|
+| `src/hooks/useSessions.ts` (l. 40-46) | `areaName === 'local'` uniquement | Reactualise les sessions quand `local.sessions` change. Pas impacte. |
+| `src/hooks/useSyncedSettings.ts` (l. 81-86) | Via `item.watch()` de WXT (interne) | Surveille les changements de chaque item `sync:*`. A migrer vers `local:*`. |
+
+---
+
+## 1.2 Cles stockees dans `storage.sync`
+
+| Cle WXT | Cle brute | Schema Zod | Type TypeScript | Valeur par defaut | Lecture | Ecriture |
+|---|---|---|---|---|---|---|
+| `sync:globalGroupingEnabled` | `globalGroupingEnabled` | `z.boolean()` | `boolean` | `true` | `getSyncSettings`, `useSyncedSettings` | `setSyncSettings`, `updateSyncSettings`, `useSyncedSettings` |
+| `sync:globalDeduplicationEnabled` | `globalDeduplicationEnabled` | `z.boolean()` | `boolean` | `true` | id. | id. |
+| `sync:deduplicateUnmatchedDomains` | `deduplicateUnmatchedDomains` | `z.boolean()` | `boolean` | `false` | id. | id. |
+| `sync:deduplicationKeepStrategy` | `deduplicationKeepStrategy` | `z.enum([...])` | `DeduplicationKeepStrategyValue` | `'keep-grouped-or-new'` | id. | id. |
+| `sync:domainRules` | `domainRules` | `z.array(domainRuleSchema)` | `DomainRuleSettings` | `[]` | id. | id. |
+| `sync:notifyOnGrouping` | `notifyOnGrouping` | `z.boolean()` | `boolean` | `true` | id. | id. |
+| `sync:notifyOnDeduplication` | `notifyOnDeduplication` | `z.boolean()` | `boolean` | `true` | id. | id. |
+
+Toutes ces cles sont agregees dans l'interface `SyncSettings` (`src/types/syncSettings.ts`) et dans `syncSettingsItemMap` (`src/utils/storageItems.ts`).
+
+---
+
+## 1.3 Impact sur les user stories existantes
+
+Aucune user story du dossier `user-stories/` ne reference `storage.sync`, `chrome.storage.sync`, `browser.storage.sync` ou la notion de synchronisation inter-devices. Les seules references a la persistance dans les US sont :
+
+- `US-S-DND.md` (l. 39) : mentionne `browser.storage.local` pour les sessions. Pas impacte.
+- `US-S-sessions.md` (l. 151) : parle de "stockage" de maniere generique. Pas impacte.
+
+**Conclusion : aucune user story ne necessite de modification.**
+
+---
+
+## 1.4 Impact sur les tests
+
+### Tests Vitest mockant `storage.sync`
+
+| Fichier | Nombre d'usages | Nature |
+|---|---|---|
+| `tests/migration.test.ts` | 11 | `fakeBrowser.storage.sync.set(...)` pour seeder l'etat initial, `fakeBrowser.storage.sync.get(...)` pour assertion |
+| `tests/hooks/useSyncedSettings.test.ts` | 2 | `fakeBrowser.storage.sync.set(...)` pour pre-remplir le storage |
+| `tests/utils/settingsUtils.test.ts` | 4 | `fakeBrowser.storage.sync.set/get(...)`, `vi.spyOn(fakeBrowser.storage.sync, 'get')` |
+
+**Total : 17 usages a migrer vers `fakeBrowser.storage.local`.**
+
+### Tests Playwright E2E utilisant `chrome.storage.sync`
+
+| Fichier | Nombre d'usages | Nature |
+|---|---|---|
+| `tests/e2e/fixtures.ts` | 4 | Fonctions `syncSet`, `addDomainRule`, `clearDomainRules`, `getSettings` |
+| `tests/e2e/import-export.spec.ts` | 2 | Setup de regles avant test |
+| `tests/e2e/options-toasts.spec.ts` | 1 | `chrome.storage.sync.set({ domainRules: [] })` |
+| `tests/e2e/notifications.spec.ts` | 1 | `chrome.storage.sync.set(...)` |
+| `tests/e2e/popup-organize.spec.ts` | 4 | `chrome.storage.sync.set(...)` pour notifyOn* |
+
+**Total : 12 usages E2E a migrer vers `chrome.storage.local`.**
+
+La fonction helper `syncSet` dans `tests/e2e/fixtures.ts` (l. 92-113) gere le retry sur `MAX_WRITE_OPERATIONS_PER_MINUTE` : ce probleme disparait avec `storage.local` (quota illimite en ecriture). La logique de retry peut etre supprimee ou simplifiee.
+
+### Tests marques flaky
+
+Aucun test ne porte de marqueur `.only`, `test.skip`, commentaire `// flaky` ou `// TODO flaky` dans les fichiers analyses. La flakiness mentionnee dans la motivation est comportementale (lenteur async de `storage.sync` en E2E), pas annotee dans le code.
+
+---
+
+## 1.5 Strategie de migration runtime
+
+### Principe
+
+Lors du premier demarrage avec la nouvelle version, le background lit les donnees dans `storage.sync` et les copie dans `storage.local`, puis pose un flag `settingsMigratedToLocal: true` dans `storage.local`. Les versions suivantes detectent ce flag et sautent la migration.
+
+Les donnees dans `storage.sync` **ne sont pas supprimees** afin de permettre un rollback vers l'ancienne version.
+
+### Ou placer le code
+
+Creer `src/background/migration.ts` (distinct de `src/utils/migration.ts` qui gere l'initialisation des defaults). Appeler ce module dans `event-handlers.ts > setupInstallationHandler()`, juste avant `initializeDefaults()`.
+
+Sequence d'appel dans `setupInstallationHandler` :
+```
+1. migrateSettingsFromSyncToLocal()   // nouveau
+2. initializeDefaults()               // existant
+```
+
+### Detection de la migration
+
+```ts
+const { settingsMigratedToLocal } = await browser.storage.local.get('settingsMigratedToLocal');
+if (settingsMigratedToLocal) return; // deja fait
+```
+
+### Logique de migration (idempotente)
+
+```
+1. Lire toutes les cles sync (* ou cles nommees) depuis browser.storage.sync
+2. Pour chaque cle connue (domainRules, globalGroupingEnabled, ...),
+   si la valeur existe dans sync ET n'existe pas encore dans local :
+     ecrire dans local
+3. Poser le flag: browser.storage.local.set({ settingsMigratedToLocal: true })
+```
+
+La condition "n'existe pas encore dans local" assure l'idempotence : si la migration a ete partiellement executee puis interrompue, la re-executer ne corrompt pas les donnees deja migrees.
+
+### Cas : fresh install (pas de donnees dans sync)
+
+`browser.storage.sync.get(keys)` retourne un objet vide ou avec des valeurs `undefined` pour les cles absentes. La migration saute simplement toutes les cles, pose le flag, et `initializeDefaults()` ecrit les valeurs par defaut dans `local`. Comportement inchange.
+
+### Cas : rollback utilisateur
+
+Les donnees restent dans `storage.sync`. L'ancienne version les lira comme avant. Pas de degradation.
+
+### Gestion des erreurs
+
+- Encapsuler la migration dans un `try/catch`.
+- En cas d'erreur, logger avec `logger.error` et ne pas poser le flag : la migration sera retentee au prochain demarrage.
+- Pas de retry immediat pour ne pas bloquer le service worker.
+
+---
+
+## 1.6 Renommage des hooks
+
+### Probleme
+
+Apres la migration, `useSyncedSettings` et `useSyncedState` ont des noms trompeurs : "synced" evoque la synchronisation inter-devices, qui n'existe plus.
+
+### Propositions
+
+| Nom actuel | Nom propose | Justification |
+|---|---|---|
+| `useSyncedSettings` | `useSettings` | Court, precis. Le hook gere les settings de l'extension, point. |
+| `useSyncedState<T>` | `useStorageState<T>` | Indique que l'etat est persiste en storage, sans prejudger du backend. |
+| `getSyncSettings` | `getSettings` | Alignement avec le nouveau nom du hook. |
+| `setSyncSettings` | `setSettings` | id. |
+| `updateSyncSettings` | `updateSettings` | id. |
+| `watchSyncSettings` | `watchSettings` | id. |
+| `watchSyncSettingsField` | `watchSettingsField` | id. |
+| `SyncSettings` (type) | `AppSettings` | Evite la confusion avec la notion de sync, reste distinct de types generiques. |
+| `defaultSyncSettings` | `defaultAppSettings` | Alignement. |
+| `syncSettingsItemMap` | `settingsItemMap` | id. |
+
+### Fichiers a mettre a jour pour le renommage
+
+**Hook et utilitaires (renommage fichier + contenu) :**
+- `src/hooks/useSyncedSettings.ts` -> `src/hooks/useSettings.ts`
+- `src/hooks/useSyncedState.ts` -> `src/hooks/useStorageState.ts`
+- `src/utils/settingsUtils.ts` (renommage des fonctions exportees)
+- `src/utils/storageItems.ts` (renommage `syncSettingsItemMap`)
+- `src/types/syncSettings.ts` (renommage type + constante)
+
+**Consommateurs (imports + usages) :**
+- `src/background/settings.ts`
+- `src/background/deduplication.ts`
+- `src/background/grouping.ts`
+- `src/background/organize.ts`
+- `src/hooks/useStatistics.ts`
+- `src/pages/options.tsx`
+- `src/pages/popup.tsx`
+- `src/pages/DomainRulesPage.tsx`
+- `src/pages/ImportExportPage.tsx`
+- `src/pages/StatisticsPage.tsx`
+- `src/pages/SessionsPage.tsx`
+- `src/components/Core/DomainRule/RuleWizardModal.tsx`
+- `src/components/Core/DomainRule/RuleDetailPopover.tsx`
+- `src/components/Core/DomainRule/DomainRuleCard.tsx`
+- `src/components/UI/ImportExportWizards/ImportWizard.tsx`
+- `src/components/UI/ImportExportWizards/ExportWizard.tsx`
+- `src/components/UI/ImportExportWizards/RuleImportRows.tsx`
+- `src/components/UI/PageLayout/PageLayout.tsx`
+- `src/components/UI/SettingsPage/SettingsPage.tsx`
+- `src/utils/importClassification.ts`
+- `src/utils/migration.ts` (existant) et `src/background/migration.ts` (nouveau)
+- `src/utils/ruleOrderUtils.ts`
+- Stories : `src/components/*/**.stories.tsx` (partout ou `SyncSettings` est importe)
+- Tests : `tests/hooks/useSyncedSettings.test.ts` -> `tests/hooks/useSettings.test.ts`
+- Tests : `tests/utils/settingsUtils.test.ts`
+
+---
+
+## 1.7 Plan de decoupage (phase 2)
+
+### Lot 1 : storageItems + settingsUtils + types (utilitaires)
+
+Changements :
+- `src/utils/storageItems.ts` : changer les 7 prefixes `sync:` en `local:`, renommer `syncSettingsItemMap` en `settingsItemMap`.
+- `src/types/syncSettings.ts` : renommer `SyncSettings` en `AppSettings`, `defaultSyncSettings` en `defaultAppSettings`.
+- `src/utils/settingsUtils.ts` : renommer toutes les fonctions exportees (`getSyncSettings` -> `getSettings`, etc.).
+- `src/background/settings.ts` : mettre a jour les imports.
+
+Invariant : `pnpm compile` doit passer. Les autres fichiers ne compilent pas encore car les imports sont casses.
+
+**Note : ce lot est le plus delicat car il casse tous les imports. Il doit etre fait en une seule passe avec mise a jour simultanee de tous les consommateurs (voir lot 2).**
+
+### Lot 2 : hooks + consommateurs React
+
+Changements :
+- Renommer `useSyncedSettings.ts` -> `useSettings.ts`, adapter le contenu.
+- Renommer `useSyncedState.ts` -> `useStorageState.ts`, adapter le contenu.
+- `src/hooks/useStatistics.ts` : mettre a jour l'import.
+- Tous les fichiers pages/ et components/ listés en 1.6 : mettre a jour les imports.
+
+Invariant : `pnpm compile` passe, `pnpm test` passe.
+
+### Lot 3 : migration runtime
+
+Changements :
+- Creer `src/background/migration.ts` avec `migrateSettingsFromSyncToLocal()`.
+- Adapter `src/utils/migration.ts` (`initializeDefaults`) : remplacer `browser.storage.sync.get('domainRules')` par une lecture `local:domainRules`.
+- Adapter `src/entrypoints/background.ts` ou `event-handlers.ts` pour appeler la migration.
+
+Invariant : `pnpm compile` passe, `pnpm test` passe.
+
+### Lot 4 : tests Vitest
+
+Changements :
+- `tests/migration.test.ts` : migrer 11 usages de `fakeBrowser.storage.sync` vers `fakeBrowser.storage.local`. Adapter les assertions.
+- `tests/hooks/useSyncedSettings.test.ts` -> renommer en `useSettings.test.ts`, migrer 2 usages.
+- `tests/utils/settingsUtils.test.ts` : migrer 4 usages, adapter le spy.
+
+Invariant : `pnpm test` passe entierement.
+
+### Lot 5 : tests E2E (helpers uniquement, sans execution)
+
+Changements :
+- `tests/e2e/fixtures.ts` : remplacer `syncSet` (et son retry sur quota) par un appel direct `chrome.storage.local.set`. Mettre a jour `addDomainRule`, `clearDomainRules`, `getSettings`.
+- `tests/e2e/import-export.spec.ts`, `options-toasts.spec.ts`, `notifications.spec.ts`, `popup-organize.spec.ts` : remplacer `chrome.storage.sync.set` par `chrome.storage.local.set`.
+
+Invariant : fichiers modifient mais tests non executes (a la charge de l'utilisateur).
+
+### Lot 6 : documentation
+
+Changements :
+- `CLAUDE.md` : mettre a jour le tableau Storage, les noms des hooks dans l'architecture.
+- `wxt.config.ts` : mettre a jour le commentaire ligne 22 (supprime "sync").
+- Creer `user-stories/migration-storage/clarifications.md`.
+
+---
+
+## 1.8 Risques identifies
+
+| Risque | Probabilite | Mitigation |
+|---|---|---|
+| **Race condition pendant la migration** : deux fenetres s'ouvrent en meme temps, `onInstalled` se declenche dans deux SW, les deux migrent en parallele et ecrasent des donnees. | Faible (onInstalled ne se declenche qu'une fois par installation/update, pas par fenetre). Le SW est unique. | Confirmer que onInstalled ne se declenche pas deux fois en lecture des docs WXT/MV3. Sinon, utiliser un lock via `storage.session`. |
+| **Ancien code lit `sync` apres migration** : si une ancienne instance du SW reste active (en cache), elle lit encore `sync`. | Tres faible (MV3 termine le SW apres inactivite). | Les donnees `sync` sont preservees donc l'ancienne version fonctionnerait en lecture. |
+| **Donnees trop volumineuses pour `storage.local`** : theoriquement pas de limite par item (contrairement a `sync` : 8KB/item), mais le quota global est de 5MB par defaut. | Negligeable (les regles de domaine depassent rarement quelques KB). | Aucune. |
+| **Tests E2E cassent sur les `storage.local` quotas** : `storage.local` n'a pas de limite d'operations/minute. | Positif : le risque disparait apres la migration. La logique de retry dans `syncSet` peut etre supprimee. | Supprimer le retry. |
+| **Regression dans `initializeDefaults`** : la detection du fresh install utilise actuellement `browser.storage.sync.get('domainRules')`. Apres migration, elle doit lire `local:domainRules`. | Reel si on oublie d'adapter ce code. | Lot 3 couvre explicitement ce point. Couvert par les tests du lot 4. |
+| **Stories Storybook cassent** : les stories qui importent `SyncSettings` ou `useSyncedSettings` cesseront de compiler si le lot 1 n'est pas atomique avec le lot 2. | Reel en cas de commit partiel. | Faire les lots 1 et 2 dans la meme session de travail, `pnpm compile` avant chaque commit. |
+| **Utilisateur installe la nouvelle version, rollback, reinstalle** : a la reinstallation, `settingsMigratedToLocal` est present dans `local`, donc la migration est sautee. Mais les donnees sont dans `local` depuis le premier passage. | Bening. | La migration est idempotente, `initializeDefaults` remplit les valeurs manquantes. |

--- a/migration-storage-local-audit.md
+++ b/migration-storage-local-audit.md
@@ -303,18 +303,12 @@ Changements :
 ```
 | Backend | Contents |
 |---|---|
-| `browser.storage.local` | Domain rules, grouping/dedup toggles, notification prefs, sessions, UI prefs, help prefs, statistics |
-| `browser.storage.session` | Profile-window map, sync drafts, editing guard |
+| `browser.storage.local` | Domain rules, grouping/dedup toggles, notification prefs, sessions, UI prefs (e.g. `popupPinnedEmptyCollapsed`), statistics |
 ```
 
-Note : "sync drafts" ligne 45 designe les drafts de synchronisation automatique des profils (feature auto-sync des sessions epinglees), pas `storage.sync`. Terme conserve. Pour lever l'ambiguite, reformuler en "profile auto-sync drafts".
+Note : `browser.storage.session` ne contient aucun item dans le code actuel (verifie : zero appel a `browser.storage.session` dans `src/`). L'auto-sync des profils n'est plus implemente. La ligne `storage.session` du tableau est donc a **supprimer entierement**.
 
-**Reformulation ligne 45 :**
-```
-| `browser.storage.session` | Profile-window map, profile auto-sync drafts, editing guard |
-```
-
-Aussi, `popupStatsCollapsed` mentionne ligne 44 n'existe pas dans le code (la cle reelle est `popupPinnedEmptyCollapsed`). A corriger au passage.
+Aussi, `popupStatsCollapsed` mentionne ligne 44 n'existe pas dans le code (la cle reelle est `popupPinnedEmptyCollapsed`). Corrige dans la reformulation ci-dessus.
 
 ### Ligne 47 (description des hooks)
 
@@ -354,7 +348,7 @@ Aussi, `popupStatsCollapsed` mentionne ligne 44 n'existe pas dans le code (la cl
 
 ### Ligne 93 (feature Sessions & Profiles)
 
-Le terme "auto-sync" designe la synchronisation automatique profil -> fenetre (feature produit), pas `storage.sync`. **Aucun changement.**
+Le terme "auto-sync" designe la synchronisation automatique profil -> fenetre. Cette feature n'est plus implementee selon le retour du projet. La phrase "pinned profiles with icon, auto-sync, window exclusivity" devra etre revue en phase 2 dans le lot 6 (en dehors du scope de la migration storage, mais a noter).
 
 ### Ligne 172 (skill jscpd)
 
@@ -366,7 +360,8 @@ Le terme "synchronise" designe la synchronisation du lockfile skills, pas `stora
 |---|---|
 | 43 | Supprimer la ligne `browser.storage.sync` et fusionner son contenu dans `browser.storage.local` |
 | 44 | Enrichir le contenu et corriger `popupStatsCollapsed` -> `popupPinnedEmptyCollapsed` |
-| 45 | Reformuler "sync drafts" en "profile auto-sync drafts" (clarte) |
+| 45 | Supprimer la ligne `browser.storage.session` (non utilise dans le code ; auto-sync profils non implemente) |
 | 47 | Renommer `useSyncedSettings` -> `useSettings`, `useSyncedState` -> `useStorageState` |
 | 71 | id. dans la liste des hooks |
+| 93 | Retirer "auto-sync" de la description Sessions & Profiles (feature non implementee) |
 | 157 | Retirer la mention `chrome.storage.sync` |

--- a/migration-storage-local-audit.md
+++ b/migration-storage-local-audit.md
@@ -261,8 +261,11 @@ Invariant : fichiers modifient mais tests non executes (a la charge de l'utilisa
 ### Lot 6 : documentation
 
 Changements :
-- `CLAUDE.md` : mettre a jour le tableau Storage, les noms des hooks dans l'architecture.
+- `CLAUDE.md` : modifications detaillees en section 1.9.
 - `wxt.config.ts` : mettre a jour le commentaire ligne 22 (supprime "sync").
+- `README.md`, `README-fr.md`, `README-es.md` : aucune mention de sync detectee, pas d'action (verifie au scan).
+- `DESIGN.md` : a verifier au moment du lot (pas d'occurrence de `storage.sync` au scan, mais relecture prudente).
+- `CHANGELOG.md` : ajouter une entree pour la migration.
 - Creer `user-stories/migration-storage/clarifications.md`.
 
 ---
@@ -278,3 +281,92 @@ Changements :
 | **Regression dans `initializeDefaults`** : la detection du fresh install utilise actuellement `browser.storage.sync.get('domainRules')`. Apres migration, elle doit lire `local:domainRules`. | Reel si on oublie d'adapter ce code. | Lot 3 couvre explicitement ce point. Couvert par les tests du lot 4. |
 | **Stories Storybook cassent** : les stories qui importent `SyncSettings` ou `useSyncedSettings` cesseront de compiler si le lot 1 n'est pas atomique avec le lot 2. | Reel en cas de commit partiel. | Faire les lots 1 et 2 dans la meme session de travail, `pnpm compile` avant chaque commit. |
 | **Utilisateur installe la nouvelle version, rollback, reinstalle** : a la reinstallation, `settingsMigratedToLocal` est present dans `local`, donc la migration est sautee. Mais les donnees sont dans `local` depuis le premier passage. | Bening. | La migration est idempotente, `initializeDefaults` remplit les valeurs manquantes. |
+
+---
+
+## 1.9 Modifications de `CLAUDE.md`
+
+`CLAUDE.md` contient plusieurs references a `storage.sync` et aux hooks a renommer. Voici les emplacements exacts et les reformulations proposees :
+
+### Ligne 43-45 (tableau Storage)
+
+**Avant :**
+```
+| Backend | Contents |
+|---|---|
+| `browser.storage.sync` | Domain rules, grouping/dedup toggles, notification prefs |
+| `browser.storage.local` | Sessions, UI prefs (e.g. `popupStatsCollapsed`), help prefs |
+| `browser.storage.session` | Profile-window map, sync drafts, editing guard |
+```
+
+**Apres :**
+```
+| Backend | Contents |
+|---|---|
+| `browser.storage.local` | Domain rules, grouping/dedup toggles, notification prefs, sessions, UI prefs, help prefs, statistics |
+| `browser.storage.session` | Profile-window map, sync drafts, editing guard |
+```
+
+Note : "sync drafts" ligne 45 designe les drafts de synchronisation automatique des profils (feature auto-sync des sessions epinglees), pas `storage.sync`. Terme conserve. Pour lever l'ambiguite, reformuler en "profile auto-sync drafts".
+
+**Reformulation ligne 45 :**
+```
+| `browser.storage.session` | Profile-window map, profile auto-sync drafts, editing guard |
+```
+
+Aussi, `popupStatsCollapsed` mentionne ligne 44 n'existe pas dans le code (la cle reelle est `popupPinnedEmptyCollapsed`). A corriger au passage.
+
+### Ligne 47 (description des hooks)
+
+**Avant :**
+```
+`useSyncedSettings` hook uses refs to prevent race conditions. `useSyncedState` unifies synchronized storage access for settings and statistics.
+```
+
+**Apres :**
+```
+`useSettings` hook uses refs to prevent race conditions. `useStorageState` unifies local storage access for settings and statistics.
+```
+
+### Ligne 71 (arborescence des hooks)
+
+**Avant :**
+```
+  hooks/           # useSyncedState · useSyncedSettings · useStatistics · useSessions
+```
+
+**Apres :**
+```
+  hooks/           # useStorageState · useSettings · useStatistics · useSessions
+```
+
+### Ligne 157 (regle de clarification)
+
+**Avant :**
+```
+- La US interagit avec `chrome.storage.sync` ou `browser.storage.local`.
+```
+
+**Apres :**
+```
+- La US interagit avec `browser.storage.local` ou `browser.storage.session`.
+```
+
+### Ligne 93 (feature Sessions & Profiles)
+
+Le terme "auto-sync" designe la synchronisation automatique profil -> fenetre (feature produit), pas `storage.sync`. **Aucun changement.**
+
+### Ligne 172 (skill jscpd)
+
+Le terme "synchronise" designe la synchronisation du lockfile skills, pas `storage.sync`. **Aucun changement.**
+
+### Synthese des occurrences a modifier dans `CLAUDE.md`
+
+| Ligne | Action |
+|---|---|
+| 43 | Supprimer la ligne `browser.storage.sync` et fusionner son contenu dans `browser.storage.local` |
+| 44 | Enrichir le contenu et corriger `popupStatsCollapsed` -> `popupPinnedEmptyCollapsed` |
+| 45 | Reformuler "sync drafts" en "profile auto-sync drafts" (clarte) |
+| 47 | Renommer `useSyncedSettings` -> `useSettings`, `useSyncedState` -> `useStorageState` |
+| 71 | id. dans la liste des hooks |
+| 157 | Retirer la mention `chrome.storage.sync` |

--- a/src/background/deduplication.ts
+++ b/src/background/deduplication.ts
@@ -7,7 +7,7 @@ import { showNotification, type UndoAction } from '@/utils/notifications.js';
 import { getMessage } from '@/utils/i18n.js';
 import { shouldSkipDeduplication } from '@/utils/deduplicationSkip.js';
 import { normalizeUrlIgnoringParams } from '@/utils/urlNormalization.js';
-import type { DomainRuleSetting, SyncSettings } from '@/types/syncSettings.js';
+import type { DomainRuleSetting, AppSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
 
 // Cache pour éviter de traiter plusieurs fois le même onglet
@@ -183,7 +183,7 @@ export async function checkAndDeduplicateTab(
     newUrl: string,
     matchMode: string,
     windowId: number,
-    settings: SyncSettings,
+    settings: AppSettings,
     ignoredParams: string[] = [],
 ): Promise<void> {
     try {

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -1,5 +1,6 @@
 import { browser, Browser } from 'wxt/browser';
 import { initializeDefaults } from '@/utils/migration.js';
+import { migrateSettingsFromSyncToLocal } from './migration.js';
 import { logger } from '@/utils/logger.js';
 import {
     handleMiddleClickMessage,
@@ -19,6 +20,7 @@ function isBackgroundMessage(value: unknown): value is BackgroundMessage {
 export function setupInstallationHandler(): void {
     browser.runtime.onInstalled.addListener(async (details: Browser.runtime.InstalledDetails) => {
         logger.debug("SmartTab Organizer installed/updated.", details.reason);
+        await migrateSettingsFromSyncToLocal();
         await initializeDefaults();
     });
 }

--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -5,7 +5,7 @@ import { getSettings } from './settings.js';
 import { promptForGroupName } from './messaging.js';
 import { showNotification, type UndoAction } from '@/utils/notifications.js';
 import { getMessage } from '@/utils/i18n.js';
-import type { DomainRuleSetting, SyncSettings } from '@/types/syncSettings.js';
+import type { DomainRuleSetting, AppSettings } from '@/types/syncSettings.js';
 import { getRuleCategory } from '@/schemas/enums.js';
 import { logger } from '@/utils/logger.js';
 
@@ -21,7 +21,7 @@ export function findMatchingRule(url: string, domainRules: DomainRuleSetting[]):
     return domainRules.find(r => r.enabled && matchesDomain(url, r.domainFilter));
 }
 
-export function determineGroupColor(rule: DomainRuleSetting, _settings?: SyncSettings): string | null {
+export function determineGroupColor(rule: DomainRuleSetting, _settings?: AppSettings): string | null {
     const category = getRuleCategory(rule.categoryId);
     if (category) {
         logger.debug(`[GROUPING_DEBUG] Using category "${rule.categoryId}" color: "${category.color}".`);
@@ -164,7 +164,7 @@ export function createGroupingContext(
     rule: DomainRuleSetting,
     openerTab: Browser.tabs.Tab,
     newTab: Browser.tabs.Tab,
-    settings: SyncSettings
+    settings: AppSettings
 ): GroupingContext | null {
     const groupName = extractGroupNameFromRule(rule, openerTab);
     if (groupName === null) return null;

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -1,0 +1,52 @@
+import { browser } from 'wxt/browser';
+import { logger } from '@/utils/logger.js';
+
+const SETTINGS_KEYS = [
+  'globalGroupingEnabled',
+  'globalDeduplicationEnabled',
+  'deduplicateUnmatchedDomains',
+  'deduplicationKeepStrategy',
+  'domainRules',
+  'notifyOnGrouping',
+  'notifyOnDeduplication',
+] as const;
+
+const MIGRATION_FLAG = 'settingsMigratedToLocal';
+
+/**
+ * Copies settings from storage.sync into storage.local once per installation.
+ * Idempotent: guarded by a flag in storage.local.
+ * Never deletes storage.sync data so the user can rollback to the previous version.
+ * On error, the flag is not set so the migration is retried on next startup.
+ */
+export async function migrateSettingsFromSyncToLocal(): Promise<void> {
+  try {
+    const localState = await browser.storage.local.get(MIGRATION_FLAG);
+    if (localState[MIGRATION_FLAG]) {
+      logger.debug('[MIGRATION] Settings already migrated to local.');
+      return;
+    }
+
+    const syncData = await browser.storage.sync.get([...SETTINGS_KEYS]);
+    const localData = await browser.storage.local.get([...SETTINGS_KEYS]);
+
+    const toWrite: Record<string, unknown> = {};
+    for (const key of SETTINGS_KEYS) {
+      if (syncData[key] !== undefined && localData[key] === undefined) {
+        toWrite[key] = syncData[key];
+        logger.debug(`[MIGRATION] Copying "${key}" from sync to local.`);
+      }
+    }
+
+    if (Object.keys(toWrite).length > 0) {
+      await browser.storage.local.set(toWrite);
+    } else {
+      logger.debug('[MIGRATION] Nothing to migrate (fresh install or sync was empty).');
+    }
+
+    await browser.storage.local.set({ [MIGRATION_FLAG]: true });
+    logger.debug('[MIGRATION] Migration complete.');
+  } catch (error) {
+    logger.error('[MIGRATION] Migration failed, will retry on next startup:', error);
+  }
+}

--- a/src/background/organize.ts
+++ b/src/background/organize.ts
@@ -11,7 +11,7 @@ import { getMatchMode, isUrlMatch } from './deduplication.js';
 import { getStatisticsData, updateStatisticsData } from '@/utils/statisticsUtils.js';
 import { getMessage } from '@/utils/i18n.js';
 import { logger } from '@/utils/logger.js';
-import type { DomainRuleSetting, SyncSettings } from '@/types/syncSettings.js';
+import type { DomainRuleSetting, AppSettings } from '@/types/syncSettings.js';
 import type { ChromeTabGroupsExtended, ChromeNotificationsAPI } from '@/types/chromeApi.js';
 
 // ---------------------------------------------------------------------------
@@ -49,7 +49,7 @@ function isOrganizableUrl(url: string | undefined): url is string {
  * matching rule are included (bucketed together under exact-match mode).
  * Returns the number of duplicate tabs removed.
  */
-async function batchDeduplicateTabs(windowId: number, settings: SyncSettings): Promise<number> {
+async function batchDeduplicateTabs(windowId: number, settings: AppSettings): Promise<number> {
     const allTabs = await browser.tabs.query({ windowId });
     const organizable = allTabs
         .filter(t => isOrganizableUrl(t.url))
@@ -148,7 +148,7 @@ async function batchDeduplicateTabs(windowId: number, settings: SyncSettings): P
  * Returns only entries whose target group has ≥ 2 members.
  * Per US-PO008: single-member target groups are excluded.
  */
-async function buildOrganizePlan(windowId: number, settings: SyncSettings): Promise<PlanEntry[]> {
+async function buildOrganizePlan(windowId: number, settings: AppSettings): Promise<PlanEntry[]> {
     // Re-query after dedup so removed tabs are no longer present
     const allTabs = await browser.tabs.query({ windowId });
     const organizable = allTabs.filter(t => isOrganizableUrl(t.url));

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -1,8 +1,8 @@
-import { getSyncSettings } from '@/utils/settingsUtils.js';
-import type { SyncSettings, DomainRuleSetting } from '@/types/syncSettings.js';
+import { getSettings as getAppSettings } from '@/utils/settingsUtils.js';
+import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings.js';
 
-export async function getSettings(): Promise<SyncSettings> {
-    const settings = await getSyncSettings();
+export async function getSettings(): Promise<AppSettings> {
+    const settings = await getAppSettings();
     settings.domainRules = settings.domainRules || [];
     settings.domainRules = settings.domainRules.map((rule: DomainRuleSetting) => ({
         ...rule,

--- a/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { RuleWizardModal } from './RuleWizardModal';
 const action = (name: string) => (...args: any[]) => console.log(name, ...args);
 import type { DomainRule } from '@/schemas/domainRule';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 
-const mockSyncSettings: SyncSettings = {
+const mockAppSettings: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
@@ -58,7 +58,7 @@ const meta: Meta<typeof RuleWizardModal> = {
   args: {
     onClose: action('onClose'),
     onSubmit: action('onSubmit'),
-    syncSettings: mockSyncSettings,
+    syncSettings: mockAppSettings,
   },
 };
 
@@ -133,9 +133,9 @@ export const RuleWizardModalLabelUniqueness: Story = {
     isOpen: true,
     domainRule: undefined,
     syncSettings: {
-      ...mockSyncSettings,
+      ...mockAppSettings,
       domainRules: [
-        ...mockSyncSettings.domainRules,
+        ...mockAppSettings.domainRules,
         {
           id: 'test-rule',
           domainFilter: 'test.com',

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -17,7 +17,7 @@ import { generateUUID } from '@/utils/utils';
 import { createDomainRuleSchemaWithUniqueness, type DomainRule } from '@/schemas/domainRule';
 import { groupNameSourceOptions, type GroupNameSourceValue } from '@/schemas/enums';
 import { getPresetById, loadPresets, type PresetCategory } from '@/utils/presetUtils';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 import { logger } from '@/utils/logger';
 
 interface RuleWizardModalProps {
@@ -25,7 +25,7 @@ interface RuleWizardModalProps {
   onClose: () => void;
   onSubmit: (domainRule: DomainRule) => void;
   domainRule?: DomainRule;
-  syncSettings: SyncSettings;
+  syncSettings: AppSettings;
 }
 
 const VALID_GROUP_NAME_SOURCES = groupNameSourceOptions.map(o => o.value) as GroupNameSourceValue[];

--- a/src/components/UI/PageLayout/PageLayout.stories.tsx
+++ b/src/components/UI/PageLayout/PageLayout.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { PageLayout } from './PageLayout';
 import { Text, Box, Button, Flex } from '@radix-ui/themes';
 import { Shield, FileText, BarChart3 } from 'lucide-react';
-import { defaultSyncSettings } from '@/types/syncSettings';
+import { defaultAppSettings } from '@/types/syncSettings';
 
 const meta: Meta<typeof PageLayout> = {
   title: 'Components/UI/PageLayout/PageLayout',
@@ -29,7 +29,7 @@ export const PageLayoutDomainRules: Story = {
     titleKey: 'domainRulesTab',
     descriptionKey: 'domainRulesPageDescription',
     icon: Shield,
-    syncSettings: defaultSyncSettings,
+    syncSettings: defaultAppSettings,
     children: (settings) => (
       <Box>
         <Text size="3" style={{ marginBottom: '16px', display: 'block' }}>
@@ -53,7 +53,7 @@ export const PageLayoutImportExport: Story = {
     titleKey: 'importExportTab',
     descriptionKey: 'importExportPageDescription',
     icon: FileText,
-    syncSettings: defaultSyncSettings,
+    syncSettings: defaultAppSettings,
     children: () => (
       <Box>
         <Text size="3" style={{ marginBottom: '16px', display: 'block' }}>
@@ -73,7 +73,7 @@ export const PageLayoutStatistics: Story = {
     titleKey: 'statisticsTab',
     descriptionKey: 'statisticsPageDescription',
     icon: BarChart3,
-    syncSettings: defaultSyncSettings,
+    syncSettings: defaultAppSettings,
     children: (settings) => (
       <Box>
         <Text size="3" style={{ marginBottom: '16px', display: 'block' }}>

--- a/src/components/UI/PageLayout/PageLayout.tsx
+++ b/src/components/UI/PageLayout/PageLayout.tsx
@@ -1,14 +1,14 @@
 import { Heading, Box, Flex, Separator, Text } from '@radix-ui/themes';
 import type { LucideIcon } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import type { SyncSettings } from '@/types/syncSettings.js';
+import type { AppSettings } from '@/types/syncSettings.js';
 
 interface PageLayoutProps {
   titleKey: string;
   descriptionKey: string;
   icon?: LucideIcon;
-  syncSettings: SyncSettings;
-  children: (settings: SyncSettings) => React.ReactNode;
+  syncSettings: AppSettings;
+  children: (settings: AppSettings) => React.ReactNode;
 }
 
 export function PageLayout({ titleKey, descriptionKey, icon: Icon, syncSettings, children }: PageLayoutProps) {

--- a/src/components/UI/SettingsPage/SettingsPage.stories.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { SettingsPage } from './SettingsPage';
-import { defaultSyncSettings } from '@/types/syncSettings';
+import { defaultAppSettings } from '@/types/syncSettings';
 
 const meta: Meta<typeof SettingsPage> = {
   title: 'Components/UI/SettingsPage/SettingsPage',
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 export const SettingsPageDefault: Story = {
   args: {
-    syncSettings: defaultSyncSettings,
+    syncSettings: defaultAppSettings,
     updateSettings: (settings) => console.log('Settings updated:', settings),
   },
 };
@@ -26,7 +26,7 @@ export const SettingsPageDefault: Story = {
 export const SettingsPageNotificationsDisabled: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       notifyOnGrouping: false,
       notifyOnDeduplication: false,
     },
@@ -37,7 +37,7 @@ export const SettingsPageNotificationsDisabled: Story = {
 export const SettingsPageGroupingOnly: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       notifyOnGrouping: true,
       notifyOnDeduplication: false,
     },
@@ -48,7 +48,7 @@ export const SettingsPageGroupingOnly: Story = {
 export const SettingsPageDedupUnmatchedDisabled: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       deduplicateUnmatchedDomains: false,
     },
     updateSettings: (settings) => console.log('Settings updated:', settings),
@@ -58,7 +58,7 @@ export const SettingsPageDedupUnmatchedDisabled: Story = {
 export const SettingsPageKeepNewStrategy: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       deduplicationKeepStrategy: 'keep-new',
     },
     updateSettings: (settings) => console.log('Settings updated:', settings),
@@ -68,7 +68,7 @@ export const SettingsPageKeepNewStrategy: Story = {
 export const SettingsPageKeepGroupedStrategy: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       deduplicationKeepStrategy: 'keep-grouped',
     },
     updateSettings: (settings) => console.log('Settings updated:', settings),
@@ -78,7 +78,7 @@ export const SettingsPageKeepGroupedStrategy: Story = {
 export const SettingsPageKeepGroupedOrNewStrategy: Story = {
   args: {
     syncSettings: {
-      ...defaultSyncSettings,
+      ...defaultAppSettings,
       deduplicationKeepStrategy: 'keep-grouped-or-new',
     },
     updateSettings: (settings) => console.log('Settings updated:', settings),

--- a/src/components/UI/SettingsPage/SettingsPage.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.tsx
@@ -2,15 +2,15 @@ import { Box, Flex, Text, Switch, Card, RadioGroup } from '@radix-ui/themes';
 import { Settings, Bell, Copy } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { getMessage } from '@/utils/i18n';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 import {
   deduplicationKeepStrategyOptions,
   type DeduplicationKeepStrategyValue,
 } from '@/schemas/enums';
 
 interface SettingsPageProps {
-  syncSettings: SyncSettings;
-  updateSettings: (settings: Partial<SyncSettings>) => void;
+  syncSettings: AppSettings;
+  updateSettings: (settings: Partial<AppSettings>) => void;
 }
 
 export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps) {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 import { storage } from 'wxt/utils/storage';
-import type { SyncSettings, DomainRuleSettings } from '@/types/syncSettings.js';
+import type { AppSettings, DomainRuleSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
 import {
   globalGroupingEnabledItem,
@@ -9,12 +9,12 @@ import {
   domainRulesItem,
   notifyOnGroupingItem,
   notifyOnDeduplicationItem,
-  syncSettingsItemMap,
+  settingsItemMap,
 } from '@/utils/storageItems.js';
-import { useSyncedState } from './useSyncedState.js';
+import { useStorageState } from './useStorageState.js';
 
-export interface UseSyncedSettingsReturn {
-  settings: SyncSettings | null;
+export interface UseSettingsReturn {
+  settings: AppSettings | null;
   isLoaded: boolean;
 
   setGlobalGroupingEnabled: (value: boolean) => Promise<void>;
@@ -31,13 +31,13 @@ export interface UseSyncedSettingsReturn {
   ) => () => void;
   onDomainRulesChange: (callback: (value: DomainRuleSettings) => void) => () => void;
 
-  updateSettings: (updates: Partial<SyncSettings>) => Promise<void>;
+  updateSettings: (updates: Partial<AppSettings>) => Promise<void>;
   reloadSettings: () => Promise<void>;
 }
 
 // --- Storage helpers (module-level, stable references) ---
 
-async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
+async function loadSettingsFromStorage(): Promise<AppSettings> {
   const results = await storage.getItems([
     globalGroupingEnabledItem,
     globalDeduplicationEnabledItem,
@@ -49,7 +49,7 @@ async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
   ]);
 
   const rawRules = results[4].value as DomainRuleSettings;
-  // Migrate legacy wildcard syntax: *.example.com → example.com
+  // Migrate legacy wildcard syntax: *.example.com -> example.com
   const hasWildcards = rawRules?.some(r => r.domainFilter?.startsWith('*.'));
   const domainRules = hasWildcards
     ? rawRules.map(r => ({
@@ -78,9 +78,9 @@ async function loadSyncSettingsFromStorage(): Promise<SyncSettings> {
  * Each watcher fires `onChanged` with a single-field partial so the generic
  * hook can merge it into state and invoke per-field callbacks.
  */
-function watchSyncSettings(onChanged: (update: Partial<SyncSettings>) => void): () => void {
+function watchAppSettings(onChanged: (update: Partial<AppSettings>) => void): () => void {
   const unwatchers = (
-    Object.entries(syncSettingsItemMap) as [keyof SyncSettings, { watch: (cb: (v: unknown) => void) => () => void }][]
+    Object.entries(settingsItemMap) as [keyof AppSettings, { watch: (cb: (v: unknown) => void) => () => void }][]
   ).map(([field, item]) => item.watch((v) => onChanged({ [field]: v })));
   return () => unwatchers.forEach(u => u());
 }
@@ -88,20 +88,20 @@ function watchSyncSettings(onChanged: (update: Partial<SyncSettings>) => void): 
 /**
  * Persist only the fields present in `updates` to their respective storage items.
  */
-async function saveSettingsToStorage(updates: Partial<SyncSettings>): Promise<void> {
-  const items = (Object.entries(updates) as [keyof typeof syncSettingsItemMap, SyncSettings[keyof SyncSettings]][])
-    .filter(([key]) => key in syncSettingsItemMap)
-    .map(([key, value]) => ({ item: syncSettingsItemMap[key], value }));
+async function saveSettingsToStorage(updates: Partial<AppSettings>): Promise<void> {
+  const items = (Object.entries(updates) as [keyof typeof settingsItemMap, AppSettings[keyof AppSettings]][])
+    .filter(([key]) => key in settingsItemMap)
+    .map(([key, value]) => ({ item: settingsItemMap[key], value }));
   if (items.length > 0) await storage.setItems(items);
 }
 
 // --- Hook ---
 
-export function useSyncedSettings(): UseSyncedSettingsReturn {
+export function useSettings(): UseSettingsReturn {
   const { value: settings, isLoaded, update, onFieldChange, reload } =
-    useSyncedState<SyncSettings>({
-      load: loadSyncSettingsFromStorage,
-      watch: watchSyncSettings,
+    useStorageState<AppSettings>({
+      load: loadSettingsFromStorage,
+      watch: watchAppSettings,
       // Only save changed fields; `current` is not needed here.
       save: (updates) => saveSettingsToStorage(updates),
     });

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import type { Statistics } from '@/types/statistics.js';
 import { defaultStatistics } from '@/types/statistics.js';
 import { statisticsItem } from '@/utils/storageItems.js';
-import { useSyncedState } from './useSyncedState.js';
+import { useStorageState } from './useStorageState.js';
 
 export interface UseStatisticsReturn {
   statistics: Statistics | null;
@@ -27,7 +27,7 @@ function mergeWithDefaults(v: Statistics | null): Statistics {
 
 export function useStatistics(): UseStatisticsReturn {
   const { value: statistics, isLoaded, update, reset, onFieldChange, reload } =
-    useSyncedState<Statistics>({
+    useStorageState<Statistics>({
       load: async () => mergeWithDefaults(await statisticsItem.getValue()),
 
       // The statistics object is stored as a single item.

--- a/src/hooks/useStorageState.ts
+++ b/src/hooks/useStorageState.ts
@@ -2,11 +2,11 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { logger } from '@/utils/logger';
 
 /**
- * Configuration for useSyncedState.
+ * Configuration for useStorageState.
  *
  * @template T - Shape of the state object (must be a plain object).
  */
-export interface SyncedStateOptions<T extends object> {
+export interface StorageStateOptions<T extends object> {
   /**
    * Async function that loads the full initial state from storage.
    * Called once on mount.
@@ -35,7 +35,7 @@ export interface SyncedStateOptions<T extends object> {
   defaults?: T;
 }
 
-export interface SyncedStateReturn<T extends object> {
+export interface StorageStateReturn<T extends object> {
   /** Current state, or null while the initial load is pending. */
   value: T | null;
   /** True once the initial load completed successfully. */
@@ -56,7 +56,7 @@ export interface SyncedStateReturn<T extends object> {
 
 /**
  * Generic hook for state that is persisted to browser storage and watched for
- * changes made by other extension contexts (background, popup, options…).
+ * changes made by other extension contexts (background, popup, options).
  *
  * Handles:
  * - Initial load
@@ -64,12 +64,12 @@ export interface SyncedStateReturn<T extends object> {
  * - Optimistic local writes (state updated before storage write completes)
  * - isLocalUpdate guard to avoid reacting to own writes
  */
-export function useSyncedState<T extends object>({
+export function useStorageState<T extends object>({
   load,
   watch: setupWatch,
   save,
   defaults,
-}: SyncedStateOptions<T>): SyncedStateReturn<T> {
+}: StorageStateOptions<T>): StorageStateReturn<T> {
   // --- State ---
   const [value, _setValue] = useState<T | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -124,7 +124,7 @@ export function useSyncedState<T extends object>({
   useEffect(() => {
     loadRef.current()
       .then(v => { setValue(v); setIsLoaded(true); })
-      .catch(error => logger.error('[useSyncedState] load error:', error));
+      .catch(error => logger.error('[useStorageState] load error:', error));
   }, [setValue]);
 
   useEffect(() => {
@@ -190,7 +190,7 @@ export function useSyncedState<T extends object>({
     try {
       setValue(await loadRef.current());
     } catch (error) {
-      logger.error('[useSyncedState] reload error:', error);
+      logger.error('[useStorageState] reload error:', error);
     }
   }, [setValue]);
 

--- a/src/pages/DomainRulesPage.stories.tsx
+++ b/src/pages/DomainRulesPage.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { DomainRulesPage } from './DomainRulesPage';
-import type { SyncSettings, DomainRuleSetting } from '@/types/syncSettings';
+import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
 
 const rules: DomainRuleSetting[] = [
   {
@@ -31,7 +31,7 @@ const rules: DomainRuleSetting[] = [
   },
 ];
 
-const mockSyncSettings: SyncSettings = {
+const mockSyncSettings: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -21,7 +21,7 @@ import {
   moveToLastOfDomain,
   getRulesForRootDomain,
 } from '@/utils/ruleOrderUtils';
-import type { SyncSettings, DomainRuleSetting } from '@/types/syncSettings';
+import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
 import type { DomainRule } from '@/schemas/domainRule';
 
 type DeleteTarget =
@@ -29,7 +29,7 @@ type DeleteTarget =
   | { type: 'bulk'; ruleIds: string[] };
 
 interface DomainRulesPageProps {
-  syncSettings: SyncSettings;
+  syncSettings: AppSettings;
   updateRules: (rules: DomainRuleSetting[]) => void;
 }
 

--- a/src/pages/ImportExportPage.stories.tsx
+++ b/src/pages/ImportExportPage.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ImportExportPage } from './ImportExportPage';
-import { defaultSyncSettings } from '@/types/syncSettings';
-import type { SyncSettings } from '@/types/syncSettings';
+import { defaultAppSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 
-const mockSyncSettingsWithRules: SyncSettings = {
-  ...defaultSyncSettings,
+const mockSyncSettingsWithRules: AppSettings = {
+  ...defaultAppSettings,
   domainRules: [
     {
       id: 'rule-1',
@@ -64,7 +64,7 @@ type Story = StoryObj<typeof meta>;
 
 export const ImportExportPageDefault: Story = {
   args: {
-    syncSettings: defaultSyncSettings,
+    syncSettings: defaultAppSettings,
     onSettingsUpdate: (settings) => console.log('Settings updated:', settings),
   },
 };

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -9,11 +9,11 @@ import { ExportSessionsWizard } from '@/components/UI/ImportExportWizards/Export
 import { ImportSessionsWizard } from '@/components/UI/ImportExportWizards/ImportSessionsWizard';
 import { ImportExportActionCard } from '@/components/UI/ImportExportWizards/ImportExportActionCard';
 import { useSessions } from '@/hooks/useSessions';
-import type { SyncSettings, DomainRuleSetting } from '@/types/syncSettings';
+import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
 
 interface ImportExportPageProps {
-  syncSettings: SyncSettings;
-  onSettingsUpdate: (settings: SyncSettings) => void;
+  syncSettings: AppSettings;
+  onSettingsUpdate: (settings: AppSettings) => void;
 }
 
 export function ImportExportPage({ syncSettings, onSettingsUpdate }: ImportExportPageProps) {

--- a/src/pages/SessionsPage.stories.tsx
+++ b/src/pages/SessionsPage.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { SessionsPage } from './SessionsPage';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 import type { Session } from '@/types/session';
 
 const now = '2025-01-01T10:00:00.000Z';
@@ -18,7 +18,7 @@ function makeSession(id: string, name: string, isPinned: boolean): Session {
   };
 }
 
-const mockSyncSettings: SyncSettings = {
+const mockSyncSettings: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -24,10 +24,10 @@ import { showSuccessNotification } from '@/utils/notifications';
 import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 
 interface SessionsPageProps {
-  syncSettings: SyncSettings;
+  syncSettings: AppSettings;
   /** Controlled by options.tsx: true when a deep-link requests the snapshot wizard. */
   snapshotWizardOpen?: boolean;
   /** Called by SessionsPage to let options.tsx know the wizard closed (or page unmounted). */

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -2,11 +2,11 @@ import { Box, Flex, Text, Button, Card } from '@radix-ui/themes';
 import { BarChart3, RotateCcw, Layers, Copy } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { getMessage } from '@/utils/i18n';
-import type { SyncSettings } from '@/types/syncSettings';
+import type { AppSettings } from '@/types/syncSettings';
 import type { Statistics } from '@/types/statistics';
 
 interface StatisticsPageProps {
-  syncSettings: SyncSettings;
+  syncSettings: AppSettings;
   stats: Statistics;
   onReset: () => void;
 }

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -5,7 +5,7 @@ import { browser } from 'wxt/browser';
 import { Flex, Spinner, Text, Theme } from '@radix-ui/themes';
 import { ThemeProvider } from 'next-themes';
 
-import { useSyncedSettings } from '@/hooks/useSyncedSettings.js';
+import { useSettings } from '@/hooks/useSettings.js';
 import { useStatistics } from '@/hooks/useStatistics.js';
 import { useDeepLinking } from '@/hooks/useDeepLinking.js';
 import { getMessage } from '@/utils/i18n';
@@ -30,7 +30,7 @@ import type { DomainRuleSettings } from '@/types/syncSettings';
 (() => {
 
 function OptionsContent() {
-    const { settings, updateSettings } = useSyncedSettings();
+    const { settings, updateSettings } = useSettings();
     const { statistics: stats, resetStatistics } = useStatistics();
     const {
         currentTab, setCurrentTab,

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -9,12 +9,12 @@ import { PopupHeader } from '@/components/UI/PopupHeader/PopupHeader';
 import { SettingsToggles } from '@/components/UI/SettingsToggles/SettingsToggles';
 import { PopupToolbar } from '@/components/UI/PopupToolbar/PopupToolbar';
 import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfilesList';
-import { useSyncedSettings } from '@/hooks/useSyncedSettings';
+import { useSettings } from '@/hooks/useSettings';
 
 (() => {
 
 function PopupContent() {
-  const { settings, isLoaded, setGlobalGroupingEnabled, setGlobalDeduplicationEnabled } = useSyncedSettings();
+  const { settings, isLoaded, setGlobalGroupingEnabled, setGlobalDeduplicationEnabled } = useSettings();
 
   const openOptionsPage = useCallback(() => {
     browser.runtime.openOptionsPage();

--- a/src/types/syncSettings.ts
+++ b/src/types/syncSettings.ts
@@ -23,9 +23,6 @@ export interface AppSettings {
   notifyOnDeduplication: boolean;
 }
 
-// Alias de compatibilité (sera supprimé au lot 3)
-export type SyncSettings = AppSettings;
-
 // Valeurs par défaut pour AppSettings
 export const defaultAppSettings: AppSettings = {
   globalGroupingEnabled: true,
@@ -36,6 +33,3 @@ export const defaultAppSettings: AppSettings = {
   notifyOnGrouping: true,
   notifyOnDeduplication: true
 };
-
-// Alias de compatibilité (sera supprimé au lot 3)
-export const defaultSyncSettings: AppSettings = defaultAppSettings;

--- a/src/types/syncSettings.ts
+++ b/src/types/syncSettings.ts
@@ -11,8 +11,8 @@ export interface DomainRuleSetting extends DomainRule {
 // Types pour les arrays
 export type DomainRuleSettings = DomainRuleSetting[];
 
-// Interface SyncSettings qui étend les types Zod inférés
-export interface SyncSettings {
+// Interface AppSettings qui étend les types Zod inférés
+export interface AppSettings {
   globalGroupingEnabled: boolean;
   globalDeduplicationEnabled: boolean;
   deduplicateUnmatchedDomains: boolean;
@@ -23,8 +23,11 @@ export interface SyncSettings {
   notifyOnDeduplication: boolean;
 }
 
-// Valeurs par défaut pour SyncSettings
-export const defaultSyncSettings: SyncSettings = {
+// Alias de compatibilité (sera supprimé au lot 3)
+export type SyncSettings = AppSettings;
+
+// Valeurs par défaut pour AppSettings
+export const defaultAppSettings: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: false,
@@ -33,3 +36,6 @@ export const defaultSyncSettings: SyncSettings = {
   notifyOnGrouping: true,
   notifyOnDeduplication: true
 };
+
+// Alias de compatibilité (sera supprimé au lot 3)
+export const defaultSyncSettings: AppSettings = defaultAppSettings;

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -1,13 +1,13 @@
 import { browser } from 'wxt/browser';
-import { getSyncSettings, setSyncSettings } from './settingsUtils.js';
+import { getSettings, setSettings } from './settingsUtils.js';
 import { logger } from './logger.js';
 import { setStatisticsData } from './statisticsUtils.js';
-import { defaultSyncSettings } from '@/types/syncSettings.js';
+import { defaultAppSettings } from '@/types/syncSettings.js';
 import { defaultStatistics } from '@/types/statistics.js';
-import type { SyncSettings, DomainRuleSetting } from '@/types/syncSettings.js';
+import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings.js';
 
 const defaultSettingsPath = '/data/default_settings.json' as const;
-let cachedDefaultSettings: SyncSettings | null = null;
+let cachedDefaultSettings: AppSettings | null = null;
 
 function isObject(item: unknown): item is Record<string, unknown> {
   return typeof item === 'object' && item !== null && !Array.isArray(item);
@@ -27,9 +27,9 @@ function mergeDeep(target: unknown, source: unknown): unknown {
   return output;
 }
 
-async function loadDefaultSettings(): Promise<SyncSettings> {
+async function loadDefaultSettings(): Promise<AppSettings> {
   if (cachedDefaultSettings) return cachedDefaultSettings;
-  
+
   try {
     const url = browser.runtime.getURL(defaultSettingsPath);
     const response = await fetch(url);
@@ -38,7 +38,7 @@ async function loadDefaultSettings(): Promise<SyncSettings> {
     return cachedDefaultSettings!;
   } catch (error) {
     logger.error("Cannot load defaults:", error);
-    return defaultSyncSettings;
+    return defaultAppSettings;
   }
 }
 
@@ -47,15 +47,16 @@ export async function initializeDefaults(): Promise<void> {
   // WXT stores each setting as an individual key (e.g. 'domainRules'), not as a
   // single 'settings' object. Check for the presence of 'domainRules' to detect
   // whether the extension has been installed before.
+  // NOTE: still reads storage.sync here for fresh-install detection (lot 3 will migrate this)
   const rawSync = await browser.storage.sync.get('domainRules');
 
   if (rawSync.domainRules === undefined) {
     logger.debug("Init defaults from JSON...");
-    await setSyncSettings(defaults);
+    await setSettings(defaults);
   } else {
     logger.debug("Merging existing with JSON defaults...");
-    const currentSettings = await getSyncSettings();
-    const merged = mergeDeep(defaults, currentSettings) as SyncSettings;
+    const currentSettings = await getSettings();
+    const merged = mergeDeep(defaults, currentSettings) as AppSettings;
 
     // Migrate missing fields on existing rules (never inject new default rules)
     if (merged.domainRules && Array.isArray(merged.domainRules)) {
@@ -82,9 +83,9 @@ export async function initializeDefaults(): Promise<void> {
         }
       });
     }
-    await setSyncSettings(merged);
+    await setSettings(merged);
   }
-  
+
   const localData = await browser.storage.local.get('statistics');
   if (!localData.statistics) {
     logger.debug("Init stats...");

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -44,13 +44,12 @@ async function loadDefaultSettings(): Promise<AppSettings> {
 
 export async function initializeDefaults(): Promise<void> {
   const defaults = await loadDefaultSettings();
-  // WXT stores each setting as an individual key (e.g. 'domainRules'), not as a
-  // single 'settings' object. Check for the presence of 'domainRules' to detect
-  // whether the extension has been installed before.
-  // NOTE: still reads storage.sync here for fresh-install detection (lot 3 will migrate this)
-  const rawSync = await browser.storage.sync.get('domainRules');
+  // Check storage.local for 'domainRules' to detect whether the extension has been
+  // installed before. migrateSettingsFromSyncToLocal() runs before this function so
+  // any existing sync data is already copied to local.
+  const rawLocal = await browser.storage.local.get('domainRules');
 
-  if (rawSync.domainRules === undefined) {
+  if (rawLocal.domainRules === undefined) {
     logger.debug("Init defaults from JSON...");
     await setSettings(defaults);
   } else {

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,6 +1,6 @@
 import { storage } from 'wxt/utils/storage';
-import type { SyncSettings } from '@/types/syncSettings.js';
-import { defaultSyncSettings } from '@/types/syncSettings.js';
+import type { AppSettings } from '@/types/syncSettings.js';
+import { defaultAppSettings } from '@/types/syncSettings.js';
 import { logger } from './logger.js';
 import {
   globalGroupingEnabledItem,
@@ -10,7 +10,7 @@ import {
   domainRulesItem,
   notifyOnGroupingItem,
   notifyOnDeduplicationItem,
-  syncSettingsItemMap,
+  settingsItemMap,
 } from './storageItems.js';
 
 /**
@@ -18,7 +18,7 @@ import {
  * (background, content scripts, popup, options)
  */
 
-export async function getSyncSettings(): Promise<SyncSettings> {
+export async function getSettings(): Promise<AppSettings> {
   try {
     const results = await storage.getItems([
       globalGroupingEnabledItem,
@@ -33,18 +33,18 @@ export async function getSyncSettings(): Promise<SyncSettings> {
       globalGroupingEnabled: results[0].value as boolean,
       globalDeduplicationEnabled: results[1].value as boolean,
       deduplicateUnmatchedDomains: results[2].value as boolean,
-      deduplicationKeepStrategy: results[3].value as SyncSettings['deduplicationKeepStrategy'],
-      domainRules: results[4].value as SyncSettings['domainRules'],
+      deduplicationKeepStrategy: results[3].value as AppSettings['deduplicationKeepStrategy'],
+      domainRules: results[4].value as AppSettings['domainRules'],
       notifyOnGrouping: results[5].value as boolean,
       notifyOnDeduplication: results[6].value as boolean,
     };
   } catch (error) {
-    logger.error('Error getting sync settings:', error);
-    return defaultSyncSettings;
+    logger.error('Error getting settings:', error);
+    return defaultAppSettings;
   }
 }
 
-export async function setSyncSettings(settings: SyncSettings): Promise<void> {
+export async function setSettings(settings: AppSettings): Promise<void> {
   try {
     await storage.setItems([
       { item: globalGroupingEnabledItem, value: settings.globalGroupingEnabled },
@@ -56,11 +56,11 @@ export async function setSyncSettings(settings: SyncSettings): Promise<void> {
       { item: notifyOnDeduplicationItem, value: settings.notifyOnDeduplication },
     ]);
   } catch (error) {
-    logger.error('Error setting sync settings:', error);
+    logger.error('Error setting settings:', error);
   }
 }
 
-export async function updateSyncSettings(updates: Partial<SyncSettings>): Promise<void> {
+export async function updateSettings(updates: Partial<AppSettings>): Promise<void> {
   try {
     const items: Parameters<typeof storage.setItems>[0] = [];
     if ('globalGroupingEnabled' in updates)
@@ -79,38 +79,38 @@ export async function updateSyncSettings(updates: Partial<SyncSettings>): Promis
       items.push({ item: notifyOnDeduplicationItem, value: updates.notifyOnDeduplication! });
     if (items.length > 0) await storage.setItems(items);
   } catch (error) {
-    logger.error('Error updating sync settings:', error);
+    logger.error('Error updating settings:', error);
   }
 }
 
 
 /**
- * Écouter les changements de settings
- * Retourne une fonction de cleanup
+ * Ecouter les changements de settings.
+ * Retourne une fonction de cleanup.
  */
-export function watchSyncSettings(
-  callback: (settings: SyncSettings) => void,
+export function watchSettings(
+  callback: (settings: AppSettings) => void,
 ): () => void {
   const unwatchers = [
-    globalGroupingEnabledItem.watch(() => getSyncSettings().then(callback)),
-    globalDeduplicationEnabledItem.watch(() => getSyncSettings().then(callback)),
-    deduplicateUnmatchedDomainsItem.watch(() => getSyncSettings().then(callback)),
-    deduplicationKeepStrategyItem.watch(() => getSyncSettings().then(callback)),
-    domainRulesItem.watch(() => getSyncSettings().then(callback)),
-    notifyOnGroupingItem.watch(() => getSyncSettings().then(callback)),
-    notifyOnDeduplicationItem.watch(() => getSyncSettings().then(callback)),
+    globalGroupingEnabledItem.watch(() => getSettings().then(callback)),
+    globalDeduplicationEnabledItem.watch(() => getSettings().then(callback)),
+    deduplicateUnmatchedDomainsItem.watch(() => getSettings().then(callback)),
+    deduplicationKeepStrategyItem.watch(() => getSettings().then(callback)),
+    domainRulesItem.watch(() => getSettings().then(callback)),
+    notifyOnGroupingItem.watch(() => getSettings().then(callback)),
+    notifyOnDeduplicationItem.watch(() => getSettings().then(callback)),
   ];
   return () => unwatchers.forEach(u => u());
 }
 
 /**
- * Écouter un champ spécifique des settings
+ * Ecouter un champ spécifique des settings.
  */
-export function watchSyncSettingsField<K extends keyof SyncSettings>(
+export function watchSettingsField<K extends keyof AppSettings>(
   field: K,
-  callback: (value: SyncSettings[K]) => void,
+  callback: (value: AppSettings[K]) => void,
 ): () => void {
-  return (syncSettingsItemMap[field] as unknown as { watch: (cb: (v: SyncSettings[K]) => void) => () => void }).watch(
-    (newValue: SyncSettings[K]) => callback(newValue),
+  return (settingsItemMap[field] as unknown as { watch: (cb: (v: AppSettings[K]) => void) => () => void }).watch(
+    (newValue: AppSettings[K]) => callback(newValue),
   );
 }

--- a/src/utils/storageItems.ts
+++ b/src/utils/storageItems.ts
@@ -1,6 +1,6 @@
 import { storage } from 'wxt/utils/storage';
 import type { DomainRuleSettings } from '@/types/syncSettings.js';
-import { defaultSyncSettings } from '@/types/syncSettings.js';
+import { defaultAppSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
 import type { Statistics } from '@/types/statistics.js';
 import { defaultStatistics } from '@/types/statistics.js';
@@ -9,38 +9,38 @@ import type { Session } from '@/types/session.js';
 // --- Sync storage items ---
 
 export const globalGroupingEnabledItem = storage.defineItem<boolean>(
-  'sync:globalGroupingEnabled',
-  { defaultValue: defaultSyncSettings.globalGroupingEnabled },
+  'local:globalGroupingEnabled',
+  { defaultValue: defaultAppSettings.globalGroupingEnabled },
 );
 
 export const globalDeduplicationEnabledItem = storage.defineItem<boolean>(
-  'sync:globalDeduplicationEnabled',
-  { defaultValue: defaultSyncSettings.globalDeduplicationEnabled },
+  'local:globalDeduplicationEnabled',
+  { defaultValue: defaultAppSettings.globalDeduplicationEnabled },
 );
 
 export const deduplicateUnmatchedDomainsItem = storage.defineItem<boolean>(
-  'sync:deduplicateUnmatchedDomains',
-  { defaultValue: defaultSyncSettings.deduplicateUnmatchedDomains },
+  'local:deduplicateUnmatchedDomains',
+  { defaultValue: defaultAppSettings.deduplicateUnmatchedDomains },
 );
 
 export const deduplicationKeepStrategyItem = storage.defineItem<DeduplicationKeepStrategyValue>(
-  'sync:deduplicationKeepStrategy',
-  { defaultValue: defaultSyncSettings.deduplicationKeepStrategy },
+  'local:deduplicationKeepStrategy',
+  { defaultValue: defaultAppSettings.deduplicationKeepStrategy },
 );
 
 export const domainRulesItem = storage.defineItem<DomainRuleSettings>(
-  'sync:domainRules',
-  { defaultValue: defaultSyncSettings.domainRules },
+  'local:domainRules',
+  { defaultValue: defaultAppSettings.domainRules },
 );
 
 export const notifyOnGroupingItem = storage.defineItem<boolean>(
-  'sync:notifyOnGrouping',
-  { defaultValue: defaultSyncSettings.notifyOnGrouping },
+  'local:notifyOnGrouping',
+  { defaultValue: defaultAppSettings.notifyOnGrouping },
 );
 
 export const notifyOnDeduplicationItem = storage.defineItem<boolean>(
-  'sync:notifyOnDeduplication',
-  { defaultValue: defaultSyncSettings.notifyOnDeduplication },
+  'local:notifyOnDeduplication',
+  { defaultValue: defaultAppSettings.notifyOnDeduplication },
 );
 
 // --- Local storage items ---
@@ -60,8 +60,8 @@ export const popupPinnedEmptyCollapsedItem = storage.defineItem<boolean>(
   { defaultValue: false },
 );
 
-// Map des items sync par champ (pour watchSyncSettingsField)
-export const syncSettingsItemMap = {
+// Map des items settings par champ (pour watchSettingsField)
+export const settingsItemMap = {
   globalGroupingEnabled: globalGroupingEnabledItem,
   globalDeduplicationEnabled: globalDeduplicationEnabledItem,
   deduplicateUnmatchedDomains: deduplicateUnmatchedDomainsItem,

--- a/tests/background/_helpers.ts
+++ b/tests/background/_helpers.ts
@@ -11,7 +11,7 @@
  * vi.mock() factories can import from it.
  */
 import { vi } from 'vitest';
-import type { DomainRuleSetting, SyncSettings } from '../../src/types/syncSettings';
+import type { DomainRuleSetting, AppSettings } from '../../src/types/syncSettings';
 
 // ---- Types ------------------------------------------------------------------
 
@@ -118,7 +118,7 @@ export function makeRule(overrides: Partial<DomainRuleSetting> = {}): DomainRule
   };
 }
 
-export function makeSettings(overrides: Partial<SyncSettings> = {}): SyncSettings {
+export function makeSettings(overrides: Partial<AppSettings> = {}): AppSettings {
   // Intentionally pinned to the legacy defaults (keep-old, unmatched-enabled)
   // so existing dedup tests keep asserting the same observable behavior.
   // Tests that want the new production defaults override explicitly.

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -89,27 +89,11 @@ export interface Statistics {
   tabsDeduplicatedCount: number;
 }
 
-/**
- * Writes to chrome.storage.sync, retrying with backoff on quota errors.
- * Tests run fast enough on a single worker that MAX_WRITE_OPERATIONS_PER_MINUTE
- * (120/min) can be exceeded when many tests each call addDomainRule + clearDomainRules.
- */
-async function syncSet(sw: Page, data: Record<string, unknown>): Promise<void> {
-  const delays = [1000, 2000, 4000, 8000];
-  for (let i = 0; i <= delays.length; i++) {
-    try {
-      await sw.evaluate(async (d: Record<string, unknown>) => {
-        await chrome.storage.sync.set(d);
-      }, data as Record<string, unknown>);
-      return;
-    } catch (e: unknown) {
-      if (i < delays.length && String(e).includes('MAX_WRITE_OPERATIONS')) {
-        await new Promise(r => setTimeout(r, delays[i]));
-      } else {
-        throw e;
-      }
-    }
-  }
+/** Writes to chrome.storage.local (settings are no longer in storage.sync). */
+async function localSet(sw: Page, data: Record<string, unknown>): Promise<void> {
+  await sw.evaluate(async (d: Record<string, unknown>) => {
+    await chrome.storage.local.set(d);
+  }, data as Record<string, unknown>);
 }
 
 // Create a temporary user data directory for each test run
@@ -242,32 +226,32 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       // Set global grouping enabled/disabled
       setGlobalGroupingEnabled: async (enabled: boolean) => {
         const sw = await getServiceWorker();
-        await syncSet(sw, { globalGroupingEnabled: enabled });
+        await localSet(sw, { globalGroupingEnabled: enabled });
       },
 
       // Set global deduplication enabled/disabled
       setGlobalDeduplicationEnabled: async (enabled: boolean) => {
         const sw = await getServiceWorker();
-        await syncSet(sw, { globalDeduplicationEnabled: enabled });
+        await localSet(sw, { globalDeduplicationEnabled: enabled });
       },
 
       // Set deduplication scope for tabs without matching rule
       setDeduplicateUnmatchedDomains: async (enabled: boolean) => {
         const sw = await getServiceWorker();
-        await syncSet(sw, { deduplicateUnmatchedDomains: enabled });
+        await localSet(sw, { deduplicateUnmatchedDomains: enabled });
       },
 
       // Set which tab survives when a duplicate is detected
       setDeduplicationKeepStrategy: async (strategy: 'keep-old' | 'keep-new' | 'keep-grouped' | 'keep-grouped-or-new') => {
         const sw = await getServiceWorker();
-        await syncSet(sw, { deduplicationKeepStrategy: strategy });
+        await localSet(sw, { deduplicationKeepStrategy: strategy });
       },
 
       // Add a domain rule
       addDomainRule: async (rule: DomainRuleConfig) => {
         const sw = await getServiceWorker();
         const updatedRules = await sw.evaluate(async (ruleConfig) => {
-          const result = await chrome.storage.sync.get({ domainRules: [] });
+          const result = await chrome.storage.local.get({ domainRules: [] });
           const rules: unknown[] = result.domainRules || [];
           rules.push({
             id: `rule-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
@@ -287,7 +271,7 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
           });
           return rules;
         }, rule);
-        await syncSet(sw, { domainRules: updatedRules });
+        await localSet(sw, { domainRules: updatedRules });
         // Wait for storage to propagate
         await new Promise(resolve => setTimeout(resolve, 100));
       },
@@ -295,7 +279,7 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       // Clear all domain rules
       clearDomainRules: async () => {
         const sw = await getServiceWorker();
-        await syncSet(sw, { domainRules: [] });
+        await localSet(sw, { domainRules: [] });
         await new Promise(resolve => setTimeout(resolve, 100));
       },
 
@@ -303,7 +287,7 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
       getSettings: async () => {
         const sw = await getServiceWorker();
         return await sw.evaluate(async () => {
-          return await chrome.storage.sync.get({
+          return await chrome.storage.local.get({
             globalGroupingEnabled: true,
             globalDeduplicationEnabled: true,
             deduplicateUnmatchedDomains: true,

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -61,7 +61,7 @@ function makeRuleJson(label: string, domainFilter: string): string {
 async function seedDomainRules(extensionContext: any, rules: any[]): Promise<void> {
   const sw = extensionContext.serviceWorkers()[0];
   await sw.evaluate(async (r: any[]) => {
-    await chrome.storage.sync.set({ domainRules: r });
+    await chrome.storage.local.set({ domainRules: r });
   }, rules);
   await new Promise(r => setTimeout(r, 200));
 }
@@ -70,7 +70,7 @@ async function seedDomainRules(extensionContext: any, rules: any[]): Promise<voi
 async function clearDomainRules(extensionContext: any): Promise<void> {
   const sw = extensionContext.serviceWorkers()[0];
   await sw.evaluate(async () => {
-    await chrome.storage.sync.set({ domainRules: [] });
+    await chrome.storage.local.set({ domainRules: [] });
   });
   await new Promise(r => setTimeout(r, 200));
 }

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -33,7 +33,7 @@ async function setNotificationPrefs(
   prefs: { notifyOnGrouping?: boolean; notifyOnDeduplication?: boolean },
 ) {
   await sw.evaluate(async (p: { notifyOnGrouping?: boolean; notifyOnDeduplication?: boolean }) => {
-    await chrome.storage.sync.set(p);
+    await chrome.storage.local.set(p);
   }, prefs);
   await new Promise(r => setTimeout(r, 100));
 }

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -34,7 +34,7 @@ async function goToImportExportSection(page: any, extensionId: string): Promise<
 async function clearDomainRules(extensionContext: any): Promise<void> {
   const sw = extensionContext.serviceWorkers()[0];
   await sw.evaluate(async () => {
-    await chrome.storage.sync.set({ domainRules: [] });
+    await chrome.storage.local.set({ domainRules: [] });
   });
   await new Promise((r) => setTimeout(r, 200));
 }

--- a/tests/e2e/popup-organize.spec.ts
+++ b/tests/e2e/popup-organize.spec.ts
@@ -206,7 +206,7 @@ test.describe('[US-PO007] Batch deduplication', () => {
   }) => {
     const sw = await getServiceWorker(extensionContext);
     await sw.evaluate(async () => {
-      await chrome.storage.sync.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
+      await chrome.storage.local.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
     });
     await clearNotifications(sw);
 
@@ -237,7 +237,7 @@ test.describe('[US-PO007] Batch deduplication', () => {
   }) => {
     const sw = await getServiceWorker(extensionContext);
     await sw.evaluate(async () => {
-      await chrome.storage.sync.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
+      await chrome.storage.local.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
     });
     await clearNotifications(sw);
 
@@ -466,7 +466,7 @@ test.describe('[US-PO008] Batch grouping', () => {
   }) => {
     const sw = await getServiceWorker(extensionContext);
     await sw.evaluate(async () => {
-      await chrome.storage.sync.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
+      await chrome.storage.local.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
     });
     await clearNotifications(sw);
 
@@ -494,7 +494,7 @@ test.describe('[US-PO008] Batch grouping', () => {
   }) => {
     const sw = await getServiceWorker(extensionContext);
     await sw.evaluate(async () => {
-      await chrome.storage.sync.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
+      await chrome.storage.local.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
     });
     await clearNotifications(sw);
 

--- a/tests/fixtures/storyData.ts
+++ b/tests/fixtures/storyData.ts
@@ -2,7 +2,7 @@
  * Shared mock data for Storybook stories and portable-story tests.
  */
 import type { Session } from '../../src/types/session';
-import type { SyncSettings, DomainRuleSetting } from '../../src/types/syncSettings';
+import type { AppSettings, DomainRuleSetting } from '../../src/types/syncSettings';
 
 export const mockTab = (id: string, title: string, url: string) => ({
   id,
@@ -64,7 +64,7 @@ export const mockRule: DomainRuleSetting = {
   enabled: true,
 };
 
-export const mockSyncSettings: SyncSettings = {
+export const mockAppSettings: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,

--- a/tests/hooks/useSettings.test.ts
+++ b/tests/hooks/useSettings.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
 import { fakeBrowser } from 'wxt/testing';
-import { useSyncedSettings } from '../../src/hooks/useSyncedSettings';
+import { useSettings } from '../../src/hooks/useSettings';
 
 // fakeBrowser.reset() est appelé avant chaque test via tests/setup.ts
 
-describe('useSyncedSettings', () => {
+describe('useSettings', () => {
   afterEach(() => {
     cleanup();
   });
 
   it('devrait charger les paramètres par défaut', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -25,7 +25,7 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait mettre à jour deduplicateUnmatchedDomains', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -39,13 +39,13 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait charger les paramètres existants', async () => {
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       globalGroupingEnabled: false,
       globalDeduplicationEnabled: true,
       domainRules: [{ id: '1', label: 'Test Rule' }]
     });
 
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -56,7 +56,7 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait mettre à jour globalGroupingEnabled', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -70,7 +70,7 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait mettre à jour globalDeduplicationEnabled', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -84,7 +84,7 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait mettre à jour les domainRules', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -103,7 +103,7 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait mettre à jour plusieurs paramètres', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
@@ -121,15 +121,14 @@ describe('useSyncedSettings', () => {
   });
 
   it('devrait recharger les paramètres', async () => {
-    const { result } = renderHook(() => useSyncedSettings());
+    const { result } = renderHook(() => useSettings());
 
     await waitFor(() => {
       expect(result.current.isLoaded).toBe(true);
     });
 
-    // Modifier directement le storage
     await act(async () => {
-      await fakeBrowser.storage.sync.set({
+      await fakeBrowser.storage.local.set({
         globalGroupingEnabled: false,
         globalDeduplicationEnabled: false,
         domainRules: [{ id: 'new', label: 'New Rule' }]

--- a/tests/hooks/useStatistics.test.ts
+++ b/tests/hooks/useStatistics.test.ts
@@ -236,7 +236,7 @@ describe('useStatistics', () => {
 
     expect(result.current.isLoaded).toBe(false);
     expect(result.current.statistics).toBe(null);
-    expect(consoleSpy).toHaveBeenCalledWith('[smart-tab-organizer]', '[useSyncedState] load error:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('[smart-tab-organizer]', '[useStorageState] load error:', expect.any(Error));
 
     consoleSpy.mockRestore();
   });

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
-import type { SyncSettings, DomainRuleSetting } from '../src/types/syncSettings';
+import type { AppSettings, DomainRuleSetting } from '../src/types/syncSettings';
 
 // The fetch response body returned by loadDefaultSettings() when the
 // extension is first installed or upgraded.
-const TEST_DEFAULTS: SyncSettings = {
+const TEST_DEFAULTS: AppSettings = {
   globalGroupingEnabled: true,
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: false,
@@ -49,11 +49,11 @@ describe('initializeDefaults — fresh install', () => {
   it('writes default settings when domainRules is absent from storage', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    const stored = await getSyncSettings();
+    const stored = await getSettings();
     expect(stored.globalGroupingEnabled).toBe(true);
     expect(stored.domainRules).toHaveLength(1);
     expect(stored.domainRules[0].id).toBe('default-rule-1');
@@ -76,7 +76,7 @@ describe('initializeDefaults — upgrade path', () => {
   it('preserves existing settings and merges with defaults (existing wins)', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
     // Seed an existing rule with a distinct label — merge should keep it.
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'existing-rule',
@@ -93,11 +93,11 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    const merged = await getSyncSettings();
+    const merged = await getSettings();
     expect(merged.globalGroupingEnabled).toBe(false); // existing preserved
     expect(merged.domainRules).toHaveLength(1);
     expect(merged.domainRules[0].label).toBe('My Custom Label');
@@ -106,7 +106,7 @@ describe('initializeDefaults — upgrade path', () => {
 
   it('injects a label on a rule missing it, using the matching default rule', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'default-rule-1', // matches TEST_DEFAULTS
@@ -118,17 +118,17 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    const merged = await getSyncSettings();
+    const merged = await getSettings();
     expect(merged.domainRules[0].label).toBe('Default Label');
   });
 
   it('falls back to domainFilter for a label when no default rule matches', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'unknown-id',
@@ -140,30 +140,30 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    expect((await getSyncSettings()).domainRules[0].label).toBe('custom.com');
+    expect((await getSettings()).domainRules[0].label).toBe('custom.com');
   });
 
   it('falls back to "Untitled Rule" when both default and domainFilter are missing', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [{ id: 'orphan', enabled: true, color: 'grey' }],
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    expect((await getSyncSettings()).domainRules[0].label).toBe('Untitled Rule');
+    expect((await getSettings()).domainRules[0].label).toBe('Untitled Rule');
   });
 
   it('removes the legacy groupId field from existing rules', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'legacy',
@@ -180,29 +180,29 @@ describe('initializeDefaults — upgrade path', () => {
 
     await initializeDefaults();
 
-    const { domainRules } = await fakeBrowser.storage.sync.get('domainRules');
+    const { domainRules } = await fakeBrowser.storage.local.get('domainRules');
     expect(domainRules).toBeDefined();
     expect((domainRules as any)[0].groupId).toBeUndefined();
   });
 
   it('injects default color "grey" when the rule has no color', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         { id: 'no-color', label: 'X', domainFilter: 'x.com', enabled: true },
       ],
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
-    expect((await getSyncSettings()).domainRules[0].color).toBe('grey');
+    expect((await getSettings()).domainRules[0].color).toBe('grey');
   });
 
   it('injects default urlParsingRegEx = "" when missing', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'no-url-regex',
@@ -215,15 +215,15 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
-    expect((await getSyncSettings()).domainRules[0].urlParsingRegEx).toBe('');
+    expect((await getSettings()).domainRules[0].urlParsingRegEx).toBe('');
   });
 
   it('injects default groupNameSource = "title" when missing', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         {
           id: 'no-source',
@@ -236,15 +236,15 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
-    expect((await getSyncSettings()).domainRules[0].groupNameSource).toBe('title');
+    expect((await getSettings()).domainRules[0].groupNameSource).toBe('title');
   });
 
   it('does not overwrite an explicit user choice for deduplicationKeepStrategy on upgrade', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         { id: 'r1', label: 'R', domainFilter: 'r.com', enabled: true, color: 'blue' },
       ],
@@ -252,17 +252,17 @@ describe('initializeDefaults — upgrade path', () => {
     });
 
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    const merged = await getSyncSettings();
+    const merged = await getSettings();
     expect(merged.deduplicationKeepStrategy).toBe('keep-old');
   });
 
   it('does not overwrite existing statistics on upgrade', async () => {
     vi.stubGlobal('fetch', mockOkFetch(TEST_DEFAULTS));
-    await fakeBrowser.storage.sync.set({
+    await fakeBrowser.storage.local.set({
       domainRules: [
         { id: 'existing', label: 'X', domainFilter: 'x.com', enabled: true, color: 'blue' },
       ],
@@ -282,15 +282,15 @@ describe('initializeDefaults — upgrade path', () => {
 });
 
 describe('initializeDefaults — fetch failures', () => {
-  it('falls back to defaultSyncSettings when fetch throws', async () => {
+  it('falls back to defaultAppSettings when fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
     // defaultSyncSettings.domainRules is empty — migration wrote that.
-    const stored = await getSyncSettings();
+    const stored = await getSettings();
     expect(stored.domainRules).toEqual([]);
     expect(stored.globalGroupingEnabled).toBe(true);
   });
@@ -301,11 +301,11 @@ describe('initializeDefaults — fetch failures', () => {
       vi.fn().mockResolvedValue({ ok: false, statusText: 'Not Found', json: async () => ({}) }),
     );
     const { initializeDefaults } = await import('../src/utils/migration');
-    const { getSyncSettings } = await import('../src/utils/settingsUtils');
+    const { getSettings } = await import('../src/utils/settingsUtils');
 
     await initializeDefaults();
 
-    const stored = await getSyncSettings();
+    const stored = await getSettings();
     expect(stored.domainRules).toEqual([]);
   });
 });

--- a/tests/utils/settingsUtils.test.ts
+++ b/tests/utils/settingsUtils.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
 import {
-  getSyncSettings,
-  setSyncSettings,
-  updateSyncSettings,
+  getSettings,
+  setSettings,
+  updateSettings,
 } from '../../src/utils/settingsUtils';
-import { defaultSyncSettings } from '../../src/types/syncSettings';
+import { defaultAppSettings } from '../../src/types/syncSettings';
 
 // fakeBrowser.reset() est appelé avant chaque test via tests/setup.ts
 
 describe('settingsUtils', () => {
-  describe('getSyncSettings', () => {
+  describe('getSettings', () => {
     it('retourne les valeurs par défaut si le storage est vide', async () => {
-      const settings = await getSyncSettings();
-      expect(settings).toEqual(defaultSyncSettings);
+      const settings = await getSettings();
+      expect(settings).toEqual(defaultAppSettings);
     });
 
     it('retourne les paramètres stockés', async () => {
-      await fakeBrowser.storage.sync.set({
+      await fakeBrowser.storage.local.set({
         globalGroupingEnabled: false,
         globalDeduplicationEnabled: false,
         deduplicateUnmatchedDomains: false,
@@ -25,62 +25,61 @@ describe('settingsUtils', () => {
         notifyOnGrouping: false,
         notifyOnDeduplication: false,
       });
-      const settings = await getSyncSettings();
+      const settings = await getSettings();
       expect(settings.globalGroupingEnabled).toBe(false);
       expect(settings.globalDeduplicationEnabled).toBe(false);
       expect(settings.deduplicateUnmatchedDomains).toBe(false);
     });
 
     it('retourne false par défaut pour deduplicateUnmatchedDomains si absent du storage', async () => {
-      const settings = await getSyncSettings();
+      const settings = await getSettings();
       expect(settings.deduplicateUnmatchedDomains).toBe(false);
     });
 
     it('retourne keep-grouped-or-new par défaut pour deduplicationKeepStrategy si absent du storage', async () => {
-      const settings = await getSyncSettings();
+      const settings = await getSettings();
       expect(settings.deduplicationKeepStrategy).toBe('keep-grouped-or-new');
     });
 
-    it('retourne les valeurs par défaut en cas d\'erreur', async () => {
-      vi.spyOn(fakeBrowser.storage.sync, 'get').mockRejectedValueOnce(
-        new Error('Sync storage error'),
+    it("retourne les valeurs par défaut en cas d'erreur", async () => {
+      vi.spyOn(fakeBrowser.storage.local, 'get').mockRejectedValueOnce(
+        new Error('Local storage error'),
       );
-      const settings = await getSyncSettings();
-      expect(settings).toEqual(defaultSyncSettings);
+      const settings = await getSettings();
+      expect(settings).toEqual(defaultAppSettings);
     });
   });
 
-  describe('setSyncSettings', () => {
+  describe('setSettings', () => {
     it('écrit tous les paramètres dans le storage', async () => {
       const newSettings = {
-        ...defaultSyncSettings,
+        ...defaultAppSettings,
         globalGroupingEnabled: false,
       };
-      await setSyncSettings(newSettings);
-      const stored = await fakeBrowser.storage.sync.get(null);
+      await setSettings(newSettings);
+      const stored = await fakeBrowser.storage.local.get(null);
       expect(stored.globalGroupingEnabled).toBe(false);
     });
   });
 
-  describe('updateSyncSettings', () => {
+  describe('updateSettings', () => {
     it('met à jour partiellement les paramètres', async () => {
-      await fakeBrowser.storage.sync.set({
+      await fakeBrowser.storage.local.set({
         globalGroupingEnabled: true,
         globalDeduplicationEnabled: true,
       });
-      await updateSyncSettings({ globalGroupingEnabled: false });
-      const settings = await getSyncSettings();
+      await updateSettings({ globalGroupingEnabled: false });
+      const settings = await getSettings();
       expect(settings.globalGroupingEnabled).toBe(false);
       expect(settings.globalDeduplicationEnabled).toBe(true); // inchangé
     });
 
     it('met à jour deduplicateUnmatchedDomains isolément', async () => {
-      await updateSyncSettings({ deduplicateUnmatchedDomains: true });
-      const settings = await getSyncSettings();
+      await updateSettings({ deduplicateUnmatchedDomains: true });
+      const settings = await getSettings();
       expect(settings.deduplicateUnmatchedDomains).toBe(true);
       // Autres champs inchangés (valeurs par défaut conservées)
       expect(settings.globalDeduplicationEnabled).toBe(true);
     });
   });
-
 });

--- a/user-stories/migration-storage/clarifications.md
+++ b/user-stories/migration-storage/clarifications.md
@@ -1,0 +1,44 @@
+# Migration storage.sync -> storage.local : decisions
+
+## Contexte
+
+Migration de tous les parametres applicatifs (domainRules, toggles, prefs notifications)
+de `browser.storage.sync` vers `browser.storage.local`.
+
+## Decisions
+
+**D1 - Suppression des donnees sync apres migration**
+Decision : ne pas supprimer les cles `storage.sync` apres migration.
+Raison : permettre un rollback manuel sans perte de donnees si l'utilisateur
+revient a une version anterieure de l'extension.
+
+**D2 - Idempotence de la migration**
+Decision : la migration est protegeee par un flag `settingsMigratedToLocal`
+dans `storage.local`. Elle ne s'execute qu'une seule fois, meme si
+`onInstalled` se declenche plusieurs fois (mises a jour).
+
+**D3 - Priorite des donnees en cas de conflit**
+Decision : si une cle existe deja dans `storage.local`, les donnees sync
+ne la remplacent pas (local a la priorite).
+Raison : eviter d'ecraser un etat plus recent avec un etat sync potentiellement
+obsolete (ex. : utilisateur qui a modifie ses regles apres installation).
+
+**D4 - auto-sync des profils**
+La feature "auto-sync" des profils epingles n'est pas implementee.
+La mention dans CLAUDE.md etait une documentation obsolete : supprimee.
+
+**D5 - storage.session**
+Apres audit du code, `storage.session` est utilise uniquement pour des
+etats ephemeres (map profil-fenetre, guards d'edition). Il n'est pas
+migre : il reste inchange.
+
+**D6 - Nommage des hooks**
+`useSyncedSettings` renomme en `useSettings`.
+`useSyncedState` renomme en `useStorageState`.
+Pas de periode de deprecation : remplacement direct dans tous les consommateurs.
+
+**D7 - Quota sync**
+Le quota sync (100 Ko total, 8 Ko/item, 120 ecritures/min) etait la source
+de fragilite des tests E2E (retries avec backoff dans `syncSet()`).
+Apres migration vers local, le helper `syncSet` est remplace par `localSet`
+sans logique de retry.

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         strict_min_version: '109.0',
         // Required by AMO since 2025: declare that the extension does not
         // collect or transmit any user data. SmartTab Organizer only reads
-        // /writes user preferences via browser.storage (local + sync) — no
+        // /writes user preferences via browser.storage (local) — no
         // telemetry, no analytics, no external network calls.
           data_collection_permissions: {
             required: ['none']


### PR DESCRIPTION
## Summary

Migrates all application settings (domain rules, grouping/deduplication toggles, notification preferences) from `browser.storage.sync` to `browser.storage.local`. This eliminates dependency on the sync storage quota limits (8KB/item, 120 writes/minute) that were causing test flakiness and improves reliability.

## Key Changes

- **Storage migration**: All 7 settings keys (`globalGroupingEnabled`, `globalDeduplicationEnabled`, `deduplicateUnmatchedDomains`, `deduplicationKeepStrategy`, `domainRules`, `notifyOnGrouping`, `notifyOnDeduplication`) now use `local:` prefix instead of `sync:`

- **Runtime migration logic**: Added `src/background/migration.ts` with `migrateSettingsFromSyncToLocal()` that:
  - Copies existing data from `storage.sync` to `storage.local` on first run
  - Uses idempotent flag (`settingsMigratedToLocal`) to run only once
  - Preserves `storage.sync` data for rollback capability
  - Handles fresh installs gracefully

- **Hook renaming** for clarity (no longer implies cross-device sync):
  - `useSyncedSettings` → `useSettings`
  - `useSyncedState<T>` → `useStorageState<T>`
  - `SyncSettings` type → `AppSettings`
  - All related utility functions renamed (`getSyncSettings` → `getSettings`, etc.)

- **Test updates**:
  - Vitest: Migrated 17 usages from `fakeBrowser.storage.sync` to `fakeBrowser.storage.local`
  - E2E: Replaced `syncSet()` helper with simpler `localSet()` (no quota retry logic needed)
  - Updated 12 E2E test calls to use `chrome.storage.local`

- **Documentation**: Updated `CLAUDE.md` to reflect new storage architecture and removed obsolete references to cross-device sync

## Implementation Details

- Migration is called in `setupInstallationHandler()` before `initializeDefaults()` to ensure settings are available
- Conditional logic in `initializeDefaults()` updated to read from `local:domainRules` instead of `sync:domainRules`
- All 40+ consumer files updated with new import paths and function names
- Storybook stories updated to use `AppSettings` type
- No breaking changes to user-facing functionality; settings persist identically

https://claude.ai/code/session_01382Fj4aTbVXJFkKWgsj884