### PR TITLE
Refactor AlertDialogs and extract shared utility functions

### DIFF
--- a/src/components/Core/TabTree/AlertDialogShell.tsx
+++ b/src/components/Core/TabTree/AlertDialogShell.tsx
@@ -1,0 +1,70 @@
+import { AlertDialog, Button, Flex } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+
+export interface AlertDialogShellProps {
+  /** Controls dialog visibility */
+  open: boolean;
+  /** Called when the dialog requests to close (e.g. Escape key or overlay click) */
+  onClose: () => void;
+  /** Max width of the dialog content box */
+  maxWidth?: string;
+  /** Dialog title node */
+  title: React.ReactNode;
+  /** Dialog description node */
+  description: React.ReactNode;
+  /** Label for the soft (non-destructive) secondary action button */
+  softActionLabel: string;
+  /** Handler for the soft secondary action */
+  onSoftAction: () => void;
+  /** Label for the destructive (red) primary action button */
+  destructiveActionLabel: string;
+  /** Handler for the destructive primary action */
+  onDestructiveAction: () => void;
+}
+
+/**
+ * Shared shell for AlertDialogs that present three buttons:
+ * Cancel (gray soft), a non-destructive soft action, and a destructive red action.
+ *
+ * Used by the two AlertDialogs in TabTreeEditor (delete last tab and delete group).
+ */
+export function AlertDialogShell({
+  open,
+  onClose,
+  maxWidth = '400px',
+  title,
+  description,
+  softActionLabel,
+  onSoftAction,
+  destructiveActionLabel,
+  onDestructiveAction,
+}: AlertDialogShellProps) {
+  return (
+    <AlertDialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose();
+      }}
+    >
+      <AlertDialog.Content maxWidth={maxWidth}>
+        <AlertDialog.Title>{title}</AlertDialog.Title>
+        <AlertDialog.Description size="2">{description}</AlertDialog.Description>
+        <Flex gap="2" mt="4" justify="end" wrap="wrap">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              {getMessage('cancel')}
+            </Button>
+          </AlertDialog.Cancel>
+          <Button variant="soft" onClick={onSoftAction}>
+            {softActionLabel}
+          </Button>
+          <AlertDialog.Action>
+            <Button color="red" onClick={onDestructiveAction}>
+              {destructiveActionLabel}
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/src/components/Core/TabTree/TabTreeEditor.tsx
+++ b/src/components/Core/TabTree/TabTreeEditor.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import {
-  Flex,
   Box,
   IconButton,
-  Button,
   ScrollArea,
-  AlertDialog,
 } from '@radix-ui/themes';
 import { ChevronUp, ChevronDown, Pencil, Trash2 } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
@@ -15,6 +12,7 @@ import { GroupRowBase } from './GroupRowBase';
 import { TabEditRow } from './TabEditRow';
 import { GroupEditRow } from './GroupEditRow';
 import { MoveTabDropdown } from './MoveTabDropdown';
+import { AlertDialogShell } from './AlertDialogShell';
 import { useTabTreeEditor } from './useTabTreeEditor';
 import type { Session } from '@/types/session';
 import styles from './TabTreeEditor.module.css';
@@ -318,100 +316,56 @@ export function TabTreeEditor({ session, onSessionChange, maxHeight }: TabTreeEd
       })}
 
       {/* AlertDialog: delete last tab in group */}
-      <AlertDialog.Root
+      <AlertDialogShell
         open={alertDialog?.type === 'delete_last_tab'}
-        onOpenChange={(open) => {
-          if (!open) setAlertDialog(null);
+        onClose={() => setAlertDialog(null)}
+        maxWidth="400px"
+        title={getMessage('tabEditorLastTabTitle')}
+        description={getMessage('tabEditorLastTabDescription')}
+        softActionLabel={getMessage('tabEditorKeepEmptyGroup')}
+        onSoftAction={() => {
+          if (alertDialog?.type === 'delete_last_tab') {
+            performDeleteTab(alertDialog.tabId, alertDialog.groupId, false);
+          }
         }}
-      >
-        <AlertDialog.Content maxWidth="400px">
-          <AlertDialog.Title>{getMessage('tabEditorLastTabTitle')}</AlertDialog.Title>
-          <AlertDialog.Description size="2">
-            {getMessage('tabEditorLastTabDescription')}
-          </AlertDialog.Description>
-          <Flex gap="2" mt="4" justify="end" wrap="wrap">
-            <AlertDialog.Cancel>
-              <Button variant="soft" color="gray">
-                {getMessage('cancel')}
-              </Button>
-            </AlertDialog.Cancel>
-            <Button
-              variant="soft"
-              onClick={() => {
-                if (alertDialog?.type === 'delete_last_tab') {
-                  performDeleteTab(alertDialog.tabId, alertDialog.groupId, false);
-                }
-              }}
-            >
-              {getMessage('tabEditorKeepEmptyGroup')}
-            </Button>
-            <AlertDialog.Action>
-              <Button
-                color="red"
-                onClick={() => {
-                  if (alertDialog?.type === 'delete_last_tab') {
-                    performDeleteTab(alertDialog.tabId, alertDialog.groupId, true);
-                  }
-                }}
-              >
-                {getMessage('tabEditorDeleteEmptyGroup')}
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        destructiveActionLabel={getMessage('tabEditorDeleteEmptyGroup')}
+        onDestructiveAction={() => {
+          if (alertDialog?.type === 'delete_last_tab') {
+            performDeleteTab(alertDialog.tabId, alertDialog.groupId, true);
+          }
+        }}
+      />
 
       {/* AlertDialog: delete group */}
-      <AlertDialog.Root
+      <AlertDialogShell
         open={alertDialog?.type === 'delete_group'}
-        onOpenChange={(open) => {
-          if (!open) setAlertDialog(null);
+        onClose={() => setAlertDialog(null)}
+        maxWidth="420px"
+        title={getMessage('tabEditorDeleteGroupTitle', [
+          alertDialog?.type === 'delete_group' ? alertDialog.groupTitle : '',
+        ])}
+        description={
+          alertDialog?.type === 'delete_group'
+            ? getMessage('tabEditorDeleteGroupDescription', [String(alertDialog.tabCount)])
+            : ''
+        }
+        softActionLabel={getMessage('tabEditorUngroupTabs')}
+        onSoftAction={() => {
+          if (alertDialog?.type === 'delete_group') {
+            handleDeleteGroup(alertDialog.groupId, 'ungroup_tabs');
+          }
         }}
-      >
-        <AlertDialog.Content maxWidth="420px">
-          <AlertDialog.Title>
-            {getMessage('tabEditorDeleteGroupTitle', [
-              alertDialog?.type === 'delete_group' ? alertDialog.groupTitle : '',
-            ])}
-          </AlertDialog.Title>
-          <AlertDialog.Description size="2">
-            {alertDialog?.type === 'delete_group'
-              ? getMessage('tabEditorDeleteGroupDescription', [String(alertDialog.tabCount)])
-              : ''}
-          </AlertDialog.Description>
-          <Flex gap="2" mt="4" justify="end" wrap="wrap">
-            <AlertDialog.Cancel>
-              <Button variant="soft" color="gray">
-                {getMessage('cancel')}
-              </Button>
-            </AlertDialog.Cancel>
-            <Button
-              variant="soft"
-              onClick={() => {
-                if (alertDialog?.type === 'delete_group') {
-                  handleDeleteGroup(alertDialog.groupId, 'ungroup_tabs');
-                }
-              }}
-            >
-              {getMessage('tabEditorUngroupTabs')}
-            </Button>
-            <AlertDialog.Action>
-              <Button
-                color="red"
-                onClick={() => {
-                  if (alertDialog?.type === 'delete_group') {
-                    handleDeleteGroup(alertDialog.groupId, 'delete_tabs');
-                  }
-                }}
-              >
-                {alertDialog?.type === 'delete_group'
-                  ? getMessage('tabEditorDeleteGroupAndTabs', [String(alertDialog.tabCount)])
-                  : getMessage('delete')}
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        destructiveActionLabel={
+          alertDialog?.type === 'delete_group'
+            ? getMessage('tabEditorDeleteGroupAndTabs', [String(alertDialog.tabCount)])
+            : getMessage('delete')
+        }
+        onDestructiveAction={() => {
+          if (alertDialog?.type === 'delete_group') {
+            handleDeleteGroup(alertDialog.groupId, 'delete_tabs');
+          }
+        }}
+      />
     </Box>
   );
 

--- a/src/components/UI/ImportExportWizards/Classification/index.ts
+++ b/src/components/UI/ImportExportWizards/Classification/index.ts
@@ -1,4 +1,4 @@
-export { useImportClassification, type ImportClassificationState, type ConflictMode } from './useImportClassification';
+export { useImportClassification, computeImportCount, type ImportClassificationState, type ConflictMode } from './useImportClassification';
 export { ConflictModeSelector } from './ConflictModeSelector';
 export { ClassificationGroup } from './ClassificationGroup';
 export { ClassificationScrollArea } from './ClassificationScrollArea';

--- a/src/components/UI/ImportExportWizards/Classification/useImportClassification.ts
+++ b/src/components/UI/ImportExportWizards/Classification/useImportClassification.ts
@@ -3,6 +3,23 @@ import { useToggleSet, type ToggleSetState } from '@/components/UI/ImportExportW
 
 export type ConflictMode = 'overwrite' | 'duplicate' | 'ignore';
 
+/**
+ * Calcule le nombre d'items qui seront effectivement importes :
+ * items nouveaux selectionnes + items conflictuels (selon le mode).
+ *
+ * Extrait pour eviter la duplication entre ImportWizard et ImportSessionsWizard.
+ */
+export function computeImportCount(
+  newItems: { id?: string }[],
+  conflictingItemsCount: number,
+  selection: ToggleSetState<string>,
+  conflictMode: ConflictMode,
+): number {
+  const newCount = newItems.filter((item) => item.id !== undefined && selection.has(item.id)).length;
+  const conflictCount = conflictMode === 'ignore' ? 0 : conflictingItemsCount;
+  return newCount + conflictCount;
+}
+
 export interface ImportClassificationState<TClassification> {
   classification: TClassification | null;
   setClassification: (c: TClassification | null) => void;

--- a/src/components/UI/ImportExportWizards/Export/ExportWizardFooter.tsx
+++ b/src/components/UI/ImportExportWizards/Export/ExportWizardFooter.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Button, Dialog } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+import { ExportSplitButton } from './ExportSplitButton';
+import type { ExportActions } from './useExportActions';
+
+interface ExportWizardFooterProps {
+  /** i18n key for the primary export button label. */
+  labelKey: string;
+  actions: ExportActions;
+  disabled: boolean;
+}
+
+/**
+ * Shared footer for export wizards (rules and sessions).
+ *
+ * Renders a Cancel button (wrapped in Dialog.Close) and the primary
+ * ExportSplitButton offering file and clipboard export options.
+ */
+export function ExportWizardFooter({ labelKey, actions, disabled }: ExportWizardFooterProps) {
+  return (
+    <>
+      <Dialog.Close>
+        <Button variant="soft" color="gray">{getMessage('cancel')}</Button>
+      </Dialog.Close>
+      <ExportSplitButton labelKey={labelKey} actions={actions} disabled={disabled} />
+    </>
+  );
+}

--- a/src/components/UI/ImportExportWizards/Export/index.ts
+++ b/src/components/UI/ImportExportWizards/Export/index.ts
@@ -1,7 +1,8 @@
 export { useExportActions, type ExportActions, type ExportActionsConfig } from './useExportActions';
 export { ExportNoteField } from './ExportNoteField';
-export { SelectionToolbar } from './SelectionToolbar';
 export { ExportSplitButton } from './ExportSplitButton';
+export { ExportWizardFooter } from './ExportWizardFooter';
+export { SelectionToolbar } from './SelectionToolbar';
 export { SelectableListContainer } from './SelectableListContainer';
 export { SelectableSessionRow } from './SelectableSessionRow';
 export { SessionExportGroupSection } from './SessionExportGroupSection';

--- a/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Box, Button, Dialog, Separator } from '@radix-ui/themes';
+import { Box, Separator } from '@radix-ui/themes';
 import { Archive, FileDown, Pin } from 'lucide-react';
 import { SessionsTheme } from '@/components/Form/themes';
 import { getMessage } from '@/utils/i18n';
@@ -10,7 +10,7 @@ import { WizardModal } from '@/components/UI/WizardModal';
 import { CountLabel, useDialogReset, useToggleSet } from './Shared';
 import {
   ExportNoteField,
-  ExportSplitButton,
+  ExportWizardFooter,
   SelectableListContainer,
   SelectionToolbar,
   SessionExportGroupSection,
@@ -125,10 +125,7 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
         </WizardModal.Body>
 
         <WizardModal.Footer>
-          <Dialog.Close>
-            <Button variant="soft" color="gray">{getMessage('cancel')}</Button>
-          </Dialog.Close>
-          <ExportSplitButton
+          <ExportWizardFooter
             labelKey="exportSessionsButton"
             actions={actions}
             disabled={selection.size === 0}

--- a/src/components/UI/ImportExportWizards/ExportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Box, Button, Dialog } from '@radix-ui/themes';
+import { Box } from '@radix-ui/themes';
 import { FileDown } from 'lucide-react';
 import { ExportTheme } from '@/components/Form/themes';
 import type { DomainRuleSetting } from '@/types/syncSettings';
@@ -8,7 +8,7 @@ import { WizardModal } from '@/components/UI/WizardModal';
 import { CountLabel, useDialogReset, useToggleSet } from './Shared';
 import {
   ExportNoteField,
-  ExportSplitButton,
+  ExportWizardFooter,
   SelectableListContainer,
   SelectionToolbar,
   useExportActions,
@@ -86,10 +86,7 @@ export function ExportWizard({ open, onOpenChange, rules }: ExportWizardProps) {
         </WizardModal.Body>
 
         <WizardModal.Footer>
-          <Dialog.Close>
-            <Button variant="soft" color="gray">{getMessage('cancel')}</Button>
-          </Dialog.Close>
-          <ExportSplitButton
+          <ExportWizardFooter
             labelKey="exportButton"
             actions={actions}
             disabled={selection.size === 0}

--- a/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box } from '@radix-ui/themes';
 import { Upload } from 'lucide-react';
 import { SessionsTheme } from '@/components/Form/themes';
@@ -20,6 +20,7 @@ import { SourceStep, ImportedNoteCallout, useJsonSourceInput } from './Source';
 import { ImportWizardFooter } from './ImportWizardFooter';
 import {
   useImportClassification,
+  computeImportCount,
   ClassificationGroup,
   ClassificationScrollArea,
   ConflictModeSelector,
@@ -80,12 +81,14 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
     setStep(1);
   }, [source.parsedData, existingSessions, classificationState, newSessionSelection]);
 
-  const importCount = useMemo(() => {
-    if (!classification) return 0;
-    const newCount = classification.newSessions.filter(s => newSessionSelection.has(s.id)).length;
-    const conflictCount = conflictMode === 'ignore' ? 0 : classification.conflictingSessions.length;
-    return newCount + conflictCount;
-  }, [classification, newSessionSelection, conflictMode]);
+  const importCount = classification
+    ? computeImportCount(
+        classification.newSessions,
+        classification.conflictingSessions.length,
+        newSessionSelection,
+        conflictMode,
+      )
+    : 0;
 
   const executeImport = useCallback(async () => {
     if (!classification) return;

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Box } from '@radix-ui/themes';
 import { FileUp } from 'lucide-react';
 import { ImportTheme } from '@/components/Form/themes';
@@ -14,6 +14,7 @@ import { SourceStep, ImportedNoteCallout, useJsonSourceInput } from './Source';
 import { ImportWizardFooter } from './ImportWizardFooter';
 import {
   useImportClassification,
+  computeImportCount,
   ClassificationGroup,
   ClassificationScrollArea,
   ConflictModeSelector,
@@ -64,13 +65,14 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
     setStep(1);
   }, [source.parsedData, existingRules, classificationState, newRuleSelection]);
 
-  // Compute import count
-  const importCount = useMemo(() => {
-    if (!classification) return 0;
-    const newCount = classification.newRules.filter(r => newRuleSelection.has(r.id)).length;
-    const conflictCount = conflictMode === 'ignore' ? 0 : classification.conflictingRules.length;
-    return newCount + conflictCount;
-  }, [classification, newRuleSelection, conflictMode]);
+  const importCount = classification
+    ? computeImportCount(
+        classification.newRules,
+        classification.conflictingRules.length,
+        newRuleSelection,
+        conflictMode,
+      )
+    : 0;
 
   // Execute import
   const executeImport = useCallback(() => {

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -9,7 +9,7 @@ import { ConflictResolutionStep } from './ConflictResolutionStep';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast, showErrorToast } from '@/utils/toast';
 import { showSuccessNotification } from '@/utils/notifications';
-import { sessionToTabTreeData } from '@/utils/sessionUtils';
+import { sessionToTabTreeData, resolveTabUuids } from '@/utils/sessionUtils';
 import {
   analyzeConflicts,
   type ConflictAnalysis,
@@ -73,14 +73,10 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
   }, [open, session]);
 
   // Derive selected SavedTab UUIDs
-  const selectedSavedTabIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const numId of selectedTabIds) {
-      const uuid = numericIdToSavedTabId.get(numId);
-      if (uuid) ids.add(uuid);
-    }
-    return ids;
-  }, [selectedTabIds, numericIdToSavedTabId]);
+  const selectedSavedTabIds = useMemo(
+    () => resolveTabUuids(selectedTabIds, numericIdToSavedTabId),
+    [selectedTabIds, numericIdToSavedTabId],
+  );
 
   // Get the selected tabs and groups from the session
   const getSelectedData = useCallback(() => {

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -11,7 +11,7 @@ import { WizardModal } from '@/components/UI/WizardModal';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast } from '@/utils/toast';
 import { captureCurrentTabs } from '@/utils/tabCapture';
-import { createSessionFromSelection, formatSessionDate } from '@/utils/sessionUtils';
+import { createSessionFromSelection, formatSessionDate, resolveTabUuids } from '@/utils/sessionUtils';
 import type { Session, SavedTab, SavedTabGroup } from '@/types/session';
 import type { TabTreeData } from '@/types/tabTree';
 import type { RuleCategoryId } from '@/schemas/enums';
@@ -88,14 +88,10 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
   }, [open, initialGroupId]);
 
   // Derive selected SavedTab UUIDs from selected numeric IDs
-  const selectedSavedTabIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const numId of selectedTabIds) {
-      const uuid = numericIdToSavedTabId.get(numId);
-      if (uuid) ids.add(uuid);
-    }
-    return ids;
-  }, [selectedTabIds, numericIdToSavedTabId]);
+  const selectedSavedTabIds = useMemo(
+    () => resolveTabUuids(selectedTabIds, numericIdToSavedTabId),
+    [selectedTabIds, numericIdToSavedTabId],
+  );
 
   const handleSave = useCallback(async () => {
     const trimmed = sessionName.trim();

--- a/src/utils/sessionUtils.ts
+++ b/src/utils/sessionUtils.ts
@@ -153,6 +153,28 @@ export function splitByPinned<T extends { isPinned: boolean }>(items: T[]): { pi
   };
 }
 
+/**
+ * Resolve a set of numeric TabTree IDs to their corresponding SavedTab UUIDs.
+ * Used by wizards that maintain a numericIdToSavedTabId mapping between the
+ * TabTree component (which operates with sequential integer IDs) and the
+ * underlying SavedTab objects (which use UUIDs).
+ *
+ * @param selectedNumericIds - The numeric IDs currently selected in TabTree
+ * @param numericIdToSavedTabId - Mapping produced by sessionToTabTreeData or tabCapture
+ * @returns A set of SavedTab UUIDs corresponding to the selected numeric IDs
+ */
+export function resolveTabUuids(
+  selectedNumericIds: Set<number>,
+  numericIdToSavedTabId: Map<number, string>,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const numId of selectedNumericIds) {
+    const uuid = numericIdToSavedTabId.get(numId);
+    if (uuid) ids.add(uuid);
+  }
+  return ids;
+}
+
 /** Create a Session object from TabTreeData and selected tab IDs */
 export function createSessionFromSelection(
   ungroupedTabs: SavedTab[],


### PR DESCRIPTION
## Summary
This PR refactors repeated AlertDialog implementations and extracts shared utility logic to reduce code duplication and improve maintainability.

## Key Changes

### AlertDialog Refactoring
- **Created `AlertDialogShell` component** (`src/components/Core/TabTree/AlertDialogShell.tsx`): A reusable wrapper for AlertDialogs with a consistent three-button pattern (Cancel, soft action, destructive action)
- **Replaced two AlertDialog implementations** in `TabTreeEditor.tsx` with the new `AlertDialogShell` component, reducing ~100 lines of duplicated code
- Removed unused imports (`Flex`, `Button`, `AlertDialog`) from `TabTreeEditor.tsx`

### Utility Function Extraction
- **Added `resolveTabUuids()` function** in `sessionUtils.ts`: Converts numeric TabTree IDs to SavedTab UUIDs using a mapping, eliminating duplicate logic across wizards
- **Added `computeImportCount()` function** in `useImportClassification.ts`: Calculates the number of items to import based on selection and conflict mode
- **Updated `ImportWizard.tsx`**: Replaced inline `useMemo` calculation with call to `computeImportCount()`
- **Updated `ImportSessionsWizard.tsx`**: Replaced inline `useMemo` calculation with call to `computeImportCount()`
- **Updated `RestoreWizard.tsx`**: Replaced inline UUID resolution logic with `resolveTabUuids()` call
- **Updated `SnapshotWizard.tsx`**: Replaced inline UUID resolution logic with `resolveTabUuids()` call
- **Updated exports** in `Classification/index.ts` to include `computeImportCount`

## Implementation Details
- The `AlertDialogShell` component maintains the same visual and functional behavior as the original implementations while accepting props for customization
- Extracted utility functions are pure and reusable, reducing cognitive load and maintenance burden
- All changes are backward compatible with no functional modifications to existing behavior

https://claude.ai/code/session_014jWJLMJAFPgfJHd1WSB2En