### PR TITLE
Migrate rule categories from hardcoded enum to dynamic storage

### DIFF
--- a/public/data/categories.json
+++ b/public/data/categories.json
@@ -1,0 +1,14 @@
+{
+  "categories": [
+    { "id": "development",  "emoji": "💻", "color": "blue",   "labelKey": "category_development",  "builtIn": true },
+    { "id": "productivity", "emoji": "📋", "color": "purple", "labelKey": "category_productivity", "builtIn": true },
+    { "id": "commerce",     "emoji": "🛍️", "color": "orange", "labelKey": "category_commerce",     "builtIn": true },
+    { "id": "travel",       "emoji": "✈️",  "color": "cyan",   "labelKey": "category_travel",       "builtIn": true },
+    { "id": "search",       "emoji": "🔍", "color": "yellow", "labelKey": "category_search",       "builtIn": true },
+    { "id": "social",       "emoji": "💬", "color": "pink",   "labelKey": "category_social",       "builtIn": true },
+    { "id": "media",        "emoji": "🎬", "color": "red",    "labelKey": "category_media",        "builtIn": true },
+    { "id": "cloud",        "emoji": "☁️",  "color": "blue",   "labelKey": "category_cloud",        "builtIn": true },
+    { "id": "finance",      "emoji": "💰", "color": "green",  "labelKey": "category_finance",      "builtIn": true },
+    { "id": "education",    "emoji": "🎓", "color": "yellow", "labelKey": "category_education",    "builtIn": true }
+  ]
+}

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -1,6 +1,7 @@
 import { browser, Browser } from 'wxt/browser';
 import { initializeDefaults } from '@/utils/migration.js';
-import { migrateSettingsFromSyncToLocal } from './migration.js';
+import { migrateSettingsFromSyncToLocal, seedBuiltInCategories } from './migration.js';
+import { initCategoriesStore } from '@/utils/categoriesStore.js';
 import { logger } from '@/utils/logger.js';
 import {
     handleMiddleClickMessage,
@@ -22,6 +23,8 @@ export function setupInstallationHandler(): void {
         logger.debug("SmartTab Organizer installed/updated.", details.reason);
         await migrateSettingsFromSyncToLocal();
         await initializeDefaults();
+        await seedBuiltInCategories();
+        await initCategoriesStore();
     });
 }
 

--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -6,7 +6,7 @@ import { promptForGroupName } from './messaging.js';
 import { showNotification, type UndoAction } from '@/utils/notifications.js';
 import { getMessage } from '@/utils/i18n.js';
 import type { DomainRuleSetting, AppSettings } from '@/types/syncSettings.js';
-import { getRuleCategory } from '@/schemas/enums.js';
+import { getRuleCategory } from '@/utils/categoriesStore.js';
 import { logger } from '@/utils/logger.js';
 
 export interface GroupingContext {

--- a/src/background/migration.ts
+++ b/src/background/migration.ts
@@ -1,5 +1,7 @@
 import { browser } from 'wxt/browser';
 import { logger } from '@/utils/logger.js';
+import { categoriesItem, categoriesSeededItem } from '@/utils/storageItems.js';
+import { fetchBuiltInCategories } from '@/utils/categoriesStore.js';
 
 const SETTINGS_KEYS = [
   'globalGroupingEnabled',
@@ -48,5 +50,32 @@ export async function migrateSettingsFromSyncToLocal(): Promise<void> {
     logger.debug('[MIGRATION] Migration complete.');
   } catch (error) {
     logger.error('[MIGRATION] Migration failed, will retry on next startup:', error);
+  }
+}
+
+/**
+ * Seeds the built-in categories from public/data/categories.json into storage.local.
+ * Idempotent: guarded by categoriesSeededItem.
+ * Never overwrites existing categories (safety net if the user already has customs).
+ */
+export async function seedBuiltInCategories(): Promise<void> {
+  try {
+    if (await categoriesSeededItem.getValue()) {
+      logger.debug('[MIGRATION] Categories already seeded.');
+      return;
+    }
+
+    const existing = await categoriesItem.getValue();
+    if (!existing || existing.length === 0) {
+      const builtIns = await fetchBuiltInCategories();
+      await categoriesItem.setValue(builtIns);
+      logger.debug(`[MIGRATION] Seeded ${builtIns.length} built-in categories.`);
+    } else {
+      logger.debug('[MIGRATION] Categories storage already populated, skipping seed.');
+    }
+
+    await categoriesSeededItem.setValue(true);
+  } catch (error) {
+    logger.error('[MIGRATION] Category seeding failed, will retry on next startup:', error);
   }
 }

--- a/src/components/Core/DomainRule/CategoryPicker.tsx
+++ b/src/components/Core/DomainRule/CategoryPicker.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { Popover, Tooltip } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
-import { RULE_CATEGORIES, getRuleCategory } from '@/schemas/enums';
+import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import type { RuleCategoryId } from '@/schemas/enums';
+import { useSettings } from '@/hooks/useSettings';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import styles from './CategoryPicker.module.css';
 
@@ -13,7 +14,10 @@ export interface CategoryPickerProps {
 
 export function CategoryPicker({ value, onChange }: CategoryPickerProps) {
   const [open, setOpen] = useState(false);
+  const { settings } = useSettings();
+  const categories = settings?.categories ?? [];
   const selectedCategory = getRuleCategory(value);
+  const selectedLabel = selectedCategory ? getCategoryLabel(selectedCategory) : getMessage('categoryNone');
 
   function handleSelect(id: RuleCategoryId | null) {
     onChange(id);
@@ -25,8 +29,8 @@ export function CategoryPicker({ value, onChange }: CategoryPickerProps) {
       <Popover.Trigger>
         <button
           type="button"
-          aria-label={selectedCategory ? getMessage(selectedCategory.labelKey) : getMessage('categoryNone')}
-          title={selectedCategory ? getMessage(selectedCategory.labelKey) : getMessage('categoryNone')}
+          aria-label={selectedLabel}
+          title={selectedLabel}
           className={`${styles.trigger} ${!selectedCategory ? styles.triggerNone : ''}`}
           style={selectedCategory ? { backgroundColor: chromeGroupColors[selectedCategory.color] } : undefined}
         >
@@ -52,21 +56,24 @@ export function CategoryPicker({ value, onChange }: CategoryPickerProps) {
           </Tooltip>
 
           {/* Category options */}
-          {RULE_CATEGORIES.map((category) => (
-            <Tooltip key={category.id} content={getMessage(category.labelKey)}>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={value === category.id}
-                aria-label={getMessage(category.labelKey)}
-                className={`${styles.swatch} ${value === category.id ? styles.swatchActive : ''}`}
-                style={{ backgroundColor: chromeGroupColors[category.color] }}
-                onClick={() => handleSelect(category.id as RuleCategoryId)}
-              >
-                {category.emoji}
-              </button>
-            </Tooltip>
-          ))}
+          {categories.map((category) => {
+            const label = getCategoryLabel(category);
+            return (
+              <Tooltip key={category.id} content={label}>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={value === category.id}
+                  aria-label={label}
+                  className={`${styles.swatch} ${value === category.id ? styles.swatchActive : ''}`}
+                  style={{ backgroundColor: chromeGroupColors[category.color] }}
+                  onClick={() => handleSelect(category.id)}
+                >
+                  {category.emoji}
+                </button>
+              </Tooltip>
+            );
+          })}
         </div>
       </Popover.Content>
     </Popover.Root>

--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -6,7 +6,7 @@ import { RuleDetailPopover } from './RuleDetailPopover';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { getMessage } from '@/utils/i18n';
 import { getRadixColor } from '@/utils/utils';
-import { getRuleCategory } from '@/schemas/enums';
+import { getRuleCategory } from '@/utils/categoriesStore';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 
 export interface DomainRuleCardProps {

--- a/src/components/Core/DomainRule/RuleDetailPopover.tsx
+++ b/src/components/Core/DomainRule/RuleDetailPopover.tsx
@@ -2,7 +2,8 @@ import { Flex, Text, Box, Badge } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { getRadixColor } from '@/utils/utils';
-import { getRuleCategory, deduplicationMatchModeOptions } from '@/schemas/enums';
+import { deduplicationMatchModeOptions } from '@/schemas/enums';
+import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 
 interface RuleDetailPopoverProps {
@@ -46,7 +47,7 @@ export function RuleDetailPopover({ rule, searchTerm }: RuleDetailPopoverProps) 
               }}>
                 {cat.emoji}
               </div>
-              <Text size="2">{getMessage(cat.labelKey)}</Text>
+              <Text size="2">{getCategoryLabel(cat)}</Text>
             </>
           ) : (
             <Text size="2" color="gray">{getMessage('categoryNone')}</Text>

--- a/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
@@ -10,6 +10,7 @@ const mockAppSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
   domainRules: [

--- a/src/components/Core/DomainRule/WizardStep4Summary.tsx
+++ b/src/components/Core/DomainRule/WizardStep4Summary.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Badge, Box, Button, Flex, Separator, Text } from '@radix-ui/themes';
 import { Pencil } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import { getRuleCategory, deduplicationMatchModeOptions, groupNameSourceOptions } from '@/schemas/enums';
+import { deduplicationMatchModeOptions, groupNameSourceOptions } from '@/schemas/enums';
+import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import type { DomainRule } from '@/schemas/domainRule';
 
 interface WizardStep4SummaryProps {
@@ -85,7 +86,7 @@ export function WizardStep4Summary({ values, configMode, presetName, onEditStep 
             <Flex align="center" gap="2">
               {category && (
                 <Badge color="gray" variant="soft" size="1">
-                  {category.emoji} {getMessage(category.labelKey)}
+                  {category.emoji} {getCategoryLabel(category)}
                 </Badge>
               )}
               <Text size="2">{values.label}</Text>

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -14,7 +14,7 @@ import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { countSessionTabs, formatSessionDate } from '@/utils/sessionUtils';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
-import { getRuleCategory } from '@/schemas/enums';
+import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import { getRadixColor } from '@/utils/utils';
 import { SessionPreviewTree } from './SessionPreviewTree';
 import { SessionRestoreButton } from './SessionRestoreButton/SessionRestoreButton';
@@ -306,7 +306,7 @@ export function SessionCard({
                 </IconButton>
                 {category && (
                   <Badge color={getRadixColor(category.color)} size="1" style={{ flexShrink: 0 }}>
-                    {category.emoji} {getMessage(category.labelKey)}
+                    {category.emoji} {getCategoryLabel(category)}
                   </Badge>
                 )}
               </>

--- a/src/components/UI/ImportExportWizards/RuleImportRows.tsx
+++ b/src/components/UI/ImportExportWizards/RuleImportRows.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Badge, Checkbox, Flex, Text } from '@radix-ui/themes';
 import type { BadgeProps } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
-import { getRuleCategory } from '@/schemas/enums';
+import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import { getRadixColor } from '@/utils/utils';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 import type { ConflictingRule } from '@/utils/importClassification';
@@ -43,7 +43,7 @@ export function RuleRow({ rule, checkbox, checked, onToggle, dimmed, statusBadge
       </Flex>
       {category && (
         <Badge color={getRadixColor(category.color) as RadixAccentColor} variant="soft" size="1">
-          {category.emoji} {getMessage(category.labelKey)}
+          {category.emoji} {getCategoryLabel(category)}
         </Badge>
       )}
       {statusBadge && (

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -8,7 +8,7 @@ import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { showSuccessNotification } from '@/utils/notifications';
-import { getRuleCategory } from '@/schemas/enums';
+import { getRuleCategory } from '@/utils/categoriesStore';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { popupPinnedEmptyCollapsedItem } from '@/utils/storageItems';
 import type { Session } from '@/types/session';

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -7,10 +7,15 @@ import { middleClickedTabs } from '@/background/messaging.js';
 import { processGroupingForNewTab } from '@/background/grouping.js';
 import { handleOrganizeAllTabs } from '@/background/organize.js';
 import { shouldSkipDeduplication } from '@/utils/deduplicationSkip.js';
+import { initCategoriesStore } from '@/utils/categoriesStore.js';
 
 export default defineBackground(() => {
     // Initialize all event handlers
     setupAllEventHandlers();
+
+    // Populate the categories cache so grouping.ts (sync) can resolve colors.
+    // Fire-and-forget: the watcher will keep the cache in sync afterwards.
+    initCategoriesStore().catch(e => logger.error('[CATEGORIES] init failed:', e));
 
     // Start periodic cleanup for deduplication cache
     startPeriodicCleanup();

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,12 +1,14 @@
 import { storage } from 'wxt/utils/storage';
 import type { AppSettings, DomainRuleSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import type { RuleCategory } from '@/schemas/category.js';
 import {
   globalGroupingEnabledItem,
   globalDeduplicationEnabledItem,
   deduplicateUnmatchedDomainsItem,
   deduplicationKeepStrategyItem,
   domainRulesItem,
+  categoriesItem,
   notifyOnGroupingItem,
   notifyOnDeduplicationItem,
   settingsItemMap,
@@ -22,6 +24,7 @@ export interface UseSettingsReturn {
   setDeduplicateUnmatchedDomains: (value: boolean) => Promise<void>;
   setDeduplicationKeepStrategy: (value: DeduplicationKeepStrategyValue) => Promise<void>;
   setDomainRules: (value: DomainRuleSettings) => Promise<void>;
+  setCategories: (value: RuleCategory[]) => Promise<void>;
 
   onGlobalGroupingEnabledChange: (callback: (value: boolean) => void) => () => void;
   onGlobalDeduplicationEnabledChange: (callback: (value: boolean) => void) => () => void;
@@ -30,6 +33,7 @@ export interface UseSettingsReturn {
     callback: (value: DeduplicationKeepStrategyValue) => void,
   ) => () => void;
   onDomainRulesChange: (callback: (value: DomainRuleSettings) => void) => () => void;
+  onCategoriesChange: (callback: (value: RuleCategory[]) => void) => () => void;
 
   updateSettings: (updates: Partial<AppSettings>) => Promise<void>;
   reloadSettings: () => Promise<void>;
@@ -44,6 +48,7 @@ async function loadSettingsFromStorage(): Promise<AppSettings> {
     deduplicateUnmatchedDomainsItem,
     deduplicationKeepStrategyItem,
     domainRulesItem,
+    categoriesItem,
     notifyOnGroupingItem,
     notifyOnDeduplicationItem,
   ]);
@@ -68,8 +73,9 @@ async function loadSettingsFromStorage(): Promise<AppSettings> {
     deduplicateUnmatchedDomains: results[2].value as boolean,
     deduplicationKeepStrategy: results[3].value as DeduplicationKeepStrategyValue,
     domainRules,
-    notifyOnGrouping: results[5].value as boolean,
-    notifyOnDeduplication: results[6].value as boolean,
+    categories: results[5].value as RuleCategory[],
+    notifyOnGrouping: results[6].value as boolean,
+    notifyOnDeduplication: results[7].value as boolean,
   };
 }
 
@@ -115,12 +121,14 @@ export function useSettings(): UseSettingsReturn {
     setDeduplicateUnmatchedDomains: (v) => update({ deduplicateUnmatchedDomains: v }),
     setDeduplicationKeepStrategy: (v) => update({ deduplicationKeepStrategy: v }),
     setDomainRules: (v) => update({ domainRules: v }),
+    setCategories: (v) => update({ categories: v }),
 
     onGlobalGroupingEnabledChange: (cb) => onFieldChange('globalGroupingEnabled', cb),
     onGlobalDeduplicationEnabledChange: (cb) => onFieldChange('globalDeduplicationEnabled', cb),
     onDeduplicateUnmatchedDomainsChange: (cb) => onFieldChange('deduplicateUnmatchedDomains', cb),
     onDeduplicationKeepStrategyChange: (cb) => onFieldChange('deduplicationKeepStrategy', cb),
     onDomainRulesChange: (cb) => onFieldChange('domainRules', cb),
+    onCategoriesChange: (cb) => onFieldChange('categories', cb),
 
     updateSettings: update,
     reloadSettings: reload,

--- a/src/pages/DomainRulesPage.stories.tsx
+++ b/src/pages/DomainRulesPage.stories.tsx
@@ -36,6 +36,7 @@ const mockSyncSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
   domainRules: rules,

--- a/src/pages/SessionsPage.stories.tsx
+++ b/src/pages/SessionsPage.stories.tsx
@@ -23,6 +23,7 @@ const mockSyncSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
   domainRules: [],

--- a/src/schemas/category.ts
+++ b/src/schemas/category.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const chromeGroupColorSchema = z.enum([
+  'grey', 'blue', 'red', 'yellow', 'green',
+  'pink', 'purple', 'cyan', 'orange',
+]);
+
+export const ruleCategorySchema = z
+  .object({
+    id: z.string().min(1),
+    emoji: z.string().min(1),
+    color: chromeGroupColorSchema,
+    labelKey: z.string().optional(),
+    label: z.string().optional(),
+    builtIn: z.boolean().default(false),
+  })
+  .refine(v => Boolean(v.labelKey) || Boolean(v.label), {
+    message: 'Category must have either labelKey (built-in) or label (custom)',
+  });
+
+export const categoriesFileSchema = z.object({
+  categories: z.array(ruleCategorySchema),
+});
+
+export type RuleCategory = z.infer<typeof ruleCategorySchema>;
+export type CategoriesFile = z.infer<typeof categoriesFileSchema>;

--- a/src/schemas/enums.ts
+++ b/src/schemas/enums.ts
@@ -11,26 +11,11 @@ export const colorOptions = [
   { value: 'orange', keyLabel: 'color_orange' }
 ] as const;
 
-// Catégories de règles de domaine (chacune associe un emoji + une couleur Chrome)
-export const RULE_CATEGORIES = [
-  { id: 'development',  emoji: '💻', color: 'blue',   labelKey: 'category_development' },
-  { id: 'productivity', emoji: '📋', color: 'purple', labelKey: 'category_productivity' },
-  { id: 'commerce',     emoji: '🛍️', color: 'orange', labelKey: 'category_commerce' },
-  { id: 'travel',       emoji: '✈️',  color: 'cyan',   labelKey: 'category_travel' },
-  { id: 'search',       emoji: '🔍', color: 'yellow', labelKey: 'category_search' },
-  { id: 'social',       emoji: '💬', color: 'pink',   labelKey: 'category_social' },
-  { id: 'media',        emoji: '🎬', color: 'red',    labelKey: 'category_media' },
-  { id: 'cloud',        emoji: '☁️',  color: 'blue',   labelKey: 'category_cloud' },
-  { id: 'finance',      emoji: '💰', color: 'green',  labelKey: 'category_finance' },
-  { id: 'education',    emoji: '🎓', color: 'yellow', labelKey: 'category_education' },
-] as const;
-
-export type RuleCategoryId = typeof RULE_CATEGORIES[number]['id'];
-
-export function getRuleCategory(categoryId?: string | null) {
-  if (!categoryId) return null;
-  return RULE_CATEGORIES.find(c => c.id === categoryId) ?? null;
-}
+// Category IDs are stored loosely as strings (built-ins seeded from
+// public/data/categories.json, customs will be added by the user later).
+// The actual catalog lives in browser.storage.local, accessed via
+// src/utils/categoriesStore.ts.
+export type RuleCategoryId = string;
 
 export const groupNameSourceOptions = [
   { value: 'title', keyLabel: 'groupNameSourceTitle' },

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -36,7 +36,7 @@ export interface Session {
   ungroupedTabs: SavedTab[];
   /** If true, this session is pinned as a profile */
   isPinned: boolean;
-  /** Optional category ID (from RULE_CATEGORIES) */
+  /** Optional category ID (resolved via src/utils/categoriesStore.ts) */
   categoryId?: string | null;
   /** Optional free-text note associated with the session */
   note?: string;

--- a/src/types/syncSettings.ts
+++ b/src/types/syncSettings.ts
@@ -1,5 +1,6 @@
 import type { DomainRule } from '@/schemas/domainRule.js';
 import { type BadgeType, type DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import type { RuleCategory } from '@/schemas/category.js';
 
 // Types Settings qui étendent les types Zod inférés
 export interface DomainRuleSetting extends DomainRule {
@@ -18,6 +19,7 @@ export interface AppSettings {
   deduplicateUnmatchedDomains: boolean;
   deduplicationKeepStrategy: DeduplicationKeepStrategyValue;
   domainRules: DomainRuleSettings;
+  categories: RuleCategory[];
   // Notification settings
   notifyOnGrouping: boolean;
   notifyOnDeduplication: boolean;
@@ -30,6 +32,7 @@ export const defaultAppSettings: AppSettings = {
   deduplicateUnmatchedDomains: false,
   deduplicationKeepStrategy: 'keep-grouped-or-new',
   domainRules: [],
+  categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true
 };

--- a/src/utils/categoriesStore.ts
+++ b/src/utils/categoriesStore.ts
@@ -1,0 +1,55 @@
+import { categoriesFileSchema, type RuleCategory } from '@/schemas/category.js';
+import { categoriesItem } from './storageItems.js';
+import { getMessage } from './i18n.js';
+import { logger } from './logger.js';
+
+let cache: RuleCategory[] = [];
+let initialized = false;
+let unwatch: (() => void) | null = null;
+
+export async function initCategoriesStore(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  try {
+    cache = (await categoriesItem.getValue()) ?? [];
+  } catch (error) {
+    logger.error('[CATEGORIES] Failed to read categories from storage:', error);
+    cache = [];
+  }
+  unwatch = categoriesItem.watch((next) => {
+    cache = next ?? [];
+  });
+}
+
+export function getAllCategories(): RuleCategory[] {
+  return cache;
+}
+
+export function getRuleCategory(categoryId?: string | null): RuleCategory | null {
+  if (!categoryId) return null;
+  return cache.find(c => c.id === categoryId) ?? null;
+}
+
+export function getCategoryLabel(category: RuleCategory): string {
+  if (category.labelKey) return getMessage(category.labelKey);
+  return category.label ?? '';
+}
+
+export async function fetchBuiltInCategories(): Promise<RuleCategory[]> {
+  const response = await fetch('/data/categories.json');
+  if (!response.ok) {
+    throw new Error(`Failed to load categories: ${response.status}`);
+  }
+  const data = await response.json();
+  const parsed = categoriesFileSchema.parse(data);
+  return parsed.categories;
+}
+
+export function _resetCategoriesStoreForTests(): void {
+  cache = [];
+  initialized = false;
+  if (unwatch) {
+    unwatch();
+    unwatch = null;
+  }
+}

--- a/src/utils/mountExtensionApp.ts
+++ b/src/utils/mountExtensionApp.ts
@@ -2,12 +2,15 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { browser } from 'wxt/browser';
 import { logger } from './logger.js';
+import { initCategoriesStore } from './categoriesStore.js';
 
 /**
  * Bootstrap utility shared by all extension entry points.
  *
  * - Applies the browser UI language to `document.documentElement.lang`
  *   so screen readers announce content in the correct locale.
+ * - Populates the categories in-memory cache so sync accessors
+ *   (`getRuleCategory`, `getAllCategories`) return data on first render.
  * - Mounts the given React element into the DOM node identified by `rootId`.
  *
  * @param rootId - The `id` attribute of the target DOM element (e.g. `"options-app"`).
@@ -27,5 +30,13 @@ export function mountExtensionApp(rootId: string, app: React.ReactElement): void
   }
 
   const root = createRoot(container);
-  root.render(app);
+
+  // Categories are read synchronously from a module-level cache, so populate
+  // it before the first render. On first install the cache may be empty until
+  // the background service worker seeds it; the storage watcher inside the
+  // store will refresh the cache and consumers that rely on useSettings will
+  // re-render via the normal subscription path.
+  initCategoriesStore()
+    .catch(e => logger.error('[CATEGORIES] init failed:', e))
+    .finally(() => root.render(app));
 }

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -8,6 +8,7 @@ import {
   deduplicateUnmatchedDomainsItem,
   deduplicationKeepStrategyItem,
   domainRulesItem,
+  categoriesItem,
   notifyOnGroupingItem,
   notifyOnDeduplicationItem,
   settingsItemMap,
@@ -26,6 +27,7 @@ export async function getSettings(): Promise<AppSettings> {
       deduplicateUnmatchedDomainsItem,
       deduplicationKeepStrategyItem,
       domainRulesItem,
+      categoriesItem,
       notifyOnGroupingItem,
       notifyOnDeduplicationItem,
     ]);
@@ -35,8 +37,9 @@ export async function getSettings(): Promise<AppSettings> {
       deduplicateUnmatchedDomains: results[2].value as boolean,
       deduplicationKeepStrategy: results[3].value as AppSettings['deduplicationKeepStrategy'],
       domainRules: results[4].value as AppSettings['domainRules'],
-      notifyOnGrouping: results[5].value as boolean,
-      notifyOnDeduplication: results[6].value as boolean,
+      categories: results[5].value as AppSettings['categories'],
+      notifyOnGrouping: results[6].value as boolean,
+      notifyOnDeduplication: results[7].value as boolean,
     };
   } catch (error) {
     logger.error('Error getting settings:', error);
@@ -52,6 +55,7 @@ export async function setSettings(settings: AppSettings): Promise<void> {
       { item: deduplicateUnmatchedDomainsItem, value: settings.deduplicateUnmatchedDomains },
       { item: deduplicationKeepStrategyItem, value: settings.deduplicationKeepStrategy },
       { item: domainRulesItem, value: settings.domainRules },
+      { item: categoriesItem, value: settings.categories },
       { item: notifyOnGroupingItem, value: settings.notifyOnGrouping },
       { item: notifyOnDeduplicationItem, value: settings.notifyOnDeduplication },
     ]);
@@ -73,6 +77,8 @@ export async function updateSettings(updates: Partial<AppSettings>): Promise<voi
       items.push({ item: deduplicationKeepStrategyItem, value: updates.deduplicationKeepStrategy! });
     if ('domainRules' in updates)
       items.push({ item: domainRulesItem, value: updates.domainRules! });
+    if ('categories' in updates)
+      items.push({ item: categoriesItem, value: updates.categories! });
     if ('notifyOnGrouping' in updates)
       items.push({ item: notifyOnGroupingItem, value: updates.notifyOnGrouping! });
     if ('notifyOnDeduplication' in updates)
@@ -97,6 +103,7 @@ export function watchSettings(
     deduplicateUnmatchedDomainsItem.watch(() => getSettings().then(callback)),
     deduplicationKeepStrategyItem.watch(() => getSettings().then(callback)),
     domainRulesItem.watch(() => getSettings().then(callback)),
+    categoriesItem.watch(() => getSettings().then(callback)),
     notifyOnGroupingItem.watch(() => getSettings().then(callback)),
     notifyOnDeduplicationItem.watch(() => getSettings().then(callback)),
   ];

--- a/src/utils/storageItems.ts
+++ b/src/utils/storageItems.ts
@@ -2,6 +2,7 @@ import { storage } from 'wxt/utils/storage';
 import type { DomainRuleSettings } from '@/types/syncSettings.js';
 import { defaultAppSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import type { RuleCategory } from '@/schemas/category.js';
 import type { Statistics } from '@/types/statistics.js';
 import { defaultStatistics } from '@/types/statistics.js';
 import type { Session } from '@/types/session.js';
@@ -31,6 +32,16 @@ export const deduplicationKeepStrategyItem = storage.defineItem<DeduplicationKee
 export const domainRulesItem = storage.defineItem<DomainRuleSettings>(
   'local:domainRules',
   { defaultValue: defaultAppSettings.domainRules },
+);
+
+export const categoriesItem = storage.defineItem<RuleCategory[]>(
+  'local:categories',
+  { defaultValue: defaultAppSettings.categories },
+);
+
+export const categoriesSeededItem = storage.defineItem<boolean>(
+  'local:categoriesSeeded',
+  { defaultValue: false },
 );
 
 export const notifyOnGroupingItem = storage.defineItem<boolean>(
@@ -67,6 +78,7 @@ export const settingsItemMap = {
   deduplicateUnmatchedDomains: deduplicateUnmatchedDomainsItem,
   deduplicationKeepStrategy: deduplicationKeepStrategyItem,
   domainRules: domainRulesItem,
+  categories: categoriesItem,
   notifyOnGrouping: notifyOnGroupingItem,
   notifyOnDeduplication: notifyOnDeduplicationItem,
 } as const;

--- a/tests/background/seedBuiltInCategories.test.ts
+++ b/tests/background/seedBuiltInCategories.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import type { RuleCategory } from '../../src/schemas/category';
+
+const BUILT_IN_SEED: RuleCategory[] = [
+  { id: 'development', emoji: '💻', color: 'blue', labelKey: 'category_development', builtIn: true },
+  { id: 'media', emoji: '🎬', color: 'red', labelKey: 'category_media', builtIn: true },
+];
+
+function mockOkFetch(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('seedBuiltInCategories', () => {
+  it('seed les built-ins depuis le JSON quand le storage est vide', async () => {
+    vi.stubGlobal('fetch', mockOkFetch({ categories: BUILT_IN_SEED }));
+    const { seedBuiltInCategories } = await import('../../src/background/migration');
+
+    await seedBuiltInCategories();
+
+    const { categories, categoriesSeeded } = await fakeBrowser.storage.local.get([
+      'categories', 'categoriesSeeded',
+    ]);
+    expect(categories).toHaveLength(2);
+    expect((categories as RuleCategory[])[0].id).toBe('development');
+    expect(categoriesSeeded).toBe(true);
+  });
+
+  it('n\'écrase pas des catégories déjà présentes dans le storage', async () => {
+    const fetchMock = mockOkFetch({ categories: BUILT_IN_SEED });
+    vi.stubGlobal('fetch', fetchMock);
+    const existing: RuleCategory[] = [
+      { id: 'gaming', emoji: '🎮', color: 'purple', label: 'Gaming', builtIn: false },
+    ];
+    await fakeBrowser.storage.local.set({ categories: existing });
+
+    const { seedBuiltInCategories } = await import('../../src/background/migration');
+    await seedBuiltInCategories();
+
+    const { categories, categoriesSeeded } = await fakeBrowser.storage.local.get([
+      'categories', 'categoriesSeeded',
+    ]);
+    expect(categories).toEqual(existing);
+    expect(categoriesSeeded).toBe(true);
+    // fetch should not be called since existing data was present
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('est idempotent : ne refait rien si le flag categoriesSeeded est déjà posé', async () => {
+    const fetchMock = mockOkFetch({ categories: BUILT_IN_SEED });
+    vi.stubGlobal('fetch', fetchMock);
+    await fakeBrowser.storage.local.set({ categoriesSeeded: true });
+
+    const { seedBuiltInCategories } = await import('../../src/background/migration');
+    await seedBuiltInCategories();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const { categories } = await fakeBrowser.storage.local.get('categories');
+    expect(categories).toBeUndefined();
+  });
+
+  it('ne pose pas le flag si fetch échoue (retry au prochain démarrage)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    const { seedBuiltInCategories } = await import('../../src/background/migration');
+
+    await seedBuiltInCategories();
+
+    const { categoriesSeeded } = await fakeBrowser.storage.local.get('categoriesSeeded');
+    expect(categoriesSeeded).toBeUndefined();
+  });
+});

--- a/tests/components/PopupProfilesList.test.tsx
+++ b/tests/components/PopupProfilesList.test.tsx
@@ -41,7 +41,7 @@ vi.mock('../../src/utils/tabRestore', () => ({
 }));
 
 // Mock getRuleCategory
-vi.mock('../../src/schemas/enums', () => ({
+vi.mock('../../src/utils/categoriesStore', () => ({
   getRuleCategory: vi.fn(() => null),
 }));
 

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -9,6 +9,7 @@ const TEST_DEFAULTS: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: false,
   deduplicationKeepStrategy: 'keep-grouped-or-new',
+  categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
   domainRules: [

--- a/tests/schemas/category.test.ts
+++ b/tests/schemas/category.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { ruleCategorySchema, categoriesFileSchema } from '../../src/schemas/category';
+
+describe('ruleCategorySchema', () => {
+  it('accepte une catégorie built-in avec labelKey uniquement', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: 'development',
+      emoji: '💻',
+      color: 'blue',
+      labelKey: 'category_development',
+      builtIn: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte une catégorie custom avec label uniquement', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: 'gaming',
+      emoji: '🎮',
+      color: 'purple',
+      label: 'Gaming',
+      builtIn: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('remplit builtIn à false par défaut', () => {
+    const parsed = ruleCategorySchema.parse({
+      id: 'x',
+      emoji: '✨',
+      color: 'green',
+      label: 'X',
+    });
+    expect(parsed.builtIn).toBe(false);
+  });
+
+  it('rejette une catégorie sans labelKey ni label', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: 'x',
+      emoji: '✨',
+      color: 'green',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejette une couleur non supportée', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: 'x',
+      emoji: '✨',
+      color: 'magenta',
+      label: 'X',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejette un id vide', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: '',
+      emoji: '✨',
+      color: 'green',
+      label: 'X',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejette un emoji vide', () => {
+    const result = ruleCategorySchema.safeParse({
+      id: 'x',
+      emoji: '',
+      color: 'green',
+      label: 'X',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('categoriesFileSchema', () => {
+  it('accepte une liste vide', () => {
+    const result = categoriesFileSchema.safeParse({ categories: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepte le fichier de seed complet', () => {
+    const result = categoriesFileSchema.safeParse({
+      categories: [
+        { id: 'development', emoji: '💻', color: 'blue', labelKey: 'category_development', builtIn: true },
+        { id: 'media', emoji: '🎬', color: 'red', labelKey: 'category_media', builtIn: true },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/utils/categoriesStore.test.ts
+++ b/tests/utils/categoriesStore.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import type { RuleCategory } from '../../src/schemas/category';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+const SAMPLE_CATEGORIES: RuleCategory[] = [
+  { id: 'development', emoji: '💻', color: 'blue', labelKey: 'category_development', builtIn: true },
+  { id: 'media', emoji: '🎬', color: 'red', labelKey: 'category_media', builtIn: true },
+  { id: 'gaming', emoji: '🎮', color: 'purple', label: 'Gaming', builtIn: false },
+];
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('initCategoriesStore', () => {
+  it('remplit le cache depuis storage au premier appel', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getAllCategories } = await import('../../src/utils/categoriesStore');
+
+    await initCategoriesStore();
+
+    expect(getAllCategories()).toHaveLength(3);
+    expect(getAllCategories()[0].id).toBe('development');
+  });
+
+  it('retourne un cache vide si storage est vide', async () => {
+    const { initCategoriesStore, getAllCategories } = await import('../../src/utils/categoriesStore');
+
+    await initCategoriesStore();
+
+    expect(getAllCategories()).toEqual([]);
+  });
+
+  it('est idempotent sur plusieurs appels', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getAllCategories } = await import('../../src/utils/categoriesStore');
+
+    await initCategoriesStore();
+    await initCategoriesStore();
+
+    expect(getAllCategories()).toHaveLength(3);
+  });
+});
+
+describe('getRuleCategory', () => {
+  it('retourne la catégorie correspondante à l\'id', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getRuleCategory } = await import('../../src/utils/categoriesStore');
+    await initCategoriesStore();
+
+    const cat = getRuleCategory('development');
+    expect(cat?.emoji).toBe('💻');
+  });
+
+  it('retourne null pour un id inconnu', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getRuleCategory } = await import('../../src/utils/categoriesStore');
+    await initCategoriesStore();
+
+    expect(getRuleCategory('unknown')).toBeNull();
+  });
+
+  it('retourne null pour null/undefined/chaîne vide', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getRuleCategory } = await import('../../src/utils/categoriesStore');
+    await initCategoriesStore();
+
+    expect(getRuleCategory(null)).toBeNull();
+    expect(getRuleCategory(undefined)).toBeNull();
+    expect(getRuleCategory('')).toBeNull();
+  });
+});
+
+describe('getCategoryLabel', () => {
+  it('résout labelKey via getMessage pour les built-ins', async () => {
+    const { getCategoryLabel } = await import('../../src/utils/categoriesStore');
+    const cat: RuleCategory = { id: 'x', emoji: '✨', color: 'blue', labelKey: 'category_x', builtIn: true };
+
+    expect(getCategoryLabel(cat)).toBe('i18n(category_x)');
+  });
+
+  it('utilise label en texte brut pour les customs', async () => {
+    const { getCategoryLabel } = await import('../../src/utils/categoriesStore');
+    const cat: RuleCategory = { id: 'x', emoji: '✨', color: 'blue', label: 'Custom Label', builtIn: false };
+
+    expect(getCategoryLabel(cat)).toBe('Custom Label');
+  });
+
+  it('privilégie labelKey sur label quand les deux sont présents', async () => {
+    const { getCategoryLabel } = await import('../../src/utils/categoriesStore');
+    const cat: RuleCategory = {
+      id: 'x',
+      emoji: '✨',
+      color: 'blue',
+      labelKey: 'category_x',
+      label: 'Fallback',
+      builtIn: true,
+    };
+
+    expect(getCategoryLabel(cat)).toBe('i18n(category_x)');
+  });
+});
+
+describe('fetchBuiltInCategories', () => {
+  it('télécharge et valide le fichier categories.json', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ categories: SAMPLE_CATEGORIES }),
+      }),
+    );
+    const { fetchBuiltInCategories } = await import('../../src/utils/categoriesStore');
+
+    const result = await fetchBuiltInCategories();
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe('development');
+  });
+
+  it('lève une erreur si la réponse HTTP est KO', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }),
+    );
+    const { fetchBuiltInCategories } = await import('../../src/utils/categoriesStore');
+
+    await expect(fetchBuiltInCategories()).rejects.toThrow();
+  });
+
+  it('lève une erreur si le JSON ne respecte pas le schéma', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ not: 'the right shape' }),
+      }),
+    );
+    const { fetchBuiltInCategories } = await import('../../src/utils/categoriesStore');
+
+    await expect(fetchBuiltInCategories()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
This PR refactors rule categories from a static hardcoded enum into a dynamic system backed by browser storage, enabling users to create custom categories while maintaining built-in defaults.

## Key Changes

- **New category schema** (`src/schemas/category.ts`): Zod schemas for validating rule categories with support for both built-in (i18n-based labels) and custom (plain text labels) categories.

- **Categories store** (`src/utils/categoriesStore.ts`): New module providing synchronous accessors (`getRuleCategory`, `getAllCategories`, `getCategoryLabel`) backed by an in-memory cache that syncs with storage. Includes `fetchBuiltInCategories()` to load from the seed file.

- **Built-in categories seed** (`public/data/categories.json`): Moved the 10 hardcoded categories from `RULE_CATEGORIES` enum into a JSON file for easier maintenance and future extensibility.

- **Migration logic** (`src/background/migration.ts`): Added `seedBuiltInCategories()` function that idempotently populates storage with built-in categories on first run, respecting existing user data.

- **Storage integration**: 
  - Added `categoriesItem` and `categoriesSeededItem` to `storageItems.ts`
  - Updated `AppSettings` type to include `categories: RuleCategory[]`
  - Integrated category initialization into app bootstrap (`mountExtensionApp.ts`, `background.ts`)

- **Component updates**: Modified `CategoryPicker` and related components to read from the dynamic store instead of the static enum.

- **Type changes**: `RuleCategoryId` is now a loose string type instead of a literal union, allowing custom category IDs.

## Implementation Details

- Categories are loaded into an in-memory cache during app initialization via `initCategoriesStore()`, enabling synchronous access patterns in components.
- The migration is guarded by a `categoriesSeeded` flag to ensure idempotency across restarts.
- Built-in categories are never overwritten if user data already exists in storage.
- Label resolution supports both i18n keys (built-ins) and plain text (customs) via `getCategoryLabel()`.
- Comprehensive test coverage for schema validation, store operations, and migration logic.

https://claude.ai/code/session_01TVygBnYF7ZqSfbvjCkcz1E