### PR TITLE
Add comprehensive test coverage for messaging, components, and utilities

### DIFF
--- a/src/components/UI/ImportExportWizards/ImportExportActionCard.stories.tsx
+++ b/src/components/UI/ImportExportWizards/ImportExportActionCard.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Download, Upload } from 'lucide-react';
+import { ImportExportActionCard } from './ImportExportActionCard';
+
+const meta: Meta<typeof ImportExportActionCard> = {
+  title: 'Components/UI/ImportExportWizards/ImportExportActionCard',
+  component: ImportExportActionCard,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ImportExportActionCardExport: Story = {
+  args: {
+    testId: 'action-card-export',
+    icon: Download,
+    title: 'Export Rules',
+    description: 'Export your domain rules to a JSON file.',
+    buttonLabel: 'Export',
+    onClick: () => {},
+  },
+};
+
+export const ImportExportActionCardImport: Story = {
+  args: {
+    testId: 'action-card-import',
+    icon: Upload,
+    title: 'Import Rules',
+    description: 'Import domain rules from a JSON file.',
+    buttonLabel: 'Import',
+    onClick: () => {},
+  },
+};
+
+export const ImportExportActionCardDisabled: Story = {
+  args: {
+    testId: 'action-card-disabled',
+    icon: Download,
+    title: 'Export Rules',
+    description: 'No rules to export yet.',
+    buttonLabel: 'Export',
+    onClick: () => {},
+    disabled: true,
+  },
+};

--- a/src/components/UI/ImportExportWizards/Source/FileDropZone.stories.tsx
+++ b/src/components/UI/ImportExportWizards/Source/FileDropZone.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Theme } from '@radix-ui/themes';
+import { FileDropZone } from './FileDropZone';
+import type { JsonSourceInputState } from './useJsonSourceInput';
+
+function makeMockSource(
+  overrides: Partial<JsonSourceInputState<unknown>> = {},
+): JsonSourceInputState<unknown> {
+  return {
+    sourceMode: 'file',
+    setSourceMode: () => {},
+    jsonText: '',
+    parsedData: null,
+    parseError: null,
+    importedNote: null,
+    fileName: null,
+    isDragOver: false,
+    fileInputRef: { current: null } as React.RefObject<HTMLInputElement>,
+    handleTextChange: () => {},
+    handleDrop: () => {},
+    handleDragOver: () => {},
+    handleDragLeave: () => {},
+    handleBrowse: () => {},
+    handleFileSelect: () => {},
+    reset: () => {},
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof FileDropZone> = {
+  title: 'Components/UI/ImportExportWizards/Source/FileDropZone',
+  component: FileDropZone,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <Theme>
+        <div style={{ width: 400 }}>
+          <Story />
+        </div>
+      </Theme>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FileDropZoneEmpty: Story = {
+  args: {
+    source: makeMockSource(),
+  },
+};
+
+export const FileDropZoneWithFile: Story = {
+  args: {
+    source: makeMockSource({ fileName: 'import.json' }),
+  },
+};
+
+export const FileDropZoneDragOver: Story = {
+  args: {
+    source: makeMockSource({ isDragOver: true }),
+  },
+};

--- a/src/components/UI/OptionsLayout/OptionsFooter.stories.tsx
+++ b/src/components/UI/OptionsLayout/OptionsFooter.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { OptionsFooter, OptionsFooterCollapsed } from './OptionsFooter';
+
+const meta: Meta<typeof OptionsFooter> = {
+  title: 'Components/UI/OptionsLayout/OptionsFooter',
+  component: OptionsFooter,
+  parameters: { layout: 'centered' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OptionsFooterDefault: Story = {};
+
+export const OptionsFooterCollapsedStory: Story = {
+  render: () => React.createElement(OptionsFooterCollapsed),
+  name: 'Collapsed',
+};

--- a/src/components/UI/OptionsLayout/OptionsHeader.stories.tsx
+++ b/src/components/UI/OptionsLayout/OptionsHeader.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { OptionsHeader, OptionsHeaderCollapsed } from './OptionsHeader';
+
+const metaExpanded: Meta<typeof OptionsHeader> = {
+  title: 'Components/UI/OptionsLayout/OptionsHeader',
+  component: OptionsHeader,
+  parameters: { layout: 'centered' },
+};
+
+export default metaExpanded;
+type Story = StoryObj<typeof metaExpanded>;
+
+export const OptionsHeaderDefault: Story = {
+  args: {
+    version: '1.1.3',
+  },
+};
+
+export const OptionsHeaderCollapsedStory: Story = {
+  render: () => React.createElement(OptionsHeaderCollapsed),
+  name: 'Collapsed',
+};

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -9,7 +9,6 @@ import { useSettings } from '@/hooks/useSettings.js';
 import { useStatistics } from '@/hooks/useStatistics.js';
 import { useDeepLinking } from '@/hooks/useDeepLinking.js';
 import { getMessage } from '@/utils/i18n';
-const version = browser.runtime.getManifest().version;
 
 import { Sidebar } from '@/components/UI/Sidebar/Sidebar';
 import type { SidebarItem } from '@/components/UI/Sidebar/Sidebar';
@@ -27,9 +26,9 @@ import { SessionsPage } from './SessionsPage';
 import { Toaster } from '@/components/UI/Toaster/Toaster';
 import type { DomainRuleSettings } from '@/types/syncSettings';
 
-(() => {
+export function OptionsContent() {
+    const version = browser.runtime.getManifest().version;
 
-function OptionsContent() {
     const { settings, updateSettings } = useSettings();
     const { statistics: stats, resetStatistics } = useStatistics();
     const {
@@ -127,7 +126,7 @@ function OptionsContent() {
     );
 }
 
-function OptionsApp() {
+export function OptionsApp() {
     return (
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <Theme>
@@ -139,4 +138,3 @@ function OptionsApp() {
 }
 
 mountExtensionApp('options-app', <OptionsApp />);
-})();

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -11,9 +11,7 @@ import { PopupToolbar } from '@/components/UI/PopupToolbar/PopupToolbar';
 import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfilesList';
 import { useSettings } from '@/hooks/useSettings';
 
-(() => {
-
-function PopupContent() {
+export function PopupContent() {
   const { settings, isLoaded, setGlobalGroupingEnabled, setGlobalDeduplicationEnabled } = useSettings();
 
   const openOptionsPage = useCallback(() => {
@@ -69,7 +67,7 @@ function PopupContent() {
   );
 }
 
-function PopupApp() {
+export function PopupApp() {
   return (
     <ThemeProvider
       attribute="class"
@@ -85,4 +83,3 @@ function PopupApp() {
 }
 
 mountExtensionApp('popup-app', <PopupApp />);
-})();

--- a/tests/background/messaging.test.ts
+++ b/tests/background/messaging.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---- Mocks (avant les imports) -----------------------------------------------
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    tabs: {
+      sendMessage: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/utils/deduplicationSkip.js', () => ({
+  markUrlToSkipDeduplication: vi.fn(),
+}));
+
+// ---- Imports après mocks -------------------------------------------------------
+
+import { browser } from 'wxt/browser';
+import { markUrlToSkipDeduplication } from '../../src/utils/deduplicationSkip.js';
+import {
+  middleClickedTabs,
+  handleMiddleClickMessage,
+  handleSessionRestoreSkipDedupMessage,
+  cleanupMiddleClickedTabsForTab,
+  promptForGroupName,
+  findMiddleClickOpener,
+} from '../../src/background/messaging.js';
+
+const mockedSendMessage = browser.tabs.sendMessage as ReturnType<typeof vi.fn>;
+const mockedMarkUrl = markUrlToSkipDeduplication as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  middleClickedTabs.clear();
+});
+
+// ---- handleMiddleClickMessage ------------------------------------------------
+
+describe('handleMiddleClickMessage', () => {
+  it('enregistre l\'URL dans middleClickedTabs et répond "received" quand sender.tab.id est présent', () => {
+    const sendResponse = vi.fn();
+    handleMiddleClickMessage(
+      { type: 'MIDDLE_CLICK', url: 'https://example.com' },
+      { tab: { id: 42 } } as any,
+      sendResponse,
+    );
+
+    expect(middleClickedTabs.get('https://example.com')).toBe(42);
+    expect(sendResponse).toHaveBeenCalledWith({ status: 'received' });
+  });
+
+  it('répond "error" quand sender.tab est absent', () => {
+    const sendResponse = vi.fn();
+    handleMiddleClickMessage(
+      { type: 'MIDDLE_CLICK', url: 'https://example.com' },
+      {} as any,
+      sendResponse,
+    );
+
+    expect(middleClickedTabs.size).toBe(0);
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error' }),
+    );
+  });
+
+  it('répond "error" quand sender.tab.id est absent', () => {
+    const sendResponse = vi.fn();
+    handleMiddleClickMessage(
+      { type: 'MIDDLE_CLICK', url: 'https://example.com' },
+      { tab: {} } as any,
+      sendResponse,
+    );
+
+    expect(middleClickedTabs.size).toBe(0);
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'error' }),
+    );
+  });
+});
+
+// ---- handleSessionRestoreSkipDedupMessage ------------------------------------
+
+describe('handleSessionRestoreSkipDedupMessage', () => {
+  it('appelle markUrlToSkipDeduplication pour chaque URL et répond "received"', () => {
+    const sendResponse = vi.fn();
+    handleSessionRestoreSkipDedupMessage(
+      { type: 'SESSION_RESTORE_SKIP_DEDUP', urls: ['https://a.com', 'https://b.com'] },
+      sendResponse,
+    );
+
+    expect(mockedMarkUrl).toHaveBeenCalledWith('https://a.com');
+    expect(mockedMarkUrl).toHaveBeenCalledWith('https://b.com');
+    expect(sendResponse).toHaveBeenCalledWith({ status: 'received' });
+  });
+});
+
+// ---- cleanupMiddleClickedTabsForTab ------------------------------------------
+
+describe('cleanupMiddleClickedTabsForTab', () => {
+  it('supprime les entrées correspondant au tabId donné', () => {
+    middleClickedTabs.set('https://a.com', 10);
+    middleClickedTabs.set('https://b.com', 20);
+    middleClickedTabs.set('https://c.com', 10);
+
+    cleanupMiddleClickedTabsForTab(10);
+
+    expect(middleClickedTabs.has('https://a.com')).toBe(false);
+    expect(middleClickedTabs.has('https://c.com')).toBe(false);
+    expect(middleClickedTabs.has('https://b.com')).toBe(true);
+  });
+
+  it('ne fait rien si aucune entrée ne correspond au tabId', () => {
+    middleClickedTabs.set('https://a.com', 10);
+    cleanupMiddleClickedTabsForTab(99);
+    expect(middleClickedTabs.size).toBe(1);
+  });
+});
+
+// ---- promptForGroupName ------------------------------------------------------
+
+describe('promptForGroupName', () => {
+  it('retourne le nom trimé quand la réponse est valide', async () => {
+    mockedSendMessage.mockResolvedValueOnce({ name: '  Mon groupe  ' });
+    const result = await promptForGroupName('Default', 5);
+    expect(result).toBe('Mon groupe');
+  });
+
+  it('retourne null quand la réponse name est vide ou absent', async () => {
+    mockedSendMessage.mockResolvedValueOnce({ name: '   ' });
+    expect(await promptForGroupName('Default', 5)).toBeNull();
+
+    mockedSendMessage.mockResolvedValueOnce({});
+    expect(await promptForGroupName('Default', 5)).toBeNull();
+  });
+
+  it('retourne null et ne lève pas d\'erreur si sendMessage rejette', async () => {
+    mockedSendMessage.mockRejectedValueOnce(new Error('Tab gone'));
+    const result = await promptForGroupName('Default', 5);
+    expect(result).toBeNull();
+  });
+});
+
+// ---- findMiddleClickOpener ---------------------------------------------------
+
+describe('findMiddleClickOpener', () => {
+  it('retourne null quand openerTabId est absent', () => {
+    const tab = { id: 1, url: 'https://example.com' } as any;
+    expect(findMiddleClickOpener(tab)).toBeNull();
+  });
+
+  it('retourne l\'openerTabId via correspondance directe et nettoie la Map', () => {
+    middleClickedTabs.set('https://example.com', 10);
+    const tab = { id: 1, url: 'https://example.com', openerTabId: 10 } as any;
+
+    const result = findMiddleClickOpener(tab);
+
+    expect(result).toBe(10);
+    expect(middleClickedTabs.has('https://example.com')).toBe(false);
+  });
+
+  it('retourne l\'openerTabId via la recherche de secours quand l\'URL ne correspond pas directement', () => {
+    middleClickedTabs.set('https://other-url.com', 10);
+    const tab = { id: 1, url: 'https://example.com', openerTabId: 10 } as any;
+
+    const result = findMiddleClickOpener(tab);
+
+    expect(result).toBe(10);
+    expect(middleClickedTabs.has('https://other-url.com')).toBe(false);
+  });
+
+  it('retourne null si aucune entrée ne correspond à l\'openerTabId', () => {
+    middleClickedTabs.set('https://other.com', 99);
+    const tab = { id: 1, url: 'https://example.com', openerTabId: 10 } as any;
+
+    expect(findMiddleClickOpener(tab)).toBeNull();
+  });
+
+  it('utilise pendingUrl en priorité sur url pour la correspondance directe', () => {
+    middleClickedTabs.set('https://pending.com', 10);
+    const tab = { id: 1, pendingUrl: 'https://pending.com', url: 'about:blank', openerTabId: 10 } as any;
+
+    const result = findMiddleClickOpener(tab);
+
+    expect(result).toBe(10);
+    expect(middleClickedTabs.has('https://pending.com')).toBe(false);
+  });
+});

--- a/tests/components/DomainRuleCard.stories.test.tsx
+++ b/tests/components/DomainRuleCard.stories.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/DomainRule/DomainRuleCard.stories';
+
+vi.mock('../../src/utils/categoriesStore', () => ({
+  getRuleCategory: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+import { getRuleCategory } from '../../src/utils/categoriesStore';
+
+const mockGetRuleCategory = getRuleCategory as ReturnType<typeof vi.fn>;
+
+const {
+  DomainRuleCardDefault,
+  DomainRuleCardDisabled,
+  DomainRuleCardDragDisabled,
+  DomainRuleCardDomainActionsDisabled,
+  DomainRuleCardWithSearch,
+} = composeStories(stories);
+
+describe('DomainRuleCard (portable stories)', () => {
+  beforeEach(() => {
+    mockGetRuleCategory.mockReturnValue(null);
+  });
+
+  it('rend la carte par défaut avec le label et le domaine', () => {
+    render(<DomainRuleCardDefault />);
+    expect(screen.getByTestId('rule-card-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('rule-card-rule-1-btn-dropdown')).toBeInTheDocument();
+  });
+
+  it('rend la carte désactivée (rule.enabled = false => opacité 0.6)', () => {
+    render(<DomainRuleCardDisabled />);
+    const card = screen.getByTestId('rule-card-rule-1');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveStyle({ opacity: '0.6' });
+  });
+
+  it('rend la carte avec drag désactivé (isDragDisabled = true)', () => {
+    render(<DomainRuleCardDragDisabled />);
+    const handle = screen.getByTestId('rule-card-rule-1-drag-handle');
+    expect(handle).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('rend la carte avec actions domaine désactivées', () => {
+    render(<DomainRuleCardDomainActionsDisabled />);
+    expect(screen.getByTestId('rule-card-rule-1')).toBeInTheDocument();
+  });
+
+  it('rend la carte avec mise en évidence de la recherche', () => {
+    render(<DomainRuleCardWithSearch />);
+    expect(screen.getByTestId('rule-card-rule-1')).toBeInTheDocument();
+  });
+
+  it('rend le badge avec la couleur et l\'emoji de la catégorie quand category != null', () => {
+    mockGetRuleCategory.mockReturnValue({
+      id: 'dev',
+      label: 'Dev',
+      labelKey: null,
+      emoji: '🔧',
+      color: '#4299E1',
+    });
+    render(<DomainRuleCardDefault />);
+    expect(screen.getByTestId('rule-card-rule-1')).toBeInTheDocument();
+  });
+});

--- a/tests/components/DomainRulesPage.stories.test.tsx
+++ b/tests/components/DomainRulesPage.stories.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/pages/DomainRulesPage.stories';
 
@@ -22,5 +22,54 @@ describe('DomainRulesPage (portable stories)', () => {
     expect(screen.getByTestId('page-rules-btn-add')).toBeInTheDocument();
     // Toolbar is hidden when there are no rules (search is useless, add is already in the placeholder).
     expect(screen.queryByTestId('page-rules-toolbar')).not.toBeInTheDocument();
+  });
+
+  it("affiche l'état vide compact quand la recherche ne retourne aucun résultat", async () => {
+    render(<DomainRulesPageDefault />);
+
+    const searchInput = screen.getByTestId('page-rules-search');
+    fireEvent.change(searchInput, { target: { value: 'xyznotexist' } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('page-rules-list')).not.toBeInTheDocument();
+    });
+    // Full empty state doit être absent (pas 0 règles sans recherche)
+    expect(screen.queryByTestId('page-rules-empty')).not.toBeInTheDocument();
+    // État vide compact avec message "No rules found"
+    expect(screen.getByText('No rules found')).toBeInTheDocument();
+  });
+
+  it("ouvre la boite de dialogue de suppression unique avec le bon titre", async () => {
+    render(<DomainRulesPageDefault />);
+
+    // Radix UI DropdownMenu s'ouvre sur pointerDown (pas click)
+    const trigger = screen.getByTestId('rule-card-rule-1-btn-dropdown');
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+
+    // Attendre l'apparition de l'item de suppression (rendu dans un portal)
+    const deleteItem = await screen.findByTestId('rule-card-rule-1-menu-delete');
+    fireEvent.click(deleteItem);
+
+    // Le dialog de suppression unitaire doit s'afficher
+    await waitFor(() => {
+      expect(screen.getByText('Delete this rule?')).toBeInTheDocument();
+    });
+  });
+
+  it("ouvre la boite de dialogue de suppression en masse avec le bon titre", async () => {
+    render(<DomainRulesPageDefault />);
+
+    // Cocher la première règle pour faire apparaître la BulkActionsBar
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    // Attendre l'apparition de la barre d'actions groupées
+    const deleteSelectedBtn = await screen.findByText('Delete Selected');
+    fireEvent.click(deleteSelectedBtn);
+
+    // Le dialog de suppression en masse doit s'afficher
+    await waitFor(() => {
+      expect(screen.getByText('Delete the selected rules?')).toBeInTheDocument();
+    });
   });
 });

--- a/tests/components/DomainRulesPage.stories.test.tsx
+++ b/tests/components/DomainRulesPage.stories.test.tsx
@@ -72,4 +72,54 @@ describe('DomainRulesPage (portable stories)', () => {
       expect(screen.getByText('Delete the selected rules?')).toBeInTheDocument();
     });
   });
+
+  it('confirme la suppression unique (handleConfirmDelete - single)', async () => {
+    render(<DomainRulesPageDefault />);
+
+    const trigger = screen.getByTestId('rule-card-rule-1-btn-dropdown');
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+
+    const deleteItem = await screen.findByTestId('rule-card-rule-1-menu-delete');
+    fireEvent.click(deleteItem);
+
+    const confirmBtn = await screen.findByTestId('confirm-dialog-btn-confirm');
+    fireEvent.click(confirmBtn);
+
+    // Le dialog se ferme après confirmation
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('confirme la suppression en masse (handleConfirmDelete - bulk)', async () => {
+    render(<DomainRulesPageDefault />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    const deleteSelectedBtn = await screen.findByText('Delete Selected');
+    fireEvent.click(deleteSelectedBtn);
+
+    const confirmBtn = await screen.findByTestId('confirm-dialog-btn-confirm');
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it("ouvre la modale d'ajout quand on clique sur le bouton Add (handleSaveRule)", async () => {
+    render(<DomainRulesPageDefault />);
+
+    fireEvent.click(screen.getByTestId('page-rules-btn-add'));
+
+    // La modale s'ouvre
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Fermer la modale (handleCloseModal)
+    const closeBtn = document.querySelector('[aria-label="Close"]') as HTMLElement | null;
+    if (closeBtn) fireEvent.click(closeBtn);
+  });
 });

--- a/tests/components/FileDropZone.stories.test.tsx
+++ b/tests/components/FileDropZone.stories.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/ImportExportWizards/Source/FileDropZone.stories';
+import { FileDropZone } from '../../src/components/UI/ImportExportWizards/Source/FileDropZone';
+import type { JsonSourceInputState } from '../../src/components/UI/ImportExportWizards/Source/useJsonSourceInput';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => {
+    const messages: Record<string, string> = {
+      dragDropZone: 'Drag a JSON file here',
+      browse: 'Browse...',
+    };
+    return messages[key] ?? key;
+  }),
+}));
+
+const { FileDropZoneEmpty, FileDropZoneWithFile } = composeStories(stories);
+
+function makeMockSource(
+  overrides: Partial<JsonSourceInputState<unknown>> = {},
+): JsonSourceInputState<unknown> {
+  return {
+    sourceMode: 'file',
+    setSourceMode: () => {},
+    jsonText: '',
+    parsedData: null,
+    parseError: null,
+    importedNote: null,
+    fileName: null,
+    isDragOver: false,
+    fileInputRef: { current: null } as React.RefObject<HTMLInputElement>,
+    handleTextChange: () => {},
+    handleDrop: () => {},
+    handleDragOver: () => {},
+    handleDragLeave: () => {},
+    handleBrowse: () => {},
+    handleFileSelect: () => {},
+    reset: () => {},
+    ...overrides,
+  };
+}
+
+describe('FileDropZone (portable stories)', () => {
+  it("affiche la zone de glisser-déposer sans nom de fichier", () => {
+    render(<FileDropZoneEmpty />);
+    expect(screen.getByText('Drag a JSON file here')).toBeInTheDocument();
+    expect(screen.getByText('Browse...')).toBeInTheDocument();
+    expect(screen.queryByText('import.json')).not.toBeInTheDocument();
+  });
+
+  it("affiche le nom du fichier quand source.fileName est défini", () => {
+    render(<FileDropZoneWithFile />);
+    expect(screen.getByText('import.json')).toBeInTheDocument();
+  });
+});
+
+describe('FileDropZone - branches', () => {
+  it("appelle handleBrowse et stopPropagation quand le bouton Browse est cliqué", () => {
+    const handleBrowse = vi.fn();
+    render(
+      <Theme>
+        <FileDropZone source={makeMockSource({ handleBrowse })} />
+      </Theme>,
+    );
+    const browseBtn = screen.getByText('Browse...');
+    fireEvent.click(browseBtn);
+    expect(handleBrowse).toHaveBeenCalledTimes(1);
+  });
+
+  it("n'affiche pas le nom du fichier quand source.fileName est null", () => {
+    render(
+      <Theme>
+        <FileDropZone source={makeMockSource({ fileName: null })} />
+      </Theme>,
+    );
+    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/Header.stories.test.tsx
+++ b/tests/components/Header.stories.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/Header/Header.stories';
+
+const { HeaderDefault, HeaderLight, HeaderDark } = composeStories(stories);
+
+describe('Header (portable stories)', () => {
+  it('renders the header with a title and theme toggle', () => {
+    render(<HeaderDefault />);
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+  });
+
+  it('renders in light mode', () => {
+    render(<HeaderLight />);
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+  });
+
+  it('renders in dark mode', () => {
+    render(<HeaderDark />);
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+  });
+});

--- a/tests/components/ImportExportActionCard.stories.test.tsx
+++ b/tests/components/ImportExportActionCard.stories.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { Download } from 'lucide-react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/ImportExportWizards/ImportExportActionCard.stories';
+import { ImportExportActionCard } from '../../src/components/UI/ImportExportWizards/ImportExportActionCard';
+
+const { ImportExportActionCardExport, ImportExportActionCardDisabled } = composeStories(stories);
+
+describe('ImportExportActionCard (portable stories)', () => {
+  it('renders title, description and button', () => {
+    render(<ImportExportActionCardExport />);
+    expect(screen.getByTestId('action-card-export')).toBeInTheDocument();
+    expect(screen.getByText('Export Rules')).toBeInTheDocument();
+    expect(screen.getByText('Export your domain rules to a JSON file.')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('button is disabled when disabled=true', () => {
+    render(<ImportExportActionCardDisabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});
+
+describe('ImportExportActionCard - branches', () => {
+  it('appelle onClick quand le bouton est cliqué', () => {
+    const onClick = vi.fn();
+    render(
+      <Theme>
+        <ImportExportActionCard
+          testId="card"
+          icon={Download}
+          title="Export"
+          description="Desc"
+          buttonLabel="Export"
+          onClick={onClick}
+        />
+      </Theme>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/ImportExportPage.stories.test.tsx
+++ b/tests/components/ImportExportPage.stories.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/pages/ImportExportPage.stories';
+
+const { ImportExportPageDefault, ImportExportPageWithRules } = composeStories(stories);
+
+describe('ImportExportPage (portable stories)', () => {
+  it('renders the page with four action cards', async () => {
+    render(<ImportExportPageDefault />);
+    await waitFor(() => {
+      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('page-import-export-card-export-rules')).toBeInTheDocument();
+    expect(screen.getByTestId('page-import-export-card-import-rules')).toBeInTheDocument();
+    expect(screen.getByTestId('page-import-export-card-export-sessions')).toBeInTheDocument();
+    expect(screen.getByTestId('page-import-export-card-import-sessions')).toBeInTheDocument();
+  });
+
+  it('désactive le bouton export-rules quand il n\'y a aucune règle', async () => {
+    render(<ImportExportPageDefault />);
+    await waitFor(() => {
+      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
+    });
+    const card = screen.getByTestId('page-import-export-card-export-rules');
+    expect(card.querySelector('button')).toBeDisabled();
+  });
+
+  it('active le bouton export-rules quand des règles existent', async () => {
+    render(<ImportExportPageWithRules />);
+    await waitFor(() => {
+      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
+    });
+    const card = screen.getByTestId('page-import-export-card-export-rules');
+    expect(card.querySelector('button')).not.toBeDisabled();
+  });
+
+  it('ouvre le dialog d\'export de règles au clic', async () => {
+    render(<ImportExportPageWithRules />);
+    await waitFor(() => {
+      expect(screen.getByTestId('page-import-export-card-export-rules')).toBeInTheDocument();
+    });
+    const exportBtn = screen.getByTestId('page-import-export-card-export-rules').querySelector('button')!;
+    fireEvent.click(exportBtn);
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('ouvre le dialog d\'import de règles au clic', async () => {
+    render(<ImportExportPageDefault />);
+    await waitFor(() => {
+      expect(screen.getByTestId('page-import-export-card-import-rules')).toBeInTheDocument();
+    });
+    const importBtn = screen.getByTestId('page-import-export-card-import-rules').querySelector('button')!;
+    fireEvent.click(importBtn);
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/OptionsFooter.stories.test.tsx
+++ b/tests/components/OptionsFooter.stories.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/OptionsLayout/OptionsFooter.stories';
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    tabs: {
+      create: vi.fn(),
+    },
+    i18n: {
+      getMessage: (key: string) => key,
+    },
+  },
+}));
+
+import { browser } from 'wxt/browser';
+
+const mockedTabsCreate = browser.tabs.create as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockedTabsCreate.mockClear();
+});
+
+const { OptionsFooterDefault, OptionsFooterCollapsedStory } = composeStories(stories);
+
+describe('OptionsFooter (portable stories)', () => {
+  it('renders the expanded footer with username and GitHub icon', () => {
+    render(<OptionsFooterDefault />);
+    expect(screen.getByTestId('options-footer')).toBeInTheDocument();
+    expect(screen.getByText('EspritVorace')).toBeInTheDocument();
+    expect(screen.getByAltText('EspritVorace')).toBeInTheDocument();
+  });
+
+  it('renders the collapsed footer with avatar only', () => {
+    render(<OptionsFooterCollapsedStory />);
+    expect(screen.getByAltText('EspritVorace')).toBeInTheDocument();
+    expect(screen.queryByText('EspritVorace')).not.toBeInTheDocument();
+  });
+});
+
+describe('OptionsFooter - branches', () => {
+  it('ouvre GitHub via browser.tabs.create au clic', () => {
+    render(<OptionsFooterDefault />);
+    fireEvent.click(screen.getByTestId('options-footer'));
+    expect(mockedTabsCreate).toHaveBeenCalledWith({
+      url: 'https://github.com/EspritVorace/smart-tab-organizer',
+    });
+  });
+
+  it('ouvre GitHub au clavier (Enter)', () => {
+    render(<OptionsFooterDefault />);
+    fireEvent.keyDown(screen.getByTestId('options-footer'), { key: 'Enter' });
+    expect(mockedTabsCreate).toHaveBeenCalledWith({
+      url: 'https://github.com/EspritVorace/smart-tab-organizer',
+    });
+  });
+
+  it('ouvre GitHub au clavier (Space)', () => {
+    render(<OptionsFooterDefault />);
+    fireEvent.keyDown(screen.getByTestId('options-footer'), { key: ' ' });
+    expect(mockedTabsCreate).toHaveBeenCalledWith({
+      url: 'https://github.com/EspritVorace/smart-tab-organizer',
+    });
+  });
+
+  it("n'ouvre pas GitHub sur une autre touche", () => {
+    render(<OptionsFooterDefault />);
+    fireEvent.keyDown(screen.getByTestId('options-footer'), { key: 'Tab' });
+    expect(mockedTabsCreate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/OptionsHeader.stories.test.tsx
+++ b/tests/components/OptionsHeader.stories.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/UI/OptionsLayout/OptionsHeader.stories';
+
+const { OptionsHeaderDefault, OptionsHeaderCollapsedStory } = composeStories(stories);
+
+describe('OptionsHeader (portable stories)', () => {
+  it('renders the expanded header with version and theme toggle', () => {
+    render(<OptionsHeaderDefault />);
+    expect(screen.getByTestId('options-header')).toBeInTheDocument();
+    expect(screen.getByText('(v1.1.3)')).toBeInTheDocument();
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+  });
+
+  it('renders the collapsed header with logo only', () => {
+    render(<OptionsHeaderCollapsedStory />);
+    const logo = screen.getByAltText('SmartTab Organizer');
+    expect(logo).toBeInTheDocument();
+    expect(screen.queryByTestId('theme-toggle')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/Sidebar.stories.test.tsx
+++ b/tests/components/Sidebar.stories.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/UI/Sidebar/Sidebar.stories';
+import { SidebarSearch } from '../../src/components/UI/Sidebar/SidebarSearch';
 
 const {
   SidebarDefault,
@@ -70,5 +71,34 @@ describe('Sidebar — static renders', () => {
   it('renders the complete sidebar with all features', () => {
     render(<SidebarComplete />);
     expect(screen.getByText('Analytics')).toBeInTheDocument();
+  });
+});
+
+describe('SidebarSearch', () => {
+  it('retourne null quand isCollapsed=true', () => {
+    const { container } = render(<SidebarSearch isCollapsed={true} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('appelle onSearch avec la valeur courante quand Enter est pressé', () => {
+    const onSearch = vi.fn();
+    render(<SidebarSearch value="test" onSearch={onSearch} />);
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSearch).toHaveBeenCalledWith('test');
+  });
+
+  it("n'appelle pas onSearch quand une autre touche est pressée", () => {
+    const onSearch = vi.fn();
+    render(<SidebarSearch value="test" onSearch={onSearch} />);
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.keyDown(input, { key: 'a' });
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it("n'appelle pas onSearch quand onSearch n'est pas fourni", () => {
+    render(<SidebarSearch value="test" />);
+    const input = screen.getByPlaceholderText('Search...');
+    expect(() => fireEvent.keyDown(input, { key: 'Enter' })).not.toThrow();
   });
 });

--- a/tests/pages/options.test.tsx
+++ b/tests/pages/options.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ── Mocks (hoissés avant les imports) ──────────────────────────────────────
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      getManifest: vi.fn(() => ({ version: '1.1.3' })),
+      getURL: vi.fn((path: string) => `chrome-extension://fakeid${path}`),
+    },
+    tabs: {
+      create: vi.fn(() => Promise.resolve()),
+    },
+    i18n: {
+      getMessage: vi.fn((key: string) => key),
+      getUILanguage: vi.fn(() => 'en'),
+    },
+  },
+}));
+
+vi.mock('../../src/hooks/useSettings', () => ({ useSettings: vi.fn() }));
+vi.mock('../../src/hooks/useStatistics', () => ({ useStatistics: vi.fn() }));
+vi.mock('../../src/hooks/useDeepLinking', () => ({ useDeepLinking: vi.fn() }));
+
+vi.mock('../../src/pages/DomainRulesPage', () => ({ DomainRulesPage: () => <div data-testid="page-rules-mock" /> }));
+vi.mock('../../src/pages/SessionsPage', () => ({ SessionsPage: () => <div data-testid="page-sessions-mock" /> }));
+vi.mock('../../src/pages/ImportExportPage', () => ({ ImportExportPage: () => <div data-testid="page-importexport-mock" /> }));
+vi.mock('../../src/pages/StatisticsPage', () => ({
+  StatisticsPage: ({ onReset }: { onReset: () => void }) => (
+    <div data-testid="page-stats-mock">
+      <button data-testid="stats-reset-mock" onClick={onReset}>reset</button>
+    </div>
+  ),
+}));
+vi.mock('../../src/components/UI/SettingsPage/SettingsPage', () => ({ SettingsPage: () => <div data-testid="page-settings-mock" /> }));
+vi.mock('../../src/components/UI/Toaster/Toaster', () => ({ Toaster: () => null }));
+
+// ── Imports après mocks ───────────────────────────────────────────────────
+
+import { useSettings } from '../../src/hooks/useSettings';
+import { useStatistics } from '../../src/hooks/useStatistics';
+import { useDeepLinking } from '../../src/hooks/useDeepLinking';
+import { OptionsApp } from '../../src/pages/options';
+
+const mockedUseSettings = useSettings as ReturnType<typeof vi.fn>;
+const mockedUseStatistics = useStatistics as ReturnType<typeof vi.fn>;
+const mockedUseDeepLinking = useDeepLinking as ReturnType<typeof vi.fn>;
+
+const mockSettings = {
+  domainRules: [],
+  globalGroupingEnabled: true,
+  globalDeduplicationEnabled: true,
+};
+
+const mockStats = { tabGroupsCreatedCount: 0, tabsDeduplicatedCount: 0 };
+
+function makeDeepLinking(currentTab = 'rules') {
+  return {
+    currentTab,
+    setCurrentTab: vi.fn(),
+    openSnapshotWizard: false,
+    setOpenSnapshotWizard: vi.fn(),
+    snapshotGroupId: null,
+    setSnapshotGroupId: vi.fn(),
+    restoreSessionId: null,
+    setRestoreSessionId: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseSettings.mockReturnValue({ settings: mockSettings, updateSettings: vi.fn() });
+  mockedUseStatistics.mockReturnValue({ statistics: mockStats, resetStatistics: vi.fn() });
+  mockedUseDeepLinking.mockReturnValue(makeDeepLinking('rules'));
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('OptionsApp rendu', () => {
+  it('affiche le spinner quand settings est null', () => {
+    mockedUseSettings.mockReturnValue({ settings: null, updateSettings: vi.fn() });
+    render(<OptionsApp />);
+    expect(screen.getByText('loadingText')).toBeInTheDocument();
+    expect(screen.queryByTestId('options')).not.toBeInTheDocument();
+  });
+
+  it('affiche la sidebar et le header quand settings est chargé', () => {
+    render(<OptionsApp />);
+    expect(screen.getByTestId('options')).toBeInTheDocument();
+    expect(screen.getByTestId('options-header')).toBeInTheDocument();
+  });
+
+  it('affiche la page rules par défaut (currentTab=rules)', () => {
+    render(<OptionsApp />);
+    expect(screen.getByTestId('page-rules-mock')).toBeInTheDocument();
+  });
+
+  it('affiche la page sessions quand currentTab=sessions', () => {
+    mockedUseDeepLinking.mockReturnValue(makeDeepLinking('sessions'));
+    render(<OptionsApp />);
+    expect(screen.getByTestId('page-sessions-mock')).toBeInTheDocument();
+  });
+
+  it('affiche la page importexport quand currentTab=importexport', () => {
+    mockedUseDeepLinking.mockReturnValue(makeDeepLinking('importexport'));
+    render(<OptionsApp />);
+    expect(screen.getByTestId('page-importexport-mock')).toBeInTheDocument();
+  });
+
+  it('affiche la page stats quand currentTab=stats', () => {
+    mockedUseDeepLinking.mockReturnValue(makeDeepLinking('stats'));
+    render(<OptionsApp />);
+    expect(screen.getByTestId('page-stats-mock')).toBeInTheDocument();
+  });
+
+  it('affiche la page settings quand currentTab=settings', () => {
+    mockedUseDeepLinking.mockReturnValue(makeDeepLinking('settings'));
+    render(<OptionsApp />);
+    expect(screen.getByTestId('page-settings-mock')).toBeInTheDocument();
+  });
+});
+
+describe('OptionsContent callbacks', () => {
+  it('handleTabChange appelle setCurrentTab et met à jour le hash', () => {
+    const setCurrentTab = vi.fn();
+    mockedUseDeepLinking.mockReturnValue({ ...makeDeepLinking('rules'), setCurrentTab });
+    render(<OptionsApp />);
+
+    fireEvent.click(screen.getByTestId('sidebar-nav-item-sessions'));
+    expect(setCurrentTab).toHaveBeenCalledWith('sessions');
+    expect(window.location.hash).toBe('#sessions');
+  });
+
+  it('handleResetStats ouvre le dialog de confirmation', async () => {
+    mockedUseDeepLinking.mockReturnValue(makeDeepLinking('stats'));
+    render(<OptionsApp />);
+
+    fireEvent.click(screen.getByTestId('stats-reset-mock'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('sidebar se replie au clic sur le bouton collapse', () => {
+    render(<OptionsApp />);
+    expect(screen.getByTestId('sidebar')).toHaveStyle({ width: '280px' });
+    fireEvent.click(screen.getByTestId('sidebar-collapse-btn'));
+    expect(screen.getByTestId('sidebar')).toHaveStyle({ width: '80px' });
+  });
+});

--- a/tests/pages/popup.test.tsx
+++ b/tests/pages/popup.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ── Mocks (hoissés avant les imports) ──────────────────────────────────────
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    runtime: {
+      openOptionsPage: vi.fn(),
+      getURL: vi.fn((path: string) => `chrome-extension://fakeid${path}`),
+    },
+    tabs: {
+      query: vi.fn(() => Promise.resolve([])),
+      update: vi.fn(() => Promise.resolve()),
+      create: vi.fn(() => Promise.resolve()),
+    },
+    windows: {
+      update: vi.fn(() => Promise.resolve()),
+    },
+    i18n: {
+      getMessage: vi.fn((key: string) => key),
+      getUILanguage: vi.fn(() => 'en'),
+    },
+  },
+}));
+
+vi.mock('../../src/utils/mountExtensionApp.js', () => ({
+  mountExtensionApp: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useSettings', () => ({
+  useSettings: vi.fn(),
+}));
+
+vi.mock('../../src/components/UI/PopupToolbar/PopupToolbar', () => ({
+  PopupToolbar: () => null,
+}));
+
+vi.mock('../../src/components/UI/PopupProfilesList/PopupProfilesList', () => ({
+  PopupProfilesList: () => null,
+}));
+
+// ── Imports après mocks ───────────────────────────────────────────────────
+
+import { browser } from 'wxt/browser';
+import { mountExtensionApp } from '../../src/utils/mountExtensionApp.js';
+import { useSettings } from '../../src/hooks/useSettings';
+import '../../src/pages/popup';
+
+const mockedMount = mountExtensionApp as ReturnType<typeof vi.fn>;
+const mockedUseSettings = useSettings as ReturnType<typeof vi.fn>;
+const mockedTabsQuery = browser.tabs.query as ReturnType<typeof vi.fn>;
+
+const appElement = mockedMount.mock.calls[0][1];
+
+const defaultSettings = {
+  domainRules: [],
+  globalGroupingEnabled: true,
+  globalDeduplicationEnabled: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedTabsQuery.mockResolvedValue([]);
+  mockedUseSettings.mockReturnValue({
+    settings: defaultSettings,
+    isLoaded: true,
+    setGlobalGroupingEnabled: vi.fn(),
+    setGlobalDeduplicationEnabled: vi.fn(),
+  });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('popup.tsx IIFE', () => {
+  it("monte un composant React sur 'popup-app'", () => {
+    expect(appElement).toBeTruthy();
+  });
+});
+
+describe('PopupApp rendu', () => {
+  it('affiche le header popup', () => {
+    render(appElement);
+    expect(screen.getByTestId('popup-header')).toBeInTheDocument();
+  });
+
+  it('affiche SettingsToggles sans règles (hasRules=false)', () => {
+    mockedUseSettings.mockReturnValue({
+      settings: { ...defaultSettings, domainRules: [] },
+      isLoaded: true,
+      setGlobalGroupingEnabled: vi.fn(),
+      setGlobalDeduplicationEnabled: vi.fn(),
+    });
+    render(appElement);
+    expect(screen.queryByTestId('settings-toggles')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'popupGoToRules' })).toBeInTheDocument();
+  });
+
+  it('affiche SettingsToggles avec règles (hasRules=true)', () => {
+    mockedUseSettings.mockReturnValue({
+      settings: { ...defaultSettings, domainRules: [{ id: '1' }] },
+      isLoaded: true,
+      setGlobalGroupingEnabled: vi.fn(),
+      setGlobalDeduplicationEnabled: vi.fn(),
+    });
+    render(appElement);
+    expect(screen.getByTestId('settings-toggles')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'popupGoToRules' })).not.toBeInTheDocument();
+  });
+
+  it("n'affiche aucun SettingsToggles pendant le chargement (isLoaded=false)", () => {
+    mockedUseSettings.mockReturnValue({
+      settings: null,
+      isLoaded: false,
+      setGlobalGroupingEnabled: vi.fn(),
+      setGlobalDeduplicationEnabled: vi.fn(),
+    });
+    render(appElement);
+    expect(screen.queryByTestId('settings-toggles')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'popupGoToRules' })).not.toBeInTheDocument();
+  });
+});
+
+describe('openOptionsPage', () => {
+  it('appelle browser.runtime.openOptionsPage au clic sur le bouton settings', () => {
+    render(appElement);
+    fireEvent.click(screen.getByTestId('popup-header-btn-settings'));
+    expect(browser.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('openRulesPage', () => {
+  beforeEach(() => {
+    mockedUseSettings.mockReturnValue({
+      settings: { ...defaultSettings, domainRules: [] },
+      isLoaded: true,
+      setGlobalGroupingEnabled: vi.fn(),
+      setGlobalDeduplicationEnabled: vi.fn(),
+    });
+    vi.spyOn(window, 'close').mockImplementation(() => {});
+  });
+
+  it("crée un nouvel onglet si aucun onglet options n'est ouvert", async () => {
+    mockedTabsQuery.mockResolvedValue([]);
+    render(appElement);
+    fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
+    await waitFor(() => {
+      expect(browser.tabs.create).toHaveBeenCalledWith(
+        expect.objectContaining({ url: expect.stringContaining('#rules') }),
+      );
+    });
+    expect(window.close).toHaveBeenCalled();
+  });
+
+  it("met à jour l'onglet existant si un onglet options est déjà ouvert", async () => {
+    mockedTabsQuery.mockResolvedValue([{ id: 42, windowId: 1 }]);
+    render(appElement);
+    fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
+    await waitFor(() => {
+      expect(browser.tabs.update).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ active: true }),
+      );
+    });
+    expect(browser.windows.update).toHaveBeenCalledWith(1, { focused: true });
+    expect(window.close).toHaveBeenCalled();
+  });
+});

--- a/tests/pages/popup.test.tsx
+++ b/tests/pages/popup.test.tsx
@@ -24,10 +24,6 @@ vi.mock('wxt/browser', () => ({
   },
 }));
 
-vi.mock('../../src/utils/mountExtensionApp.js', () => ({
-  mountExtensionApp: vi.fn(),
-}));
-
 vi.mock('../../src/hooks/useSettings', () => ({
   useSettings: vi.fn(),
 }));
@@ -43,15 +39,11 @@ vi.mock('../../src/components/UI/PopupProfilesList/PopupProfilesList', () => ({
 // ── Imports après mocks ───────────────────────────────────────────────────
 
 import { browser } from 'wxt/browser';
-import { mountExtensionApp } from '../../src/utils/mountExtensionApp.js';
 import { useSettings } from '../../src/hooks/useSettings';
-import '../../src/pages/popup';
+import { PopupApp } from '../../src/pages/popup';
 
-const mockedMount = mountExtensionApp as ReturnType<typeof vi.fn>;
 const mockedUseSettings = useSettings as ReturnType<typeof vi.fn>;
 const mockedTabsQuery = browser.tabs.query as ReturnType<typeof vi.fn>;
-
-const appElement = mockedMount.mock.calls[0][1];
 
 const defaultSettings = {
   domainRules: [],
@@ -72,15 +64,9 @@ beforeEach(() => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
-describe('popup.tsx IIFE', () => {
-  it("monte un composant React sur 'popup-app'", () => {
-    expect(appElement).toBeTruthy();
-  });
-});
-
 describe('PopupApp rendu', () => {
   it('affiche le header popup', () => {
-    render(appElement);
+    render(<PopupApp />);
     expect(screen.getByTestId('popup-header')).toBeInTheDocument();
   });
 
@@ -91,7 +77,7 @@ describe('PopupApp rendu', () => {
       setGlobalGroupingEnabled: vi.fn(),
       setGlobalDeduplicationEnabled: vi.fn(),
     });
-    render(appElement);
+    render(<PopupApp />);
     expect(screen.queryByTestId('settings-toggles')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'popupGoToRules' })).toBeInTheDocument();
   });
@@ -103,7 +89,7 @@ describe('PopupApp rendu', () => {
       setGlobalGroupingEnabled: vi.fn(),
       setGlobalDeduplicationEnabled: vi.fn(),
     });
-    render(appElement);
+    render(<PopupApp />);
     expect(screen.getByTestId('settings-toggles')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'popupGoToRules' })).not.toBeInTheDocument();
   });
@@ -115,7 +101,7 @@ describe('PopupApp rendu', () => {
       setGlobalGroupingEnabled: vi.fn(),
       setGlobalDeduplicationEnabled: vi.fn(),
     });
-    render(appElement);
+    render(<PopupApp />);
     expect(screen.queryByTestId('settings-toggles')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'popupGoToRules' })).not.toBeInTheDocument();
   });
@@ -123,7 +109,7 @@ describe('PopupApp rendu', () => {
 
 describe('openOptionsPage', () => {
   it('appelle browser.runtime.openOptionsPage au clic sur le bouton settings', () => {
-    render(appElement);
+    render(<PopupApp />);
     fireEvent.click(screen.getByTestId('popup-header-btn-settings'));
     expect(browser.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
   });
@@ -142,7 +128,7 @@ describe('openRulesPage', () => {
 
   it("crée un nouvel onglet si aucun onglet options n'est ouvert", async () => {
     mockedTabsQuery.mockResolvedValue([]);
-    render(appElement);
+    render(<PopupApp />);
     fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
     await waitFor(() => {
       expect(browser.tabs.create).toHaveBeenCalledWith(
@@ -154,7 +140,7 @@ describe('openRulesPage', () => {
 
   it("met à jour l'onglet existant si un onglet options est déjà ouvert", async () => {
     mockedTabsQuery.mockResolvedValue([{ id: 42, windowId: 1 }]);
-    render(appElement);
+    render(<PopupApp />);
     fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
     await waitFor(() => {
       expect(browser.tabs.update).toHaveBeenCalledWith(

--- a/tests/pages/popup.test.tsx
+++ b/tests/pages/popup.test.tsx
@@ -126,19 +126,23 @@ describe('openRulesPage', () => {
     vi.spyOn(window, 'close').mockImplementation(() => {});
   });
 
-  it("crée un nouvel onglet si aucun onglet options n'est ouvert", async () => {
+  it("crée un nouvel onglet si aucun onglet n'est ouvert, ou met à jour l'onglet existant", async () => {
+    // Scenario 1: no existing options tab -> creates a new one
     mockedTabsQuery.mockResolvedValue([]);
-    render(<PopupApp />);
+    const { unmount } = render(<PopupApp />);
     fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
     await waitFor(() => {
       expect(browser.tabs.create).toHaveBeenCalledWith(
         expect.objectContaining({ url: expect.stringContaining('#rules') }),
       );
+      expect(window.close).toHaveBeenCalled();
     });
-    expect(window.close).toHaveBeenCalled();
-  });
 
-  it("met à jour l'onglet existant si un onglet options est déjà ouvert", async () => {
+    unmount();
+    vi.clearAllMocks();
+    vi.spyOn(window, 'close').mockImplementation(() => {});
+
+    // Scenario 2: existing options tab -> updates and focuses it
     mockedTabsQuery.mockResolvedValue([{ id: 42, windowId: 1 }]);
     render(<PopupApp />);
     fireEvent.click(screen.getByRole('button', { name: 'popupGoToRules' }));
@@ -147,8 +151,8 @@ describe('openRulesPage', () => {
         42,
         expect.objectContaining({ active: true }),
       );
+      expect(browser.windows.update).toHaveBeenCalledWith(1, { focused: true });
+      expect(window.close).toHaveBeenCalled();
     });
-    expect(browser.windows.update).toHaveBeenCalledWith(1, { focused: true });
-    expect(window.close).toHaveBeenCalled();
   });
 });

--- a/tests/tabCapture.test.ts
+++ b/tests/tabCapture.test.ts
@@ -193,6 +193,17 @@ describe('captureCurrentTabs', () => {
     expect(result.groups[0].color).toBe('blue');
   });
 
+  it('normalizeColor : retourne "grey" quand la couleur est invalide ou absente', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'not-a-valid-color' });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups[0].color).toBe('grey');
+  });
+
   it('ignore silencieusement un groupe si tabGroups.get rejette', async () => {
     mockTabsQuery.mockResolvedValue([
       { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },

--- a/tests/tabCapture.test.ts
+++ b/tests/tabCapture.test.ts
@@ -217,6 +217,16 @@ describe('captureCurrentTabs', () => {
     expect(result.ungroupedTabs[0].url).toBe('https://a.com');
   });
 
+  it('utilise url comme title quand title est absent', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: undefined, groupId: -1 },
+    ]);
+
+    const result = await captureCurrentTabs();
+
+    expect(result.ungroupedTabs[0].title).toBe('https://a.com');
+  });
+
   it('excludes Firefox extension Options page from captured tabs', async () => {
     // Regression: moz-extension:// URLs were previously kept, so the Options
     // page itself showed up in the snapshot wizard and got auto-selected.

--- a/tests/tabCapture.test.ts
+++ b/tests/tabCapture.test.ts
@@ -182,6 +182,30 @@ describe('captureCurrentTabs', () => {
     expect(result.groups[0].collapsed).toBe(false);
   });
 
+  it('normalizeColor : retourne la couleur inchangée si elle est valide', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockResolvedValue({ title: 'Work', color: 'blue' });
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups[0].color).toBe('blue');
+  });
+
+  it('ignore silencieusement un groupe si tabGroups.get rejette', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 10, index: 0, url: 'https://a.com', title: 'A', groupId: 5 },
+    ]);
+    mockTabGroupsGet.mockRejectedValue(new Error('Group no longer exists'));
+
+    const result = await captureCurrentTabs();
+
+    expect(result.groups).toHaveLength(0);
+    expect(result.ungroupedTabs).toHaveLength(1);
+    expect(result.ungroupedTabs[0].url).toBe('https://a.com');
+  });
+
   it('excludes Firefox extension Options page from captured tabs', async () => {
     // Regression: moz-extension:// URLs were previously kept, so the Options
     // page itself showed up in the snapshot wizard and got auto-selected.

--- a/tests/utils/mountExtensionApp.test.tsx
+++ b/tests/utils/mountExtensionApp.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+
+vi.mock('../../src/utils/categoriesStore.js', () => ({
+  initCategoriesStore: vi.fn(() => Promise.resolve()),
+}));
+
+import { mountExtensionApp } from '../../src/utils/mountExtensionApp';
+
+describe('mountExtensionApp', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'test-mount-root';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  });
+
+  it('monte un élément React dans le container', async () => {
+    mountExtensionApp(
+      'test-mount-root',
+      React.createElement('div', { 'data-testid': 'mounted-content' }, 'hello'),
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(document.getElementById('test-mount-root')?.querySelector('[data-testid="mounted-content"]')).toBeTruthy();
+  });
+
+  it('log une erreur et ne lance pas si le container est absent', () => {
+    expect(() => mountExtensionApp('nonexistent-id', React.createElement('div'))).not.toThrow();
+  });
+
+  it("ne lance pas même si browser.i18n.getUILanguage n'est pas disponible", () => {
+    expect(() => mountExtensionApp('test-mount-root', React.createElement('div'))).not.toThrow();
+  });
+});

--- a/tests/utils/settingsUtils.test.ts
+++ b/tests/utils/settingsUtils.test.ts
@@ -62,6 +62,13 @@ describe('settingsUtils', () => {
       const stored = await fakeBrowser.storage.local.get(null);
       expect(stored.globalGroupingEnabled).toBe(false);
     });
+
+    it("ne lance pas d'erreur si storage.set échoue", async () => {
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(
+        new Error('Storage write error'),
+      );
+      await expect(setSettings(defaultAppSettings)).resolves.toBeUndefined();
+    });
   });
 
   describe('updateSettings', () => {
@@ -82,6 +89,13 @@ describe('settingsUtils', () => {
       expect(settings.deduplicateUnmatchedDomains).toBe(true);
       // Autres champs inchangés (valeurs par défaut conservées)
       expect(settings.globalDeduplicationEnabled).toBe(true);
+    });
+
+    it("ne lance pas d'erreur si storage.set échoue", async () => {
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(
+        new Error('Storage write error'),
+      );
+      await expect(updateSettings({ globalGroupingEnabled: false })).resolves.toBeUndefined();
     });
   });
 

--- a/tests/utils/settingsUtils.test.ts
+++ b/tests/utils/settingsUtils.test.ts
@@ -127,6 +127,12 @@ describe('settingsUtils', () => {
       const settings = await getSettings();
       expect(settings.notifyOnDeduplication).toBe(false);
     });
+
+    it('met à jour categories', async () => {
+      await updateSettings({ categories: [] });
+      const settings = await getSettings();
+      expect(settings.categories).toEqual([]);
+    });
   });
 
   describe('watchSettings', () => {

--- a/tests/utils/settingsUtils.test.ts
+++ b/tests/utils/settingsUtils.test.ts
@@ -97,6 +97,36 @@ describe('settingsUtils', () => {
       );
       await expect(updateSettings({ globalGroupingEnabled: false })).resolves.toBeUndefined();
     });
+
+    it('met à jour globalDeduplicationEnabled', async () => {
+      await updateSettings({ globalDeduplicationEnabled: false });
+      const settings = await getSettings();
+      expect(settings.globalDeduplicationEnabled).toBe(false);
+    });
+
+    it('met à jour deduplicationKeepStrategy', async () => {
+      await updateSettings({ deduplicationKeepStrategy: 'keep-old' });
+      const settings = await getSettings();
+      expect(settings.deduplicationKeepStrategy).toBe('keep-old');
+    });
+
+    it('met à jour domainRules', async () => {
+      await updateSettings({ domainRules: [] });
+      const settings = await getSettings();
+      expect(settings.domainRules).toEqual([]);
+    });
+
+    it('met à jour notifyOnGrouping', async () => {
+      await updateSettings({ notifyOnGrouping: false });
+      const settings = await getSettings();
+      expect(settings.notifyOnGrouping).toBe(false);
+    });
+
+    it('met à jour notifyOnDeduplication', async () => {
+      await updateSettings({ notifyOnDeduplication: false });
+      const settings = await getSettings();
+      expect(settings.notifyOnDeduplication).toBe(false);
+    });
   });
 
   describe('watchSettings', () => {

--- a/tests/utils/statisticsUtils.test.ts
+++ b/tests/utils/statisticsUtils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
 import { fakeBrowser } from 'wxt/testing';
 import {
   getStatisticsData,
@@ -132,6 +133,13 @@ describe('statisticsUtils', () => {
       const stats = await getStatisticsData();
       expect(stats).toEqual(defaultStatistics);
     });
+
+    it("ne lance pas d'erreur si setStatisticsData échoue", async () => {
+      vi.spyOn(fakeBrowser.storage.local, 'set').mockRejectedValueOnce(
+        new Error('Storage write error'),
+      );
+      await expect(resetStatisticsData()).resolves.toBeUndefined();
+    });
   });
 
   describe('watchStatisticsData', () => {
@@ -144,6 +152,22 @@ describe('statisticsUtils', () => {
     it('la fonction de cleanup peut être appelée sans erreur', () => {
       const unwatch = watchStatisticsData(vi.fn());
       expect(() => unwatch()).not.toThrow();
+    });
+
+    it('invoque le callback avec les données fusionnées aux défauts quand le storage change', async () => {
+      const callback = vi.fn();
+      const unwatch = watchStatisticsData(callback);
+
+      await setStatisticsData({ tabGroupsCreatedCount: 3, tabsDeduplicatedCount: 1 });
+
+      await waitFor(() => {
+        expect(callback).toHaveBeenCalled();
+      });
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ tabGroupsCreatedCount: 3, tabsDeduplicatedCount: 1 }),
+      );
+      unwatch();
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR significantly expands test coverage across the codebase by adding new test files and enhancing existing ones. The changes focus on testing background messaging logic, Storybook component stories, and utility functions with improved error handling scenarios.

## Key Changes

### New Test Files
- **`tests/background/messaging.test.ts`**: Comprehensive test suite for background messaging functions including:
  - `handleMiddleClickMessage`: Tests for URL registration and error handling
  - `handleSessionRestoreSkipDedupMessage`: Tests for deduplication marking
  - `cleanupMiddleClickedTabsForTab`: Tests for tab cleanup logic
  - `promptForGroupName`: Tests for group name prompting with validation
  - `findMiddleClickOpener`: Tests for middle-click opener detection with fallback logic

- **`tests/components/FileDropZone.stories.test.tsx`**: Portable Storybook story tests for the FileDropZone component covering empty state, file display, and button interactions

- **`tests/components/DomainRuleCard.stories.test.tsx`**: Portable Storybook story tests for DomainRuleCard covering default, disabled, drag-disabled, and search highlight states

- **`src/components/UI/ImportExportWizards/Source/FileDropZone.stories.tsx`**: New Storybook stories for FileDropZone component with empty, with-file, and drag-over variants

### Enhanced Test Coverage
- **`tests/components/DomainRulesPage.stories.test.tsx`**: Added three new test cases:
  - Empty state display when search returns no results
  - Single rule deletion dialog opening
  - Bulk rule deletion dialog opening

- **`tests/tabCapture.test.ts`**: Added two new test cases:
  - Color normalization validation
  - Graceful handling when tab group retrieval fails

- **`tests/utils/statisticsUtils.test.ts`**: Added two new test cases:
  - Error handling when storage write fails in `resetStatisticsData`
  - Callback invocation with merged data in `watchStatisticsData`

- **`tests/utils/settingsUtils.test.ts`**: Added two new test cases:
  - Error handling when storage write fails in `setSettings`
  - Error handling when storage write fails in `updateSettings`

## Notable Implementation Details
- All new tests use proper mocking with `vi.mock()` for external dependencies
- Tests follow French naming conventions for test descriptions (matching existing codebase style)
- Comprehensive error scenario coverage including storage failures and missing data
- Portable Storybook stories enable testing component behavior in isolation
- Tests validate both happy paths and edge cases (missing IDs, empty values, rejected promises)

https://claude.ai/code/session_01587WgTHBzwxPCuaEN7LEeG