### PR TITLE
feat(a11y): associate form labels via @radix-ui/react-label

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@radix-ui/themes": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.8
+        version: 2.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toast':
         specifier: ^1.2.14
         version: 1.2.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1296,6 +1299,19 @@ packages:
 
   '@radix-ui/react-label@2.1.7':
     resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-label@2.1.8':
+    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5661,6 +5677,15 @@ snapshots:
   '@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-label@2.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/src/components/Core/DomainRule/ConfigModeSelector.tsx
+++ b/src/components/Core/DomainRule/ConfigModeSelector.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { Box, Flex, HoverCard, SegmentedControl, Text } from '@radix-ui/themes';
 import { Info } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
@@ -29,13 +30,15 @@ interface ConfigModeSelectorProps {
  * Shared between ConfigEditModal and WizardStep2Config.
  */
 export function ConfigModeSelector({ value, onValueChange }: ConfigModeSelectorProps) {
+  const labelId = useId();
   return (
     <Flex direction="column" gap="1">
-      <Text as="label" size="2" weight="bold">
+      <Text id={labelId} size="2" weight="bold">
         {getMessage('configurationMode')}
       </Text>
       <SegmentedControl.Root
         data-testid="wizard-rule-segmented-config"
+        aria-labelledby={labelId}
         value={value}
         onValueChange={(v) => onValueChange(v as ConfigMode)}
         size="2"

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
@@ -1,4 +1,5 @@
 import { Box, Callout, Flex, Grid, Select, Text, TextField } from '@radix-ui/themes';
+import * as Label from '@radix-ui/react-label';
 import { Info } from 'lucide-react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
@@ -83,8 +84,10 @@ export function DomainRuleConfigForm({
         <Grid columns="2" gap="4">
           <RegexPresetsTheme>
             <Flex direction="column" gap="1">
-              <Text as="label" htmlFor={presetInputId} size="2" weight="bold">
-                {getMessage('presetRuleLabel')}
+              <Text size="2" weight="bold" asChild>
+                <Label.Root htmlFor={presetInputId}>
+                  {getMessage('presetRuleLabel')}
+                </Label.Root>
               </Text>
               <SearchableSelect
                 id={presetInputId}
@@ -113,8 +116,10 @@ export function DomainRuleConfigForm({
       {configMode === 'manual' && (
         <Grid columns="2" gap="4">
           <Flex direction="column">
-            <Text as="label" htmlFor={groupNameSourceInputId} size="2" weight="bold">
-              {getMessage('groupNameSource')}
+            <Text size="2" weight="bold" asChild>
+              <Label.Root htmlFor={groupNameSourceInputId}>
+                {getMessage('groupNameSource')}
+              </Label.Root>
             </Text>
             <Select.Root
               value={groupNameSource}
@@ -154,13 +159,16 @@ export function DomainRuleConfigForm({
           required={true}
           error={titleParsingRegExError}
         >
-          <TextField.Root
-            value={titleParsingRegEx}
-            onChange={(e) => onTitleParsingRegExChange(e.target.value)}
-            name="titleParsingRegEx"
-            placeholder="(.+)"
-            style={{ marginTop: '4px' }}
-          />
+          {(fieldId) => (
+            <TextField.Root
+              id={fieldId}
+              value={titleParsingRegEx}
+              onChange={(e) => onTitleParsingRegExChange(e.target.value)}
+              name="titleParsingRegEx"
+              placeholder="(.+)"
+              style={{ marginTop: '4px' }}
+            />
+          )}
         </FormField>
       )}
 
@@ -171,13 +179,16 @@ export function DomainRuleConfigForm({
           required={true}
           error={urlParsingRegExError}
         >
-          <TextField.Root
-            value={urlParsingRegEx}
-            onChange={(e) => onUrlParsingRegExChange(e.target.value)}
-            name="urlParsingRegEx"
-            placeholder="(.+)"
-            style={{ marginTop: '4px' }}
-          />
+          {(fieldId) => (
+            <TextField.Root
+              id={fieldId}
+              value={urlParsingRegEx}
+              onChange={(e) => onUrlParsingRegExChange(e.target.value)}
+              name="urlParsingRegEx"
+              placeholder="(.+)"
+              style={{ marginTop: '4px' }}
+            />
+          )}
         </FormField>
       )}
     </Flex>

--- a/src/components/Core/DomainRule/EditSummaryView.tsx
+++ b/src/components/Core/DomainRule/EditSummaryView.tsx
@@ -79,31 +79,34 @@ export function EditSummaryView({
             required={true}
             error={errors.label}
           >
-            <div style={{ marginTop: '4px' }}>
-              <Controller
-                name="label"
-                control={control}
-                render={({ field: labelField }) => (
-                  <Controller
-                    name="categoryId"
-                    control={control}
-                    render={({ field: catField }) => (
-                      <TextFieldWithCategory
-                        ref={labelField.ref}
-                        name={labelField.name}
-                        value={labelField.value ?? ''}
-                        onChange={labelField.onChange}
-                        onBlur={labelField.onBlur}
-                        data-testid="wizard-rule-field-label"
-                        placeholder={getMessage('labelPlaceholder')}
-                        categoryId={catField.value as RuleCategoryId | null | undefined}
-                        onCategoryChange={catField.onChange}
-                      />
-                    )}
-                  />
-                )}
-              />
-            </div>
+            {(fieldId) => (
+              <div style={{ marginTop: '4px' }}>
+                <Controller
+                  name="label"
+                  control={control}
+                  render={({ field: labelField }) => (
+                    <Controller
+                      name="categoryId"
+                      control={control}
+                      render={({ field: catField }) => (
+                        <TextFieldWithCategory
+                          id={fieldId}
+                          ref={labelField.ref}
+                          name={labelField.name}
+                          value={labelField.value ?? ''}
+                          onChange={labelField.onChange}
+                          onBlur={labelField.onBlur}
+                          data-testid="wizard-rule-field-label"
+                          placeholder={getMessage('labelPlaceholder')}
+                          categoryId={catField.value as RuleCategoryId | null | undefined}
+                          onCategoryChange={catField.onChange}
+                        />
+                      )}
+                    />
+                  )}
+                />
+              </div>
+            )}
           </FormField>
 
           <FormField
@@ -111,19 +114,22 @@ export function EditSummaryView({
             required={true}
             error={errors.domainFilter}
           >
-            <Controller
-              name="domainFilter"
-              control={control}
-              render={({ field }) => (
-                <TextField.Root
-                  {...field}
-                  name="domainFilter"
-                  data-testid="wizard-rule-field-domain"
-                  placeholder={getMessage('domainFilterPlaceholder')}
-                  style={{ marginTop: '4px' }}
-                />
-              )}
-            />
+            {(fieldId) => (
+              <Controller
+                name="domainFilter"
+                control={control}
+                render={({ field }) => (
+                  <TextField.Root
+                    {...field}
+                    id={fieldId}
+                    name="domainFilter"
+                    data-testid="wizard-rule-field-domain"
+                    placeholder={getMessage('domainFilterPlaceholder')}
+                    style={{ marginTop: '4px' }}
+                  />
+                )}
+              />
+            )}
           </FormField>
         </Flex>
       </Box>

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -20,31 +20,34 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
         required={true}
         error={errors.label}
       >
-        <div style={{ marginTop: '4px' }}>
-          <Controller
-            name="label"
-            control={control}
-            render={({ field: labelField }) => (
-              <Controller
-                name="categoryId"
-                control={control}
-                render={({ field: catField }) => (
-                  <TextFieldWithCategory
-                    ref={labelField.ref}
-                    name={labelField.name}
-                    value={labelField.value ?? ''}
-                    onChange={labelField.onChange}
-                    onBlur={labelField.onBlur}
-                    data-testid="wizard-rule-field-label"
-                    placeholder={getMessage('labelPlaceholder')}
-                    categoryId={catField.value as RuleCategoryId | null | undefined}
-                    onCategoryChange={catField.onChange}
-                  />
-                )}
-              />
-            )}
-          />
-        </div>
+        {(fieldId) => (
+          <div style={{ marginTop: '4px' }}>
+            <Controller
+              name="label"
+              control={control}
+              render={({ field: labelField }) => (
+                <Controller
+                  name="categoryId"
+                  control={control}
+                  render={({ field: catField }) => (
+                    <TextFieldWithCategory
+                      id={fieldId}
+                      ref={labelField.ref}
+                      name={labelField.name}
+                      value={labelField.value ?? ''}
+                      onChange={labelField.onChange}
+                      onBlur={labelField.onBlur}
+                      data-testid="wizard-rule-field-label"
+                      placeholder={getMessage('labelPlaceholder')}
+                      categoryId={catField.value as RuleCategoryId | null | undefined}
+                      onCategoryChange={catField.onChange}
+                    />
+                  )}
+                />
+              )}
+            />
+          </div>
+        )}
       </FormField>
 
       {/* Domain Filter */}
@@ -53,19 +56,22 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
         required={true}
         error={errors.domainFilter}
       >
-        <Controller
-          name="domainFilter"
-          control={control}
-          render={({ field }) => (
-            <TextField.Root
-              {...field}
-              data-testid="wizard-rule-field-domain"
-              name="domainFilter"
-              placeholder={getMessage('domainFilterPlaceholder')}
-              style={{ marginTop: '4px' }}
-            />
-          )}
-        />
+        {(fieldId) => (
+          <Controller
+            name="domainFilter"
+            control={control}
+            render={({ field }) => (
+              <TextField.Root
+                {...field}
+                id={fieldId}
+                data-testid="wizard-rule-field-domain"
+                name="domainFilter"
+                placeholder={getMessage('domainFilterPlaceholder')}
+                style={{ marginTop: '4px' }}
+              />
+            )}
+          />
+        )}
       </FormField>
     </Flex>
   );

--- a/src/components/Core/Session/SessionEditDialog.tsx
+++ b/src/components/Core/Session/SessionEditDialog.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Separator,
 } from '@radix-ui/themes';
+import * as Label from '@radix-ui/react-label';
 import { Pencil } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { SessionsTheme } from '@/components/Form/themes';
@@ -140,13 +141,14 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
         {/* Session name + category inline */}
         <Box mb="4" mt="4">
           <Text
-            as="label"
             size="2"
             weight="medium"
-            htmlFor="session-edit-name"
             style={{ display: 'block', marginBottom: 'var(--space-1)' }}
+            asChild
           >
-            {getMessage('sessionEditorNameLabel')}
+            <Label.Root htmlFor="session-edit-name">
+              {getMessage('sessionEditorNameLabel')}
+            </Label.Root>
           </Text>
           <TextFieldWithCategory
             id="session-edit-name"
@@ -156,7 +158,6 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
               editor.updateSessionName(nextValue);
               setSaveNameError(null);
             }}
-            aria-label={getMessage('sessionEditorNameLabel')}
             categoryId={categoryId as RuleCategoryId | null}
             onCategoryChange={setCategoryId}
           />
@@ -179,13 +180,14 @@ function SessionEditDialogInner({ session, open, onOpenChange, onSave, existingS
         {/* Note */}
         <Box mt="3">
           <Text
-            as="label"
             size="2"
             weight="medium"
-            htmlFor="session-edit-note"
             style={{ display: 'block', marginBottom: 'var(--space-1)' }}
+            asChild
           >
-            {getMessage('sessionNoteLabel')}
+            <Label.Root htmlFor="session-edit-note">
+              {getMessage('sessionNoteLabel')}
+            </Label.Root>
           </Text>
           <TextArea
             id="session-edit-note"

--- a/src/components/Form/FormFields/FieldLabel.tsx
+++ b/src/components/Form/FormFields/FieldLabel.tsx
@@ -1,15 +1,19 @@
 import { Text } from '@radix-ui/themes';
+import * as Label from '@radix-ui/react-label';
 
 interface FieldLabelProps {
   children: React.ReactNode;
   required?: boolean;
+  htmlFor?: string;
 }
 
-export function FieldLabel({ children, required = false }: FieldLabelProps) {
+export function FieldLabel({ children, required = false, htmlFor }: FieldLabelProps) {
   return (
-    <Text as="label" size="2" weight="bold">
-      {children}
-      {required && <Text color="red" style={{ marginLeft: '2px' }}>*</Text>}
+    <Text size="2" weight="bold" asChild>
+      <Label.Root htmlFor={htmlFor}>
+        {children}
+        {required && <Text color="red" style={{ marginLeft: '2px' }}>*</Text>}
+      </Label.Root>
     </Text>
   );
 }

--- a/src/components/Form/FormFields/FormField.tsx
+++ b/src/components/Form/FormFields/FormField.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { Box } from '@radix-ui/themes';
 import { FieldLabel } from './FieldLabel';
 import { FieldError } from './FieldError';
@@ -8,19 +9,29 @@ interface FormFieldProps {
   error?: {
     message?: string;
   };
-  children: React.ReactNode;
+  /**
+   * Children can be a ReactNode or a render function receiving the generated id.
+   * Use the render function to associate a non-wrappable control (TextField, TextArea,
+   * Select.Trigger, SearchableSelect) with the field's <label>.
+   */
+  children: React.ReactNode | ((id: string) => React.ReactNode);
+  /** Explicit id for the field control. Defaults to a useId(). */
+  id?: string;
 }
 
-export function FormField({ 
-  label, 
-  required = false, 
-  error, 
-  children 
+export function FormField({
+  label,
+  required = false,
+  error,
+  children,
+  id,
 }: FormFieldProps) {
+  const fallbackId = useId();
+  const fieldId = id ?? fallbackId;
   return (
     <Box>
-      <FieldLabel required={required}>{label}</FieldLabel>
-      {children}
+      <FieldLabel required={required} htmlFor={fieldId}>{label}</FieldLabel>
+      {typeof children === 'function' ? children(fieldId) : children}
       <FieldError error={error} />
     </Box>
   );

--- a/src/components/Form/FormFields/TagInputField.tsx
+++ b/src/components/Form/FormFields/TagInputField.tsx
@@ -46,7 +46,7 @@ export function TagInputField<T extends FieldValues>({
 
   return (
     <Flex direction="column" gap="1">
-      <FieldLabel required={required}>{label}</FieldLabel>
+      <FieldLabel required={required} htmlFor={inputId}>{label}</FieldLabel>
 
       <VisuallyHidden aria-live="polite" aria-atomic="true">
         {announcement}
@@ -173,7 +173,6 @@ export function TagInputField<T extends FieldValues>({
                 onBlur={() => { commitDraft(); setIsFocused(false); }}
                 onFocus={() => setIsFocused(true)}
                 placeholder={tags.length === 0 ? placeholder : undefined}
-                aria-label={label}
                 style={{
                   border: 'none',
                   outline: 'none',

--- a/src/components/UI/ImportExportWizards/Export/ExportNoteField.tsx
+++ b/src/components/UI/ImportExportWizards/Export/ExportNoteField.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { Box, Text, TextArea } from '@radix-ui/themes';
+import * as Label from '@radix-ui/react-label';
 import { getMessage } from '@/utils/i18n';
 
 interface ExportNoteFieldProps {
@@ -8,12 +9,16 @@ interface ExportNoteFieldProps {
 }
 
 export function ExportNoteField({ value, onChange }: ExportNoteFieldProps) {
+  const id = useId();
   return (
     <Box mb="4">
-      <Text as="label" size="2" weight="medium">
-        {getMessage('exportNoteLabel')}
+      <Text size="2" weight="medium" asChild>
+        <Label.Root htmlFor={id}>
+          {getMessage('exportNoteLabel')}
+        </Label.Root>
       </Text>
       <TextArea
+        id={id}
         mt="1"
         value={value}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}

--- a/src/components/UI/SettingsPage/SettingsPage.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.tsx
@@ -76,13 +76,13 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                   </Flex>
 
                   <Flex direction="column" gap="2">
-                    <Text size="2" as="label" htmlFor="page-settings-dedup-keep-strategy">
+                    <Text size="2" id="page-settings-dedup-keep-strategy-label">
                       {getMessage('deduplicationKeepStrategyLabel')}
                     </Text>
                     <RadioGroup.Root
                       id="page-settings-dedup-keep-strategy"
                       data-testid="page-settings-dedup-keep-strategy"
-                      aria-label={getMessage('deduplicationKeepStrategyLabel')}
+                      aria-labelledby="page-settings-dedup-keep-strategy-label"
                       value={syncSettings.deduplicationKeepStrategy}
                       onValueChange={(value) =>
                         updateSettings({ deduplicationKeepStrategy: value as DeduplicationKeepStrategyValue })


### PR DESCRIPTION
Adopt @radix-ui/react-label on non-wrappable controls (TextField, TextArea,
SearchableSelect, Select.Trigger, SegmentedControl, RadioGroup.Root) so every
visible label is linked to its control via htmlFor/id (or aria-labelledby for
groups). FormField now generates a stable id (useId) and exposes it through a
render-prop API so consumers can forward it to the inner control, including
through react-hook-form Controllers. Wrapping labels around RadioGroup.Item
and Switch stay as-is: native implicit association already works there.