### PR TITLE
Fix design-system:zip after themeConstants removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ src/
                    # sessionClassification · sessionOrderUtils · ruleOrderUtils
                    # presetsToSearchableGroups · stringUtils · migration · tabTreeUtils
                    # storageItems · settingsUtils · statisticsUtils
-                   # themeConstants · notifications · utils
+                   # notifications · utils
   styles/          # radix-themes.css (custom focus for non-Radix markup only)
 tests/             # Vitest unit tests
 tests/e2e/         # Playwright E2E tests
@@ -92,7 +92,7 @@ tests/e2e/         # Playwright E2E tests
 6. **Sessions & Profiles** : snapshots of open tabs with optional note; pinned profiles with icon, window exclusivity; restore wizard with conflict resolution; interactive session editor; collapsed/expanded group state persistence; drag-and-drop session reordering; session card with HoverCard metadata and inline rename
 
 ### Theming
-Accent unique `indigo` (défaut Radix Themes). `src/utils/themeConstants.ts` garde les constantes par feature pour compat mais toutes pointent désormais sur `indigo`. Préférer les tokens Radix (`var(--accent-a3)`, `var(--gray-a2)`, etc.) aux couleurs hardcodées. Les wrappers dans `src/components/Form/themes/` restent en place mais n'appliquent plus d'accent différencié.
+Accent unique `indigo` (défaut Radix Themes). Préférer les tokens Radix (`var(--accent-a3)`, `var(--gray-a2)`, etc.) aux couleurs hardcodées. Les wrappers dans `src/components/Form/themes/` restent en place mais n'appliquent plus d'accent différencié.
 
 ### Internationalization
 Always use `getMessage()` from `src/utils/i18n.ts` — for UI text, `aria-label`, and `title` attributes. Never hardcode strings.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,7 +39,7 @@ import { Theme } from '@radix-ui/themes';
 </Theme>
 ```
 
-`src/utils/themeConstants.ts` expose `FEATURE_THEMES` et `FEATURE_BASE_COLORS` : **tous pointent vers `indigo`**. Les wrappers par feature dans `src/components/Form/themes/index.tsx` (`DomainRulesTheme`, `SessionsTheme`, etc.) existent pour compat mais n'appliquent plus d'accent differencie.
+Accent unique `indigo` applique au `<Theme>` racine. Les wrappers par feature dans `src/components/Form/themes/index.tsx` (`DomainRulesTheme`, `SessionsTheme`, etc.) existent pour compat mais n'appliquent plus d'accent differencie.
 
 ### Regle
 

--- a/scripts/build-design-system-bundle.mjs
+++ b/scripts/build-design-system-bundle.mjs
@@ -4,7 +4,7 @@
  * containing only the design-system surface of the extension:
  *   - src/components/UI, src/components/Form, src/pages
  *   - src/styles/radix-themes.css
- *   - src/utils/themeConstants.ts, src/utils/i18n.ts
+ *   - src/utils/i18n.ts
  *   - src/stories (Welcome), .storybook/
  *   - DESIGN.md, package.json, tsconfig.json
  *
@@ -31,7 +31,6 @@ const ENTRIES = [
   { from: 'src/components/Form', to: 'src/components/Form' },
   { from: 'src/pages', to: 'src/pages' },
   { from: 'src/styles/radix-themes.css', to: 'src/styles/radix-themes.css' },
-  { from: 'src/utils/themeConstants.ts', to: 'src/utils/themeConstants.ts' },
   { from: 'src/utils/i18n.ts', to: 'src/utils/i18n.ts' },
   { from: 'src/stories', to: 'src/stories', optional: true },
   { from: '.storybook', to: '.storybook' },


### PR DESCRIPTION
The build-design-system-bundle script still referenced src/utils/themeConstants.ts
which was deleted in #164, causing pnpm design-system:zip to fail with "Missing
required source". Drop the entry from the bundle manifest and update the stale
mentions in CLAUDE.md and DESIGN.md.

https://claude.ai/code/session_01NSuwu57wSiWrSKw6yYVtX3