### PR TITLE
Refactor grouping rule matching to support multiple rules per domain

### DIFF
--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -33,6 +33,43 @@ export function findMatchingRule(url: string, domainRules: DomainRuleSetting[]):
     return domainRules.find(r => r.enabled && matchesDomain(url, r.domainFilter));
 }
 
+export function findMatchingRules(url: string, domainRules: DomainRuleSetting[]): DomainRuleSetting[] {
+    return domainRules.filter(r => r.enabled && matchesDomain(url, r.domainFilter));
+}
+
+// Returns the first enabled rule matching the URL's domain whose
+// groupingEnabled is true AND that produces a non-null group name.
+// Skips rules whose groupingEnabled=false or whose extraction returns null,
+// so that a later rule on the same domain can apply.
+export function findGroupingRuleForTab(
+    openerTab: Browser.tabs.Tab,
+    domainRules: DomainRuleSetting[],
+    options: { coerceManualToLabel?: boolean } = {}
+): { rule: DomainRuleSetting; groupName: string } | null {
+    if (!openerTab.url) return null;
+
+    for (const rule of findMatchingRules(openerTab.url, domainRules)) {
+        if (!rule.groupingEnabled) {
+            logger.debug(`[GROUPING_DEBUG] Rule "${rule.label}" has groupingEnabled=false. Trying next matching rule.`);
+            continue;
+        }
+
+        const effectiveRule: DomainRuleSetting =
+            options.coerceManualToLabel &&
+            (rule.groupNameSource === 'manual' || rule.groupNameSource === 'smart_manual')
+                ? { ...rule, groupNameSource: 'smart_label' as const }
+                : rule;
+
+        const groupName = extractGroupNameFromRule(effectiveRule, openerTab);
+        if (groupName !== null) {
+            return { rule, groupName };
+        }
+        logger.debug(`[GROUPING_DEBUG] Rule "${rule.label}" matched the domain but produced no group name. Trying next.`);
+    }
+
+    return null;
+}
+
 export function determineGroupColor(rule: DomainRuleSetting, _settings?: AppSettings): string | null {
     const category = getRuleCategory(rule.categoryId);
     if (category) {
@@ -289,22 +326,15 @@ export async function processGroupingForNewTab(openerTab: Browser.tabs.Tab, newT
         }
     }
 
-    const rule = findMatchingRule(openerTab.url, settings.domainRules);
-    if (!rule) {
-        logger.debug(`[GROUPING_DEBUG] No matching rule for opener tab URL: ${openerTab.url}`);
+    const grouping = findGroupingRuleForTab(openerTab, settings.domainRules);
+    if (!grouping) {
+        logger.debug(`[GROUPING_DEBUG] No applicable grouping rule for opener tab URL: ${openerTab.url}`);
         return;
     }
 
-    if (!rule.groupingEnabled) {
-        logger.debug(`[GROUPING_DEBUG] Rule "${rule.label}" has groupingEnabled=false. No grouping.`);
-        return;
-    }
-
-    const context = createGroupingContext(rule, openerTab, newTab, settings);
-    if (context === null) {
-        logger.debug(`[GROUPING_DEBUG] Skipping grouping: no name could be extracted for rule "${rule.label}".`);
-        return;
-    }
+    const { rule, groupName } = grouping;
+    const groupColor = determineGroupColor(rule, settings);
+    const context: GroupingContext = { rule, groupName, groupColor, openerTab, newTab };
     logger.debug(`[GROUPING_DEBUG] Rule found: "${rule.label}", groupName: "${context.groupName}"`);
 
     try {

--- a/src/background/organize.ts
+++ b/src/background/organize.ts
@@ -2,7 +2,7 @@ import { browser, Browser } from 'wxt/browser';
 import { getSettings } from './settings.js';
 import {
     findMatchingRule,
-    extractGroupNameFromRule,
+    findGroupingRuleForTab,
     determineGroupColor,
     createNewGroup,
     addToExistingGroup,
@@ -156,20 +156,19 @@ async function buildOrganizePlan(windowId: number, settings: AppSettings): Promi
     const allEntries: PlanEntry[] = [];
 
     for (const tab of organizable) {
-        const rule = findMatchingRule(tab.url!, settings.domainRules);
-        if (!rule || !rule.enabled || !rule.groupingEnabled) continue;
+        // Pass the tab itself as "openerTab": safe for label/url/title/smart sources.
+        // coerceManualToLabel maps manual / smart_manual sources to smart_label so
+        // bulk organize falls back to the rule label without prompting the user.
+        const grouping = findGroupingRuleForTab(
+            tab as Browser.tabs.Tab,
+            settings.domainRules,
+            { coerceManualToLabel: true },
+        );
+        if (!grouping) continue;
 
-        // Skip sources that require user interaction — fall back to rule.label via smart_label
-        const effectiveRule: DomainRuleSetting =
-            rule.groupNameSource === 'manual' || rule.groupNameSource === 'smart_manual'
-                ? { ...rule, groupNameSource: 'smart_label' as const }
-                : rule;
-
-        // Pass the tab itself as "openerTab" — safe for label/url/title/smart sources
-        const targetGroupName = extractGroupNameFromRule(effectiveRule, tab as Browser.tabs.Tab);
+        const { rule, groupName } = grouping;
         const groupColor = determineGroupColor(rule);
-
-        allEntries.push({ tab, targetGroupName, groupColor, rule });
+        allEntries.push({ tab, targetGroupName: groupName, groupColor, rule });
     }
 
     // Count members per target group name

--- a/tests/background/organize.test.ts
+++ b/tests/background/organize.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../src/background/settings.js', () => ({
 
 vi.mock('../../src/background/grouping.js', () => ({
   findMatchingRule: vi.fn(),
-  extractGroupNameFromRule: vi.fn(),
+  findGroupingRuleForTab: vi.fn(),
   determineGroupColor: vi.fn(),
   createNewGroup: vi.fn(),
   addToExistingGroup: vi.fn(),
@@ -44,7 +44,7 @@ import { browser } from 'wxt/browser';
 import { getSettings } from '../../src/background/settings';
 import {
   findMatchingRule,
-  extractGroupNameFromRule,
+  findGroupingRuleForTab,
   determineGroupColor,
   createNewGroup,
   addToExistingGroup,
@@ -59,7 +59,7 @@ import {
 const mockedBrowser = browser as unknown as MockedBrowser;
 const mockedGetSettings = getSettings as ReturnType<typeof vi.fn>;
 const mockedFindMatchingRule = findMatchingRule as ReturnType<typeof vi.fn>;
-const mockedExtractGroupName = extractGroupNameFromRule as ReturnType<typeof vi.fn>;
+const mockedFindGroupingRule = findGroupingRuleForTab as ReturnType<typeof vi.fn>;
 const mockedDetermineColor = determineGroupColor as ReturnType<typeof vi.fn>;
 const mockedCreateGroup = createNewGroup as ReturnType<typeof vi.fn>;
 const mockedAddToGroup = addToExistingGroup as ReturnType<typeof vi.fn>;
@@ -214,8 +214,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(11, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('My Group');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'My Group' });
       mockedDetermineColor.mockReturnValue('blue');
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
 
@@ -238,8 +237,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(21, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Existing');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Existing' });
       mockedDetermineColor.mockReturnValue('purple');
       mockedBrowser.tabGroups.query
         .mockResolvedValueOnce([{ id: 99, title: 'Existing' }])
@@ -262,8 +260,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(30, 'https://x.com/a'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Solo');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Solo' });
       mockedDetermineColor.mockReturnValue('red');
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
 
@@ -284,7 +281,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(41, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
+      mockedFindGroupingRule.mockReturnValue(null);
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
 
       await handleOrganizeAllTabs(1);
@@ -292,7 +289,7 @@ describe('handleOrganizeAllTabs', () => {
       expect(mockedCreateGroup).not.toHaveBeenCalled();
     });
 
-    it('overrides "manual" groupNameSource to "smart_label"', async () => {
+    it('passes coerceManualToLabel: true so manual sources fall back to the rule label', async () => {
       const rule = makeRule({ groupNameSource: 'manual' });
       mockedGetSettings.mockResolvedValue(makeSettings({ domainRules: [rule] }));
 
@@ -302,15 +299,14 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(51, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Example');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Example' });
       mockedDetermineColor.mockReturnValue('blue');
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
 
       await handleOrganizeAllTabs(1);
 
-      const [passedRule] = mockedExtractGroupName.mock.calls[0];
-      expect(passedRule.groupNameSource).toBe('smart_label');
+      const callArgs = mockedFindGroupingRule.mock.calls[0];
+      expect(callArgs[2]).toEqual({ coerceManualToLabel: true });
     });
 
     it('does not re-move tabs that are already in the target group', async () => {
@@ -323,8 +319,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(61, 'https://x.com/b', { groupId: 77 }),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Already There');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Already There' });
       mockedDetermineColor.mockReturnValue('blue');
       mockedBrowser.tabGroups.query
         .mockResolvedValueOnce([{ id: 77, title: 'Already There' }])
@@ -349,8 +344,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(71, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Work');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Work' });
       mockedDetermineColor.mockReturnValue('blue');
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
 
@@ -370,8 +364,7 @@ describe('handleOrganizeAllTabs', () => {
         makeTab(81, 'https://x.com/b'),
       ]);
 
-      mockedFindMatchingRule.mockReturnValue(rule);
-      mockedExtractGroupName.mockReturnValue('Fails');
+      mockedFindGroupingRule.mockReturnValue({ rule, groupName: 'Fails' });
       mockedDetermineColor.mockReturnValue('blue');
       mockedBrowser.tabGroups.query.mockResolvedValue([]);
       mockedCreateGroup.mockRejectedValueOnce(new Error('api error'));
@@ -437,6 +430,7 @@ describe('handleOrganizeAllTabs', () => {
       await handleOrganizeAllTabs(1);
 
       expect(mockedFindMatchingRule).not.toHaveBeenCalled();
+      expect(mockedFindGroupingRule).not.toHaveBeenCalled();
       expect(mockedBrowser.tabs.remove).not.toHaveBeenCalled();
     });
 

--- a/tests/grouping.test.ts
+++ b/tests/grouping.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   findMatchingRule,
+  findMatchingRules,
+  findGroupingRuleForTab,
   determineGroupColor,
   extractGroupNameFromRule,
   createGroupingContext
@@ -151,6 +153,169 @@ describe('grouping', () => {
       const result = findMatchingRule('https://example.com/page', rules);
 
       expect(result?.label).toBe('First');
+    });
+  });
+
+  describe('findMatchingRules', () => {
+    it('retourne toutes les règles activées correspondant au domaine, dans l\'ordre', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({ domainFilter: 'example.com', label: 'First' }),
+        createMockRule({ domainFilter: 'example.com', label: 'Second' }),
+        createMockRule({ domainFilter: 'other.com', label: 'Other' }),
+      ];
+
+      const result = findMatchingRules('https://example.com/page', rules);
+
+      expect(result.map(r => r.label)).toEqual(['First', 'Second']);
+    });
+
+    it('ignore les règles désactivées', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({ domainFilter: 'example.com', label: 'Off', enabled: false }),
+        createMockRule({ domainFilter: 'example.com', label: 'On' }),
+      ];
+
+      const result = findMatchingRules('https://example.com/page', rules);
+
+      expect(result.map(r => r.label)).toEqual(['On']);
+    });
+
+    it('retourne un tableau vide quand aucune règle ne correspond', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({ domainFilter: 'other.com' }),
+      ];
+
+      expect(findMatchingRules('https://example.com/page', rules)).toEqual([]);
+    });
+  });
+
+  describe('findGroupingRuleForTab', () => {
+    it('saute la première règle si son extraction échoue et utilise la suivante', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({
+          id: '1',
+          domainFilter: 'example.com',
+          label: 'First',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'NoMatch - (\\w+)',
+        }),
+        createMockRule({
+          id: '2',
+          domainFilter: 'example.com',
+          label: 'Second',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'Test Page - (\\w+)',
+        }),
+      ];
+      const tab = createMockTab({ title: 'Test Page - Example' });
+
+      const result = findGroupingRuleForTab(tab, rules);
+
+      expect(result?.rule.label).toBe('Second');
+      expect(result?.groupName).toBe('Example');
+    });
+
+    it('retourne null si aucune règle ne produit un nom de groupe', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({
+          id: '1',
+          domainFilter: 'example.com',
+          label: 'First',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'NoMatch - (\\w+)',
+        }),
+        createMockRule({
+          id: '2',
+          domainFilter: 'example.com',
+          label: 'Second',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'AlsoNoMatch (\\w+)',
+        }),
+      ];
+      const tab = createMockTab({ title: 'Test Page - Example' });
+
+      expect(findGroupingRuleForTab(tab, rules)).toBeNull();
+    });
+
+    it('saute les règles dont groupingEnabled est faux', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({
+          id: '1',
+          domainFilter: 'example.com',
+          label: 'GroupingDisabled',
+          groupingEnabled: false,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'Test Page - (\\w+)',
+        }),
+        createMockRule({
+          id: '2',
+          domainFilter: 'example.com',
+          label: 'Active',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'Test Page - (\\w+)',
+        }),
+      ];
+      const tab = createMockTab({ title: 'Test Page - Example' });
+
+      const result = findGroupingRuleForTab(tab, rules);
+
+      expect(result?.rule.label).toBe('Active');
+    });
+
+    it('retourne la première règle qui réussit (ordre préservé)', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({
+          id: '1',
+          domainFilter: 'example.com',
+          label: 'First',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'Test Page - (\\w+)',
+        }),
+        createMockRule({
+          id: '2',
+          domainFilter: 'example.com',
+          label: 'Second',
+          groupingEnabled: true,
+          groupNameSource: 'title',
+          titleParsingRegEx: 'Test Page - (\\w+)',
+        }),
+      ];
+      const tab = createMockTab({ title: 'Test Page - Example' });
+
+      const result = findGroupingRuleForTab(tab, rules);
+
+      expect(result?.rule.label).toBe('First');
+    });
+
+    it('coerce manual et smart_manual en smart_label quand demandé', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({
+          domainFilter: 'example.com',
+          label: 'My Label',
+          groupingEnabled: true,
+          groupNameSource: 'manual',
+        }),
+      ];
+      const tab = createMockTab({ url: 'https://example.com/page', title: 'No regex match' });
+
+      const result = findGroupingRuleForTab(tab, rules, { coerceManualToLabel: true });
+
+      expect(result?.groupName).toBe('My Label');
+    });
+
+    it('retourne null quand l\'URL est absente', () => {
+      const rules: DomainRuleSetting[] = [
+        createMockRule({ domainFilter: 'example.com', groupingEnabled: true }),
+      ];
+      const tab = createMockTab({ url: undefined });
+
+      expect(findGroupingRuleForTab(tab, rules)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
This PR refactors the grouping rule matching logic to support multiple matching rules per domain, with fallback behavior when rule extraction fails. The new `findGroupingRuleForTab` function encapsulates the logic for finding the first applicable grouping rule, replacing scattered logic across multiple functions.

## Key Changes

- **New `findMatchingRules` function**: Returns all enabled rules matching a domain (plural), complementing the existing `findMatchingRule` (singular)

- **New `findGroupingRuleForTab` function**: Iterates through matching rules in order and returns the first one that:
  - Has `groupingEnabled: true`
  - Successfully extracts a non-null group name
  - Supports optional `coerceManualToLabel` to convert manual sources to smart_label (for bulk operations)

- **Simplified `processGroupingForNewTab`**: Now uses `findGroupingRuleForTab` directly, eliminating separate checks for `groupingEnabled` and group name extraction

- **Updated `buildOrganizePlan`**: Refactored to use `findGroupingRuleForTab` with `coerceManualToLabel: true`, removing inline rule coercion logic

- **Test updates**: Added comprehensive test coverage for the new functions and updated existing tests to mock `findGroupingRuleForTab` instead of separate extraction functions

## Implementation Details

- Rules are processed in order; if a rule matches the domain but fails to extract a group name, the next matching rule is tried
- The `coerceManualToLabel` option allows bulk operations to fall back to rule labels without user interaction
- Maintains backward compatibility with existing rule matching behavior

https://claude.ai/code/session_01JfTHWyUBds9jhxcQnu189K