### PR TITLE
Simplify Save button to single contextual button instead of SplitButton

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -386,6 +386,7 @@
   "snapshotConfirmMessage": { "message": "Save \"$1\" with $2 tab(s)?" },
   "snapshotSaveButton": { "message": "Save Session" },
   "snapshotSaveSuccess": { "message": "Session \"$1\" saved successfully!" },
+  "snapshotActiveGroupCallout": { "message": "Selection limited to the active group. You can extend it before saving." },
 
   "restoreTitle": { "message": "Restore \"$1\"" },
   "restoreDescription": { "message": "Choose which tabs to restore from this session." },
@@ -458,8 +459,6 @@
   "popupRestore": { "message": "Restore" },
   "popupSaveSession": { "message": "Save session" },
   "popupSaveActiveGroup": { "message": "Save active tab group" },
-  "popupSaveAllTabs": { "message": "Save all tabs" },
-  "popupSaveGroupOptions": { "message": "More save options" },
   "popupRestoreSession": { "message": "Restore session" },
   "popupPinnedSessionsLabel": { "message": "Pinned sessions" },
   "popupPinnedEmptyHint": { "message": "Pin a session for one-click access from here." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -386,6 +386,7 @@
   "snapshotConfirmMessage": { "message": "¿Guardar \"$1\" con $2 pestaña(s)?" },
   "snapshotSaveButton": { "message": "Guardar sesión" },
   "snapshotSaveSuccess": { "message": "¡Sesión \"$1\" guardada con éxito!" },
+  "snapshotActiveGroupCallout": { "message": "Selección limitada al grupo activo. Puedes ampliarla antes de guardar." },
 
   "restoreTitle": { "message": "Restaurar \"$1\"" },
   "restoreDescription": { "message": "Elige qué pestañas restaurar de esta sesión." },
@@ -459,8 +460,6 @@
   "popupRestore": { "message": "Restaurar" },
   "popupSaveSession": { "message": "Guardar sesión" },
   "popupSaveActiveGroup": { "message": "Guardar grupo activo" },
-  "popupSaveAllTabs": { "message": "Guardar todas las pestañas" },
-  "popupSaveGroupOptions": { "message": "Más opciones de guardado" },
   "popupRestoreSession": { "message": "Restaurar sesión" },
   "popupPinnedSessionsLabel": { "message": "Sesiones fijadas" },
   "popupPinnedEmptyHint": { "message": "Fija una sesión para acceder en un clic desde aquí." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -386,6 +386,7 @@
   "snapshotConfirmMessage": { "message": "Sauvegarder « $1 » avec $2 onglet(s) ?" },
   "snapshotSaveButton": { "message": "Sauvegarder la session" },
   "snapshotSaveSuccess": { "message": "Session « $1 » sauvegardée avec succès !" },
+  "snapshotActiveGroupCallout": { "message": "Sélection restreinte au groupe actif. Vous pouvez l'étendre avant de sauvegarder." },
 
   "restoreTitle": { "message": "Restaurer « $1 »" },
   "restoreDescription": { "message": "Choisissez les onglets à restaurer depuis cette session." },
@@ -459,8 +460,6 @@
   "popupRestore": { "message": "Restaurer" },
   "popupSaveSession": { "message": "Sauvegarder la session" },
   "popupSaveActiveGroup": { "message": "Sauvegarder le groupe actif" },
-  "popupSaveAllTabs": { "message": "Sauvegarder tous les onglets" },
-  "popupSaveGroupOptions": { "message": "Plus d'options de sauvegarde" },
   "popupRestoreSession": { "message": "Restaurer une session" },
   "popupPinnedSessionsLabel": { "message": "Sessions épinglées" },
   "popupPinnedEmptyHint": { "message": "Épinglez une session pour y accéder en un clic depuis ici." },

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, DropdownMenu, Flex, Text } from '@radix-ui/themes';
-import { ChevronDown } from 'lucide-react';
+import { Box, Button, Flex, Text } from '@radix-ui/themes';
 import { browser } from 'wxt/browser';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
@@ -62,6 +61,13 @@ export function PopupToolbar() {
   };
 
   const saveDisabledHint = !canSave ? getMessage('popupSaveDisabledHint') : undefined;
+  const isInGroup = activeTabGroupId !== null && canSave;
+  const saveHash = isInGroup
+    ? `#sessions?action=snapshot&groupId=${activeTabGroupId}`
+    : '#sessions?action=snapshot';
+  const saveAriaLabel = isInGroup
+    ? getMessage('popupSaveActiveGroup')
+    : getMessage('popupSaveSession');
 
   return (
     <Box
@@ -73,84 +79,22 @@ export function PopupToolbar() {
       }}
     >
       <Flex gap="1">
-        {activeTabGroupId !== null && canSave ? (
-          <Flex style={{ flex: 1 }}>
-            <Button
-              data-testid="popup-toolbar-btn-save"
-              variant="soft"
-              onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
-              aria-label={getMessage('popupSaveSession')}
-              style={{
-                ...actionButtonStyle,
-                borderTopRightRadius: 0,
-                borderBottomRightRadius: 0,
-              }}
-            >
-              <span aria-hidden="true" style={actionEmojiStyle}>
-                📸
-              </span>
-              <Text as="span" size="1">
-                {getMessage('popupSave')}
-              </Text>
-            </Button>
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger>
-                <Button
-                  variant="soft"
-                  aria-label={getMessage('popupSaveGroupOptions')}
-                  title={getMessage('popupSaveGroupOptions')}
-                  style={{
-                    borderTopLeftRadius: 0,
-                    borderBottomLeftRadius: 0,
-                    borderTopRightRadius: 'var(--radius-5)',
-                    borderBottomRightRadius: 'var(--radius-5)',
-                    paddingLeft: 4,
-                    paddingRight: 4,
-                    minWidth: 20,
-                    height: 'auto',
-                    paddingTop: 10,
-                    paddingBottom: 10,
-                  }}
-                >
-                  <ChevronDown size={12} aria-hidden="true" />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Item
-                  onClick={() =>
-                    void openOptionsWithHash(
-                      `#sessions?action=snapshot&groupId=${activeTabGroupId}`,
-                    )
-                  }
-                >
-                  {getMessage('popupSaveActiveGroup')}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
-                >
-                  {getMessage('popupSaveAllTabs')}
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
-          </Flex>
-        ) : (
-          <Button
-            data-testid="popup-toolbar-btn-save"
-            variant="soft"
-            disabled={!canSave}
-            onClick={() => void openOptionsWithHash('#sessions?action=snapshot')}
-            aria-label={getMessage('popupSaveSession')}
-            title={saveDisabledHint}
-            style={actionButtonStyle}
-          >
-            <span aria-hidden="true" style={actionEmojiStyle}>
-              📸
-            </span>
-            <Text as="span" size="1">
-              {getMessage('popupSave')}
-            </Text>
-          </Button>
-        )}
+        <Button
+          data-testid="popup-toolbar-btn-save"
+          variant="soft"
+          disabled={!canSave}
+          onClick={() => void openOptionsWithHash(saveHash)}
+          aria-label={saveAriaLabel}
+          title={saveDisabledHint}
+          style={actionButtonStyle}
+        >
+          <span aria-hidden="true" style={actionEmojiStyle}>
+            📸
+          </span>
+          <Text as="span" size="1">
+            {getMessage('popupSave')}
+          </Text>
+        </Button>
 
         <Button
           data-testid="popup-toolbar-btn-restore"

--- a/src/components/UI/SessionWizards/SnapshotWizard.stories.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.stories.tsx
@@ -3,6 +3,41 @@ import { within, userEvent, expect, waitFor } from 'storybook/test';
 import { SnapshotWizard } from './SnapshotWizard';
 import type { Session } from '@/types/session';
 
+interface FakeTab {
+  id: number;
+  index: number;
+  url: string;
+  title: string;
+  groupId?: number;
+}
+interface FakeGroup {
+  title: string;
+  color: string;
+  collapsed?: boolean;
+}
+
+/**
+ * Patch the storybook browser mock with synthetic tabs/tabGroups so the
+ * wizard's `captureCurrentTabs()` resolves with deterministic data.
+ * Mutates the shared singleton; subsequent stories that need a different
+ * snapshot must redefine the mock through their own decorator.
+ */
+function patchTabsMock(tabs: FakeTab[], groups: Record<number, FakeGroup>): void {
+  const slot = globalThis as typeof globalThis & {
+    browser?: Record<string, unknown>;
+  };
+  const browser = (slot.browser ?? {}) as Record<string, unknown>;
+  browser.tabs = { query: async () => tabs };
+  browser.tabGroups = {
+    get: async (id: number) => {
+      const group = groups[id];
+      if (!group) throw new Error(`Group ${id} not found`);
+      return group;
+    },
+  };
+  slot.browser = browser;
+}
+
 const meta: Meta<typeof SnapshotWizard> = {
   title: 'Components/UI/SessionWizards/SnapshotWizard',
   component: SnapshotWizard,
@@ -61,6 +96,55 @@ export const SnapshotWizardCancel: Story = {
     const body = within(canvasElement.ownerDocument.body);
     const cancelBtn = await body.findByTestId('wizard-snapshot-btn-cancel');
     await userEvent.click(cancelBtn);
+  },
+};
+
+// Window contains a group + an ungrouped tab. Pre-selecting only the group
+// triggers the partial selection callout at the top of the wizard body.
+export const SnapshotWizardWithGroupCallout: Story = {
+  args: { open: true, initialGroupId: 42 },
+  decorators: [
+    (Story) => {
+      patchTabsMock(
+        [
+          { id: 1, index: 0, url: 'https://example.com/a', title: 'Group tab A', groupId: 42 },
+          { id: 2, index: 1, url: 'https://example.com/b', title: 'Group tab B', groupId: 42 },
+          { id: 3, index: 2, url: 'https://example.org', title: 'Ungrouped tab' },
+        ],
+        { 42: { title: 'Active group', color: 'green', collapsed: false } },
+      );
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await waitFor(() =>
+      expect(body.getByTestId('wizard-snapshot-group-callout')).toBeVisible(),
+    );
+  },
+};
+
+// Window contains only the active group: pre-selection covers everything,
+// so the callout must NOT be displayed.
+export const SnapshotWizardSingleGroupNoCallout: Story = {
+  args: { open: true, initialGroupId: 7 },
+  decorators: [
+    (Story) => {
+      patchTabsMock(
+        [
+          { id: 10, index: 0, url: 'https://example.com/x', title: 'Solo group tab', groupId: 7 },
+        ],
+        { 7: { title: 'Solo group', color: 'orange', collapsed: false } },
+      );
+      return <Story />;
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    // Wait for capture to land (name input populated with group title)
+    const nameInput = await body.findByTestId<HTMLInputElement>('wizard-snapshot-field-name');
+    await waitFor(() => expect(nameInput.value).toBe('Solo group'));
+    expect(body.queryByTestId('wizard-snapshot-group-callout')).toBeNull();
   },
 };
 

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -3,7 +3,7 @@ import {
   Dialog, Flex, Button, Text,
   TextArea, Callout,
 } from '@radix-ui/themes';
-import { Camera, AlertCircle } from 'lucide-react';
+import { Camera, AlertCircle, Info } from 'lucide-react';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { WizardModal } from '@/components/UI/WizardModal';
@@ -38,6 +38,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
   const [saveError, setSaveError] = useState<string | null>(null);
   const [categoryId, setCategoryId] = useState<string | null>(null);
   const [note, setNote] = useState('');
+  const [cameFromActiveGroup, setCameFromActiveGroup] = useState(false);
 
   // Reset and capture on open
   useEffect(() => {
@@ -51,6 +52,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
     setIsCapturing(true);
     setCategoryId(null);
     setNote('');
+    setCameFromActiveGroup(false);
 
     captureCurrentTabs()
       .then(data => {
@@ -72,6 +74,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
             if (targetGroup.title) {
               setSessionName(targetGroup.title);
             }
+            setCameFromActiveGroup(true);
             setIsCapturing(false);
             return;
           }
@@ -85,6 +88,9 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
         setIsCapturing(false);
       });
   }, [open, initialGroupId]);
+
+  const showGroupCallout =
+    cameFromActiveGroup && selectedTabIds.size < numericIdToSavedTabId.size;
 
   // Derive selected SavedTab UUIDs from selected numeric IDs
   const selectedSavedTabIds = useMemo(
@@ -141,6 +147,18 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
     >
       <WizardModal.Body>
         <Flex direction="column" gap="3">
+          {showGroupCallout && (
+            <Callout.Root
+              color="blue"
+              variant="soft"
+              data-testid="wizard-snapshot-group-callout"
+            >
+              <Callout.Icon>
+                <Info size={16} />
+              </Callout.Icon>
+              <Callout.Text>{getMessage('snapshotActiveGroupCallout')}</Callout.Text>
+            </Callout.Root>
+          )}
           <Flex direction="column" gap="1">
             <Text size="2" weight="medium">
               {getMessage('sessionNameLabel')}

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -151,6 +151,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
             <Callout.Root
               color="blue"
               variant="soft"
+              highContrast
               data-testid="wizard-snapshot-group-callout"
             >
               <Callout.Icon>

--- a/tests/e2e/popup-save-group.spec.ts
+++ b/tests/e2e/popup-save-group.spec.ts
@@ -1,11 +1,11 @@
 /**
- * E2E tests for the "Save active tab group" SplitButton feature.
- * Covers: US-PO006 (SplitButton rendering) and US-PO007 (group snapshot deep link).
+ * E2E tests for the contextual Save button in the popup.
+ * Covers: US-PO006 (single contextual button) and US-PO007 (group snapshot deep link + callout).
  *
- * Note: The popup SplitButton rendering depends on the active tab being in a Chrome
+ * Note: The popup Save button action depends on the active tab being in a Chrome
  * tab group at the moment the popup opens. In Playwright, opening popup.html as a
  * new tab makes itself the active tab (not in any group), so we test that case directly.
- * The group pre-selection flow is tested via the options page deep link.
+ * The group pre-selection flow and callout are tested via the options page deep link.
  */
 import { test, expect } from './fixtures';
 import { goToPopup } from './helpers/navigation';
@@ -42,6 +42,15 @@ async function createTabGroupWithTitle(
   return result;
 }
 
+async function createTab(extensionContext: BrowserContext, url: string): Promise<number> {
+  const sw = extensionContext.serviceWorkers()[0];
+  const tabId = await sw.evaluate(async (u: string) => {
+    const tab = await chrome.tabs.create({ url: u, active: false });
+    return tab.id!;
+  }, url);
+  return tabId;
+}
+
 async function closeTab(extensionContext: BrowserContext, tabId: number): Promise<void> {
   const sw = extensionContext.serviceWorkers()[0];
   await sw.evaluate(async (id: number) => {
@@ -50,33 +59,31 @@ async function closeTab(extensionContext: BrowserContext, tabId: number): Promis
 }
 
 // ---------------------------------------------------------------------------
-// US-PO006 — Popup save button: plain button when active tab is not in a group
+// US-PO006 — Popup Save button stays a simple button (no SplitButton anymore)
 // ---------------------------------------------------------------------------
 test.describe('[US-PO006] Popup save button', () => {
-  test('shows plain save button when active tab is not in a group', async ({
+  test('shows a single Save button when active tab is not in a group', async ({
     extensionContext,
     extensionId,
   }) => {
     const page = await extensionContext.newPage();
     await goToPopup(page, extensionId);
 
-    // The popup page itself is the active tab (not in any group) → plain button
+    // The popup page itself is the active tab (not in any group)
     await expect(page.getByRole('button', { name: /save session/i })).toBeVisible();
-    // The dropdown trigger (chevron for group options) should NOT be present
-    await expect(page.getByRole('button', { name: /more save options/i })).toBeHidden();
+    // The legacy SplitButton chevron must never be present anymore
+    await expect(page.getByRole('button', { name: /more save options/i })).toHaveCount(0);
+    // No "Save all tabs" / dropdown menu items either
+    await expect(page.getByRole('menuitem', { name: /save all tabs/i })).toHaveCount(0);
     await page.close();
   });
 
-  test('plain save button click navigates to snapshot wizard', async ({
+  test('Save button click navigates to snapshot wizard without groupId when not in a group', async ({
     extensionContext,
     extensionId,
   }) => {
     // Create a capturable (non-system) tab so canSave becomes true
-    const sw = extensionContext.serviceWorkers()[0];
-    const tabId = await sw.evaluate(async (url: string) => {
-      const tab = await chrome.tabs.create({ url, active: false });
-      return tab.id!;
-    }, CAPTURABLE_URL);
+    const tabId = await createTab(extensionContext, CAPTURABLE_URL);
 
     const page = await extensionContext.newPage();
     await goToPopup(page, extensionId);
@@ -95,7 +102,7 @@ test.describe('[US-PO006] Popup save button', () => {
 
     await page.close();
     await newPage.close();
-    await sw.evaluate(async (id: number) => chrome.tabs.remove(id), tabId);
+    await closeTab(extensionContext, tabId);
   });
 });
 
@@ -174,6 +181,9 @@ test.describe('[US-PO007] Save active tab group via deep link', () => {
     const value = await nameInput.inputValue();
     expect(value).toMatch(/^Snapshot /);
 
+    // Fallback path: no callout
+    await expect(page.getByTestId('wizard-snapshot-group-callout')).toHaveCount(0);
+
     await page.close();
   });
 
@@ -195,6 +205,67 @@ test.describe('[US-PO007] Save active tab group via deep link', () => {
     const value = await nameInput.inputValue();
     expect(value).toMatch(/^Snapshot /);
 
+    // "Save all" path: no callout
+    await expect(page.getByTestId('wizard-snapshot-group-callout')).toHaveCount(0);
+
     await page.close();
+  });
+
+  test('shows the group callout when preselection is strictly partial', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    // Window contains: 1 group with 1 tab + 1 ungrouped capturable tab.
+    // The wizard will pre-select only the group tab → strictly partial → callout visible.
+    const { groupId, tabId: groupTabId } = await createTabGroupWithTitle(
+      extensionContext,
+      'Active group',
+      'green',
+    );
+    const ungroupedTabId = await createTab(extensionContext, 'https://example.org');
+
+    try {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#sessions?action=snapshot&groupId=${groupId}`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.getByTestId('wizard-snapshot').waitFor({ state: 'visible', timeout: 10_000 });
+      await expect(page.getByTestId('wizard-snapshot-group-callout')).toBeVisible();
+
+      await page.close();
+    } finally {
+      await closeTab(extensionContext, groupTabId);
+      await closeTab(extensionContext, ungroupedTabId);
+    }
+  });
+
+  test('hides the group callout when window only contains the active group', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    // Window contains only the group tab → preselection covers everything → no callout.
+    // (Plus the wizard tab itself, but it is a chrome-extension URL filtered by isSystemUrl.)
+    const { groupId, tabId } = await createTabGroupWithTitle(
+      extensionContext,
+      'Solo group',
+      'orange',
+    );
+
+    try {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#sessions?action=snapshot&groupId=${groupId}`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.getByTestId('wizard-snapshot').waitFor({ state: 'visible', timeout: 10_000 });
+      await expect(page.getByTestId('wizard-snapshot-group-callout')).toHaveCount(0);
+
+      await page.close();
+    } finally {
+      await closeTab(extensionContext, tabId);
+    }
   });
 });

--- a/tests/e2e/popup-save-group.spec.ts
+++ b/tests/e2e/popup-save-group.spec.ts
@@ -14,10 +14,43 @@ import type { BrowserContext } from '@playwright/test';
 
 test.beforeEach(async ({ extensionContext }) => {
   await clearSessions(extensionContext);
+  await closeAllCapturableTabs(extensionContext);
 });
 
 // A non-system URL that captures correctly (about: is filtered by isSystemUrl)
 const CAPTURABLE_URL = 'https://example.com';
+
+/**
+ * Close every non-system tab in the extension context. Prevents pollution of
+ * `chrome.tabs.query({ currentWindow: true })` between tests, which is critical
+ * for callout-presence assertions in the SnapshotWizard tests.
+ */
+async function closeAllCapturableTabs(extensionContext: BrowserContext): Promise<void> {
+  const sw = extensionContext.serviceWorkers()[0];
+  if (!sw) return;
+  await sw.evaluate(async () => {
+    const SYSTEM_URL_PREFIXES = [
+      'chrome://',
+      'chrome-extension://',
+      'moz-extension://',
+      'about:',
+      'edge://',
+    ];
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (!tab.id) continue;
+      const url = tab.url ?? '';
+      const isSystem = !url || SYSTEM_URL_PREFIXES.some(p => url.startsWith(p));
+      if (!isSystem) {
+        try {
+          await chrome.tabs.remove(tab.id);
+        } catch {
+          // ignore: tab may have been removed concurrently
+        }
+      }
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Helper: create a tab group in the browser via service worker
@@ -261,6 +294,9 @@ test.describe('[US-PO007] Save active tab group via deep link', () => {
       await page.waitForLoadState('domcontentloaded');
 
       await page.getByTestId('wizard-snapshot').waitFor({ state: 'visible', timeout: 10_000 });
+      // Wait for the async capture to settle (group title populated) before
+      // asserting on callout presence to avoid racing the initial render.
+      await expect(page.getByTestId('wizard-snapshot-field-name')).toHaveValue('Solo group');
       await expect(page.getByTestId('wizard-snapshot-group-callout')).toHaveCount(0);
 
       await page.close();

--- a/user-stories/US-PO-save-group.md
+++ b/user-stories/US-PO-save-group.md
@@ -1,49 +1,57 @@
-# User Stories — Domaine PO : Sauvegarde d'un groupe d'onglets actif
+# User Stories : Domaine PO : Sauvegarde d'un groupe d'onglets actif
 
-> Comportements couverts par `tests/e2e/popup.spec.ts` et `tests/tabCapture.test.ts`.
+> Comportements couverts par `tests/e2e/popup-save-group.spec.ts` et `tests/tabCapture.test.ts`.
 > Les US numérotées ci-dessous reprennent la continuité à partir de US-PO006.
 
 ---
 
-## US-PO006 — Transformation du bouton Save en SplitButton quand l'onglet actif est dans un groupe
+## US-PO006 : Bouton Save contextuel dans le popup
 
-**En tant qu'** utilisateur dont l'onglet actif appartient à un groupe Chrome,
-**je veux** que le bouton « Save » du popup se transforme en SplitButton (bouton principal + flèche déroulante),
-**afin de** pouvoir choisir entre sauvegarder tous les onglets ou uniquement le groupe actif.
+**En tant qu'** utilisateur du popup,
+**je veux** un bouton Save unique dont l'action s'adapte au contexte de l'onglet actif,
+**afin de** sauvegarder en un clic la portée la plus pertinente sans avoir à choisir dans un menu.
 
 ### Critères d'acceptation
 
-- [ ] Quand l'onglet actif **n'appartient pas** à un groupe Chrome, le bouton Save s'affiche comme un bouton simple (icône appareil photo + texte « Save »), comportement inchangé.
-- [ ] Quand l'onglet actif **appartient à un groupe** Chrome, le bouton Save se transforme en SplitButton : la partie principale (icône + texte) reste identique visuellement, et une petite flèche (chevron) est ajoutée à sa droite.
-- [ ] Cliquer sur la **partie principale** du SplitButton (icône + texte) déclenche le comportement actuel : ouverture du SnapshotWizard avec tous les onglets pré-cochés.
-- [ ] Cliquer sur la **flèche** du SplitButton ouvre un menu déroulant avec deux options :
-  - « Save active tab group »
-  - « Save all tabs »
-- [ ] L'option « Save all tabs » du menu déclenche le même comportement que le clic sur la partie principale.
-- [ ] Quand le bouton est désactivé (`canSave = false`), ni la partie principale ni la flèche ne sont actives.
+- [ ] Le bouton Save reste un bouton simple (icône appareil photo + texte « Save ») dans tous les cas : aucun chevron, aucun menu déroulant, aucun SplitButton.
+- [ ] Quand l'onglet actif **n'appartient pas** à un groupe Chrome, cliquer sur Save ouvre le SnapshotWizard avec tous les onglets de la fenêtre pré-cochés (deep link `#sessions?action=snapshot`).
+- [ ] Quand l'onglet actif **appartient à un groupe** Chrome, cliquer sur Save ouvre le SnapshotWizard avec uniquement les onglets de ce groupe pré-cochés (deep link `#sessions?action=snapshot&groupId=<id>`).
+- [ ] Quand le bouton est désactivé (`canSave = false`), aucun clic ne déclenche d'action.
+- [ ] Le `aria-label` reflète l'action contextuelle :
+  - hors groupe : « Save session » (clé `popupSaveSession`),
+  - dans un groupe : « Save active tab group » (clé `popupSaveActiveGroup`).
 
 ---
 
-## US-PO007 — Sauvegarde du groupe d'onglets actif
+## US-PO007 : Sauvegarde du groupe d'onglets actif
 
 **En tant qu'** utilisateur dont l'onglet actif appartient à un groupe Chrome,
-**je veux** pouvoir sauvegarder uniquement ce groupe d'onglets via l'option « Save active tab group »,
-**afin de** créer rapidement une session dédiée au groupe sans avoir à désélectionner manuellement les autres onglets.
+**je veux** que le bouton Save sauvegarde uniquement ce groupe et m'informe de cette restriction modifiable,
+**afin de** créer rapidement une session dédiée sans craindre une sélection incomplète subie.
 
 ### Critères d'acceptation
 
-- [ ] Sélectionner « Save active tab group » dans le menu ouvre le SnapshotWizard (dialogue « Save Session Snapshot »).
+- [ ] Le clic sur Save (ou l'ouverture directe du deep link `#sessions?action=snapshot&groupId=<id>`) ouvre le SnapshotWizard.
 - [ ] Le SnapshotWizard s'ouvre avec **uniquement les onglets du groupe actif pré-cochés** ; les autres onglets (hors groupe ou d'autres groupes) ne sont pas cochés.
-- [ ] La pré-sélection est **modifiable** : l'utilisateur peut cocher/décocher librement des onglets.
+- [ ] La pré-sélection est **modifiable** : l'utilisateur peut cocher ou décocher librement n'importe quel onglet.
 - [ ] Le **nom de session par défaut** est le titre du groupe Chrome (ex : « Travail »).
 - [ ] Si le groupe **n'a pas de titre** (groupe sans nom), le nom par défaut est « Snapshot \<date\> » (comportement habituel).
-- [ ] Le deep link `options.html#sessions?action=snapshot&groupId=<id>` ouvre le SnapshotWizard avec la pré-sélection et le nom du groupe correspondant.
-- [ ] Si le `groupId` passé en paramètre ne correspond à aucun groupe capturé (groupe entre-temps supprimé), le SnapshotWizard s'ouvre avec tous les onglets pré-cochés (fallback habituel).
+- [ ] Si le `groupId` passé en paramètre ne correspond à aucun groupe capturé (groupe entre-temps supprimé), le SnapshotWizard s'ouvre avec tous les onglets pré-cochés (fallback habituel) et sans callout.
+
+### Callout d'information
+
+- [ ] Quand le SnapshotWizard est ouvert avec une pré-sélection issue d'un groupe actif identifié et que cette pré-sélection est strictement partielle (au moins un onglet de la fenêtre n'est pas pré-coché), un callout d'information apparaît en haut du wizard (`data-testid="wizard-snapshot-group-callout"`) pour signaler que la sélection est restreinte au groupe actif et qu'elle reste extensible.
+- [ ] Si tous les onglets de la fenêtre sont déjà pré-cochés (la fenêtre ne contient que le groupe actif), le callout n'est pas affiché.
+- [ ] Si l'utilisateur étend la sélection à tous les onglets après ouverture, le callout disparaît (sélection complète).
+- [ ] Si aucun `groupId` n'est passé (chemin « save all » classique), le callout n'est pas affiché.
+- [ ] Si le `groupId` est invalide (groupe disparu), le callout n'est pas affiché.
 
 ### Règles métier
 
-| Situation | Nom de session par défaut | Onglets pré-cochés |
-|---|---|---|
-| Groupe avec titre | Titre du groupe | Onglets du groupe uniquement |
-| Groupe sans titre | « Snapshot \<date\> » | Onglets du groupe uniquement |
-| `groupId` inconnu au moment de la capture | « Snapshot \<date\> » | Tous les onglets |
+| Situation | Callout | Nom de session par défaut | Onglets pré-cochés |
+|---|---|---|---|
+| Fenêtre = groupe actif uniquement | Non | Titre du groupe (ou « Snapshot \<date\> ») | Tous (= groupe) |
+| Fenêtre = groupe actif + onglets hors groupe | Oui | Titre du groupe (ou « Snapshot \<date\> ») | Onglets du groupe |
+| Fenêtre = plusieurs groupes | Oui | Titre du groupe actif (ou « Snapshot \<date\> ») | Onglets du groupe actif |
+| Pas de groupe actif (chemin « save all ») | Non | « Snapshot \<date\> » | Tous |
+| `groupId` inconnu au moment de la capture | Non | « Snapshot \<date\> » | Tous |


### PR DESCRIPTION
## Summary

Replaces the conditional SplitButton UI (which showed a dropdown menu when the active tab was in a group) with a single, simpler Save button whose action adapts contextually based on whether the active tab belongs to a group.

## Key Changes

- **PopupToolbar component**: Removed `DropdownMenu` and `ChevronDown` imports; replaced the conditional SplitButton/plain button logic with a single `Button` component that computes its `onClick` hash and `aria-label` based on `activeTabGroupId` and `canSave` state.

- **SnapshotWizard component**: Added a new "group callout" feature that displays an informational callout when:
  - The wizard was opened with a valid `groupId` parameter (indicating group-specific pre-selection)
  - The pre-selection is strictly partial (i.e., not all tabs in the window are selected)
  - The callout disappears if the user extends the selection to cover all tabs

- **E2E tests** (`popup-save-group.spec.ts`): Updated test descriptions and assertions to reflect the removal of the SplitButton UI; added new test cases for the group callout visibility logic (partial vs. complete pre-selection).

- **Storybook stories** (`SnapshotWizard.stories.tsx`): Added two new stories demonstrating the callout behavior:
  - `SnapshotWizardWithGroupCallout`: Shows the callout when a group is pre-selected but other tabs exist
  - `SnapshotWizardSingleGroupNoCallout`: Confirms no callout when the window contains only the active group

- **User stories** (`US-PO-save-group.md`): Revised acceptance criteria to reflect the new single-button design and added detailed callout visibility rules.

- **Localization**: Added `snapshotActiveGroupCallout` message key in English, Spanish, and French locales.

## Implementation Details

- The Save button now uses computed `saveHash` and `saveAriaLabel` variables to determine its behavior at render time, eliminating the need for conditional UI branching.
- The group callout uses a new `cameFromActiveGroup` state flag to track whether the wizard was opened with a valid group ID, and compares `selectedTabIds.size` against `numericIdToSavedTabId.size` to detect partial selection.
- All legacy SplitButton references (chevron button, dropdown menu items) are completely removed from the codebase.

https://claude.ai/code/session_01NVgPwxHf3otZvMD4AvAjnQ