### PR TITLE
Add IconBox component with Storybook stories and tests

### DIFF
--- a/src/components/UI/IconBox/IconBox.stories.tsx
+++ b/src/components/UI/IconBox/IconBox.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Flex, Heading, Text, Theme } from '@radix-ui/themes';
+import {
+  BarChart3,
+  Bell,
+  Bookmark,
+  Layers,
+  Settings,
+  Shield,
+} from 'lucide-react';
+import { IconBox } from './IconBox';
+
+const meta: Meta<typeof IconBox> = {
+  title: 'Components/UI/IconBox/IconBox',
+  component: IconBox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof IconBox>;
+
+export const IconBoxDefault: Story = {
+  args: {
+    icon: Settings,
+  },
+};
+
+export const IconBoxAllSizes: Story = {
+  render: () => (
+    <Flex gap="3" align="center">
+      <IconBox icon={Layers} size="sm" />
+      <IconBox icon={Layers} size="md" />
+      <IconBox icon={Layers} size="lg" />
+    </Flex>
+  ),
+};
+
+export const IconBoxAllVariants: Story = {
+  render: () => (
+    <Flex gap="3" align="center">
+      <IconBox icon={Bell} size="md" variant="gradient" />
+      <IconBox icon={Bell} size="md" variant="soft" />
+    </Flex>
+  ),
+};
+
+export const IconBoxInAccentSubtheme: Story = {
+  render: () => (
+    <Flex gap="4" align="center">
+      <Theme accentColor="indigo" hasBackground={false}>
+        <IconBox icon={Settings} size="lg" />
+      </Theme>
+      <Theme accentColor="green" hasBackground={false}>
+        <IconBox icon={Settings} size="lg" />
+      </Theme>
+      <Theme accentColor="orange" hasBackground={false}>
+        <IconBox icon={Settings} size="lg" />
+      </Theme>
+      <Theme accentColor="pink" hasBackground={false}>
+        <IconBox icon={Settings} size="lg" />
+      </Theme>
+    </Flex>
+  ),
+};
+
+export const IconBoxSidebarPreview: Story = {
+  render: () => (
+    <Flex direction="column" gap="2">
+      <Flex align="center" gap="3">
+        <IconBox icon={Shield} size="sm" variant="soft" />
+        <Text>Domain Rules</Text>
+      </Flex>
+      <Flex align="center" gap="3">
+        <IconBox icon={Bookmark} size="sm" variant="soft" />
+        <Text>Sessions</Text>
+      </Flex>
+      <Flex align="center" gap="3">
+        <IconBox icon={BarChart3} size="sm" variant="soft" />
+        <Text>Statistics</Text>
+      </Flex>
+      <Flex align="center" gap="3">
+        <IconBox icon={Settings} size="sm" variant="soft" />
+        <Text>Preferences</Text>
+      </Flex>
+    </Flex>
+  ),
+};
+
+export const IconBoxPageHeaderPreview: Story = {
+  render: () => (
+    <Flex align="center" gap="3">
+      <IconBox icon={BarChart3} size="lg" variant="gradient" />
+      <Heading size="6">Statistics</Heading>
+    </Flex>
+  ),
+};

--- a/src/components/UI/IconBox/IconBox.tsx
+++ b/src/components/UI/IconBox/IconBox.tsx
@@ -1,0 +1,74 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type IconBoxSize = 'sm' | 'md' | 'lg';
+export type IconBoxVariant = 'gradient' | 'soft';
+
+export interface IconBoxProps {
+  /** Icône Lucide à afficher au centre */
+  icon: LucideIcon;
+  /** Taille du conteneur. Défaut : 'md' */
+  size?: IconBoxSize;
+  /** Style visuel. Défaut : 'gradient' (style Windows 11) */
+  variant?: IconBoxVariant;
+  /** Classe CSS additionnelle (optionnel) */
+  className?: string;
+}
+
+const SIZE_CONFIG: Record<IconBoxSize, { box: number; icon: number; radius: string }> = {
+  sm: { box: 24, icon: 14, radius: 'var(--radius-2)' },
+  md: { box: 32, icon: 18, radius: 'var(--radius-3)' },
+  lg: { box: 44, icon: 24, radius: 'var(--radius-4)' },
+};
+
+/**
+ * IconBox : conteneur arrondi affichant une icône Lucide avec un fond
+ * dérivé de la couleur d'accent du thème Radix actif.
+ *
+ * Utilise les tokens `var(--accent-*)` pour suivre automatiquement
+ * l'accentColor du <Theme> Radix parent (indigo par défaut, ou l'accent
+ * d'un sous-thème si l'IconBox est rendu dans un wrapper).
+ *
+ * Variantes :
+ * - `gradient` (défaut) : dégradé accent-9 → accent-11 avec icône blanche
+ * - `soft` : fond accent-a3 avec icône en accent-11
+ */
+export function IconBox({
+  icon: Icon,
+  size = 'md',
+  variant = 'gradient',
+  className,
+}: IconBoxProps) {
+  const config = SIZE_CONFIG[size];
+
+  const variantStyle: React.CSSProperties =
+    variant === 'gradient'
+      ? {
+          background:
+            'linear-gradient(135deg, var(--accent-9) 0%, var(--accent-11) 100%)',
+          color: 'white',
+          boxShadow: '0 1px 2px var(--accent-a5)',
+        }
+      : {
+          backgroundColor: 'var(--accent-a3)',
+          color: 'var(--accent-11)',
+        };
+
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: config.box,
+        height: config.box,
+        borderRadius: config.radius,
+        flexShrink: 0,
+        ...variantStyle,
+      }}
+    >
+      <Icon size={config.icon} strokeWidth={variant === 'gradient' ? 2.25 : 2} />
+    </span>
+  );
+}

--- a/tests/components/IconBox.test.tsx
+++ b/tests/components/IconBox.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { Settings, Bell } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { IconBox, type IconBoxSize } from '../../src/components/UI/IconBox/IconBox';
+
+const wrap = (ui: ReactNode) => render(<Theme>{ui}</Theme>);
+
+describe('IconBox', () => {
+  it('renders a span with aria-hidden and an svg child by default', () => {
+    const { container } = wrap(<IconBox icon={Settings} />);
+    const span = container.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span?.getAttribute('aria-hidden')).toBe('true');
+    expect(span?.querySelector('svg')).not.toBeNull();
+  });
+
+  it.each<[IconBoxSize, number, number]>([
+    ['sm', 24, 14],
+    ['md', 32, 18],
+    ['lg', 44, 24],
+  ])('applies the correct dimensions for size=%s', (size, boxPx, iconPx) => {
+    const { container } = wrap(<IconBox icon={Settings} size={size} />);
+    const span = container.querySelector('span') as HTMLSpanElement;
+    expect(span.style.width).toBe(`${boxPx}px`);
+    expect(span.style.height).toBe(`${boxPx}px`);
+
+    const svg = span.querySelector('svg') as SVGSVGElement;
+    expect(svg.getAttribute('width')).toBe(String(iconPx));
+    expect(svg.getAttribute('height')).toBe(String(iconPx));
+  });
+
+  it('applies the gradient variant signature styles', () => {
+    const { container } = wrap(<IconBox icon={Settings} variant="gradient" />);
+    const span = container.querySelector('span') as HTMLSpanElement;
+    const styleAttr = span.getAttribute('style') ?? '';
+    const color = span.style.color;
+    expect(color === 'white' || color === 'rgb(255, 255, 255)').toBe(true);
+    expect(styleAttr).toContain('var(--accent-a5)');
+    expect(styleAttr).not.toContain('var(--accent-a3)');
+  });
+
+  it('applies the soft variant signature styles without box-shadow', () => {
+    const { container } = wrap(<IconBox icon={Settings} variant="soft" />);
+    const span = container.querySelector('span') as HTMLSpanElement;
+    const styleAttr = span.getAttribute('style') ?? '';
+    expect(styleAttr).toContain('var(--accent-a3)');
+    expect(styleAttr).toContain('var(--accent-11)');
+    expect(styleAttr).not.toContain('var(--accent-a5)');
+  });
+
+  it('uses stroke-width 2.25 for gradient and 2 for soft', () => {
+    const gradient = wrap(<IconBox icon={Settings} variant="gradient" />);
+    const gradientSvg = gradient.container.querySelector('svg') as SVGSVGElement;
+    expect(gradientSvg.getAttribute('stroke-width')).toBe('2.25');
+
+    const soft = wrap(<IconBox icon={Settings} variant="soft" />);
+    const softSvg = soft.container.querySelector('svg') as SVGSVGElement;
+    expect(softSvg.getAttribute('stroke-width')).toBe('2');
+  });
+
+  it('applies an additional className while keeping inline styles', () => {
+    const { container } = wrap(
+      <IconBox icon={Settings} className="custom-class" />
+    );
+    const span = container.querySelector('span') as HTMLSpanElement;
+    expect(span.className).toBe('custom-class');
+    expect(span.style.width).toBe('32px');
+    expect(span.style.height).toBe('32px');
+  });
+
+  it('marks the container as decorative with aria-hidden', () => {
+    const { container } = wrap(<IconBox icon={Settings} />);
+    const span = container.querySelector('span') as HTMLSpanElement;
+    expect(span.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders the icon passed via the icon prop', () => {
+    const settings = wrap(<IconBox icon={Settings} />);
+    expect(settings.container.querySelector('svg')).not.toBeNull();
+
+    const bell = wrap(<IconBox icon={Bell} />);
+    expect(bell.container.querySelector('svg')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Introduces a new `IconBox` component that renders a Lucide icon inside a rounded container with theme-aware styling. The component automatically adapts to the Radix UI theme's accent color and supports multiple sizes and visual variants.

## Key Changes
- **New IconBox Component** (`src/components/UI/IconBox/IconBox.tsx`)
  - Displays Lucide icons in a centered, rounded container
  - Supports three sizes: `sm` (24px), `md` (32px), `lg` (44px)
  - Two visual variants: `gradient` (Windows 11-style with accent gradient) and `soft` (subtle background)
  - Automatically inherits accent color from parent Radix `<Theme>` component
  - Marked as decorative with `aria-hidden="true"`
  - Configurable stroke width per variant (2.25 for gradient, 2 for soft)

- **Comprehensive Storybook Stories** (`src/components/UI/IconBox/IconBox.stories.tsx`)
  - Default story with Settings icon
  - Size showcase (sm, md, lg)
  - Variant showcase (gradient, soft)
  - Theme accent color variations (indigo, green, orange, pink)
  - Real-world usage examples: sidebar navigation and page header

- **Full Test Coverage** (`tests/components/IconBox.test.tsx`)
  - Validates correct rendering and accessibility attributes
  - Tests all size configurations and their dimensions
  - Verifies variant-specific styling (gradient vs soft)
  - Confirms stroke width application
  - Tests custom className support
  - Validates icon rendering with different Lucide icons

## Implementation Details
- Uses inline styles for dynamic sizing and theming to ensure Radix theme tokens are properly applied
- Leverages Radix UI's CSS variable system (`var(--accent-*)`) for automatic theme integration
- Component is fully self-contained with no external dependencies beyond lucide-react and React types
- Follows accessibility best practices by marking decorative icons as hidden from screen readers

https://claude.ai/code/session_018pahMG28uJhhrWVd2Tmq5L