### PR TITLE
Add comprehensive test coverage for tab restore and session reordering

### DIFF
--- a/tests/sessionOrderUtils.test.ts
+++ b/tests/sessionOrderUtils.test.ts
@@ -4,8 +4,10 @@ import {
   moveSessionToLast,
   moveSessionToFirstInGroup,
   moveSessionToLastInGroup,
+  moveTabInGroup,
+  reassignTabToGroup,
 } from '../src/utils/sessionOrderUtils';
-import type { Session } from '../src/types/session';
+import type { SavedTab, SavedTabGroup, Session } from '../src/types/session';
 
 function makeSession(id: string): Session {
   const now = '2026-01-01T00:00:00.000Z';
@@ -19,6 +21,21 @@ function makeSession(id: string): Session {
     isPinned: false,
     categoryId: null,
   };
+}
+
+function makeTab(id: string): SavedTab {
+  return { id, title: `Tab ${id}`, url: `https://example.com/${id}` };
+}
+
+function makeGroup(id: string, tabs: SavedTab[]): SavedTabGroup {
+  return { id, title: `Group ${id}`, color: 'blue', tabs };
+}
+
+function makeSessionWithLayout(
+  groups: SavedTabGroup[],
+  ungroupedTabs: SavedTab[],
+): Session {
+  return { ...makeSession('session-1'), groups, ungroupedTabs };
 }
 
 const a = makeSession('a');
@@ -157,5 +174,201 @@ describe('moveSessionToLastInGroup', () => {
     const sessions = [pinA, a, b];
     const result = moveSessionToLastInGroup(sessions, 'unknown');
     expect(result).toBe(sessions);
+  });
+});
+
+describe('moveTabInGroup', () => {
+  describe('within ungrouped list (groupId === null)', () => {
+    it('moves a tab up within the ungrouped list', () => {
+      const t1 = makeTab('t1');
+      const t2 = makeTab('t2');
+      const t3 = makeTab('t3');
+      const session = makeSessionWithLayout([], [t1, t2, t3]);
+      const result = moveTabInGroup(session, 't2', 'up', null);
+      expect(result.ungroupedTabs.map(t => t.id)).toEqual(['t2', 't1', 't3']);
+    });
+
+    it('moves a tab down within the ungrouped list', () => {
+      const t1 = makeTab('t1');
+      const t2 = makeTab('t2');
+      const t3 = makeTab('t3');
+      const session = makeSessionWithLayout([], [t1, t2, t3]);
+      const result = moveTabInGroup(session, 't2', 'down', null);
+      expect(result.ungroupedTabs.map(t => t.id)).toEqual(['t1', 't3', 't2']);
+    });
+
+    it('returns the original session when moving up at the boundary', () => {
+      const t1 = makeTab('t1');
+      const t2 = makeTab('t2');
+      const session = makeSessionWithLayout([], [t1, t2]);
+      const result = moveTabInGroup(session, 't1', 'up', null);
+      expect(result).toBe(session);
+    });
+
+    it('returns the original session when moving down at the boundary', () => {
+      const t1 = makeTab('t1');
+      const t2 = makeTab('t2');
+      const session = makeSessionWithLayout([], [t1, t2]);
+      const result = moveTabInGroup(session, 't2', 'down', null);
+      expect(result).toBe(session);
+    });
+
+    it('returns the original session when the tab is not found in ungrouped', () => {
+      const t1 = makeTab('t1');
+      const session = makeSessionWithLayout([], [t1]);
+      const result = moveTabInGroup(session, 'unknown', 'up', null);
+      expect(result).toBe(session);
+    });
+  });
+
+  describe('within a specific group (groupId is a string)', () => {
+    it('moves a tab up within the specified group', () => {
+      const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2'), makeTab('t3')]);
+      const session = makeSessionWithLayout([g1], []);
+      const result = moveTabInGroup(session, 't3', 'up', 'g1');
+      expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 't3', 't2']);
+    });
+
+    it('moves a tab down within the specified group', () => {
+      const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2'), makeTab('t3')]);
+      const session = makeSessionWithLayout([g1], []);
+      const result = moveTabInGroup(session, 't1', 'down', 'g1');
+      expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t2', 't1', 't3']);
+    });
+
+    it('returns the original session when moving up at the boundary in a group', () => {
+      const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+      const session = makeSessionWithLayout([g1], []);
+      const result = moveTabInGroup(session, 't1', 'up', 'g1');
+      expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 't2']);
+    });
+
+    it('does not touch other groups when a target group is provided', () => {
+      const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+      const g2 = makeGroup('g2', [makeTab('u1'), makeTab('u2')]);
+      const session = makeSessionWithLayout([g1, g2], []);
+      const result = moveTabInGroup(session, 't1', 'down', 'g1');
+      expect(result.groups[1].tabs.map(t => t.id)).toEqual(['u1', 'u2']);
+    });
+  });
+
+  describe('auto-detection (groupId === undefined)', () => {
+    it('detects an ungrouped tab and moves it', () => {
+      const t1 = makeTab('t1');
+      const t2 = makeTab('t2');
+      const session = makeSessionWithLayout([makeGroup('g1', [makeTab('x1')])], [t1, t2]);
+      const result = moveTabInGroup(session, 't1', 'down');
+      expect(result.ungroupedTabs.map(t => t.id)).toEqual(['t2', 't1']);
+    });
+
+    it('detects a tab inside a group and moves it', () => {
+      const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+      const g2 = makeGroup('g2', [makeTab('u1'), makeTab('u2')]);
+      const session = makeSessionWithLayout([g1, g2], []);
+      const result = moveTabInGroup(session, 'u2', 'up');
+      expect(result.groups[1].tabs.map(t => t.id)).toEqual(['u2', 'u1']);
+    });
+
+    it('returns the original session when the tab cannot be found anywhere', () => {
+      const session = makeSessionWithLayout(
+        [makeGroup('g1', [makeTab('t1')])],
+        [makeTab('u1')],
+      );
+      const result = moveTabInGroup(session, 'unknown', 'up');
+      expect(result.ungroupedTabs.map(t => t.id)).toEqual(['u1']);
+      expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1']);
+    });
+  });
+});
+
+describe('reassignTabToGroup', () => {
+  it('moves a tab from one group to another and preserves relative order', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2'), makeTab('t3')]);
+    const g2 = makeGroup('g2', [makeTab('u1'), makeTab('u2')]);
+    const session = makeSessionWithLayout([g1, g2], []);
+    const result = reassignTabToGroup(session, 't2', 'g1', 'g2');
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 't3']);
+    expect(result.groups[1].tabs.map(t => t.id)).toEqual(['u1', 'u2', 't2']);
+  });
+
+  it('moves a grouped tab to ungrouped (targetGroupId === null)', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+    const session = makeSessionWithLayout([g1], [makeTab('u1')]);
+    const result = reassignTabToGroup(session, 't1', 'g1', null);
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t2']);
+    expect(result.ungroupedTabs.map(t => t.id)).toEqual(['u1', 't1']);
+  });
+
+  it('moves an ungrouped tab into a group (sourceGroupId === null)', () => {
+    const g1 = makeGroup('g1', [makeTab('t1')]);
+    const session = makeSessionWithLayout([g1], [makeTab('u1'), makeTab('u2')]);
+    const result = reassignTabToGroup(session, 'u1', null, 'g1');
+    expect(result.ungroupedTabs.map(t => t.id)).toEqual(['u2']);
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 'u1']);
+  });
+
+  it('moves a tab between groups using auto-detection (sourceGroupId === undefined)', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+    const g2 = makeGroup('g2', [makeTab('u1')]);
+    const session = makeSessionWithLayout([g1, g2], []);
+    const result = reassignTabToGroup(session, 't1', undefined, 'g2');
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t2']);
+    expect(result.groups[1].tabs.map(t => t.id)).toEqual(['u1', 't1']);
+  });
+
+  it('moves an ungrouped tab using auto-detection (sourceGroupId === undefined)', () => {
+    const g1 = makeGroup('g1', [makeTab('t1')]);
+    const session = makeSessionWithLayout([g1], [makeTab('u1'), makeTab('u2')]);
+    const result = reassignTabToGroup(session, 'u2', undefined, 'g1');
+    expect(result.ungroupedTabs.map(t => t.id)).toEqual(['u1']);
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 'u2']);
+  });
+
+  it('reorders within the same group when source equals target (tab moves to the end)', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2'), makeTab('t3')]);
+    const session = makeSessionWithLayout([g1], []);
+    const result = reassignTabToGroup(session, 't1', 'g1', 'g1');
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t2', 't3', 't1']);
+  });
+
+  it('reorders within ungrouped when source and target are both null', () => {
+    const session = makeSessionWithLayout([], [makeTab('u1'), makeTab('u2'), makeTab('u3')]);
+    const result = reassignTabToGroup(session, 'u1', null, null);
+    expect(result.ungroupedTabs.map(t => t.id)).toEqual(['u2', 'u3', 'u1']);
+  });
+
+  it('returns the original session when tabId is not found (explicit ungrouped source)', () => {
+    const session = makeSessionWithLayout([makeGroup('g1', [makeTab('t1')])], [makeTab('u1')]);
+    const result = reassignTabToGroup(session, 'unknown', null, 'g1');
+    expect(result).toBe(session);
+  });
+
+  it('returns the original session when tabId is not found (explicit group source)', () => {
+    const session = makeSessionWithLayout([makeGroup('g1', [makeTab('t1')])], [makeTab('u1')]);
+    const result = reassignTabToGroup(session, 'unknown', 'g1', null);
+    expect(result).toBe(session);
+  });
+
+  it('returns the original session when tabId is not found (auto-detected source)', () => {
+    const session = makeSessionWithLayout([makeGroup('g1', [makeTab('t1')])], [makeTab('u1')]);
+    const result = reassignTabToGroup(session, 'unknown', undefined, 'g1');
+    expect(result).toBe(session);
+  });
+
+  it('preserves relative order of remaining tabs in the source group', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2'), makeTab('t3'), makeTab('t4')]);
+    const g2 = makeGroup('g2', []);
+    const session = makeSessionWithLayout([g1, g2], []);
+    const result = reassignTabToGroup(session, 't2', 'g1', 'g2');
+    expect(result.groups[0].tabs.map(t => t.id)).toEqual(['t1', 't3', 't4']);
+    expect(result.groups[1].tabs.map(t => t.id)).toEqual(['t2']);
+  });
+
+  it('does not mutate the input session', () => {
+    const g1 = makeGroup('g1', [makeTab('t1'), makeTab('t2')]);
+    const session = makeSessionWithLayout([g1], [makeTab('u1')]);
+    const before = JSON.stringify(session);
+    reassignTabToGroup(session, 't1', 'g1', null);
+    expect(JSON.stringify(session)).toBe(before);
   });
 });

--- a/tests/tabRestore.test.ts
+++ b/tests/tabRestore.test.ts
@@ -426,4 +426,328 @@ describe('restoreTabs — current window', () => {
     expect(result.groupsCreated).toBe(0);
     expect(result.errors).toHaveLength(1);
   });
+
+  it('records an error when tabs.create fails for an ungrouped tab', async () => {
+    mockTabsCreate
+      .mockImplementationOnce(async () => ({ id: nextTabId() }))
+      .mockImplementationOnce(async () => { throw new Error('boom'); });
+
+    const result = await restoreTabs({
+      tabs: [makeTab('https://ok.com'), makeTab('https://fail.com')],
+      groups: [],
+      target: 'current',
+    });
+
+    expect(result.tabsCreated).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('https://fail.com');
+  });
+
+  it('falls back to create_new when groupAction is "merge" but no existingConflict matches', async () => {
+    const group = makeGroup('Work', [makeTab('https://a.com')]);
+    const analysis: ConflictAnalysis = {
+      duplicateTabs: [],
+      conflictingGroups: [],
+    } as unknown as ConflictAnalysis;
+    const resolution: ConflictResolution = {
+      duplicateTabAction: 'keep',
+      groupActions: new Map([['group-Work', 'merge']]),
+    } as unknown as ConflictResolution;
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [group],
+      target: 'current',
+      conflictAnalysis: analysis,
+      conflictResolution: resolution,
+    });
+
+    expect(mockTabsQuery).not.toHaveBeenCalled();
+    expect(mockTabsGroup).toHaveBeenCalledOnce();
+    const groupCall = mockTabsGroup.mock.calls[0][0];
+    expect(groupCall.groupId).toBeUndefined();
+    expect(result.groupsCreated).toBe(1);
+    expect(result.groupsMerged).toBe(0);
+  });
+
+  it('proceeds to create all tabs when tabs.query fails during merge (silent fallback)', async () => {
+    const group = makeGroup('Work', [
+      makeTab('https://a.com'),
+      makeTab('https://b.com'),
+    ]);
+    const analysis: ConflictAnalysis = {
+      duplicateTabs: [],
+      conflictingGroups: [{ savedGroup: group, existingGroupId: 500 }],
+    } as unknown as ConflictAnalysis;
+    const resolution: ConflictResolution = {
+      duplicateTabAction: 'keep',
+      groupActions: new Map([['group-Work', 'merge']]),
+    } as unknown as ConflictResolution;
+
+    mockTabsQuery.mockRejectedValue(new Error('query failed'));
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [group],
+      target: 'current',
+      conflictAnalysis: analysis,
+      conflictResolution: resolution,
+    });
+
+    expect(mockTabsCreate).toHaveBeenCalledTimes(2);
+    expect(result.tabsCreated).toBe(2);
+    expect(result.duplicatesSkipped).toBe(0);
+    expect(result.groupsMerged).toBe(1);
+  });
+
+  it('records an error when merging fails on tabs.group call', async () => {
+    const group = makeGroup('Work', [makeTab('https://a.com')]);
+    const analysis: ConflictAnalysis = {
+      duplicateTabs: [],
+      conflictingGroups: [{ savedGroup: group, existingGroupId: 500 }],
+    } as unknown as ConflictAnalysis;
+    const resolution: ConflictResolution = {
+      duplicateTabAction: 'keep',
+      groupActions: new Map([['group-Work', 'merge']]),
+    } as unknown as ConflictResolution;
+
+    mockTabsGroup.mockRejectedValue(new Error('merge failed'));
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [group],
+      target: 'current',
+      conflictAnalysis: analysis,
+      conflictResolution: resolution,
+    });
+
+    expect(result.tabsCreated).toBe(1);
+    expect(result.groupsMerged).toBe(0);
+    expect(result.errors.some(e => e.toLowerCase().includes('merge'))).toBe(true);
+  });
+
+  it('processes a mix of successful and failing groups without aborting the loop', async () => {
+    const okGroup = makeGroup('Ok', [makeTab('https://ok.com')]);
+    const failGroup = makeGroup('Fail', [makeTab('https://fail.com')]);
+    const okGroup2 = makeGroup('Ok2', [makeTab('https://ok2.com')]);
+
+    // First group succeeds, second group's tabs.group call fails, third group succeeds.
+    let groupCall = 0;
+    mockTabsGroup.mockImplementation(async () => {
+      groupCall++;
+      if (groupCall === 2) throw new Error('group failed');
+      return 100 + groupCall;
+    });
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [okGroup, failGroup, okGroup2],
+      target: 'current',
+    });
+
+    expect(result.tabsCreated).toBe(3);
+    expect(result.groupsCreated).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Fail');
+  });
+
+  it('continues processing groups after a tab creation error inside a previous group', async () => {
+    const g1 = makeGroup('G1', [
+      makeTab('https://g1a.com'),
+      makeTab('https://g1b.com'),
+    ]);
+    const g2 = makeGroup('G2', [makeTab('https://g2.com')]);
+
+    // First call OK (g1a), second fails (g1b), third OK (g2).
+    mockTabsCreate
+      .mockImplementationOnce(async () => ({ id: nextTabId() }))
+      .mockImplementationOnce(async () => { throw new Error('boom'); })
+      .mockImplementationOnce(async () => ({ id: nextTabId() }));
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [g1, g2],
+      target: 'current',
+    });
+
+    expect(result.tabsCreated).toBe(2);
+    expect(result.groupsCreated).toBe(2); // g1 still creates with 1 tab, g2 creates with 1 tab
+    expect(result.errors.some(e => e.includes('https://g1b.com'))).toBe(true);
+  });
+});
+
+describe('restoreTabs — replace target', () => {
+  it('closes existing non-pinned tabs and creates new ones', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, pinned: false },
+      { id: 2, pinned: false },
+      { id: 3, pinned: false },
+    ]);
+
+    const result = await restoreTabs({
+      tabs: [makeTab('https://new.com')],
+      groups: [],
+      target: 'replace',
+    });
+
+    expect(mockTabsCreate).toHaveBeenCalledWith({ url: 'https://new.com' });
+    expect(mockTabsRemove).toHaveBeenCalledWith([1, 2, 3]);
+    expect(result.tabsCreated).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('preserves pinned tabs from being closed', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, pinned: true },
+      { id: 2, pinned: false },
+      { id: 3, pinned: true },
+    ]);
+
+    await restoreTabs({
+      tabs: [makeTab('https://new.com')],
+      groups: [],
+      target: 'replace',
+    });
+
+    expect(mockTabsRemove).toHaveBeenCalledWith([2]);
+  });
+
+  it('preserves the protectedTabId from being closed', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, pinned: false },
+      { id: 2, pinned: false },
+      { id: 99, pinned: false },
+    ]);
+
+    await restoreTabs({
+      tabs: [makeTab('https://new.com')],
+      groups: [],
+      target: 'replace',
+      protectedTabId: 99,
+    });
+
+    expect(mockTabsRemove).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('does not call tabs.remove when no tabs need to be closed (only pinned + protected exist)', async () => {
+    mockTabsQuery.mockResolvedValue([
+      { id: 1, pinned: true },
+      { id: 99, pinned: false },
+    ]);
+
+    await restoreTabs({
+      tabs: [makeTab('https://new.com')],
+      groups: [],
+      target: 'replace',
+      protectedTabId: 99,
+    });
+
+    expect(mockTabsRemove).not.toHaveBeenCalled();
+  });
+
+  it('records an error when tabs.remove fails but still completes the restore', async () => {
+    mockTabsQuery.mockResolvedValue([{ id: 1, pinned: false }]);
+    mockTabsRemove.mockRejectedValue(new Error('remove failed'));
+
+    const result = await restoreTabs({
+      tabs: [makeTab('https://new.com')],
+      groups: [],
+      target: 'replace',
+    });
+
+    expect(result.tabsCreated).toBe(1);
+    expect(result.errors.some(e => e.toLowerCase().includes('failed to close'))).toBe(true);
+  });
+
+  it('restores groups in replace mode (delegates to restoreInCurrentWindow)', async () => {
+    mockTabsQuery.mockResolvedValue([{ id: 1, pinned: false }]);
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [makeGroup('Work', [makeTab('https://w1.com'), makeTab('https://w2.com')])],
+      target: 'replace',
+    });
+
+    expect(mockTabsCreate).toHaveBeenCalledTimes(2);
+    expect(mockTabsGroup).toHaveBeenCalledOnce();
+    expect(mockTabsRemove).toHaveBeenCalledWith([1]);
+    expect(result.groupsCreated).toBe(1);
+    expect(result.tabsCreated).toBe(2);
+  });
+});
+
+describe('restoreTabs — new window edge cases', () => {
+  it('opens a blank window when there are no tabs and no groups', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [],
+      target: 'new',
+    });
+
+    expect(mockWindowsCreate).toHaveBeenCalledWith({ url: undefined });
+    expect(mockTabsCreate).not.toHaveBeenCalled();
+    expect(result.tabsCreated).toBe(0);
+    expect(result.windowId).toBe(42);
+    // Default tab is left in place since no other tabs were created
+    expect(mockTabsRemove).not.toHaveBeenCalled();
+  });
+
+  it('records an error when a group tab creation fails in a new window', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+    mockTabsCreate.mockRejectedValue(new Error('tab create failed'));
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [makeGroup('Work', [makeTab('https://a.com'), makeTab('https://b.com')])],
+      target: 'new',
+    });
+
+    // First tab consumed from windows.create (a.com). b.com fails via tabs.create.
+    expect(result.tabsCreated).toBe(1);
+    expect(result.errors.some(e => e.includes('https://b.com'))).toBe(true);
+    // Group should still be created from the consumed firstTabId
+    expect(mockTabsGroup).toHaveBeenCalledOnce();
+  });
+
+  it('records an error when tabs.group fails in a new window', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+    mockTabsGroup.mockRejectedValue(new Error('group failed'));
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [makeGroup('Work', [makeTab('https://a.com')])],
+      target: 'new',
+    });
+
+    expect(result.tabsCreated).toBe(1);
+    expect(result.groupsCreated).toBe(0);
+    expect(result.errors.some(e => e.includes('Work'))).toBe(true);
+  });
+
+  it('processes mixed success and failure across groups in a new window', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    let groupCall = 0;
+    mockTabsGroup.mockImplementation(async () => {
+      groupCall++;
+      if (groupCall === 1) throw new Error('group failed');
+      return 200 + groupCall;
+    });
+
+    const result = await restoreTabs({
+      tabs: [],
+      groups: [
+        makeGroup('Fail', [makeTab('https://fail.com')]),
+        makeGroup('Ok', [makeTab('https://ok.com')]),
+      ],
+      target: 'new',
+    });
+
+    expect(result.tabsCreated).toBe(2);
+    expect(result.groupsCreated).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Fail');
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for tab restoration edge cases and new session reordering utility functions. The changes focus on improving test quality and ensuring robust error handling across various scenarios.

## Key Changes

### Tab Restoration Tests (`tabRestore.test.ts`)
- **Error handling for ungrouped tabs**: Added test for recording errors when `tabs.create` fails for individual tabs
- **Group merge fallback logic**: Tests for fallback to `create_new` when merge action has no matching existing group
- **Merge operation error handling**: Tests for silent fallback when `tabs.query` fails during merge, and error recording when `tabs.group` fails
- **Mixed success/failure scenarios**: Tests ensuring the restoration process continues processing groups/tabs even when individual operations fail
- **Replace target mode**: Comprehensive tests for closing non-pinned tabs while preserving pinned and protected tabs, with error handling
- **New window mode edge cases**: Tests for blank window creation, tab creation failures in groups, group creation failures, and mixed success/failure scenarios across multiple groups

### Session Reordering Utilities Tests (`sessionOrderUtils.test.ts`)
- **`moveTabInGroup` function**: Tests for moving tabs up/down within ungrouped lists and specific groups, boundary conditions, and auto-detection of tab location
- **`reassignTabToGroup` function**: Tests for moving tabs between groups, from grouped to ungrouped (and vice versa), auto-detection of source group, reordering within the same group, and immutability guarantees

## Notable Implementation Details
- Tests verify that operations continue gracefully when individual steps fail, rather than aborting the entire process
- Comprehensive boundary condition testing ensures edge cases like moving tabs at list boundaries are handled correctly
- Auto-detection tests confirm that functions can locate tabs across both grouped and ungrouped collections
- Immutability tests ensure session objects are not mutated during reordering operations

https://claude.ai/code/session_01PNbuWNSFJfdtrxGFMv168D