### PR TITLE
feat(shortcuts): add keyboard shortcuts infra (util + hook + tests)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -546,5 +546,41 @@
   "statsTrendUpAria": { "message": "Trending up" },
   "statsTrendDownAria": { "message": "Trending down" },
   "statsTopRulesTitle": { "message": "Most active rules (30 days)" },
-  "statsGroupingsAndDedup": { "message": "{grouping} groupings, {dedup} deduplications" }
+  "statsGroupingsAndDedup": { "message": "{grouping} groupings, {dedup} deduplications" },
+
+  "cmdOrganizeAllTabs": { "message": "Organize all tabs in the current window" },
+  "cmdSaveSession": { "message": "Save the current window as a session" },
+
+  "shortcutsPanelTitle": { "message": "Keyboard shortcuts" },
+  "shortcutsPanelDescription": { "message": "Quick reference for all available shortcuts." },
+  "shortcutsPanelClose": { "message": "Close shortcuts panel" },
+  "shortcutsPanelToggleAria": { "message": "Show keyboard shortcuts" },
+  "shortcutsCustomize": { "message": "Customize browser shortcuts" },
+  "shortcutsCustomizeFirefoxHint": { "message": "Firefox: open the gear menu, then 'Manage Extension Shortcuts'." },
+
+  "shortcutsGroupGlobal": { "message": "Browser-wide" },
+  "shortcutsGroupPopup": { "message": "Popup" },
+  "shortcutsGroupOptions": { "message": "Options page" },
+  "shortcutsGroupLists": { "message": "Lists (rules and sessions)" },
+  "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
+
+  "shortcutDescOrganize": { "message": "Organize all tabs" },
+  "shortcutDescSaveSession": { "message": "Save current window as a session" },
+  "shortcutDescOpenPopup": { "message": "Open the extension popup" },
+  "shortcutDescPopupSave": { "message": "Save snapshot" },
+  "shortcutDescPopupRestore": { "message": "Open sessions" },
+  "shortcutDescPopupOrganize": { "message": "Organize all tabs" },
+  "shortcutDescOpenShortcutsHelp": { "message": "Show this shortcuts panel" },
+  "shortcutDescNavigateTabs": { "message": "Switch sidebar tab" },
+  "shortcutDescFocusSearch": { "message": "Focus the search field" },
+  "shortcutDescClearSearch": { "message": "Clear search or close panel" },
+  "shortcutDescListNavigate": { "message": "Move focus between cards" },
+  "shortcutDescListNew": { "message": "Create new item" },
+  "shortcutDescListEdit": { "message": "Edit focused item" },
+  "shortcutDescListDelete": { "message": "Delete focused item" },
+  "shortcutDescListPin": { "message": "Pin or unpin focused session" },
+  "shortcutDescSessionRestoreCustom": { "message": "Custom restore (wizard)" },
+  "shortcutDescSessionRestoreCurrent": { "message": "Add session to current window" },
+  "shortcutDescSessionReplaceCurrent": { "message": "Replace current window tabs" },
+  "shortcutDescSessionRestoreNew": { "message": "Open session in a new window" }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -547,5 +547,41 @@
   "statsTrendUpAria": { "message": "En alza" },
   "statsTrendDownAria": { "message": "En baja" },
   "statsTopRulesTitle": { "message": "Reglas más activas (30 días)" },
-  "statsGroupingsAndDedup": { "message": "{grouping} agrupaciones, {dedup} deduplicaciones" }
+  "statsGroupingsAndDedup": { "message": "{grouping} agrupaciones, {dedup} deduplicaciones" },
+
+  "cmdOrganizeAllTabs": { "message": "Organizar todas las pestañas de la ventana" },
+  "cmdSaveSession": { "message": "Guardar la ventana actual como sesión" },
+
+  "shortcutsPanelTitle": { "message": "Atajos de teclado" },
+  "shortcutsPanelDescription": { "message": "Referencia rápida de todos los atajos disponibles." },
+  "shortcutsPanelClose": { "message": "Cerrar el panel de atajos" },
+  "shortcutsPanelToggleAria": { "message": "Mostrar atajos de teclado" },
+  "shortcutsCustomize": { "message": "Personalizar atajos del navegador" },
+  "shortcutsCustomizeFirefoxHint": { "message": "Firefox: abre el menú de engranaje y luego 'Administrar atajos de extensiones'." },
+
+  "shortcutsGroupGlobal": { "message": "Globales (navegador)" },
+  "shortcutsGroupPopup": { "message": "Popup" },
+  "shortcutsGroupOptions": { "message": "Página de opciones" },
+  "shortcutsGroupLists": { "message": "Listas (reglas y sesiones)" },
+  "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
+
+  "shortcutDescOrganize": { "message": "Organizar todas las pestañas" },
+  "shortcutDescSaveSession": { "message": "Guardar la ventana como sesión" },
+  "shortcutDescOpenPopup": { "message": "Abrir el popup de la extensión" },
+  "shortcutDescPopupSave": { "message": "Guardar instantánea" },
+  "shortcutDescPopupRestore": { "message": "Abrir sesiones" },
+  "shortcutDescPopupOrganize": { "message": "Organizar todas las pestañas" },
+  "shortcutDescOpenShortcutsHelp": { "message": "Mostrar este panel de atajos" },
+  "shortcutDescNavigateTabs": { "message": "Cambiar de pestaña en la barra lateral" },
+  "shortcutDescFocusSearch": { "message": "Enfocar el campo de búsqueda" },
+  "shortcutDescClearSearch": { "message": "Borrar la búsqueda o cerrar el panel" },
+  "shortcutDescListNavigate": { "message": "Mover el foco entre tarjetas" },
+  "shortcutDescListNew": { "message": "Crear nuevo elemento" },
+  "shortcutDescListEdit": { "message": "Editar el elemento con foco" },
+  "shortcutDescListDelete": { "message": "Eliminar el elemento con foco" },
+  "shortcutDescListPin": { "message": "Anclar o desanclar la sesión con foco" },
+  "shortcutDescSessionRestoreCustom": { "message": "Restauración personalizada (asistente)" },
+  "shortcutDescSessionRestoreCurrent": { "message": "Añadir la sesión a la ventana actual" },
+  "shortcutDescSessionReplaceCurrent": { "message": "Reemplazar las pestañas de la ventana" },
+  "shortcutDescSessionRestoreNew": { "message": "Abrir la sesión en una nueva ventana" }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -547,5 +547,41 @@
   "statsTrendUpAria": { "message": "En hausse" },
   "statsTrendDownAria": { "message": "En baisse" },
   "statsTopRulesTitle": { "message": "Règles les plus actives (30 jours)" },
-  "statsGroupingsAndDedup": { "message": "{grouping} groupages, {dedup} déduplications" }
+  "statsGroupingsAndDedup": { "message": "{grouping} groupages, {dedup} déduplications" },
+
+  "cmdOrganizeAllTabs": { "message": "Organiser tous les onglets de la fenêtre" },
+  "cmdSaveSession": { "message": "Enregistrer la fenêtre courante en session" },
+
+  "shortcutsPanelTitle": { "message": "Raccourcis clavier" },
+  "shortcutsPanelDescription": { "message": "Référence rapide de tous les raccourcis disponibles." },
+  "shortcutsPanelClose": { "message": "Fermer le panneau des raccourcis" },
+  "shortcutsPanelToggleAria": { "message": "Afficher les raccourcis clavier" },
+  "shortcutsCustomize": { "message": "Personnaliser les raccourcis du navigateur" },
+  "shortcutsCustomizeFirefoxHint": { "message": "Firefox : ouvrez le menu d'engrenage, puis 'Gérer les raccourcis des extensions'." },
+
+  "shortcutsGroupGlobal": { "message": "Globaux navigateur" },
+  "shortcutsGroupPopup": { "message": "Popup" },
+  "shortcutsGroupOptions": { "message": "Page d'options" },
+  "shortcutsGroupLists": { "message": "Listes (règles et sessions)" },
+  "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
+
+  "shortcutDescOrganize": { "message": "Organiser tous les onglets" },
+  "shortcutDescSaveSession": { "message": "Enregistrer la fenêtre comme session" },
+  "shortcutDescOpenPopup": { "message": "Ouvrir la popup de l'extension" },
+  "shortcutDescPopupSave": { "message": "Enregistrer un snapshot" },
+  "shortcutDescPopupRestore": { "message": "Ouvrir les sessions" },
+  "shortcutDescPopupOrganize": { "message": "Organiser tous les onglets" },
+  "shortcutDescOpenShortcutsHelp": { "message": "Afficher ce panneau de raccourcis" },
+  "shortcutDescNavigateTabs": { "message": "Changer d'onglet de la barre latérale" },
+  "shortcutDescFocusSearch": { "message": "Focus sur le champ de recherche" },
+  "shortcutDescClearSearch": { "message": "Effacer la recherche ou fermer le panneau" },
+  "shortcutDescListNavigate": { "message": "Déplacer le focus entre les cartes" },
+  "shortcutDescListNew": { "message": "Créer un nouvel élément" },
+  "shortcutDescListEdit": { "message": "Modifier l'élément focus" },
+  "shortcutDescListDelete": { "message": "Supprimer l'élément focus" },
+  "shortcutDescListPin": { "message": "Épingler ou désépingler la session focus" },
+  "shortcutDescSessionRestoreCustom": { "message": "Restauration personnalisée (assistant)" },
+  "shortcutDescSessionRestoreCurrent": { "message": "Ajouter la session à la fenêtre courante" },
+  "shortcutDescSessionReplaceCurrent": { "message": "Remplacer les onglets de la fenêtre" },
+  "shortcutDescSessionRestoreNew": { "message": "Ouvrir la session dans une nouvelle fenêtre" }
 }

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -12,6 +12,7 @@ import {
 import { processTabForDeduplication } from './deduplication.js';
 import { processGroupingForNewTab } from './grouping.js';
 import { handleOrganizeAllTabs } from './organize.js';
+import { openOptionsWithHash } from '@/utils/openOptions.js';
 import type { BackgroundMessage, MessageResponse } from '@/types/messages.js';
 
 function isBackgroundMessage(value: unknown): value is BackgroundMessage {
@@ -26,6 +27,27 @@ export function setupInstallationHandler(): void {
         await initializeDefaults();
         await seedBuiltInCategories();
         await initCategoriesStore();
+    });
+}
+
+export function setupCommandHandler(): void {
+    const commands = (browser as unknown as { commands?: { onCommand?: { addListener: (cb: (name: string) => void) => void } } }).commands;
+    if (!commands?.onCommand) {
+        logger.debug('[COMMANDS] browser.commands.onCommand unavailable, skipping handler.');
+        return;
+    }
+    commands.onCommand.addListener((name: string) => {
+        logger.debug('[COMMANDS] received', name);
+        if (name === 'organize-all-tabs') {
+            browser.windows.getCurrent()
+                .then(win => { if (win.id != null) return handleOrganizeAllTabs(win.id); })
+                .catch(e => logger.error('[COMMANDS] organize-all-tabs failed:', e));
+            return;
+        }
+        if (name === 'save-current-window-session') {
+            openOptionsWithHash('#sessions?action=snapshot')
+                .catch(e => logger.error('[COMMANDS] save-current-window-session failed:', e));
+        }
     });
 }
 
@@ -231,6 +253,7 @@ async function flushPendingGroupingOnComplete(
 export function setupAllEventHandlers(): void {
     setupInstallationHandler();
     setupMessageHandler();
+    setupCommandHandler();
     setupTabCreatedHandler();
     setupTabUpdatedHandler();
     setupTabRemovedHandler();

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.module.css
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.module.css
@@ -1,0 +1,9 @@
+.pinnedCard {
+  cursor: default;
+  outline: none;
+}
+
+.pinnedCard:focus-visible {
+  outline: 2px solid var(--accent-9);
+  outline-offset: 1px;
+}

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -223,7 +223,14 @@ export function PopupProfilesList() {
     <Flex direction="column" gap="2">
       <Box style={{ paddingLeft: 4 }}>{sectionLabel}</Box>
 
-      <Flex ref={listRef} data-testid="popup-profiles-list" direction="column" gap="2">
+      <Flex
+        ref={listRef}
+        data-testid="popup-profiles-list"
+        direction="column"
+        gap="2"
+        role="list"
+        aria-label={getMessage('popupPinnedSessionsLabel')}
+      >
         {pinnedSessions.map((session, index) => (
           <Card
             key={session.id}

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Button, Card, Flex, Text } from '@radix-ui/themes';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { browser } from 'wxt/browser';
@@ -12,6 +12,7 @@ import { getRuleCategory } from '@/utils/categoriesStore';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { popupPinnedEmptyCollapsedItem } from '@/utils/storageItems';
 import type { Session } from '@/types/session';
+import styles from './PopupProfilesList.module.css';
 
 function getCategoryIcon(categoryId: string | null | undefined): React.ReactNode {
   const cat = getRuleCategory(categoryId);
@@ -78,6 +79,7 @@ export function PopupProfilesList() {
   const [hasAnySession, setHasAnySession] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [emptyCollapsed, setEmptyCollapsed] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     loadSessions().then((all) => {
@@ -88,7 +90,7 @@ export function PopupProfilesList() {
     popupPinnedEmptyCollapsedItem.getValue().then(setEmptyCollapsed);
   }, []);
 
-  function handleRestore(session: Session, target: RestoreTarget) {
+  const handleRestore = useCallback((session: Session, target: RestoreTarget) => {
     // The popup is not a tab, so browser.tabs.getCurrent() returns undefined,
     // which means every non-pinned tab in the active window is replaced.
     restoreSessionTabs(session, target)
@@ -102,7 +104,46 @@ export function PopupProfilesList() {
         }
       })
       .catch(() => {});
-  }
+  }, []);
+
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, session: Session, index: number) => {
+    if (e.target !== e.currentTarget) return;
+    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-popup-pinned-card]');
+    if (!cards) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      cards[index + 1]?.focus();
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      cards[index - 1]?.focus();
+      return;
+    }
+    if (e.key === 'Home') {
+      e.preventDefault();
+      cards[0]?.focus();
+      return;
+    }
+    if (e.key === 'End') {
+      e.preventDefault();
+      cards[cards.length - 1]?.focus();
+      return;
+    }
+    if (e.key.toLowerCase() === 'r' && !e.ctrlKey && !e.metaKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.altKey && e.shiftKey) {
+        handleRestore(session, 'new');
+      } else if (e.altKey) {
+        handleRestore(session, 'replace');
+      } else if (e.shiftKey) {
+        handleRestore(session, 'current');
+      } else {
+        void openCustomizeRestore(session);
+      }
+    }
+  }, [handleRestore]);
 
   function handleToggleEmptyCollapsed(nextOpen: boolean) {
     const nextCollapsed = !nextOpen;
@@ -182,12 +223,18 @@ export function PopupProfilesList() {
     <Flex direction="column" gap="2">
       <Box style={{ paddingLeft: 4 }}>{sectionLabel}</Box>
 
-      <Flex data-testid="popup-profiles-list" direction="column" gap="2">
-        {pinnedSessions.map((session) => (
+      <Flex ref={listRef} data-testid="popup-profiles-list" direction="column" gap="2">
+        {pinnedSessions.map((session, index) => (
           <Card
             key={session.id}
             data-testid={`popup-profile-item-${session.id}`}
+            data-popup-pinned-card=""
             size="1"
+            tabIndex={0}
+            role="listitem"
+            aria-label={session.name}
+            className={styles.pinnedCard}
+            onKeyDown={(e) => handleCardKeyDown(e, session, index)}
           >
             <Flex align="center" gap="3" style={{ minWidth: 0 }}>
               <Flex align="center" style={{ flexShrink: 0 }}>

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -4,22 +4,7 @@ import { browser } from 'wxt/browser';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
 import { hasCapturableTabs } from '@/utils/tabCapture';
-
-/** Focus an existing Options tab or open a new one with the given hash. */
-async function openOptionsWithHash(hash: string) {
-  const optionsUrl = browser.runtime.getURL('/options.html');
-  const allTabs = await browser.tabs.query({});
-  const existing = allTabs.find((t) => t.url?.startsWith(optionsUrl));
-
-  if (existing?.id != null) {
-    await browser.tabs.update(existing.id, { url: optionsUrl + hash, active: true });
-    if (existing.windowId != null) {
-      await browser.windows.update(existing.windowId, { focused: true });
-    }
-  } else {
-    await browser.tabs.create({ url: optionsUrl + hash });
-  }
-}
+import { openOptionsWithHash } from '@/utils/openOptions';
 
 const actionButtonStyle: React.CSSProperties = {
   flex: 1,

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.module.css
@@ -1,0 +1,44 @@
+.aside {
+  display: flex;
+  flex-direction: column;
+  background: var(--gray-a2);
+  border-left: 1px solid var(--gray-a4);
+  overflow: hidden;
+  transition: width 200ms ease-in-out;
+  flex-shrink: 0;
+}
+
+.asideOpen {
+  width: 360px;
+}
+
+.asideClosed {
+  width: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 14px 16px 10px 20px;
+  border-bottom: 1px solid var(--gray-a3);
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  /* Avoid horizontal flicker when the parent width animates. */
+  width: 360px;
+  box-sizing: border-box;
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Flex } from '@radix-ui/themes';
+import { ShortcutsAside } from './ShortcutsAside';
+
+const meta = {
+  title: 'Components/UI/ShortcutsPanel/ShortcutsAside',
+  component: ShortcutsAside,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <Flex style={{ height: 600, alignItems: 'stretch' }}>
+        <div style={{ flex: 1, padding: 16 }}>Mock options content (squeezed when panel opens)</div>
+        <Story />
+      </Flex>
+    ),
+  ],
+} satisfies Meta<typeof ShortcutsAside>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ShortcutsAsideOpen: Story = {
+  args: {
+    open: true,
+    onClose: () => {},
+  },
+};
+
+export const ShortcutsAsideClosed: Story = {
+  args: {
+    open: false,
+    onClose: () => {},
+  },
+};

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
@@ -19,6 +19,7 @@ interface ShortcutsAsideProps {
  * and the close button takes focus. On close, focus is restored.
  */
 export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
+  const asideRef = useRef<HTMLElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const wasOpenRef = useRef(false);
@@ -35,12 +36,26 @@ export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
     wasOpenRef.current = open;
   }, [open]);
 
+  // Use the inert attribute (rather than aria-hidden + tabindex=-1) when closed,
+  // so the panel and its children are removed from interaction and the AT tree
+  // without triggering the aria-hidden-focus axe rule. React 18 typings do not
+  // expose inert as a prop, so we toggle it via the ref.
+  useEffect(() => {
+    const node = asideRef.current;
+    if (!node) return;
+    if (open) {
+      node.removeAttribute('inert');
+    } else {
+      node.setAttribute('inert', '');
+    }
+  }, [open]);
+
   return (
     <aside
+      ref={asideRef}
       data-testid="shortcuts-aside"
       data-state={open ? 'open' : 'closed'}
       aria-label={getMessage('shortcutsPanelTitle')}
-      aria-hidden={!open}
       className={`${styles.aside} ${open ? styles.asideOpen : styles.asideClosed}`}
     >
       <div className={styles.header}>
@@ -58,7 +73,6 @@ export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
           aria-label={getMessage('shortcutsPanelClose')}
           title={getMessage('shortcutsPanelClose')}
           onClick={onClose}
-          tabIndex={open ? 0 : -1}
           data-testid="shortcuts-aside-close"
         >
           <X size={14} aria-hidden="true" />

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import { Flex, IconButton, Text } from '@radix-ui/themes';
+import { Keyboard, X } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { ShortcutsContent } from './ShortcutsContent';
+import styles from './ShortcutsAside.module.css';
+
+interface ShortcutsAsideProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Non-modal side panel used in the options page. Unlike a Radix Dialog this
+ * stays inline in the layout (squeeze) and the rest of the page remains
+ * interactive while the panel is visible.
+ *
+ * Focus management: when opening, the previously-focused element is captured
+ * and the close button takes focus. On close, focus is restored.
+ */
+export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      previousActiveElementRef.current = document.activeElement as HTMLElement | null;
+      // Wait one frame so the panel is in the DOM and visible.
+      requestAnimationFrame(() => closeButtonRef.current?.focus());
+    } else if (!open && wasOpenRef.current) {
+      previousActiveElementRef.current?.focus?.();
+      previousActiveElementRef.current = null;
+    }
+    wasOpenRef.current = open;
+  }, [open]);
+
+  return (
+    <aside
+      data-testid="shortcuts-aside"
+      data-state={open ? 'open' : 'closed'}
+      aria-label={getMessage('shortcutsPanelTitle')}
+      aria-hidden={!open}
+      className={`${styles.aside} ${open ? styles.asideOpen : styles.asideClosed}`}
+    >
+      <div className={styles.header}>
+        <div className={styles.headerTitle}>
+          <Keyboard size={16} aria-hidden="true" />
+          <Text size="2" weight="bold">
+            {getMessage('shortcutsPanelTitle')}
+          </Text>
+        </div>
+        <IconButton
+          ref={closeButtonRef}
+          size="1"
+          variant="ghost"
+          color="gray"
+          aria-label={getMessage('shortcutsPanelClose')}
+          title={getMessage('shortcutsPanelClose')}
+          onClick={onClose}
+          tabIndex={open ? 0 : -1}
+          data-testid="shortcuts-aside-close"
+        >
+          <X size={14} aria-hidden="true" />
+        </IconButton>
+      </div>
+      <Flex direction="column" className={styles.body}>
+        <ShortcutsContent />
+      </Flex>
+    </aside>
+  );
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -1,0 +1,59 @@
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 6px;
+  font-family: var(--default-font-family);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--gray-12);
+  background: var(--gray-a3);
+  border: 1px solid var(--gray-a5);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-2);
+  white-space: nowrap;
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 4px 0;
+}
+
+.rowDescription {
+  flex: 1;
+  min-width: 0;
+}
+
+.rowKeys {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.altSeparator {
+  color: var(--gray-a9);
+  font-size: 11px;
+}
+
+.plus {
+  color: var(--gray-a9);
+  font-size: 10px;
+  user-select: none;
+}
+
+.groupTitle {
+  margin-bottom: 4px;
+}
+
+.firefoxHint {
+  margin-top: 4px;
+  color: var(--gray-11);
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@radix-ui/themes';
+import { ShortcutsContent } from './ShortcutsContent';
+
+const meta = {
+  title: 'Components/UI/ShortcutsPanel/ShortcutsContent',
+  component: ShortcutsContent,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <Box style={{ width: 360 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof ShortcutsContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ShortcutsContentDefault: Story = {};
+
+export const ShortcutsContentSingleGroup: Story = {
+  args: {
+    groups: [
+      {
+        titleKey: 'shortcutsGroupSessionCard',
+        shortcuts: [
+          { keys: ['R'], descriptionKey: 'shortcutDescSessionRestoreCustom' },
+          { keys: ['Shift+R'], descriptionKey: 'shortcutDescSessionRestoreCurrent' },
+          { keys: ['Alt+R'], descriptionKey: 'shortcutDescSessionReplaceCurrent' },
+          { keys: ['Alt+Shift+R'], descriptionKey: 'shortcutDescSessionRestoreNew' },
+        ],
+      },
+    ],
+  },
+};

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Box, Button, Flex, Text } from '@radix-ui/themes';
+import { ExternalLink } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { getShortcutsCustomizeInfo, openShortcutsCustomizePage } from '@/utils/browserUrls';
+import { SHORTCUT_GROUPS, type ShortcutDisplay, type ShortcutGroup } from './shortcuts';
+import styles from './ShortcutsContent.module.css';
+
+interface ShortcutsContentProps {
+  /** Optional override of the groups to display (defaults to SHORTCUT_GROUPS). */
+  groups?: ShortcutGroup[];
+}
+
+export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentProps) {
+  const { isDirect } = getShortcutsCustomizeInfo();
+  return (
+    <Flex direction="column" gap="4" data-testid="shortcuts-content">
+      {groups.map((group) => (
+        <Box key={group.titleKey}>
+          <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
+            {getMessage(group.titleKey)}
+          </Text>
+          <Flex direction="column">
+            {group.shortcuts.map((shortcut) => (
+              <ShortcutRow key={shortcut.descriptionKey} shortcut={shortcut} />
+            ))}
+          </Flex>
+        </Box>
+      ))}
+      <Box>
+        <Button
+          variant="ghost"
+          size="1"
+          onClick={() => void openShortcutsCustomizePage()}
+          data-testid="shortcuts-customize-button"
+        >
+          <ExternalLink size={12} aria-hidden="true" />
+          {getMessage('shortcutsCustomize')}
+        </Button>
+        {!isDirect && (
+          <Text as="p" size="1" className={styles.firefoxHint}>
+            {getMessage('shortcutsCustomizeFirefoxHint')}
+          </Text>
+        )}
+      </Box>
+    </Flex>
+  );
+}
+
+function ShortcutRow({ shortcut }: { shortcut: ShortcutDisplay }) {
+  return (
+    <div className={styles.row}>
+      <Text size="2" className={styles.rowDescription}>
+        {getMessage(shortcut.descriptionKey)}
+      </Text>
+      <div className={styles.rowKeys}>
+        {shortcut.keys.map((combo, index) => (
+          <React.Fragment key={combo}>
+            {index > 0 && <span className={styles.altSeparator} aria-hidden="true">/</span>}
+            <KeyCombo combo={combo} />
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function KeyCombo({ combo }: { combo: string }) {
+  const tokens = combo.split('+');
+  return (
+    <Flex gap="1" align="center">
+      {tokens.map((token, i) => (
+        <React.Fragment key={`${token}-${i}`}>
+          {i > 0 && <span className={styles.plus} aria-hidden="true">+</span>}
+          <kbd className={styles.kbd}>{token}</kbd>
+        </React.Fragment>
+      ))}
+    </Flex>
+  );
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@radix-ui/themes';
+import { ShortcutsDrawer } from './ShortcutsDrawer';
+
+const meta = {
+  title: 'Components/UI/ShortcutsPanel/ShortcutsDrawer',
+  component: ShortcutsDrawer,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <Box style={{ width: 400, minHeight: 500, background: 'var(--gray-a2)', position: 'relative' }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof ShortcutsDrawer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ShortcutsDrawerOpenInPopup: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+  },
+};

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Box, Dialog, Flex, IconButton } from '@radix-ui/themes';
+import { Keyboard, X } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { ShortcutsContent } from './ShortcutsContent';
+
+interface ShortcutsDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Modal drawer used inside the popup. The Radix Dialog auto-portals to
+ * document.body which, in a browser-action popup, is the popup document
+ * itself. Sized to fit the typical 400px popup viewport.
+ */
+export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content
+        data-testid="shortcuts-drawer"
+        size="1"
+        maxWidth="92vw"
+        style={{ maxHeight: '90vh', overflow: 'auto' }}
+      >
+        <Flex align="center" gap="2" mb="1">
+          <Keyboard size={16} aria-hidden="true" />
+          <Dialog.Title size="3" mb="0">
+            {getMessage('shortcutsPanelTitle')}
+          </Dialog.Title>
+        </Flex>
+        <Dialog.Description size="1" color="gray" mb="3">
+          {getMessage('shortcutsPanelDescription')}
+        </Dialog.Description>
+        <Dialog.Close>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            aria-label={getMessage('close')}
+            title={getMessage('close')}
+            style={{ position: 'absolute', top: 12, right: 12 }}
+          >
+            <X size={14} aria-hidden="true" />
+          </IconButton>
+        </Dialog.Close>
+        <Box>
+          <ShortcutsContent />
+        </Box>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/components/UI/ShortcutsPanel/index.ts
+++ b/src/components/UI/ShortcutsPanel/index.ts
@@ -1,0 +1,5 @@
+export { ShortcutsContent } from './ShortcutsContent';
+export { ShortcutsDrawer } from './ShortcutsDrawer';
+export { ShortcutsAside } from './ShortcutsAside';
+export { SHORTCUT_GROUPS } from './shortcuts';
+export type { ShortcutDisplay, ShortcutGroup } from './shortcuts';

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -1,0 +1,64 @@
+/**
+ * Display-only data for the shortcuts cheatsheet. Keys are formatted strings
+ * (e.g. "Alt+Shift+O", "Shift+R", "?", "Esc") split on `+` for rendering as a
+ * row of <kbd> tokens. Descriptions are i18n keys resolved at render time.
+ */
+
+export interface ShortcutDisplay {
+  /** Multiple combos for the same action display as comma-separated rows. */
+  keys: string[];
+  descriptionKey: string;
+}
+
+export interface ShortcutGroup {
+  titleKey: string;
+  shortcuts: ShortcutDisplay[];
+}
+
+export const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    titleKey: 'shortcutsGroupGlobal',
+    shortcuts: [
+      { keys: ['Alt+Shift+O'], descriptionKey: 'shortcutDescOrganize' },
+      { keys: ['Alt+Shift+S'], descriptionKey: 'shortcutDescSaveSession' },
+      { keys: ['Alt+Shift+P'], descriptionKey: 'shortcutDescOpenPopup' },
+    ],
+  },
+  {
+    titleKey: 'shortcutsGroupPopup',
+    shortcuts: [
+      { keys: ['S'], descriptionKey: 'shortcutDescPopupSave' },
+      { keys: ['R'], descriptionKey: 'shortcutDescPopupRestore' },
+      { keys: ['O'], descriptionKey: 'shortcutDescPopupOrganize' },
+      { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
+    ],
+  },
+  {
+    titleKey: 'shortcutsGroupOptions',
+    shortcuts: [
+      { keys: ['Alt+1', 'Alt+2', 'Alt+3', 'Alt+4', 'Alt+5'], descriptionKey: 'shortcutDescNavigateTabs' },
+      { keys: ['/'], descriptionKey: 'shortcutDescFocusSearch' },
+      { keys: ['Esc'], descriptionKey: 'shortcutDescClearSearch' },
+      { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
+    ],
+  },
+  {
+    titleKey: 'shortcutsGroupLists',
+    shortcuts: [
+      { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
+      { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
+      { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
+      { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
+      { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
+    ],
+  },
+  {
+    titleKey: 'shortcutsGroupSessionCard',
+    shortcuts: [
+      { keys: ['R'], descriptionKey: 'shortcutDescSessionRestoreCustom' },
+      { keys: ['Shift+R'], descriptionKey: 'shortcutDescSessionRestoreCurrent' },
+      { keys: ['Alt+R'], descriptionKey: 'shortcutDescSessionReplaceCurrent' },
+      { keys: ['Alt+Shift+R'], descriptionKey: 'shortcutDescSessionRestoreNew' },
+    ],
+  },
+];

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { shouldFire, type ShortcutDefinition } from '@/utils/keyboardShortcuts';
+
+/**
+ * Registers a global keydown listener that fires any matching shortcut.
+ * Definitions are re-read each render (no need to memoize), but the listener
+ * itself is attached once per mount.
+ */
+export function useKeyboardShortcuts(
+  shortcuts: ShortcutDefinition[],
+  options: { enabled?: boolean } = {},
+): void {
+  const enabled = options.enabled ?? true;
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (event: KeyboardEvent) => {
+      for (const def of shortcuts) {
+        if (shouldFire(event, def)) {
+          event.preventDefault();
+          def.action(event);
+          break;
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [shortcuts, enabled]);
+}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -14,6 +14,8 @@ import { getMessage } from '@/utils/i18n';
 import { foldAccents } from '@/utils/stringUtils';
 import { generateUUID } from '@/utils/utils';
 import { DomainRuleCard } from '@/components/Core/DomainRule/DomainRuleCard';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import {
   moveToFirst,
   moveToLast,
@@ -262,10 +264,15 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
     }
   }, [handleRowSelect, handleEditRule, selectedIds]);
 
-  const handleAddRule = () => {
+  const handleAddRule = useCallback(() => {
     setEditingRule(undefined);
     setIsModalOpen(true);
-  };
+  }, []);
+
+  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
+    { combo: 'n', action: handleAddRule },
+  ], [handleAddRule]);
+  useKeyboardShortcuts(pageShortcuts);
 
   const handleSubmitRule = (rule: DomainRule) => {
     if (editingRule) {

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -18,9 +18,11 @@ import { foldAccents } from '@/utils/stringUtils';
 import { matchSessionSearch, splitByPinned } from '@/utils/sessionUtils';
 import { moveSessionToFirstInGroup, moveSessionToLastInGroup } from '@/utils/sessionOrderUtils';
 import { useSessions } from '@/hooks/useSessions';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { updateSession } from '@/utils/sessionStorage';
 import { showSuccessNotification } from '@/utils/notifications';
+import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
@@ -160,43 +162,6 @@ function SessionSection({
     [handleQuickRestore],
   );
 
-  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number, session: Session) => {
-    // Only act when the card element itself has focus (not a child input/button).
-    if (e.target !== e.currentTarget) return;
-    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-session-card]');
-    if (!cards) return;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        cards[index + 1]?.focus();
-        return;
-      case 'ArrowUp':
-        e.preventDefault();
-        cards[index - 1]?.focus();
-        return;
-      case 'Home':
-        e.preventDefault();
-        cards[0]?.focus();
-        return;
-      case 'End':
-        e.preventDefault();
-        cards[cards.length - 1]?.focus();
-        return;
-    }
-    if (e.key.toLowerCase() === 'r' && !e.ctrlKey && !e.metaKey) {
-      e.preventDefault();
-      if (e.altKey && e.shiftKey) {
-        void handleRestoreNewWindow(session);
-      } else if (e.altKey) {
-        void handleReplaceCurrentWindow(session);
-      } else if (e.shiftKey) {
-        void handleRestoreCurrentWindow(session);
-      } else {
-        onOpenRestoreWizard(session);
-      }
-    }
-  }, [handleRestoreCurrentWindow, handleRestoreNewWindow, handleReplaceCurrentWindow, onOpenRestoreWizard]);
-
   const handlePin = useCallback(async (session: Session) => {
     await updateSession(session.id, { isPinned: true });
     await reload();
@@ -206,6 +171,79 @@ function SessionSection({
     await updateSession(session.id, { isPinned: false });
     await reload();
   }, [reload]);
+
+  const handleRestoreCombo = useCallback((session: Session, shiftKey: boolean, altKey: boolean) => {
+    if (altKey && shiftKey) {
+      void handleRestoreNewWindow(session);
+    } else if (altKey) {
+      void handleReplaceCurrentWindow(session);
+    } else if (shiftKey) {
+      void handleRestoreCurrentWindow(session);
+    } else {
+      onOpenRestoreWizard(session);
+    }
+  }, [handleRestoreCurrentWindow, handleRestoreNewWindow, handleReplaceCurrentWindow, onOpenRestoreWizard]);
+
+  const handleNavigationKey = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number): boolean => {
+    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-session-card]');
+    if (!cards) return false;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        cards[index + 1]?.focus();
+        return true;
+      case 'ArrowUp':
+        e.preventDefault();
+        cards[index - 1]?.focus();
+        return true;
+      case 'Home':
+        e.preventDefault();
+        cards[0]?.focus();
+        return true;
+      case 'End':
+        e.preventDefault();
+        cards[cards.length - 1]?.focus();
+        return true;
+      default:
+        return false;
+    }
+  }, []);
+
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number, session: Session) => {
+    // Only act when the card element itself has focus (not a child input/button).
+    if (e.target !== e.currentTarget) return;
+    if (handleNavigationKey(e, index)) return;
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      e.preventDefault();
+      onOpenDeleteDialog(session);
+      return;
+    }
+    const lower = e.key.toLowerCase();
+    if (e.ctrlKey || e.metaKey) return;
+    if (lower === 'r') {
+      e.preventDefault();
+      handleRestoreCombo(session, e.shiftKey, e.altKey);
+      return;
+    }
+    if (e.altKey || e.shiftKey) return;
+    if (lower === 'e') {
+      e.preventDefault();
+      onOpenEditDialog(session);
+      return;
+    }
+    if (lower === 'p') {
+      e.preventDefault();
+      const togglePin = session.isPinned ? handleUnpin : handlePin;
+      void togglePin(session);
+    }
+  }, [
+    handleNavigationKey,
+    handleRestoreCombo,
+    onOpenEditDialog,
+    onOpenDeleteDialog,
+    handlePin,
+    handleUnpin,
+  ]);
 
   const handleMoveToFirst = useCallback((session: Session) => {
     void updateOrder(moveSessionToFirstInGroup(allSessions, session.id));
@@ -300,6 +338,12 @@ export function SessionsPage({
   const [deleteTarget, setDeleteTarget] = useState<Session | null>(null);
   const [quickRestoreMessage, setQuickRestoreMessage] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+
+  const handleOpenSnapshotWizard = useCallback(() => setSnapshotOpen(true), []);
+  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
+    { combo: 'n', action: handleOpenSnapshotWizard },
+  ], [handleOpenSnapshotWizard]);
+  useKeyboardShortcuts(pageShortcuts);
 
   // Deep-link: open the RestoreWizard when a sessionId has been provided via
   // URL hash (e.g. from the popup's customize restore action).

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -102,31 +102,6 @@ function SessionSection({
   const [dragItems, setDragItems] = useState<Session[] | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number) => {
-    // Only act when the card element itself has focus (not a child input/button).
-    if (e.target !== e.currentTarget) return;
-    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-session-card]');
-    if (!cards) return;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        cards[index + 1]?.focus();
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        cards[index - 1]?.focus();
-        break;
-      case 'Home':
-        e.preventDefault();
-        cards[0]?.focus();
-        break;
-      case 'End':
-        e.preventDefault();
-        cards[cards.length - 1]?.focus();
-        break;
-    }
-  }, []);
-
   // Drag: reorder within this section, then splice back into the global order.
   const handleDragOver = useCallback((event: Parameters<DragOverEvent>[0]) => {
     setDragItems(prev => move(prev ?? sessions, event));
@@ -184,6 +159,43 @@ function SessionSection({
     (session: Session) => handleQuickRestore(session, 'replace'),
     [handleQuickRestore],
   );
+
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number, session: Session) => {
+    // Only act when the card element itself has focus (not a child input/button).
+    if (e.target !== e.currentTarget) return;
+    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-session-card]');
+    if (!cards) return;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        cards[index + 1]?.focus();
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        cards[index - 1]?.focus();
+        return;
+      case 'Home':
+        e.preventDefault();
+        cards[0]?.focus();
+        return;
+      case 'End':
+        e.preventDefault();
+        cards[cards.length - 1]?.focus();
+        return;
+    }
+    if (e.key.toLowerCase() === 'r' && !e.ctrlKey && !e.metaKey) {
+      e.preventDefault();
+      if (e.altKey && e.shiftKey) {
+        void handleRestoreNewWindow(session);
+      } else if (e.altKey) {
+        void handleReplaceCurrentWindow(session);
+      } else if (e.shiftKey) {
+        void handleRestoreCurrentWindow(session);
+      } else {
+        onOpenRestoreWizard(session);
+      }
+    }
+  }, [handleRestoreCurrentWindow, handleRestoreNewWindow, handleReplaceCurrentWindow, onOpenRestoreWizard]);
 
   const handlePin = useCallback(async (session: Session) => {
     await updateSession(session.id, { isPinned: true });
@@ -246,7 +258,7 @@ function SessionSection({
                   isDragDisabled={!!searchQuery}
                   onMoveToFirst={() => handleMoveToFirst(session)}
                   onMoveLast={() => handleMoveLast(session)}
-                  onCardKeyDown={(e) => handleCardKeyDown(e, index)}
+                  onCardKeyDown={(e) => handleCardKeyDown(e, index, session)}
                 />
               );
             })}

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -1,5 +1,5 @@
 // options/options.ts
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Flex, Spinner, Text, Theme } from '@radix-ui/themes';
@@ -8,13 +8,15 @@ import { ThemeProvider } from 'next-themes';
 import { useSettings } from '@/hooks/useSettings.js';
 import { useStatistics } from '@/hooks/useStatistics.js';
 import { useDeepLinking } from '@/hooks/useDeepLinking.js';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts.js';
 import { getMessage } from '@/utils/i18n';
+import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 
 import { Sidebar } from '@/components/UI/Sidebar/Sidebar';
 import type { SidebarItem } from '@/components/UI/Sidebar/Sidebar';
 import { OptionsHeader, OptionsHeaderCollapsed } from '@/components/UI/OptionsLayout/OptionsHeader';
 import { OptionsFooter, OptionsFooterCollapsed } from '@/components/UI/OptionsLayout/OptionsFooter';
-import { useState } from 'react';
+import { ShortcutsAside } from '@/components/UI/ShortcutsPanel';
 import { DomainRulesPage } from './DomainRulesPage';
 import { StatisticsPage } from './StatisticsPage';
 import { SettingsPage } from '@/components/UI/SettingsPage/SettingsPage';
@@ -39,6 +41,7 @@ export function OptionsContent() {
 
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
     const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+    const [shortcutsAsideOpen, setShortcutsAsideOpen] = useState(false);
 
     const updateRules = useCallback((newRules: DomainRuleSettings) => {
         updateSettings({ domainRules: newRules });
@@ -51,13 +54,41 @@ export function OptionsContent() {
         setCurrentTab(tab);
     }, [setCurrentTab]);
 
-    const sidebarItems: SidebarItem[] = [
+    const sidebarItems: SidebarItem[] = useMemo(() => [
         { id: 'rules', label: getMessage('domainRulesTab'), icon: Shield, accentColor: 'indigo' },
         { id: 'sessions', label: getMessage('sessionsTab'), icon: Archive, accentColor: 'indigo' },
         { id: 'importexport', label: getMessage('importExportTab'), icon: FileText, accentColor: 'indigo' },
         { id: 'stats', label: getMessage('statisticsTab'), icon: BarChart3, accentColor: 'indigo' },
         { id: 'settings', label: getMessage('settingsTab'), icon: Settings, accentColor: 'indigo' },
-    ];
+    ], []);
+
+    const focusActiveSearch = useCallback(() => {
+        const node = document.querySelector<HTMLInputElement>(
+            '[data-testid$="-search"] input, [data-testid$="-search"]',
+        );
+        node?.focus();
+    }, []);
+
+    const handleEscape = useCallback(() => {
+        if (shortcutsAsideOpen) {
+            setShortcutsAsideOpen(false);
+        }
+    }, [shortcutsAsideOpen]);
+
+    const shortcuts = useMemo<ShortcutDefinition[]>(() => {
+        const tabShortcuts: ShortcutDefinition[] = sidebarItems.map((item, index) => ({
+            combo: `Alt+${index + 1}`,
+            action: () => handleTabChange(item.id),
+        }));
+        return [
+            ...tabShortcuts,
+            { combo: '/', action: focusActiveSearch },
+            { combo: '?', action: () => setShortcutsAsideOpen((open) => !open) },
+            { combo: 'Escape', action: handleEscape, allowInTypingTarget: false },
+        ];
+    }, [sidebarItems, handleTabChange, focusActiveSearch, handleEscape]);
+
+    useKeyboardShortcuts(shortcuts);
 
     if (!settings) {
         return (
@@ -83,31 +114,34 @@ export function OptionsContent() {
                 footerCollapsedContent={<OptionsFooterCollapsed />}
             />
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-                <main data-testid="options-content" style={{ flex: 1, overflow: 'auto', padding: '20px' }}>
-                    {currentTab === 'rules' && (
-                        <DomainRulesPage syncSettings={settings} updateRules={updateRules} />
-                    )}
-                    {currentTab === 'importexport' && (
-                        <ImportExportPage syncSettings={settings} onSettingsUpdate={updateSettings} />
-                    )}
-                    {currentTab === 'sessions' && (
-                        <SessionsPage
-                            syncSettings={settings}
-                            snapshotWizardOpen={openSnapshotWizard}
-                            onSnapshotWizardOpenChange={setOpenSnapshotWizard}
-                            snapshotGroupId={snapshotGroupId}
-                            onSnapshotGroupIdChange={setSnapshotGroupId}
-                            restoreSessionId={restoreSessionId}
-                            onRestoreSessionIdChange={setRestoreSessionId}
-                        />
-                    )}
-                    {currentTab === 'stats' && (
-                        <StatisticsPage syncSettings={settings} statisticsData={statisticsAggregates} onReset={handleResetStats} />
-                    )}
-                    {currentTab === 'settings' && (
-                        <SettingsPage syncSettings={settings} updateSettings={updateSettings} />
-                    )}
-                </main>
+                <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
+                    <main data-testid="options-content" style={{ flex: 1, overflow: 'auto', padding: '20px', minWidth: 0 }}>
+                        {currentTab === 'rules' && (
+                            <DomainRulesPage syncSettings={settings} updateRules={updateRules} />
+                        )}
+                        {currentTab === 'importexport' && (
+                            <ImportExportPage syncSettings={settings} onSettingsUpdate={updateSettings} />
+                        )}
+                        {currentTab === 'sessions' && (
+                            <SessionsPage
+                                syncSettings={settings}
+                                snapshotWizardOpen={openSnapshotWizard}
+                                onSnapshotWizardOpenChange={setOpenSnapshotWizard}
+                                snapshotGroupId={snapshotGroupId}
+                                onSnapshotGroupIdChange={setSnapshotGroupId}
+                                restoreSessionId={restoreSessionId}
+                                onRestoreSessionIdChange={setRestoreSessionId}
+                            />
+                        )}
+                        {currentTab === 'stats' && (
+                            <StatisticsPage syncSettings={settings} statisticsData={statisticsAggregates} onReset={handleResetStats} />
+                        )}
+                        {currentTab === 'settings' && (
+                            <SettingsPage syncSettings={settings} updateSettings={updateSettings} />
+                        )}
+                    </main>
+                    <ShortcutsAside open={shortcutsAsideOpen} onClose={() => setShortcutsAsideOpen(false)} />
+                </div>
             </div>
             <ConfirmDialog
                 open={resetConfirmOpen}

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Box, Flex, Separator, Theme } from '@radix-ui/themes';
@@ -9,10 +9,15 @@ import { PopupHeader } from '@/components/UI/PopupHeader/PopupHeader';
 import { SettingsToggles } from '@/components/UI/SettingsToggles/SettingsToggles';
 import { PopupToolbar } from '@/components/UI/PopupToolbar/PopupToolbar';
 import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfilesList';
+import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
+import { openOptionsWithHash } from '@/utils/openOptions';
 import { useSettings } from '@/hooks/useSettings';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 
 export function PopupContent() {
   const { settings, isLoaded, setGlobalGroupingEnabled, setGlobalDeduplicationEnabled } = useSettings();
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   const openOptionsPage = useCallback(() => {
     browser.runtime.openOptionsPage();
@@ -29,6 +34,27 @@ export function PopupContent() {
     }
     window.close();
   }, []);
+
+  const handlePopupSave = useCallback(() => {
+    void openOptionsWithHash('#sessions?action=snapshot');
+  }, []);
+
+  const handlePopupRestore = useCallback(() => {
+    void openOptionsWithHash('#sessions');
+  }, []);
+
+  const handlePopupOrganize = useCallback(() => {
+    browser.runtime.sendMessage({ type: 'ORGANIZE_ALL_TABS' }).finally(() => window.close());
+  }, []);
+
+  const shortcuts = useMemo<ShortcutDefinition[]>(() => [
+    { combo: 's', action: handlePopupSave, excludeIfTargetWithin: '[data-popup-pinned-card]' },
+    { combo: 'r', action: handlePopupRestore, excludeIfTargetWithin: '[data-popup-pinned-card]' },
+    { combo: 'o', action: handlePopupOrganize, excludeIfTargetWithin: '[data-popup-pinned-card]' },
+    { combo: '?', action: () => setShortcutsOpen(true), allowWhenDialogOpen: false },
+  ], [handlePopupSave, handlePopupRestore, handlePopupOrganize]);
+
+  useKeyboardShortcuts(shortcuts);
 
   const hasRules = isLoaded && (settings?.domainRules?.length ?? 0) > 0;
 
@@ -63,6 +89,7 @@ export function PopupContent() {
           </>
         ) : null}
       </Flex>
+      <ShortcutsDrawer open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
     </Box>
   );
 }

--- a/src/utils/browserUrls.ts
+++ b/src/utils/browserUrls.ts
@@ -1,0 +1,36 @@
+import { browser } from 'wxt/browser';
+
+export interface ShortcutsCustomizeInfo {
+  /** URL the user can navigate to in order to customize extension shortcuts. */
+  url: string;
+  /**
+   * True when the URL points directly to the shortcuts page (Chromium).
+   * False when the URL only opens the addons page and the user must drill
+   * down (Firefox: gear menu -> Manage Extension Shortcuts).
+   */
+  isDirect: boolean;
+}
+
+/**
+ * Cross-browser address of the keyboard-shortcuts customization screen.
+ *
+ * Chromium-based browsers (Chrome, Edge, Brave, Opera) all expose a direct
+ * page at `chrome://extensions/shortcuts`. Firefox only has `about:addons`,
+ * from which the user opens the gear menu to access shortcut customization.
+ */
+export function getShortcutsCustomizeInfo(): ShortcutsCustomizeInfo {
+  if (import.meta.env.FIREFOX) {
+    return { url: 'about:addons', isDirect: false };
+  }
+  return { url: 'chrome://extensions/shortcuts', isDirect: true };
+}
+
+/**
+ * Open the shortcuts customization page in a new tab. On Firefox this opens
+ * `about:addons` since `about:` URLs other than the addons page are blocked
+ * for extensions. The caller may want to display the manual hint anyway.
+ */
+export async function openShortcutsCustomizePage(): Promise<void> {
+  const { url } = getShortcutsCustomizeInfo();
+  await browser.tabs.create({ url });
+}

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -69,11 +69,21 @@ export interface ShortcutDefinition {
   allowInTypingTarget?: boolean;
   /** When true, fires even if a Radix dialog is currently open. */
   allowWhenDialogOpen?: boolean;
+  /**
+   * CSS selector. When the event target is within an element matching this
+   * selector, the shortcut is skipped so the inner element's own handler can
+   * take over (e.g. global popup `R` skips when focus is on a pinned card so
+   * the card's per-session R/Shift+R/Alt+R bindings stay authoritative).
+   */
+  excludeIfTargetWithin?: string;
 }
 
 export function shouldFire(event: KeyboardEvent, def: ShortcutDefinition): boolean {
   if (!matchesShortcut(event, def.combo)) return false;
   if (!def.allowInTypingTarget && isTypingTarget(event.target)) return false;
   if (!def.allowWhenDialogOpen && isDialogOpen()) return false;
+  if (def.excludeIfTargetWithin && event.target instanceof Element) {
+    if (event.target.closest(def.excludeIfTargetWithin)) return false;
+  }
   return true;
 }

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -1,0 +1,79 @@
+/**
+ * Lightweight, framework-agnostic helpers for matching keyboard events
+ * against shortcut definitions.
+ *
+ * Combos are written as `Modifier+Modifier+Key`, e.g. `Alt+Shift+r`, `Alt+1`,
+ * `Escape`, `?`, `/`. Modifier order does not matter, casing on the key does
+ * not matter.
+ *
+ * For the literal key `?` shift is ignored (most layouts require shift to type
+ * it). All other keys require strict modifier match so that `r` and `Shift+r`
+ * are distinguishable.
+ */
+
+export interface ParsedCombo {
+  key: string;
+  shift: boolean;
+  alt: boolean;
+  ctrl: boolean;
+  meta: boolean;
+}
+
+export function parseCombo(combo: string): ParsedCombo {
+  const parts = combo.split('+').map((p) => p.trim()).filter(Boolean);
+  const rawKey = parts.pop() ?? '';
+  const mods = new Set(parts.map((p) => p.toLowerCase()));
+  return {
+    key: rawKey.toLowerCase(),
+    shift: mods.has('shift'),
+    alt: mods.has('alt'),
+    ctrl: mods.has('ctrl') || mods.has('control'),
+    meta: mods.has('meta') || mods.has('cmd') || mods.has('command'),
+  };
+}
+
+export function matchesShortcut(event: KeyboardEvent, combo: string): boolean {
+  const parsed = parseCombo(combo);
+  if (event.key.toLowerCase() !== parsed.key) return false;
+  if (event.altKey !== parsed.alt) return false;
+  if (event.ctrlKey !== parsed.ctrl) return false;
+  if (event.metaKey !== parsed.meta) return false;
+  if (parsed.key !== '?' && event.shiftKey !== parsed.shift) return false;
+  return true;
+}
+
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  const ce = target.getAttribute('contenteditable');
+  if (ce === '' || ce === 'true' || ce === 'plaintext-only') return true;
+  return false;
+}
+
+/**
+ * True when a Radix Dialog is currently open. Radix sets
+ * `[data-state="open"]` on the dialog content node; we look for any open
+ * `role="dialog"` to know whether global shortcuts should be skipped.
+ */
+export function isDialogOpen(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.querySelector<HTMLElement>('[role="dialog"][data-state="open"]') !== null;
+}
+
+export interface ShortcutDefinition {
+  combo: string;
+  action: (event: KeyboardEvent) => void;
+  /** When true, fires even if focus is on an input/textarea/contenteditable. */
+  allowInTypingTarget?: boolean;
+  /** When true, fires even if a Radix dialog is currently open. */
+  allowWhenDialogOpen?: boolean;
+}
+
+export function shouldFire(event: KeyboardEvent, def: ShortcutDefinition): boolean {
+  if (!matchesShortcut(event, def.combo)) return false;
+  if (!def.allowInTypingTarget && isTypingTarget(event.target)) return false;
+  if (!def.allowWhenDialogOpen && isDialogOpen()) return false;
+  return true;
+}

--- a/src/utils/openOptions.ts
+++ b/src/utils/openOptions.ts
@@ -1,0 +1,18 @@
+import { browser } from 'wxt/browser';
+
+/** Focus an existing Options tab or open a new one with the given hash. */
+export async function openOptionsWithHash(hash: string): Promise<void> {
+  const optionsUrl = browser.runtime.getURL('/options.html');
+  const allTabs = await browser.tabs.query({});
+  const existing = allTabs.find((t) => t.url?.startsWith(optionsUrl));
+  const target = optionsUrl + hash;
+
+  if (existing?.id != null) {
+    await browser.tabs.update(existing.id, { url: target, active: true });
+    if (existing.windowId != null) {
+      await browser.windows.update(existing.windowId, { focused: true });
+    }
+  } else {
+    await browser.tabs.create({ url: target });
+  }
+}

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * E2E tests for the keyboard shortcuts feature.
+ * Covers the popup (S/R/O/?), options (Alt+1..5, /, ?), session card combos
+ * (R/Shift+R/Alt+R/Alt+Shift+R) and pinned-card navigation in the popup.
+ */
+import { test, expect } from './fixtures';
+import {
+  goToPopup,
+  goToOptionsPage,
+  goToSessionsSection,
+} from './helpers/navigation';
+import {
+  seedSessions,
+  clearSessions,
+  createTestSession,
+  createPinnedSession,
+} from './helpers/seed';
+
+test.beforeEach(async ({ extensionContext }) => {
+  await clearSessions(extensionContext);
+});
+
+// ---------------------------------------------------------------------------
+// Popup top-level shortcuts
+// ---------------------------------------------------------------------------
+test.describe('[US-KB-popup] Popup shortcuts', () => {
+  test('? opens the shortcuts drawer; Escape closes it', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    // Make sure no input is focused so the global handler fires
+    await page.locator('body').click();
+
+    await page.keyboard.press('Shift+Slash'); // produces "?"
+
+    await expect(page.getByTestId('shortcuts-drawer')).toBeVisible();
+    await expect(page.getByTestId('shortcuts-content')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('shortcuts-drawer')).toBeHidden();
+
+    await page.close();
+  });
+
+  test('R navigates to the sessions page', async ({ extensionContext, extensionId }) => {
+    const session = createTestSession({ name: 'Restorable' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    await expect(page.getByTestId('popup-toolbar-btn-restore')).toBeEnabled({
+      timeout: 5000,
+    });
+
+    await page.locator('body').click();
+    const [newPage] = await Promise.all([
+      extensionContext.waitForEvent('page'),
+      page.keyboard.press('r'),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    expect(newPage.url()).toContain('options.html');
+    expect(newPage.url()).toContain('sessions');
+
+    await newPage.close();
+    await page.close().catch(() => {});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Options shortcuts
+// ---------------------------------------------------------------------------
+test.describe('[US-KB-options] Options shortcuts', () => {
+  test('Alt+2 switches to the Sessions sidebar tab', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToOptionsPage(page, extensionId);
+
+    // First focus the document (sidebar may default to rules)
+    await page.locator('body').click();
+    await page.keyboard.press('Alt+2');
+
+    // SessionsPage marker
+    await page.getByTestId('page-sessions-btn-snapshot').waitFor({
+      state: 'visible',
+      timeout: 5000,
+    });
+    expect(page.url()).toContain('#sessions');
+
+    await page.close();
+  });
+
+  test('? opens the shortcuts aside (non-modal); Escape closes it; the page stays interactive', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToOptionsPage(page, extensionId);
+
+    await page.locator('body').click();
+    await page.keyboard.press('Shift+Slash');
+
+    const aside = page.getByTestId('shortcuts-aside');
+    await expect(aside).toHaveAttribute('data-state', 'open');
+    // Non-modal: no role="dialog" on the aside
+    await expect(aside).not.toHaveAttribute('role', 'dialog');
+
+    // The page underneath remains interactive: a sidebar item still receives clicks
+    // while the aside is open (no overlay swallows the event).
+    await page.getByTestId('sidebar-nav-item-sessions').click();
+    await expect(page.getByTestId('page-sessions-btn-snapshot')).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.keyboard.press('Escape');
+    await expect(aside).toHaveAttribute('data-state', 'closed');
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session card restore shortcuts (the user-requested ones)
+// ---------------------------------------------------------------------------
+test.describe('[US-KB-sessions] SessionCard restore shortcuts', () => {
+  test('ArrowDown moves focus from the first card to the next', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const a = createPinnedSession({ name: 'Card A' });
+    const b = createPinnedSession({ name: 'Card B' });
+    await seedSessions(extensionContext, [a, b]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const cardA = page.getByTestId(`session-card-${a.id}`);
+    const cardB = page.getByTestId(`session-card-${b.id}`);
+    await cardA.focus();
+    await expect(cardA).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(cardB).toBeFocused();
+
+    await page.close();
+  });
+
+  test('R on a focused card opens the RestoreWizard', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createTestSession({ name: 'Restorable' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const card = page.getByTestId(`session-card-${session.id}`);
+    await card.focus();
+    await expect(card).toBeFocused();
+
+    await page.keyboard.press('r');
+    await expect(page.getByTestId('wizard-restore')).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Popup pinned cards
+// ---------------------------------------------------------------------------
+test.describe('[US-KB-popup-pinned] Popup pinned card shortcuts', () => {
+  test('ArrowDown moves focus between pinned cards in the popup', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const a = createPinnedSession({ name: 'Pin A' });
+    const b = createPinnedSession({ name: 'Pin B' });
+    await seedSessions(extensionContext, [a, b]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    const cardA = page.getByTestId(`popup-profile-item-${a.id}`);
+    const cardB = page.getByTestId(`popup-profile-item-${b.id}`);
+    await cardA.focus();
+    await expect(cardA).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(cardB).toBeFocused();
+
+    await page.close();
+  });
+
+  test('R on a focused pinned card opens the customize-restore page', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createPinnedSession({ name: 'Pin A' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    const card = page.getByTestId(`popup-profile-item-${session.id}`);
+    await card.focus();
+    await expect(card).toBeFocused();
+
+    const [newPage] = await Promise.all([
+      extensionContext.waitForEvent('page'),
+      page.keyboard.press('r'),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    expect(newPage.url()).toContain('options.html');
+    expect(newPage.url()).toContain('action=restore');
+    expect(newPage.url()).toContain(encodeURIComponent(session.id));
+
+    await newPage.close();
+    await page.close().catch(() => {});
+  });
+});

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -31,16 +31,26 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
     const page = await extensionContext.newPage();
     await goToPopup(page, extensionId);
 
-    // Make sure no input is focused so the global handler fires
-    await page.locator('body').click();
+    // Wait for the toolbar to mount: this guarantees the popup-level
+    // useKeyboardShortcuts effect has run and the document keydown listener
+    // is attached before we send the key.
+    await expect(page.getByTestId('popup-toolbar')).toBeVisible();
+
+    // Move focus to the popup wrapper (data-testid="popup") so the keydown
+    // bubbles to document without being intercepted by an inner input.
+    await page.getByTestId('popup').click({ position: { x: 5, y: 5 } });
 
     await page.keyboard.press('Shift+Slash'); // produces "?"
 
-    await expect(page.getByTestId('shortcuts-drawer')).toBeVisible();
+    await expect(page.getByTestId('shortcuts-drawer')).toBeVisible({
+      timeout: 5000,
+    });
     await expect(page.getByTestId('shortcuts-content')).toBeVisible();
 
     await page.keyboard.press('Escape');
-    await expect(page.getByTestId('shortcuts-drawer')).toBeHidden();
+    await expect(page.getByTestId('shortcuts-drawer')).toBeHidden({
+      timeout: 5000,
+    });
 
     await page.close();
   });

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -117,6 +117,26 @@ test('shouldFire: allows in input when allowInTypingTarget=true', () => {
   document.body.innerHTML = '';
 });
 
+test('shouldFire: skips when target is within excludeIfTargetWithin selector', () => {
+  document.body.innerHTML = '';
+  const card = document.createElement('div');
+  card.setAttribute('data-popup-pinned-card', '');
+  const inner = document.createElement('span');
+  card.appendChild(inner);
+  document.body.appendChild(card);
+  const event = makeEvent({ key: 'r', target: inner });
+  assert.strictEqual(
+    shouldFire(event, { combo: 'r', excludeIfTargetWithin: '[data-popup-pinned-card]', action: () => {} }),
+    false,
+  );
+  // Same shortcut without the exclusion fires.
+  assert.strictEqual(
+    shouldFire(event, { combo: 'r', action: () => {} }),
+    true,
+  );
+  document.body.innerHTML = '';
+});
+
 test('shouldFire: skips when dialog is open unless allowWhenDialogOpen', () => {
   document.body.innerHTML = '';
   const dialog = document.createElement('div');

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -1,0 +1,133 @@
+import assert from 'assert';
+import {
+  parseCombo,
+  matchesShortcut,
+  isTypingTarget,
+  isDialogOpen,
+  shouldFire,
+} from '../src/utils/keyboardShortcuts';
+
+function makeEvent(init: Partial<KeyboardEventInit> & { key: string; target?: EventTarget }): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: init.key,
+    shiftKey: init.shiftKey ?? false,
+    altKey: init.altKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    metaKey: init.metaKey ?? false,
+  });
+  if (init.target) {
+    Object.defineProperty(event, 'target', { value: init.target });
+  }
+  return event;
+}
+
+test('parseCombo extracts key and modifiers', () => {
+  assert.deepStrictEqual(parseCombo('r'), { key: 'r', shift: false, alt: false, ctrl: false, meta: false });
+  assert.deepStrictEqual(parseCombo('Shift+r'), { key: 'r', shift: true, alt: false, ctrl: false, meta: false });
+  assert.deepStrictEqual(parseCombo('Alt+Shift+R'), { key: 'r', shift: true, alt: true, ctrl: false, meta: false });
+  assert.deepStrictEqual(parseCombo('Alt+1'), { key: '1', shift: false, alt: true, ctrl: false, meta: false });
+  assert.deepStrictEqual(parseCombo('?'), { key: '?', shift: false, alt: false, ctrl: false, meta: false });
+});
+
+test('matchesShortcut: plain letter without modifiers', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r' }), 'r'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'R' }), 'r'), true, 'CapsLock should match');
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', shiftKey: true }), 'r'), false, 'Shift+r != r');
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', altKey: true }), 'r'), false);
+});
+
+test('matchesShortcut: Shift+r distinguishes from r', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', shiftKey: true }), 'Shift+r'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'R', shiftKey: true }), 'Shift+r'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r' }), 'Shift+r'), false);
+});
+
+test('matchesShortcut: Alt+r and Alt+Shift+r', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', altKey: true }), 'Alt+r'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', altKey: true, shiftKey: true }), 'Alt+r'), false);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'r', altKey: true, shiftKey: true }), 'Alt+Shift+r'), true);
+});
+
+test('matchesShortcut: Alt+1 number keys', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '1', altKey: true }), 'Alt+1'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '1' }), 'Alt+1'), false);
+});
+
+test('matchesShortcut: ? ignores shift since most layouts require shift to type it', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '?' }), '?'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '?', shiftKey: true }), '?'), true);
+});
+
+test('matchesShortcut: Escape and / and named keys', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'Escape' }), 'Escape'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '/' }), '/'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: 'ArrowDown' }), 'ArrowDown'), true);
+});
+
+test('isTypingTarget: detects INPUT, TEXTAREA, contenteditable', () => {
+  document.body.innerHTML = '';
+  const input = document.createElement('input');
+  const textarea = document.createElement('textarea');
+  const div = document.createElement('div');
+  const editable = document.createElement('div');
+  editable.setAttribute('contenteditable', 'true');
+  document.body.append(input, textarea, div, editable);
+  const button = document.createElement('button');
+  assert.strictEqual(isTypingTarget(input), true);
+  assert.strictEqual(isTypingTarget(textarea), true);
+  assert.strictEqual(isTypingTarget(editable), true);
+  assert.strictEqual(isTypingTarget(div), false);
+  assert.strictEqual(isTypingTarget(button), false);
+  assert.strictEqual(isTypingTarget(null), false);
+  document.body.innerHTML = '';
+});
+
+test('isDialogOpen: detects open Radix dialog', () => {
+  document.body.innerHTML = '';
+  assert.strictEqual(isDialogOpen(), false);
+  const dialog = document.createElement('div');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('data-state', 'open');
+  document.body.appendChild(dialog);
+  assert.strictEqual(isDialogOpen(), true);
+  dialog.setAttribute('data-state', 'closed');
+  assert.strictEqual(isDialogOpen(), false);
+  document.body.innerHTML = '';
+});
+
+test('shouldFire: skips when typing in input', () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+  const event = makeEvent({ key: 'r', target: input });
+  let called = false;
+  const def = { combo: 'r', action: () => { called = true; } };
+  assert.strictEqual(shouldFire(event, def), false);
+  assert.strictEqual(called, false);
+  document.body.innerHTML = '';
+});
+
+test('shouldFire: allows in input when allowInTypingTarget=true', () => {
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+  const event = makeEvent({ key: 'Escape', target: input });
+  assert.strictEqual(
+    shouldFire(event, { combo: 'Escape', allowInTypingTarget: true, action: () => {} }),
+    true,
+  );
+  document.body.innerHTML = '';
+});
+
+test('shouldFire: skips when dialog is open unless allowWhenDialogOpen', () => {
+  document.body.innerHTML = '';
+  const dialog = document.createElement('div');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('data-state', 'open');
+  document.body.appendChild(dialog);
+  const event = makeEvent({ key: 'r' });
+  assert.strictEqual(shouldFire(event, { combo: 'r', action: () => {} }), false);
+  assert.strictEqual(
+    shouldFire(event, { combo: 'r', allowWhenDialogOpen: true, action: () => {} }),
+    true,
+  );
+  document.body.innerHTML = '';
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -28,6 +28,19 @@ export default defineConfig({
     },
     permissions: ['tabs', 'tabGroups', 'storage', 'notifications'],
     host_permissions: ['<all_urls>'],
+    commands: {
+      'organize-all-tabs': {
+        suggested_key: { default: 'Alt+Shift+O' },
+        description: '__MSG_cmdOrganizeAllTabs__',
+      },
+      'save-current-window-session': {
+        suggested_key: { default: 'Alt+Shift+S' },
+        description: '__MSG_cmdSaveSession__',
+      },
+      _execute_action: {
+        suggested_key: { default: 'Alt+Shift+P' },
+      },
+    },
     action: {
       default_icon: {
         '16': 'icons/icon16.png',


### PR DESCRIPTION
Introduce a small framework-agnostic helper (matchesShortcut, isTypingTarget,
isDialogOpen, shouldFire) and a useKeyboardShortcuts hook that registers a
single document-level keydown listener and dispatches to declared combos.

The helper supports plain keys, modifier combos (Alt/Shift/Ctrl/Meta), the
"?" special-case (shift implicit on most layouts) and skips firing when the
focus is on a typing element or when a Radix dialog is open, with explicit
opt-ins for both.