### PR TITLE
docs(readme): add Firefox Add-ons badge

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -17,6 +17,11 @@
 
 [![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
 
+## 🦊 Firefox Add-ons ##
+
+
+[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
+
 ## Características
 
 ### ⚙️ Gestión de Reglas

--- a/README-fr.md
+++ b/README-fr.md
@@ -17,6 +17,11 @@
 
 [![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
 
+## 🦊 Firefox Add-ons ##
+
+
+[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
+
 ## Fonctionnalités
 
 ### ⚙️ Gestion des Règles

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 
 [![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
 
+## 🦊 Firefox Add-ons ##
+
+
+[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
+
 ## Features
 
 ### ⚙️ Rule Management


### PR DESCRIPTION
The extension is now published on addons.mozilla.org. Mirror the
existing Chrome Web Store badge in the three READMEs (EN/FR/ES) using
shields.io's amo/v endpoint.