### PR TITLE
fix(shortcuts): repair cheatsheet layout and Firefox global shortcuts

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -557,6 +557,8 @@
   "shortcutsPanelToggleAria": { "message": "Show keyboard shortcuts" },
   "shortcutsCustomize": { "message": "Customize browser shortcuts" },
   "shortcutsCustomizeFirefoxHint": { "message": "Firefox: open the gear menu, then 'Manage Extension Shortcuts'." },
+  "shortcutsUnboundWarning": { "message": "Some browser shortcuts are not bound. The browser does not auto-apply suggested keys after an extension update; bind them via 'Customize browser shortcuts' below." },
+  "shortcutNotSet": { "message": "Not set" },
 
   "shortcutsGroupGlobal": { "message": "Browser-wide" },
   "shortcutsGroupPopup": { "message": "Popup" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -558,6 +558,8 @@
   "shortcutsPanelToggleAria": { "message": "Mostrar atajos de teclado" },
   "shortcutsCustomize": { "message": "Personalizar atajos del navegador" },
   "shortcutsCustomizeFirefoxHint": { "message": "Firefox: abre el menú de engranaje y luego 'Administrar atajos de extensiones'." },
+  "shortcutsUnboundWarning": { "message": "Algunos atajos del navegador no están definidos. El navegador no aplica automáticamente los atajos sugeridos después de una actualización de la extensión; defínelos en 'Personalizar atajos' abajo." },
+  "shortcutNotSet": { "message": "Sin definir" },
 
   "shortcutsGroupGlobal": { "message": "Globales (navegador)" },
   "shortcutsGroupPopup": { "message": "Popup" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -558,6 +558,8 @@
   "shortcutsPanelToggleAria": { "message": "Afficher les raccourcis clavier" },
   "shortcutsCustomize": { "message": "Personnaliser les raccourcis du navigateur" },
   "shortcutsCustomizeFirefoxHint": { "message": "Firefox : ouvrez le menu d'engrenage, puis 'Gérer les raccourcis des extensions'." },
+  "shortcutsUnboundWarning": { "message": "Certains raccourcis navigateur ne sont pas définis. Le navigateur n'applique pas automatiquement les raccourcis suggérés après une mise à jour de l'extension ; définissez-les via 'Personnaliser les raccourcis' ci-dessous." },
+  "shortcutNotSet": { "message": "Non défini" },
 
   "shortcutsGroupGlobal": { "message": "Globaux navigateur" },
   "shortcutsGroupPopup": { "message": "Popup" },

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -31,12 +31,11 @@ export function setupInstallationHandler(): void {
 }
 
 export function setupCommandHandler(): void {
-    const commands = (browser as unknown as { commands?: { onCommand?: { addListener: (cb: (name: string) => void) => void } } }).commands;
-    if (!commands?.onCommand) {
+    if (!browser.commands?.onCommand) {
         logger.debug('[COMMANDS] browser.commands.onCommand unavailable, skipping handler.');
         return;
     }
-    commands.onCommand.addListener((name: string) => {
+    browser.commands.onCommand.addListener((name: string) => {
         logger.debug('[COMMANDS] received', name);
         if (name === 'organize-all-tabs') {
             browser.windows.getCurrent()

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -59,3 +59,17 @@
   margin-top: 4px;
   color: var(--gray-11);
 }
+
+.unboundBanner {
+  padding: 8px 10px;
+  background: var(--amber-a3);
+  border: 1px solid var(--amber-a5);
+  border-radius: var(--radius-2);
+  color: var(--amber-12);
+}
+
+.unboundLabel {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--amber-11);
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -18,15 +18,16 @@
 
 .row {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: var(--space-2) var(--space-3);
   padding: 4px 0;
 }
 
 .rowDescription {
-  flex: 1;
-  min-width: 0;
+  flex: 1 1 140px;
+  min-width: 140px;
 }
 
 .rowKeys {
@@ -36,6 +37,7 @@
   justify-content: flex-end;
   gap: 4px;
   flex-shrink: 0;
+  max-width: 100%;
 }
 
 .altSeparator {

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Flex, Text } from '@radix-ui/themes';
 import { ExternalLink } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { getShortcutsCustomizeInfo, openShortcutsCustomizePage } from '@/utils/browserUrls';
+import { useBrowserCommands, type BrowserCommandsMap } from '@/hooks/useBrowserCommands';
 import { SHORTCUT_GROUPS, type ShortcutDisplay, type ShortcutGroup } from './shortcuts';
 import styles from './ShortcutsContent.module.css';
 
@@ -11,10 +12,34 @@ interface ShortcutsContentProps {
   groups?: ShortcutGroup[];
 }
 
+function resolveKeys(
+  shortcut: ShortcutDisplay,
+  liveCommands: BrowserCommandsMap | null,
+): { keys: string[]; unbound: boolean } {
+  if (!shortcut.commandName || liveCommands === null) {
+    return { keys: shortcut.keys, unbound: false };
+  }
+  const live = liveCommands[shortcut.commandName];
+  if (live === undefined) return { keys: shortcut.keys, unbound: false };
+  if (live === '') return { keys: [], unbound: true };
+  return { keys: [live], unbound: false };
+}
+
 export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentProps) {
   const { isDirect } = getShortcutsCustomizeInfo();
+  const liveCommands = useBrowserCommands();
+  const hasUnbound = !!liveCommands && groups.some((group) =>
+    group.shortcuts.some((s) => resolveKeys(s, liveCommands).unbound),
+  );
   return (
     <Flex direction="column" gap="4" data-testid="shortcuts-content">
+      {hasUnbound && (
+        <Box className={styles.unboundBanner} data-testid="shortcuts-unbound-banner">
+          <Text size="1" as="p">
+            {getMessage('shortcutsUnboundWarning')}
+          </Text>
+        </Box>
+      )}
       {groups.map((group) => (
         <Box key={group.titleKey}>
           <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
@@ -22,14 +47,18 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentP
           </Text>
           <Flex direction="column">
             {group.shortcuts.map((shortcut) => (
-              <ShortcutRow key={shortcut.descriptionKey} shortcut={shortcut} />
+              <ShortcutRow
+                key={shortcut.descriptionKey}
+                shortcut={shortcut}
+                liveCommands={liveCommands}
+              />
             ))}
           </Flex>
         </Box>
       ))}
       <Box>
         <Button
-          variant="ghost"
+          variant={hasUnbound ? 'soft' : 'ghost'}
           size="1"
           onClick={() => void openShortcutsCustomizePage()}
           data-testid="shortcuts-customize-button"
@@ -47,19 +76,32 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentP
   );
 }
 
-function ShortcutRow({ shortcut }: { shortcut: ShortcutDisplay }) {
+function ShortcutRow({
+  shortcut,
+  liveCommands,
+}: {
+  shortcut: ShortcutDisplay;
+  liveCommands: BrowserCommandsMap | null;
+}) {
+  const { keys, unbound } = resolveKeys(shortcut, liveCommands);
   return (
     <div className={styles.row}>
       <Text size="2" className={styles.rowDescription}>
         {getMessage(shortcut.descriptionKey)}
       </Text>
       <div className={styles.rowKeys}>
-        {shortcut.keys.map((combo, index) => (
-          <React.Fragment key={combo}>
-            {index > 0 && <span className={styles.altSeparator} aria-hidden="true">/</span>}
-            <KeyCombo combo={combo} />
-          </React.Fragment>
-        ))}
+        {unbound ? (
+          <span className={styles.unboundLabel} data-testid="shortcut-unbound">
+            {getMessage('shortcutNotSet')}
+          </span>
+        ) : (
+          keys.map((combo, index) => (
+            <React.Fragment key={combo}>
+              {index > 0 && <span className={styles.altSeparator} aria-hidden="true">/</span>}
+              <KeyCombo combo={combo} />
+            </React.Fragment>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -8,6 +8,12 @@ export interface ShortcutDisplay {
   /** Multiple combos for the same action display as comma-separated rows. */
   keys: string[];
   descriptionKey: string;
+  /**
+   * When set, the panel reads the live binding from `browser.commands.getAll()`
+   * and displays it instead of `keys`. `keys` is kept as a fallback for
+   * Storybook and for the moment before the async read resolves.
+   */
+  commandName?: string;
 }
 
 export interface ShortcutGroup {
@@ -19,9 +25,9 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     titleKey: 'shortcutsGroupGlobal',
     shortcuts: [
-      { keys: ['Alt+Shift+O'], descriptionKey: 'shortcutDescOrganize' },
-      { keys: ['Alt+Shift+S'], descriptionKey: 'shortcutDescSaveSession' },
-      { keys: ['Alt+Shift+P'], descriptionKey: 'shortcutDescOpenPopup' },
+      { keys: ['Alt+Shift+O'], descriptionKey: 'shortcutDescOrganize', commandName: 'organize-all-tabs' },
+      { keys: ['Alt+Shift+S'], descriptionKey: 'shortcutDescSaveSession', commandName: 'save-current-window-session' },
+      { keys: ['Alt+Shift+P'], descriptionKey: 'shortcutDescOpenPopup', commandName: '_execute_action' },
     ],
   },
   {

--- a/src/entrypoints/popup.html
+++ b/src/entrypoints/popup.html
@@ -5,7 +5,11 @@
     <title>SmartTab Organizer</title>
     <link rel="stylesheet" href="../styles/radix-themes.css">
     <style>
-        html, body, #popup-app, .radix-themes {
+        /* Constrain only the popup root subtree. The bare `.radix-themes`
+           selector also matched the Theme that Radix Themes wraps around
+           portaled Dialog content (asChild), forcing the overlay to
+           `height: min-content` and collapsing the cheatsheet drawer. */
+        html, body, #popup-app, #popup-app .radix-themes {
             height: min-content !important;
             min-height: 0 !important;
             overflow: hidden;

--- a/src/hooks/useBrowserCommands.ts
+++ b/src/hooks/useBrowserCommands.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { browser } from 'wxt/browser';
+import { logger } from '@/utils/logger.js';
+
+/**
+ * Map of manifest command names to their currently bound shortcut.
+ * The shortcut is an empty string when Chrome did not auto-apply
+ * `suggested_key` (typical when commands were added via an extension update)
+ * or when the user cleared the binding in chrome://extensions/shortcuts.
+ *
+ * `null` means the API call has not resolved yet (or `browser.commands` is
+ * unavailable, e.g. in Storybook). Callers should fall back to the static
+ * `keys` declared in `shortcuts.ts` until a value is loaded.
+ */
+export type BrowserCommandsMap = Record<string, string>;
+
+/**
+ * Reads the live shortcut bindings via `browser.commands.getAll()` so the
+ * cheatsheet can show the actual key (or "not set") instead of a hardcoded
+ * suggestion that may not match what the browser bound.
+ *
+ * Aliases `_execute_browser_action` (Firefox MV2) to `_execute_action` so the
+ * popup entry has a single canonical name across browsers.
+ */
+export function useBrowserCommands(): BrowserCommandsMap | null {
+  const [commands, setCommands] = useState<BrowserCommandsMap | null>(null);
+
+  useEffect(() => {
+    if (!browser.commands?.getAll) {
+      setCommands({});
+      return;
+    }
+    let cancelled = false;
+    browser.commands
+      .getAll()
+      .then((list) => {
+        if (cancelled) return;
+        const map: BrowserCommandsMap = {};
+        for (const c of list) {
+          if (!c.name) continue;
+          map[c.name] = c.shortcut ?? '';
+        }
+        if (map._execute_browser_action !== undefined && map._execute_action === undefined) {
+          map._execute_action = map._execute_browser_action;
+        }
+        setCommands(map);
+      })
+      .catch((e) => {
+        logger.error('[COMMANDS] getAll failed:', e);
+        if (!cancelled) setCommands({});
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return commands;
+}

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -34,12 +34,24 @@ export function parseCombo(combo: string): ParsedCombo {
 
 export function matchesShortcut(event: KeyboardEvent, combo: string): boolean {
   const parsed = parseCombo(combo);
-  if (event.key.toLowerCase() !== parsed.key) return false;
+  if (!keyMatches(event, parsed.key)) return false;
   if (event.altKey !== parsed.alt) return false;
   if (event.ctrlKey !== parsed.ctrl) return false;
   if (event.metaKey !== parsed.meta) return false;
   if (parsed.key !== '?' && event.shiftKey !== parsed.shift) return false;
   return true;
+}
+
+/**
+ * `event.key` is layout-dependent: on AZERTY for example, the physical "1"
+ * key emits "&" without shift, so an `Alt+1` combo would never match if we
+ * only compared `event.key`. Fall back to `event.code` for digits, which is
+ * stable across layouts (`Digit0` to `Digit9`).
+ */
+function keyMatches(event: KeyboardEvent, parsedKey: string): boolean {
+  if (event.key.toLowerCase() === parsedKey) return true;
+  if (/^\d$/.test(parsedKey) && event.code === `Digit${parsedKey}`) return true;
+  return false;
 }
 
 export function isTypingTarget(target: EventTarget | null): boolean {

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -115,7 +115,7 @@ test.describe('[US-KB-options] Options shortcuts', () => {
     await page.close();
   });
 
-  test('Alt+digit also switches tabs on a non-US layout (AZERTY emits event.key="&" for Digit1)', async ({
+  test('Alt+digit also switches tabs on a non-US layout (where event.key is not the digit)', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -123,15 +123,21 @@ test.describe('[US-KB-options] Options shortcuts', () => {
     await goToOptionsPage(page, extensionId);
     await page.locator('body').click();
 
-    // page.keyboard.press fakes both code and key from the US layout, so it
-    // never reproduces the AZERTY case. Send a raw CDP event with the
-    // AZERTY mapping (event.code = "Digit2", event.key = "é").
-    const cdp = await page.context().newCDPSession(page);
-    await cdp.send('Input.dispatchKeyEvent', {
-      type: 'keyDown',
-      code: 'Digit2',
-      key: 'é',
-      modifiers: 1, // Alt
+    // page.keyboard.press always uses the US layout (event.key === event.code's
+    // digit), so it cannot reproduce the AZERTY case where Alt+1 dispatches
+    // event.key = "&" while event.code stays "Digit1". Synthesise the event
+    // directly: what matters for the matcher is that event.key is *not* the
+    // digit but event.code is the matching DigitN.
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          code: 'Digit2',
+          key: 'layout-specific',
+          altKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
     });
 
     await page.getByTestId('page-sessions-btn-snapshot').waitFor({

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -115,6 +115,34 @@ test.describe('[US-KB-options] Options shortcuts', () => {
     await page.close();
   });
 
+  test('Alt+digit also switches tabs on a non-US layout (AZERTY emits event.key="&" for Digit1)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToOptionsPage(page, extensionId);
+    await page.locator('body').click();
+
+    // page.keyboard.press fakes both code and key from the US layout, so it
+    // never reproduces the AZERTY case. Send a raw CDP event with the
+    // AZERTY mapping (event.code = "Digit2", event.key = "é").
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      code: 'Digit2',
+      key: 'é',
+      modifiers: 1, // Alt
+    });
+
+    await page.getByTestId('page-sessions-btn-snapshot').waitFor({
+      state: 'visible',
+      timeout: 5000,
+    });
+    expect(page.url()).toContain('#sessions');
+
+    await page.close();
+  });
+
   test('? opens the shortcuts aside (non-modal); Escape closes it; the page stays interactive', async ({
     extensionContext,
     extensionId,

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -47,6 +47,16 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
     });
     await expect(page.getByTestId('shortcuts-content')).toBeVisible();
 
+    // Regression guard: the popup.html `.radix-themes` selector used to also
+    // match the Theme that Radix Themes wraps around the portaled overlay,
+    // forcing it to `height: 0; overflow: hidden`. The drawer kept its own
+    // box (so toBeVisible passed) but was clipped to nothing on screen.
+    // Assert the overlay actually covers a real area.
+    const overlayHeight = await page
+      .locator('.rt-BaseDialogOverlay')
+      .evaluate((el) => (el as HTMLElement).getBoundingClientRect().height);
+    expect(overlayHeight).toBeGreaterThan(100);
+
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('shortcuts-drawer')).toBeHidden({
       timeout: 5000,

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -7,9 +7,10 @@ import {
   shouldFire,
 } from '../src/utils/keyboardShortcuts';
 
-function makeEvent(init: Partial<KeyboardEventInit> & { key: string; target?: EventTarget }): KeyboardEvent {
+function makeEvent(init: Partial<KeyboardEventInit> & { key: string; code?: string; target?: EventTarget }): KeyboardEvent {
   const event = new KeyboardEvent('keydown', {
     key: init.key,
+    code: init.code,
     shiftKey: init.shiftKey ?? false,
     altKey: init.altKey ?? false,
     ctrlKey: init.ctrlKey ?? false,
@@ -51,6 +52,24 @@ test('matchesShortcut: Alt+r and Alt+Shift+r', () => {
 test('matchesShortcut: Alt+1 number keys', () => {
   assert.strictEqual(matchesShortcut(makeEvent({ key: '1', altKey: true }), 'Alt+1'), true);
   assert.strictEqual(matchesShortcut(makeEvent({ key: '1' }), 'Alt+1'), false);
+});
+
+test('matchesShortcut: digit shortcuts work on layouts where the key emits a different character (AZERTY Alt+1 -> "&")', () => {
+  // On French AZERTY, Alt+1 dispatches event.key = "&" with event.code = "Digit1".
+  assert.strictEqual(
+    matchesShortcut(makeEvent({ key: '&', code: 'Digit1', altKey: true }), 'Alt+1'),
+    true,
+  );
+  // The fallback only kicks in for the matching code: Digit2 must not match Alt+1.
+  assert.strictEqual(
+    matchesShortcut(makeEvent({ key: 'é', code: 'Digit2', altKey: true }), 'Alt+1'),
+    false,
+  );
+  // Modifiers still required: pressing the same physical key without Alt does not match.
+  assert.strictEqual(
+    matchesShortcut(makeEvent({ key: '&', code: 'Digit1' }), 'Alt+1'),
+    false,
+  );
 });
 
 test('matchesShortcut: ? ignores shift since most layouts require shift to type it', () => {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,6 +5,17 @@ import { resolve } from 'path';
 export default defineConfig({
   srcDir: 'src',
   outDir: '.output',
+  hooks: {
+    'build:manifestGenerated': (wxt, manifest) => {
+      // Firefox MV2 uses `_execute_browser_action`; only Chromium MV3 accepts
+      // `_execute_action`. Without this rename the popup hotkey (and on some
+      // validators the whole `commands` object) is silently dropped on Firefox.
+      if (manifest.manifest_version === 2 && manifest.commands?._execute_action) {
+        manifest.commands._execute_browser_action = manifest.commands._execute_action;
+        delete manifest.commands._execute_action;
+      }
+    },
+  },
   manifest: {
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',


### PR DESCRIPTION
The shortcuts panel collapsed the description column to a single character
wide whenever a row carried several alternative combos (e.g. Alt+1..Alt+5
on the options page), wrapping the label vertically. Allow the row to
wrap so the keys spill onto a second line instead of crushing the
description, and give the description a sensible flex basis.

Global shortcuts also had no effect on Firefox: the manifest uses
"_execute_action" which is a Manifest V3 only keyword. Firefox MV2 needs
"_execute_browser_action", so add a build:manifestGenerated hook that
renames the entry on MV2 builds.

Also drop the now-redundant TypeScript cast around browser.commands since
the WXT browser typings expose it directly.