### PR TITLE
test: improve unit test coverage on previously untested utils, hooks and schemas

### DIFF
--- a/tests/components/ExportWorkspaceDialog.test.tsx
+++ b/tests/components/ExportWorkspaceDialog.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string, subs?: string[]) =>
+    subs?.length ? `${key}(${subs.join(',')})` : key,
+  ),
+}));
+
+const collectWorkspaceExport = vi.fn();
+vi.mock('../../src/utils/workspaceImportExport', () => ({
+  collectWorkspaceExport: (...args: unknown[]) => collectWorkspaceExport(...args),
+}));
+
+const useActiveWorkspaceContextMock = vi.fn();
+vi.mock('../../src/contexts/ActiveWorkspaceContext', () => ({
+  useActiveWorkspaceContext: () => useActiveWorkspaceContextMock(),
+}));
+
+const writeText = vi.fn();
+Object.defineProperty(navigator, 'clipboard', {
+  configurable: true,
+  value: { writeText },
+});
+
+vi.mock('../../src/utils/logger', () => ({
+  logger: { debug: vi.fn(), log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../src/utils/toast', () => ({
+  showSuccessToast: vi.fn(),
+}));
+
+import { ExportWorkspaceDialog } from '../../src/components/UI/Workspace/ExportWorkspaceDialog';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const samplePayload = {
+  workspace: { name: 'Active', accentColor: 'jade' },
+  settings: {
+    globalGroupingEnabled: true,
+    globalDeduplicationEnabled: true,
+    deduplicateUnmatchedDomains: false,
+    deduplicationKeepStrategy: 'keep-grouped-or-new',
+    notifyOnGrouping: true,
+    notifyOnDeduplication: true,
+  },
+  domainRules: [{ id: 'r1' }, { id: 'r2' }, { id: 'r3' }],
+  categories: [],
+  sessions: [{ id: 's1' }],
+};
+
+beforeEach(() => {
+  collectWorkspaceExport.mockReset().mockResolvedValue(samplePayload);
+  useActiveWorkspaceContextMock.mockReset();
+  useActiveWorkspaceContextMock.mockReturnValue({
+    active: { id: 'ws-1', name: 'Active' },
+  });
+  writeText.mockReset().mockResolvedValue(undefined);
+});
+
+describe('ExportWorkspaceDialog', () => {
+  it('renders the dialog title and description with workspace name', () => {
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    expect(screen.getByTestId('workspace-export-dialog')).toBeInTheDocument();
+    expect(screen.getByText(/workspaceExportDescription/)).toBeInTheDocument();
+  });
+
+  it('does not collect when there is no active workspace', () => {
+    useActiveWorkspaceContextMock.mockReturnValue({ active: null });
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    expect(collectWorkspaceExport).not.toHaveBeenCalled();
+  });
+
+  it('collects the export payload when opened with an active workspace', async () => {
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    await waitFor(() => expect(collectWorkspaceExport).toHaveBeenCalled());
+    expect(collectWorkspaceExport).toHaveBeenCalledWith(
+      { id: 'ws-1', name: 'Active' },
+      { includeStatistics: false, note: '' },
+    );
+  });
+
+  it('updates the rule and session count after collect resolves', async () => {
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText(/workspaceExportSummaryRules\(3\)/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/workspaceExportSummarySessions\(1\)/)).toBeInTheDocument();
+  });
+
+  it('refreshes the payload when "include statistics" is toggled', async () => {
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    await waitFor(() => expect(collectWorkspaceExport).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('workspace-export-stats'));
+    await waitFor(() => {
+      expect(collectWorkspaceExport.mock.calls.at(-1)?.[1]).toEqual({
+        includeStatistics: true,
+        note: '',
+      });
+    });
+  });
+
+  it('refreshes the payload when the note changes', async () => {
+    wrap(<ExportWorkspaceDialog open onOpenChange={() => {}} />);
+    await waitFor(() => expect(collectWorkspaceExport).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('workspace-export-note'), {
+      target: { value: 'My export note' },
+    });
+    await waitFor(() => {
+      expect(collectWorkspaceExport.mock.calls.at(-1)?.[1]).toEqual({
+        includeStatistics: false,
+        note: 'My export note',
+      });
+    });
+  });
+
+  it('exports to clipboard and closes the dialog', async () => {
+    const onOpenChange = vi.fn();
+    wrap(<ExportWorkspaceDialog open onOpenChange={onOpenChange} />);
+    await waitFor(() => expect(collectWorkspaceExport).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByTestId('workspace-export-btn-clipboard'));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('"workspace"');
+  });
+});

--- a/tests/components/ImportWorkspaceDialog.test.tsx
+++ b/tests/components/ImportWorkspaceDialog.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string, subs?: string[]) =>
+    subs?.length ? `${key}(${subs.join(',')})` : key,
+  ),
+}));
+
+const applyAsNew = vi.fn();
+const applyToExisting = vi.fn();
+vi.mock('../../src/utils/workspaceImportExport', () => ({
+  applyWorkspaceImportAsNew: (...args: unknown[]) => applyAsNew(...args),
+  applyWorkspaceImportToExisting: (...args: unknown[]) => applyToExisting(...args),
+}));
+
+const useActiveWorkspaceContextMock = vi.fn();
+vi.mock('../../src/contexts/ActiveWorkspaceContext', () => ({
+  useActiveWorkspaceContext: () => useActiveWorkspaceContextMock(),
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  logger: { debug: vi.fn(), log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { ImportWorkspaceDialog } from '../../src/components/UI/Workspace/ImportWorkspaceDialog';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const validPayload = {
+  workspace: { name: 'Imported', accentColor: 'jade' },
+  settings: {
+    globalGroupingEnabled: true,
+    globalDeduplicationEnabled: true,
+    deduplicateUnmatchedDomains: false,
+    deduplicationKeepStrategy: 'keep-grouped-or-new',
+    notifyOnGrouping: true,
+    notifyOnDeduplication: true,
+  },
+  domainRules: [
+    {
+      id: 'r1',
+      domainFilter: 'example.com',
+      label: 'Example',
+      titleParsingRegEx: '',
+      urlParsingRegEx: '',
+      groupNameSource: 'smart',
+      deduplicationMatchMode: 'exact',
+      deduplicationEnabled: true,
+      ignoredQueryParams: [],
+      presetId: null,
+      urlExtractionMode: 'regex',
+      enabled: true,
+    },
+  ],
+  categories: [],
+  sessions: [],
+};
+
+beforeEach(() => {
+  applyAsNew.mockReset().mockResolvedValue(undefined);
+  applyToExisting.mockReset().mockResolvedValue(undefined);
+  useActiveWorkspaceContextMock.mockReset();
+  useActiveWorkspaceContextMock.mockReturnValue({
+    active: { id: 'ws-active', name: 'Active' },
+  });
+});
+
+describe('ImportWorkspaceDialog', () => {
+  it('renders nothing visible when closed', () => {
+    wrap(<ImportWorkspaceDialog open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByTestId('workspace-import-dialog')).toBeNull();
+  });
+
+  it('renders the dialog and disables confirm before any input', () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    expect(screen.getByTestId('workspace-import-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-import-btn-confirm')).toBeDisabled();
+  });
+
+  it('shows an error callout when invalid JSON is pasted', () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: '{not valid json' },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    expect(screen.getByTestId('workspace-import-error')).toBeInTheDocument();
+  });
+
+  it('shows an error callout when JSON does not match the schema', () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: '{"foo":"bar"}' },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    expect(screen.getByTestId('workspace-import-error')).toBeInTheDocument();
+  });
+
+  it('shows the import summary and pre-fills the name override on success', () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: JSON.stringify(validPayload) },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    expect(screen.getByTestId('workspace-import-summary')).toBeInTheDocument();
+    expect(
+      (screen.getByTestId('workspace-import-name-override') as HTMLInputElement).value,
+    ).toBe('Imported');
+  });
+
+  it('disables the merge mode when there is no active workspace', () => {
+    useActiveWorkspaceContextMock.mockReturnValue({ active: null });
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: JSON.stringify(validPayload) },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    expect(screen.getByTestId('workspace-import-mode-merge')).toBeDisabled();
+  });
+
+  it('imports as a new workspace on confirm', async () => {
+    const onOpenChange = vi.fn();
+    wrap(<ImportWorkspaceDialog open onOpenChange={onOpenChange} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: JSON.stringify(validPayload) },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    fireEvent.click(screen.getByTestId('workspace-import-btn-confirm'));
+
+    await waitFor(() => expect(applyAsNew).toHaveBeenCalled());
+    expect(applyAsNew).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: { name: 'Imported', accentColor: 'jade' } }),
+      expect.objectContaining({ includeStatistics: false, nameOverride: 'Imported' }),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('disables the paste button when no text is entered', () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    expect(screen.getByTestId('workspace-import-paste-btn')).toBeDisabled();
+  });
+
+  it('reads a JSON file and shows the summary', async () => {
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+
+    const file = new File([JSON.stringify(validPayload)], 'workspace.json', {
+      type: 'application/json',
+    });
+    const input = screen.getByTestId('workspace-import-file') as HTMLInputElement;
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-import-summary')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error callout when applyAsNew throws', async () => {
+    applyAsNew.mockRejectedValueOnce(new Error('apply failed'));
+    wrap(<ImportWorkspaceDialog open onOpenChange={() => {}} />);
+    fireEvent.change(screen.getByTestId('workspace-import-paste'), {
+      target: { value: JSON.stringify(validPayload) },
+    });
+    fireEvent.click(screen.getByTestId('workspace-import-paste-btn'));
+    fireEvent.click(screen.getByTestId('workspace-import-btn-confirm'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('workspace-import-error')).toBeInTheDocument(),
+    );
+  });
+});

--- a/tests/components/PackCard.stories.test.tsx
+++ b/tests/components/PackCard.stories.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/Pack/PackGallery/PackCard/PackCard.stories';
+
+const composed = composeStories(stories);
+const {
+  PackCardSimple,
+  PackCardSimpleSelected,
+  PackCardConfigurable,
+  PackCardConfigurableNoMatch,
+} = composed;
+
+describe('PackCard (stories)', () => {
+  it('renders the simple pack with name, description and rule count badge', () => {
+    render(<PackCardSimple />);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('GitHub & GitLab grouping')).toBeInTheDocument();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  });
+
+  it('toggles selection when the checkbox is clicked', () => {
+    render(<PackCardSimple />);
+    const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(checkbox);
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders the configurable pack with the configurable badge and a Select trigger', () => {
+    render(<PackCardConfigurable />);
+    expect(screen.getByText('Cloud Console')).toBeInTheDocument();
+    expect(screen.getByTestId('pack-card-pk-cloud-param-provider')).toBeInTheDocument();
+  });
+
+  it('renders an already-selected card variant', () => {
+    render(<PackCardSimpleSelected />);
+    const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders a configurable pack with no matching rules', () => {
+    render(<PackCardConfigurableNoMatch />);
+    expect(screen.getByText('Cloud Console')).toBeInTheDocument();
+  });
+});

--- a/tests/components/PackGallery.stories.test.tsx
+++ b/tests/components/PackGallery.stories.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/Pack/PackGallery/PackGallery.stories';
+
+const composed = composeStories(stories);
+const {
+  PackGalleryDefault,
+  PackGalleryEmpty,
+  PackGalleryWithSearch,
+  PackGalleryConfigurableExpanded,
+} = composed;
+
+describe('PackGallery (stories)', () => {
+  it('renders the gallery with packs grouped by category', () => {
+    render(<PackGalleryDefault />);
+    expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
+    expect(screen.getByText('Cloud Console')).toBeInTheDocument();
+    expect(screen.getByText('Code Hosting')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no packs', () => {
+    render(<PackGalleryEmpty />);
+    expect(screen.getByTestId('pack-gallery-empty')).toBeInTheDocument();
+  });
+
+  it('shows the configurable variant', () => {
+    render(<PackGalleryConfigurableExpanded />);
+    expect(screen.getByText('Cloud Console')).toBeInTheDocument();
+  });
+
+  it('renders the with-search variant', async () => {
+    render(<PackGalleryWithSearch />);
+    // The story applies its initialSearch via a setTimeout; wait for it.
+    const { waitFor } = await import('@testing-library/react');
+    await waitFor(() => {
+      expect(screen.queryByText('Cloud Console')).toBeNull();
+    });
+    expect(screen.getByText('Code Hosting')).toBeInTheDocument();
+  });
+
+  it('disables the confirm button while no pack is selected', () => {
+    render(<PackGalleryDefault />);
+    expect(screen.getByTestId('pack-gallery-confirm')).toBeDisabled();
+  });
+
+  it('enables the confirm button after selecting a pack', () => {
+    render(<PackGalleryDefault />);
+    const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
+    fireEvent.click(checkbox);
+    expect(screen.getByTestId('pack-gallery-confirm')).not.toBeDisabled();
+  });
+
+  it('shows the no-result message when search matches nothing', () => {
+    render(<PackGalleryDefault />);
+    const search = within(screen.getByTestId('pack-gallery')).getByRole('textbox');
+    fireEvent.change(search, { target: { value: 'no-match-xyz' } });
+    expect(screen.getByTestId('pack-gallery-search-empty')).toBeInTheDocument();
+  });
+
+  it('updates the global counter when packs are toggled on', () => {
+    render(<PackGalleryDefault />);
+    const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
+    fireEvent.click(checkbox);
+    const counter = screen.getByTestId('pack-gallery-counter');
+    expect(counter.textContent).not.toBe('packGalleryGlobalCounterEmpty');
+  });
+});

--- a/tests/components/PopupProfilesList.test.tsx
+++ b/tests/components/PopupProfilesList.test.tsx
@@ -303,6 +303,38 @@ describe('PopupProfilesList', () => {
     expect(screen.getByRole('button', { name: /Restore options/i })).toBeInTheDocument();
   });
 
+  it('should call restoreSessionTabs when clicking the primary restore button', async () => {
+    const { fireEvent } = await import('@testing-library/react');
+    const tabRestoreModule = await import('../../src/utils/tabRestore');
+    const restoreSpy = vi.mocked(tabRestoreModule.restoreSessionTabs);
+
+    const sessions: Session[] = [
+      {
+        id: 'p-restore',
+        isPinned: true,
+        updatedAt: '2026-04-10T00:00:00Z',
+        name: 'Restorable',
+        createdAt: '2026-04-10T00:00:00Z',
+        ungroupedTabs: [],
+        groups: [],
+      },
+    ];
+    mockLoadSessions.mockResolvedValue(sessions);
+
+    render(
+      <TestWrapper>
+        <PopupProfilesList />
+      </TestWrapper>,
+    );
+
+    const primary = await screen.findByRole('button', { name: /Restore in current window/i });
+    fireEvent.click(primary);
+
+    await waitFor(() => {
+      expect(restoreSpy).toHaveBeenCalled();
+    });
+  });
+
   it('should display pinned sessions label when pinned sessions exist', async () => {
     const sessions: Session[] = [
       {

--- a/tests/components/PopupToolbar.stories.test.tsx
+++ b/tests/components/PopupToolbar.stories.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import { fakeBrowser } from 'wxt/testing';
+import * as stories from '../../src/components/UI/PopupToolbar/PopupToolbar.stories';
+
+const composed = composeStories(stories);
+const {
+  PopupToolbarDefault,
+  PopupToolbarOrganizing,
+  PopupToolbarNoSessions,
+  PopupToolbarSaveDisabled,
+  PopupToolbarNoRules,
+  PopupToolbarSingleTab,
+  PopupToolbarManyTabs,
+} = composed;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PopupToolbar (stories)', () => {
+  it('renders the default story with hero and meta buttons enabled', async () => {
+    render(<PopupToolbarDefault />);
+    await waitFor(() => {
+      expect(screen.getByTestId('popup-toolbar')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('popup-toolbar-btn-organize')).not.toBeDisabled();
+    expect(screen.getByTestId('popup-toolbar-btn-save')).not.toBeDisabled();
+    expect(screen.getByTestId('popup-toolbar-btn-restore')).not.toBeDisabled();
+  });
+
+  it('disables the organize button while organizing', () => {
+    render(<PopupToolbarOrganizing />);
+    expect(screen.getByTestId('popup-toolbar-btn-organize')).toBeDisabled();
+  });
+
+  it('disables the restore button when there are no sessions', () => {
+    render(<PopupToolbarNoSessions />);
+    expect(screen.getByTestId('popup-toolbar-btn-restore')).toBeDisabled();
+  });
+
+  it('disables the save button when canSave is false', () => {
+    render(<PopupToolbarSaveDisabled />);
+    expect(screen.getByTestId('popup-toolbar-btn-save')).toBeDisabled();
+  });
+
+  it('renders without crashing when there are no active rules', () => {
+    render(<PopupToolbarNoRules />);
+    expect(screen.getByTestId('popup-toolbar')).toBeInTheDocument();
+  });
+
+  it('renders the single-tab variant', () => {
+    render(<PopupToolbarSingleTab />);
+    expect(screen.getByTestId('popup-toolbar')).toBeInTheDocument();
+  });
+
+  it('renders the many-tabs variant', () => {
+    render(<PopupToolbarManyTabs />);
+    expect(screen.getByTestId('popup-toolbar')).toBeInTheDocument();
+  });
+
+  it('clicking organize sends an ORGANIZE_ALL_TABS message', async () => {
+    const sendMessage = vi.spyOn(fakeBrowser.runtime, 'sendMessage').mockResolvedValue(undefined as never);
+    const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
+    render(<PopupToolbarDefault />);
+
+    fireEvent.click(screen.getByTestId('popup-toolbar-btn-organize'));
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({ type: 'ORGANIZE_ALL_TABS' });
+    });
+    closeSpy.mockRestore();
+  });
+});
+
+describe('PopupToolbar (no props)', () => {
+  it('queries browser data when props are not provided', async () => {
+    const tabsQuery = vi
+      .spyOn(fakeBrowser.tabs, 'query')
+      .mockResolvedValue([{ id: 1, groupId: -1 } as never]);
+
+    // Import the component directly (not via the story) so it falls into the
+    // default-prop branch that triggers loadSessions/hasCapturableTabs/tabs.query.
+    const { PopupToolbar } = await import(
+      '../../src/components/UI/PopupToolbar/PopupToolbar'
+    );
+    const { Theme } = await import('@radix-ui/themes');
+    const { render: localRender } = await import('@testing-library/react');
+
+    localRender(
+      <Theme>
+        <PopupToolbar />
+      </Theme>,
+    );
+
+    await waitFor(() => {
+      expect(tabsQuery).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/components/SearchableInlineList.test.tsx
+++ b/tests/components/SearchableInlineList.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+import { SearchableInlineList } from '../../src/components/Form/FormFields/SearchableInlineList';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const flatOptions = [
+  { value: 'a', label: 'Apple' },
+  { value: 'b', label: 'Banana' },
+  { value: 'c', label: 'Cherry' },
+];
+
+describe('SearchableInlineList', () => {
+  it('renders all options', () => {
+    wrap(<SearchableInlineList value="" onValueChange={() => {}} options={flatOptions} />);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+    expect(screen.getByText('Cherry')).toBeInTheDocument();
+  });
+
+  it('marks the active option with a selected class', () => {
+    wrap(<SearchableInlineList value="b" onValueChange={() => {}} options={flatOptions} />);
+    const banana = screen.getByText('Banana').closest('[role="option"]');
+    expect(banana?.className).toContain('ss-item--selected');
+  });
+
+  it('calls onValueChange when an option is selected', () => {
+    const onValueChange = vi.fn();
+    wrap(
+      <SearchableInlineList value="" onValueChange={onValueChange} options={flatOptions} />,
+    );
+    fireEvent.click(screen.getByText('Cherry'));
+    expect(onValueChange).toHaveBeenCalledWith('c');
+  });
+
+  it('does not call onValueChange when a disabled option is clicked', () => {
+    const onValueChange = vi.fn();
+    wrap(
+      <SearchableInlineList
+        value=""
+        onValueChange={onValueChange}
+        options={[{ value: 'd', label: 'Disabled', disabled: true }]}
+      />,
+    );
+    fireEvent.click(screen.getByText('Disabled'));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('renders grouped options with headings', () => {
+    wrap(
+      <SearchableInlineList
+        value=""
+        onValueChange={() => {}}
+        groups={[
+          { label: 'Fruits', options: [{ value: 'a', label: 'Apple' }] },
+          { label: 'Berries', options: [{ value: 'b', label: 'Blueberry' }] },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Fruits')).toBeInTheDocument();
+    expect(screen.getByText('Berries')).toBeInTheDocument();
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Blueberry')).toBeInTheDocument();
+  });
+
+  it('applies the provided id on the search input after mount', () => {
+    wrap(
+      <SearchableInlineList
+        value=""
+        onValueChange={() => {}}
+        options={flatOptions}
+        id="my-search"
+      />,
+    );
+    expect(document.getElementById('my-search')).not.toBeNull();
+  });
+
+  it('uses the searchPlaceholder for the input aria-label', () => {
+    wrap(
+      <SearchableInlineList
+        value=""
+        onValueChange={() => {}}
+        options={flatOptions}
+        searchPlaceholder="Find a fruit"
+      />,
+    );
+    expect(screen.getByLabelText('Find a fruit')).toBeInTheDocument();
+  });
+
+  it('falls back to the i18n default when searchPlaceholder is omitted', () => {
+    wrap(<SearchableInlineList value="" onValueChange={() => {}} options={flatOptions} />);
+    expect(screen.getByLabelText('searchableSelectSearchLabel')).toBeInTheDocument();
+  });
+});

--- a/tests/components/SessionEditDialog.stories.test.tsx
+++ b/tests/components/SessionEditDialog.stories.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/Core/Session/SessionEditDialog.stories';
 
@@ -22,5 +22,26 @@ describe('SessionEditDialog (portable stories)', () => {
   it('renders nothing when session is null', () => {
     const { container } = render(<SessionEditDialogClosed />);
     expect(container.querySelector('[data-testid="dialog-session-edit"]')).not.toBeInTheDocument();
+  });
+
+  it('clicking cancel without dirty edits closes immediately', () => {
+    render(<SessionEditDialogOpen />);
+    fireEvent.click(screen.getByTestId('dialog-session-edit-btn-cancel'));
+    // No alert should appear since no changes were made.
+    expect(screen.queryByText(/unsaved/i)).toBeNull();
+  });
+
+  it('typing in the name field updates the input value', () => {
+    render(<SessionEditDialogOpen />);
+    const input = screen.getByTestId('dialog-session-edit-field-name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Renamed session' } });
+    expect(input.value).toBe('Renamed session');
+  });
+
+  it('typing in the note field updates the textarea value', () => {
+    render(<SessionEditDialogOpen />);
+    const textarea = document.getElementById('session-edit-note') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Some note text' } });
+    expect(textarea.value).toBe('Some note text');
   });
 });

--- a/tests/components/SessionImportRows.test.tsx
+++ b/tests/components/SessionImportRows.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { Session } from '../../src/types/session';
+import type {
+  ConflictingSession,
+  SessionDiff,
+  GroupDiff,
+} from '../../src/utils/sessionClassification';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+  getPluralMessage: vi.fn((count: number, oneKey: string, manyKey: string) =>
+    count === 1 ? oneKey : manyKey,
+  ),
+}));
+
+import {
+  SessionRow,
+  ConflictSessionRow,
+  SessionDiffView,
+} from '../../src/components/UI/ImportExportWizards/SessionImportRows';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const baseSession: Session = {
+  id: 's1',
+  name: 'My Session',
+  createdAt: '2025-01-01T10:00:00.000Z',
+  updatedAt: '2025-01-02T10:00:00.000Z',
+  isPinned: false,
+  categoryId: null,
+  groups: [],
+  ungroupedTabs: [],
+};
+
+const emptyDiff: SessionDiff = {
+  groupsAdded: [],
+  groupsRemoved: [],
+  groupsChanged: [],
+  ungroupedTabsAdded: [],
+  ungroupedTabsRemoved: [],
+};
+
+describe('SessionRow', () => {
+  it('renders the session name', () => {
+    wrap(<SessionRow session={baseSession} />);
+    expect(screen.getByText('My Session')).toBeInTheDocument();
+  });
+
+  it('shows the pinned badge when the session is pinned', () => {
+    wrap(<SessionRow session={{ ...baseSession, isPinned: true }} />);
+    expect(screen.getByText('pinnedBadge')).toBeInTheDocument();
+  });
+
+  it('renders a status badge when provided', () => {
+    wrap(<SessionRow session={baseSession} statusBadge="IDENTICAL" />);
+    expect(screen.getByText('IDENTICAL')).toBeInTheDocument();
+  });
+
+  it('renders a checkbox when checkbox=true', () => {
+    wrap(<SessionRow session={baseSession} checkbox checked onToggle={() => {}} />);
+    expect(screen.getByLabelText('My Session')).toBeInTheDocument();
+  });
+});
+
+describe('ConflictSessionRow', () => {
+  it('renders a conflicting session card with the diff popover trigger', () => {
+    const conflict: ConflictingSession = {
+      imported: { ...baseSession, name: 'Imported' },
+      existing: baseSession,
+      diff: { ...emptyDiff, groupsAdded: ['New group'] },
+    };
+    wrap(<ConflictSessionRow conflict={conflict} />);
+    expect(screen.getByText('Imported')).toBeInTheDocument();
+  });
+
+  it('displays the pinned badge when the imported session is pinned', () => {
+    const conflict: ConflictingSession = {
+      imported: { ...baseSession, name: 'Pinned', isPinned: true },
+      existing: baseSession,
+      diff: emptyDiff,
+    };
+    wrap(<ConflictSessionRow conflict={conflict} />);
+    expect(screen.getByText('pinnedBadge')).toBeInTheDocument();
+  });
+});
+
+describe('SessionDiffView', () => {
+  it('returns null when no diff content', () => {
+    const { container } = wrap(<SessionDiffView diff={emptyDiff} />);
+    // Theme wrapper renders, but no diff content node should appear inside.
+    expect(container.querySelector('[mb]')).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows isPinned diff', () => {
+    wrap(
+      <SessionDiffView
+        diff={{ ...emptyDiff, isPinned: { current: false, imported: true } }}
+      />,
+    );
+    expect(screen.getByText(/isPinned/)).toBeInTheDocument();
+  });
+
+  it('shows categoryId diff with null fallbacks', () => {
+    wrap(
+      <SessionDiffView
+        diff={{ ...emptyDiff, categoryId: { current: null, imported: 'work' } }}
+      />,
+    );
+    expect(screen.getByText(/categoryId/)).toBeInTheDocument();
+  });
+
+  it('lists groups added and groups removed', () => {
+    wrap(
+      <SessionDiffView
+        diff={{ ...emptyDiff, groupsAdded: ['Cloud'], groupsRemoved: ['Old'] }}
+      />,
+    );
+    expect(screen.getByText('Groups added')).toBeInTheDocument();
+    expect(screen.getByText('Cloud')).toBeInTheDocument();
+    expect(screen.getByText('Groups removed')).toBeInTheDocument();
+    expect(screen.getByText('Old')).toBeInTheDocument();
+  });
+
+  it('lists ungrouped tabs added and removed', () => {
+    wrap(
+      <SessionDiffView
+        diff={{
+          ...emptyDiff,
+          ungroupedTabsAdded: ['https://added.example/'],
+          ungroupedTabsRemoved: ['https://removed.example/'],
+        }}
+      />,
+    );
+    expect(screen.getByText('Ungrouped tabs')).toBeInTheDocument();
+    expect(screen.getByText('+ https://added.example/')).toBeInTheDocument();
+    expect(screen.getByText('- https://removed.example/')).toBeInTheDocument();
+  });
+
+  it('renders a changed group with color, added and removed tabs', () => {
+    const groupDiff: GroupDiff = {
+      title: 'Work',
+      colorChanged: { current: 'blue', imported: 'red' },
+      tabsAdded: ['https://new.example/'],
+      tabsRemoved: ['https://old.example/'],
+    };
+    wrap(<SessionDiffView diff={{ ...emptyDiff, groupsChanged: [groupDiff] }} />);
+    expect(screen.getByText(/Group: Work/)).toBeInTheDocument();
+    expect(screen.getByText('+ https://new.example/')).toBeInTheDocument();
+    expect(screen.getByText('- https://old.example/')).toBeInTheDocument();
+  });
+});

--- a/tests/components/SessionsPage.stories.test.tsx
+++ b/tests/components/SessionsPage.stories.test.tsx
@@ -7,6 +7,7 @@ const {
   SessionsPageDefault,
   SessionsPageAllPinned,
   SessionsPageNonePinned,
+  SessionsPageWithSnapshotOpen,
 } = composeStories(stories);
 
 describe('SessionsPage (portable stories)', () => {
@@ -38,6 +39,13 @@ describe('SessionsPage (portable stories)', () => {
     await waitFor(() => {
       expect(screen.getByText('No pinned sessions.')).toBeInTheDocument();
       expect(screen.getByText('Pin a session to access it quickly from the popup.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders with the snapshot wizard open variant', async () => {
+    await SessionsPageWithSnapshotOpen.run();
+    await waitFor(() => {
+      expect(screen.getByTestId('page-sessions')).toBeInTheDocument();
     });
   });
 });

--- a/tests/components/Toaster.test.tsx
+++ b/tests/components/Toaster.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+import { Toaster } from '../../src/components/UI/Toaster/Toaster';
+import {
+  showSuccessToast,
+  showErrorToast,
+  showInfoToast,
+} from '../../src/utils/toast';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+describe('Toaster', () => {
+  it('mounts with the viewport but no toasts initially', () => {
+    wrap(<Toaster />);
+    expect(screen.getByTestId('toast-viewport')).toBeInTheDocument();
+    expect(screen.queryByTestId('toast-success')).toBeNull();
+  });
+
+  it('displays a success toast with title and message', () => {
+    wrap(<Toaster />);
+    act(() => {
+      showSuccessToast('Saved', 'Your changes are saved');
+    });
+    expect(screen.getByTestId('toast-success')).toBeInTheDocument();
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    expect(screen.getByText('Your changes are saved')).toBeInTheDocument();
+  });
+
+  it('displays an error toast variant', () => {
+    wrap(<Toaster />);
+    act(() => {
+      showErrorToast('Error', 'Something went wrong');
+    });
+    expect(screen.getByTestId('toast-error')).toBeInTheDocument();
+  });
+
+  it('displays an info toast variant', () => {
+    wrap(<Toaster />);
+    act(() => {
+      showInfoToast('Heads up', 'Just a note');
+    });
+    expect(screen.getByTestId('toast-info')).toBeInTheDocument();
+  });
+
+  it('queues multiple toasts simultaneously', () => {
+    wrap(<Toaster />);
+    act(() => {
+      showSuccessToast('A', 'a');
+      showErrorToast('B', 'b');
+    });
+    expect(screen.getByTestId('toast-success')).toBeInTheDocument();
+    expect(screen.getByTestId('toast-error')).toBeInTheDocument();
+  });
+
+  it('removes a toast a few ms after the close button is clicked', () => {
+    wrap(<Toaster />);
+    act(() => {
+      showSuccessToast('Bye', 'Closing');
+    });
+    expect(screen.getByTestId('toast-success')).toBeInTheDocument();
+
+    const closeBtn = screen.getByTestId('toast-btn-close');
+    act(() => {
+      fireEvent.click(closeBtn);
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByTestId('toast-success')).toBeNull();
+  });
+
+  it('cleans up the subscription on unmount', () => {
+    const { unmount } = wrap(<Toaster />);
+    unmount();
+    // emitting after unmount must not throw
+    expect(() => {
+      showSuccessToast('After', 'unmount');
+    }).not.toThrow();
+  });
+});

--- a/tests/components/WorkspaceColorPicker.test.tsx
+++ b/tests/components/WorkspaceColorPicker.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+import { WorkspaceColorPicker } from '../../src/components/UI/Workspace/WorkspaceColorPicker';
+import { workspaceAccentColors } from '../../src/schemas/workspace';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+describe('WorkspaceColorPicker', () => {
+  it('renders one swatch per accent color', () => {
+    wrap(<WorkspaceColorPicker value="indigo" onChange={() => {}} />);
+    for (const color of workspaceAccentColors) {
+      expect(screen.getByTestId(`workspace-color-swatch-${color}`)).toBeInTheDocument();
+    }
+  });
+
+  it('marks the selected swatch with aria-checked=true', () => {
+    wrap(<WorkspaceColorPicker value="jade" onChange={() => {}} />);
+    const jade = screen.getByTestId('workspace-color-swatch-jade');
+    expect(jade.getAttribute('aria-checked')).toBe('true');
+    expect(jade.dataset.active).toBe('true');
+
+    const indigo = screen.getByTestId('workspace-color-swatch-indigo');
+    expect(indigo.getAttribute('aria-checked')).toBe('false');
+    expect(indigo.dataset.active).toBeUndefined();
+  });
+
+  it('calls onChange with the selected color when a swatch is clicked', () => {
+    const onChange = vi.fn();
+    wrap(<WorkspaceColorPicker value="indigo" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('workspace-color-swatch-tomato'));
+    expect(onChange).toHaveBeenCalledWith('tomato');
+  });
+
+  it('uses the provided ariaLabel on the radiogroup', () => {
+    wrap(<WorkspaceColorPicker value="indigo" onChange={() => {}} ariaLabel="Pick" />);
+    expect(screen.getByRole('radiogroup', { name: 'Pick' })).toBeInTheDocument();
+  });
+
+  it('falls back to the i18n label when ariaLabel is omitted', () => {
+    wrap(<WorkspaceColorPicker value="indigo" onChange={() => {}} />);
+    expect(
+      screen.getByRole('radiogroup', { name: 'workspaceColorPickerLabel' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/WorkspaceDeleteConfirmDialog.test.tsx
+++ b/tests/components/WorkspaceDeleteConfirmDialog.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string, subs?: string[]) => {
+    if (subs && subs.length) return `${key}(${subs.join(',')})`;
+    return key;
+  }),
+}));
+
+import { WorkspaceDeleteConfirmDialog } from '../../src/components/UI/Workspace/WorkspaceDeleteConfirmDialog';
+
+const baseWorkspace: WorkspaceMeta = {
+  id: 'ws-1',
+  name: 'Personal',
+  accentColor: 'indigo',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+describe('WorkspaceDeleteConfirmDialog', () => {
+  it('returns null when no workspace is provided', () => {
+    const { container } = wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        workspace={null}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(container.querySelector('[data-testid="workspace-delete-dialog"]')).toBeNull();
+  });
+
+  it('renders the dialog with the destructive button initially disabled', () => {
+    wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        workspace={baseWorkspace}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('workspace-delete-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-delete-btn-confirm')).toBeDisabled();
+  });
+
+  it('keeps the confirm button disabled while the typed name does not match', () => {
+    wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        workspace={baseWorkspace}
+        onConfirm={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-delete-confirm-input'), {
+      target: { value: 'Person' },
+    });
+    expect(screen.getByTestId('workspace-delete-btn-confirm')).toBeDisabled();
+  });
+
+  it('enables the confirm button when the typed name matches exactly', () => {
+    wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        workspace={baseWorkspace}
+        onConfirm={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-delete-confirm-input'), {
+      target: { value: 'Personal' },
+    });
+    expect(screen.getByTestId('workspace-delete-btn-confirm')).not.toBeDisabled();
+  });
+
+  it('calls onConfirm and closes the dialog when confirmed', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        workspace={baseWorkspace}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-delete-confirm-input'), {
+      target: { value: 'Personal' },
+    });
+    await fireEvent.click(screen.getByTestId('workspace-delete-btn-confirm'));
+
+    // wait microtask so the async onConfirm resolves
+    await Promise.resolve();
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('does not call onConfirm if the typed name still mismatches', () => {
+    const onConfirm = vi.fn();
+    wrap(
+      <WorkspaceDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        workspace={baseWorkspace}
+        onConfirm={onConfirm}
+      />,
+    );
+    // The button is disabled, but call the click directly to ensure handler short-circuits.
+    const btn = screen.getByTestId('workspace-delete-btn-confirm');
+    fireEvent.click(btn);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/WorkspaceFooter.test.tsx
+++ b/tests/components/WorkspaceFooter.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+const ctx = {
+  workspaces: [] as WorkspaceMeta[],
+  activeId: 'default',
+  active: null as WorkspaceMeta | null,
+  accentColor: 'indigo' as const,
+  scopedItems: {} as never,
+  isLoaded: true,
+  switchTo: vi.fn().mockResolvedValue(undefined),
+  createWorkspace: vi.fn().mockResolvedValue(undefined),
+  renameWorkspace: vi.fn().mockResolvedValue(undefined),
+  setWorkspaceColor: vi.fn().mockResolvedValue(undefined),
+  removeWorkspace: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../../src/contexts/ActiveWorkspaceContext', () => ({
+  useActiveWorkspaceContext: () => ctx,
+}));
+
+import {
+  WorkspaceFooter,
+  WorkspaceFooterCollapsed,
+} from '../../src/components/UI/Workspace/WorkspaceFooter';
+import { PopupWorkspaceFooter } from '../../src/components/UI/Workspace/PopupWorkspaceFooter';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+beforeEach(() => {
+  ctx.active = null;
+  ctx.accentColor = 'indigo';
+});
+
+describe('WorkspaceFooter', () => {
+  it('renders the trigger and the manage button enabled when onManage is provided', () => {
+    const onManage = vi.fn();
+    wrap(<WorkspaceFooter onManage={onManage} />);
+    expect(screen.getByTestId('workspace-footer')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-footer-trigger')).toBeInTheDocument();
+    const manage = screen.getByTestId('workspace-manage-button');
+    expect(manage).not.toBeDisabled();
+    fireEvent.click(manage);
+    expect(onManage).toHaveBeenCalled();
+  });
+
+  it('disables the manage button when onManage is undefined', () => {
+    wrap(<WorkspaceFooter />);
+    expect(screen.getByTestId('workspace-manage-button')).toBeDisabled();
+  });
+
+  it('shows the active workspace name when one is set', () => {
+    ctx.active = {
+      id: 'ws-1',
+      name: 'My Project',
+      accentColor: 'jade',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    wrap(<WorkspaceFooter />);
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('falls back to the default workspace label when no active workspace is set', () => {
+    ctx.active = null;
+    wrap(<WorkspaceFooter />);
+    expect(screen.getByText('workspaceDefaultName')).toBeInTheDocument();
+  });
+});
+
+describe('WorkspaceFooterCollapsed', () => {
+  it('renders the collapsed trigger', () => {
+    wrap(<WorkspaceFooterCollapsed />);
+    expect(screen.getByTestId('workspace-footer-trigger-collapsed')).toBeInTheDocument();
+  });
+
+  it('uses the active workspace name when set', () => {
+    ctx.active = {
+      id: 'ws-2',
+      name: 'Personal',
+      accentColor: 'tomato',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    wrap(<WorkspaceFooterCollapsed />);
+    const trigger = screen.getByTestId('workspace-footer-trigger-collapsed');
+    expect(trigger.getAttribute('title')).toBe('Personal');
+  });
+});
+
+describe('PopupWorkspaceFooter', () => {
+  it('renders the popup-specific footer with trigger', () => {
+    wrap(<PopupWorkspaceFooter />);
+    expect(screen.getByTestId('popup-workspace-footer')).toBeInTheDocument();
+    expect(screen.getByTestId('popup-workspace-trigger')).toBeInTheDocument();
+  });
+
+  it('shows the active workspace name', () => {
+    ctx.active = {
+      id: 'ws-x',
+      name: 'Important',
+      accentColor: 'crimson',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+    wrap(<PopupWorkspaceFooter />);
+    expect(screen.getByText('Important')).toBeInTheDocument();
+  });
+});

--- a/tests/components/WorkspaceFormDialog.test.tsx
+++ b/tests/components/WorkspaceFormDialog.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => key),
+}));
+
+import { WorkspaceFormDialog } from '../../src/components/UI/Workspace/WorkspaceFormDialog';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const baseWorkspace: WorkspaceMeta = {
+  id: 'ws-1',
+  name: 'Personal',
+  accentColor: 'indigo',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('WorkspaceFormDialog (create mode)', () => {
+  it('renders the create title and create button label', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={[]}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('workspace-form-dialog')).toBeInTheDocument();
+    expect(screen.getByText('workspaceCreateTitle')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-form-btn-submit')).toHaveTextContent(
+      'workspaceFormBtnCreate',
+    );
+  });
+
+  it('disables the submit button while the name is empty', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={[]}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('workspace-form-btn-submit')).toBeDisabled();
+  });
+
+  it('shows the duplicate error when the name is already taken', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={['Personal']}
+        onSubmit={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-form-name'), {
+      target: { value: 'personal' },
+    });
+    expect(screen.getByTestId('workspace-form-error-duplicate')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-form-btn-submit')).toBeDisabled();
+  });
+
+  it('calls onSubmit with trimmed name when valid', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={onOpenChange}
+        takenNames={[]}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-form-name'), {
+      target: { value: '  My WS  ' },
+    });
+    fireEvent.click(screen.getByTestId('workspace-form-btn-submit'));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ name: 'My WS', accentColor: 'jade' }),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('submits when Enter is pressed in the name field', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={[]}
+        onSubmit={onSubmit}
+      />,
+    );
+    const input = screen.getByTestId('workspace-form-name');
+    fireEvent.change(input, { target: { value: 'New WS' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ name: 'New WS', accentColor: 'jade' }),
+    );
+  });
+});
+
+describe('WorkspaceFormDialog (edit mode)', () => {
+  it('pre-fills the form fields and shows the save button', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={['Personal']}
+        initial={baseWorkspace}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByText('workspaceEditTitle')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-form-name')).toHaveValue('Personal');
+    expect(screen.getByTestId('workspace-form-btn-submit')).toHaveTextContent('save');
+  });
+
+  it('does not flag the original name as a duplicate of itself', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={['Personal', 'Other']}
+        initial={baseWorkspace}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('workspace-form-error-duplicate')).toBeNull();
+    expect(screen.getByTestId('workspace-form-btn-submit')).not.toBeDisabled();
+  });
+
+  it('flags a clash with another existing workspace name', () => {
+    wrap(
+      <WorkspaceFormDialog
+        open
+        onOpenChange={() => {}}
+        takenNames={['Personal', 'Other']}
+        initial={baseWorkspace}
+        onSubmit={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('workspace-form-name'), {
+      target: { value: 'other' },
+    });
+    expect(screen.getByTestId('workspace-form-error-duplicate')).toBeInTheDocument();
+  });
+});

--- a/tests/components/WorkspacesPage.test.tsx
+++ b/tests/components/WorkspacesPage.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+import type { AppSettings } from '../../src/types/syncSettings';
+
+vi.mock('../../src/utils/i18n', () => ({
+  getMessage: vi.fn((key: string, subs?: string[]) =>
+    subs?.length ? `${key}(${subs.join(',')})` : key,
+  ),
+  getPluralMessage: vi.fn((count: number, oneKey: string, manyKey: string) =>
+    count === 1 ? oneKey : manyKey,
+  ),
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  logger: { debug: vi.fn(), log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const ctx = {
+  workspaces: [] as WorkspaceMeta[],
+  activeId: 'default',
+  active: null as WorkspaceMeta | null,
+  accentColor: 'indigo' as const,
+  scopedItems: {} as never,
+  isLoaded: true,
+  switchTo: vi.fn().mockResolvedValue(undefined),
+  createWorkspace: vi.fn().mockResolvedValue(undefined),
+  renameWorkspace: vi.fn().mockResolvedValue(undefined),
+  setWorkspaceColor: vi.fn().mockResolvedValue(undefined),
+  removeWorkspace: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../../src/contexts/ActiveWorkspaceContext', () => ({
+  useActiveWorkspaceContext: () => ctx,
+}));
+
+vi.mock('../../src/components/UI/PageLayout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: () => React.ReactNode }) => (
+    <div data-testid="page-layout">{children()}</div>
+  ),
+}));
+
+import { WorkspacesPage } from '../../src/pages/WorkspacesPage';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const baseSettings: AppSettings = {
+  globalGroupingEnabled: true,
+  globalDeduplicationEnabled: true,
+  deduplicateUnmatchedDomains: false,
+  deduplicationKeepStrategy: 'keep-grouped-or-new',
+  categories: [],
+  notifyOnGrouping: true,
+  notifyOnDeduplication: true,
+  domainRules: [],
+};
+
+const mkWs = (id: string, name: string, accentColor: WorkspaceMeta['accentColor'] = 'indigo'): WorkspaceMeta => ({
+  id,
+  name,
+  accentColor,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+});
+
+beforeEach(() => {
+  ctx.switchTo.mockClear();
+  ctx.createWorkspace.mockClear();
+  ctx.renameWorkspace.mockClear();
+  ctx.setWorkspaceColor.mockClear();
+  ctx.removeWorkspace.mockClear();
+});
+
+describe('WorkspacesPage', () => {
+  it('renders the create button and a row per workspace', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work', 'jade')];
+    ctx.activeId = 'default';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    expect(screen.getByTestId('workspace-create-button')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-default')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-ws-2')).toBeInTheDocument();
+  });
+
+  it('marks the active workspace and shows the default badge', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work', 'jade')];
+    ctx.activeId = 'ws-2';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    expect(screen.getByTestId('workspace-row-ws-2-active')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-default-default')).toBeInTheDocument();
+  });
+
+  it('switch button is hidden on the active row', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work')];
+    ctx.activeId = 'ws-2';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    expect(screen.queryByTestId('workspace-row-ws-2-switch')).toBeNull();
+    expect(screen.getByTestId('workspace-row-default-switch')).toBeInTheDocument();
+  });
+
+  it('disables delete on the default workspace and on the only workspace', () => {
+    ctx.workspaces = [mkWs('default', 'Personal')];
+    ctx.activeId = 'default';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+    // default + only -> deleteBlocked
+    expect(screen.getByTestId('workspace-row-default-delete')).toBeDisabled();
+  });
+
+  it('clicking switch invokes context.switchTo with the workspace id', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work')];
+    ctx.activeId = 'default';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    fireEvent.click(screen.getByTestId('workspace-row-ws-2-switch'));
+    expect(ctx.switchTo).toHaveBeenCalledWith('ws-2');
+  });
+
+  it('clicking create opens the create dialog and submits a new workspace', async () => {
+    ctx.workspaces = [mkWs('default', 'Personal')];
+    ctx.activeId = 'default';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    fireEvent.click(screen.getByTestId('workspace-create-button'));
+    fireEvent.change(screen.getByTestId('workspace-form-name'), {
+      target: { value: 'New WS' },
+    });
+    fireEvent.click(screen.getByTestId('workspace-form-btn-submit'));
+
+    await waitFor(() =>
+      expect(ctx.createWorkspace).toHaveBeenCalledWith('New WS', 'jade'),
+    );
+  });
+
+  it('clicking edit opens the edit dialog with the workspace pre-filled', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work', 'jade')];
+    ctx.activeId = 'ws-2';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    fireEvent.click(screen.getByTestId('workspace-row-ws-2-edit'));
+    expect(screen.getByTestId('workspace-form-name')).toHaveValue('Work');
+  });
+
+  it('clicking delete opens the destructive confirm dialog', () => {
+    ctx.workspaces = [mkWs('default', 'Personal'), mkWs('ws-2', 'Work')];
+    ctx.activeId = 'default';
+    wrap(<WorkspacesPage syncSettings={baseSettings} />);
+
+    fireEvent.click(screen.getByTestId('workspace-row-ws-2-delete'));
+    expect(screen.getByTestId('workspace-delete-dialog')).toBeInTheDocument();
+  });
+});

--- a/tests/components/useExportActions.test.tsx
+++ b/tests/components/useExportActions.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+const showSuccessToast = vi.fn();
+vi.mock('@/utils/toast', () => ({
+  showSuccessToast: (...args: unknown[]) => showSuccessToast(...args),
+}));
+
+import { useExportActions } from '../../src/components/UI/ImportExportWizards/Export/useExportActions';
+
+const baseConfig = {
+  filename: 'export.json',
+  notifyTitleKey: 'exportTitle',
+  selected: [{ id: 'a' }, { id: 'b' }] as const,
+  note: '',
+  buildJson: () => '{"hello":"world"}',
+};
+
+beforeEach(() => {
+  showSuccessToast.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as { showSaveFilePicker?: unknown }).showSaveFilePicker;
+});
+
+describe('useExportActions', () => {
+  it('exporte via showSaveFilePicker quand disponible', async () => {
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const createWritableMock = vi.fn().mockResolvedValue({ write: writeMock, close: closeMock });
+    const showSaveFilePicker = vi.fn().mockResolvedValue({ createWritable: createWritableMock });
+    (window as unknown as { showSaveFilePicker: unknown }).showSaveFilePicker = showSaveFilePicker;
+
+    const onFinish = vi.fn();
+    const { result } = renderHook(() =>
+      useExportActions({
+        ...baseConfig,
+        notifyMessage: 'plainKey',
+        onFinish,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.exportToFile();
+    });
+
+    expect(showSaveFilePicker).toHaveBeenCalledWith(
+      expect.objectContaining({ suggestedName: 'export.json' }),
+    );
+    expect(writeMock).toHaveBeenCalledWith('{"hello":"world"}');
+    expect(closeMock).toHaveBeenCalled();
+    expect(onFinish).toHaveBeenCalled();
+    expect(showSuccessToast).toHaveBeenCalledWith('i18n(exportTitle)', 'i18n(plainKey)');
+  });
+
+  it('utilise un message factory quand notifyMessage est une fonction', async () => {
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { showSaveFilePicker: unknown }).showSaveFilePicker = vi
+      .fn()
+      .mockResolvedValue({
+        createWritable: vi.fn().mockResolvedValue({ write: writeMock, close: closeMock }),
+      });
+
+    const onFinish = vi.fn();
+    const messageFactory = vi.fn((count: number) => `${count} sessions exportées`);
+    const { result } = renderHook(() =>
+      useExportActions({
+        ...baseConfig,
+        notifyMessage: messageFactory,
+        onFinish,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.exportToFile();
+    });
+
+    expect(messageFactory).toHaveBeenCalledWith(2);
+    expect(showSuccessToast).toHaveBeenCalledWith('i18n(exportTitle)', '2 sessions exportées');
+  });
+
+  it('avale silencieusement les AbortError de la file picker', async () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    (window as unknown as { showSaveFilePicker: unknown }).showSaveFilePicker = vi
+      .fn()
+      .mockRejectedValue(abort);
+
+    const onFinish = vi.fn();
+    const { result } = renderHook(() =>
+      useExportActions({ ...baseConfig, notifyMessage: 'k', onFinish }),
+    );
+
+    await expect(result.current.exportToFile()).resolves.toBeUndefined();
+    expect(onFinish).not.toHaveBeenCalled();
+    expect(showSuccessToast).not.toHaveBeenCalled();
+  });
+
+  it('relance les autres erreurs de file picker', async () => {
+    (window as unknown as { showSaveFilePicker: unknown }).showSaveFilePicker = vi
+      .fn()
+      .mockRejectedValue(new Error('disk full'));
+
+    const onFinish = vi.fn();
+    const { result } = renderHook(() =>
+      useExportActions({ ...baseConfig, notifyMessage: 'k', onFinish }),
+    );
+
+    await expect(result.current.exportToFile()).rejects.toThrow('disk full');
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('utilise le fallback Blob/anchor quand showSaveFilePicker est absent', async () => {
+    const clickMock = vi.fn();
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag === 'a') {
+        const anchor = { href: '', download: '', click: clickMock } as unknown as HTMLAnchorElement;
+        return anchor;
+      }
+      return document.createElementNS('http://www.w3.org/1999/xhtml', tag) as HTMLElement;
+    }) as typeof document.createElement);
+
+    const createUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+    const revokeUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const onFinish = vi.fn();
+    const { result } = renderHook(() =>
+      useExportActions({ ...baseConfig, notifyMessage: 'k', onFinish }),
+    );
+
+    await act(async () => {
+      await result.current.exportToFile();
+    });
+
+    expect(createUrlSpy).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+    expect(revokeUrlSpy).toHaveBeenCalledWith('blob:fake');
+    expect(onFinish).toHaveBeenCalled();
+    expect(showSuccessToast).toHaveBeenCalled();
+
+    createElementSpy.mockRestore();
+  });
+
+  it('exporte vers le presse-papiers via navigator.clipboard.writeText', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const onFinish = vi.fn();
+    const { result } = renderHook(() =>
+      useExportActions({ ...baseConfig, notifyMessage: 'k', onFinish }),
+    );
+
+    await act(async () => {
+      await result.current.exportToClipboard();
+    });
+
+    expect(writeText).toHaveBeenCalledWith('{"hello":"world"}');
+    expect(onFinish).toHaveBeenCalled();
+    expect(showSuccessToast).toHaveBeenCalled();
+  });
+});

--- a/tests/components/useJsonSourceInput.test.tsx
+++ b/tests/components/useJsonSourceInput.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { z } from 'zod';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+import { useJsonSourceInput } from '../../src/components/UI/ImportExportWizards/Source/useJsonSourceInput';
+
+const payloadSchema = z.object({ name: z.string() });
+
+const validate = (raw: unknown) => {
+  const data = payloadSchema.parse(raw);
+  return { data, note: (raw as { note?: string }).note ?? null };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useJsonSourceInput', () => {
+  it('démarre en mode file avec un état vide', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    expect(result.current.sourceMode).toBe('file');
+    expect(result.current.parsedData).toBeNull();
+    expect(result.current.parseError).toBeNull();
+    expect(result.current.importedNote).toBeNull();
+    expect(result.current.fileName).toBeNull();
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it('parse du JSON valide via handleTextChange', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => {
+      result.current.handleTextChange('{"name":"Alice","note":"hello"}');
+    });
+    expect(result.current.parsedData).toEqual({ name: 'Alice' });
+    expect(result.current.importedNote).toBe('hello');
+    expect(result.current.parseError).toBeNull();
+  });
+
+  it('réinitialise le résultat parsé quand le texte est vidé', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => result.current.handleTextChange('{"name":"Alice"}'));
+    expect(result.current.parsedData).not.toBeNull();
+    act(() => result.current.handleTextChange('   '));
+    expect(result.current.parsedData).toBeNull();
+    expect(result.current.parseError).toBeNull();
+  });
+
+  it('signale un message i18n pour les SyntaxError JSON', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => result.current.handleTextChange('{not json'));
+    expect(result.current.parseError).toBe('i18n(invalidJson)');
+    expect(result.current.parsedData).toBeNull();
+  });
+
+  it('signale les erreurs Zod ligne par ligne', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => result.current.handleTextChange('{"name":42}'));
+    expect(result.current.parseError).toContain('name:');
+    expect(result.current.parsedData).toBeNull();
+  });
+
+  it('signale les autres erreurs avec un message générique', () => {
+    const customValidate = () => {
+      throw new Error('custom');
+    };
+    const { result } = renderHook(() => useJsonSourceInput(customValidate));
+    act(() => result.current.handleTextChange('{"name":"x"}'));
+    expect(result.current.parseError).toBe('i18n(errorImportInvalidStructure)');
+  });
+
+  it('handleDragOver active le drag, handleDragLeave le désactive', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    const event = { preventDefault: vi.fn() } as unknown as React.DragEvent;
+    act(() => result.current.handleDragOver(event));
+    expect(result.current.isDragOver).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    act(() => result.current.handleDragLeave());
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it('handleDrop ignore les fichiers non .json', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    const file = new File(['data'], 'note.txt', { type: 'text/plain' });
+    const event = {
+      preventDefault: vi.fn(),
+      dataTransfer: { files: [file] },
+    } as unknown as React.DragEvent;
+    act(() => result.current.handleDrop(event));
+    expect(result.current.fileName).toBeNull();
+    expect(result.current.parsedData).toBeNull();
+  });
+
+  it('reset() restaure tout l\'état initial', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => result.current.handleTextChange('{"name":"Alice","note":"hi"}'));
+    act(() => result.current.setSourceMode('text'));
+    expect(result.current.parsedData).not.toBeNull();
+    act(() => result.current.reset());
+    expect(result.current.sourceMode).toBe('file');
+    expect(result.current.jsonText).toBe('');
+    expect(result.current.parsedData).toBeNull();
+    expect(result.current.parseError).toBeNull();
+    expect(result.current.importedNote).toBeNull();
+    expect(result.current.fileName).toBeNull();
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it('handleBrowse appelle le click sur la ref de l\'input fichier', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    const click = vi.fn();
+    (result.current.fileInputRef as { current: { click: () => void } }).current = { click };
+    act(() => result.current.handleBrowse());
+    expect(click).toHaveBeenCalled();
+  });
+
+  it('setSourceMode bascule entre les modes', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate));
+    act(() => result.current.setSourceMode('text'));
+    expect(result.current.sourceMode).toBe('text');
+    act(() => result.current.setSourceMode('pack'));
+    expect(result.current.sourceMode).toBe('pack');
+  });
+});

--- a/tests/hooks/useBrowserCommands.test.tsx
+++ b/tests/hooks/useBrowserCommands.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { fakeBrowser } from 'wxt/testing';
+
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  fakeBrowser.reset();
+});
+
+afterEach(() => {
+  delete (fakeBrowser as unknown as { commands?: unknown }).commands;
+  vi.restoreAllMocks();
+});
+
+async function importHook() {
+  return await import('../../src/hooks/useBrowserCommands');
+}
+
+describe('useBrowserCommands', () => {
+  it('returns null synchronously, then resolves with the commands map', async () => {
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockResolvedValue([
+        { name: 'organize-all-tabs', shortcut: 'Alt+Shift+O' },
+        { name: 'save-current-window-session', shortcut: '' },
+      ]),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      'organize-all-tabs': 'Alt+Shift+O',
+      'save-current-window-session': '',
+    });
+  });
+
+  it('returns an empty map when browser.commands is unavailable', async () => {
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    await waitFor(() => expect(result.current).toEqual({}));
+  });
+
+  it('aliases _execute_browser_action to _execute_action when only the former is set', async () => {
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockResolvedValue([
+        { name: '_execute_browser_action', shortcut: 'Alt+Shift+P' },
+      ]),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      _execute_browser_action: 'Alt+Shift+P',
+      _execute_action: 'Alt+Shift+P',
+    });
+  });
+
+  it('does not overwrite an existing _execute_action with the alias', async () => {
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockResolvedValue([
+        { name: '_execute_action', shortcut: 'Alt+Shift+P' },
+        { name: '_execute_browser_action', shortcut: 'Alt+Shift+X' },
+      ]),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current?._execute_action).toBe('Alt+Shift+P');
+  });
+
+  it('skips entries without a name', async () => {
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockResolvedValue([
+        { name: undefined, shortcut: 'X' },
+        { name: 'organize-all-tabs', shortcut: 'Y' },
+      ]),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({ 'organize-all-tabs': 'Y' });
+  });
+
+  it('falls back to empty map when getAll rejects', async () => {
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result } = renderHook(() => useBrowserCommands());
+
+    await waitFor(() => expect(result.current).toEqual({}));
+  });
+
+  it('does not call setState after unmount', async () => {
+    let resolveGetAll: (value: unknown) => void = () => {};
+    (fakeBrowser as unknown as { commands: unknown }).commands = {
+      getAll: vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveGetAll = resolve;
+        }),
+      ),
+    };
+
+    const { useBrowserCommands } = await importHook();
+    const { result, unmount } = renderHook(() => useBrowserCommands());
+
+    expect(result.current).toBeNull();
+    unmount();
+    resolveGetAll([{ name: 'x', shortcut: 'Y' }]);
+    await new Promise((r) => setTimeout(r, 10));
+    // No throw / no warning expected; result snapshot stays null at unmount.
+    expect(result.current).toBeNull();
+  });
+});

--- a/tests/hooks/useKeyboardShortcuts.test.tsx
+++ b/tests/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardShortcuts } from '../../src/hooks/useKeyboardShortcuts';
+import type { ShortcutDefinition } from '../../src/utils/keyboardShortcuts';
+
+function dispatch(combo: { key: string; alt?: boolean; shift?: boolean; ctrl?: boolean; meta?: boolean }): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: combo.key,
+    altKey: combo.alt ?? false,
+    shiftKey: combo.shift ?? false,
+    ctrlKey: combo.ctrl ?? false,
+    metaKey: combo.meta ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useKeyboardShortcuts', () => {
+  it('fires the action whose combo matches the keydown', () => {
+    const action = vi.fn();
+    const shortcuts: ShortcutDefinition[] = [{ combo: 'Alt+Shift+r', action }];
+    renderHook(() => useKeyboardShortcuts(shortcuts));
+
+    dispatch({ key: 'r', alt: true, shift: true });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('preventDefaults the matched event', () => {
+    const action = vi.fn();
+    renderHook(() => useKeyboardShortcuts([{ combo: 'Escape', action }]));
+
+    const event = dispatch({ key: 'Escape' });
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('only fires the first matching shortcut', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts([
+        { combo: 'a', action: a },
+        { combo: 'a', action: b },
+      ]),
+    );
+
+    dispatch({ key: 'a' });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no shortcut matches', () => {
+    const action = vi.fn();
+    renderHook(() => useKeyboardShortcuts([{ combo: 'Alt+r', action }]));
+
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('does not attach the listener when enabled is false', () => {
+    const action = vi.fn();
+    renderHook(() => useKeyboardShortcuts([{ combo: 'a', action }], { enabled: false }));
+
+    dispatch({ key: 'a' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener on unmount', () => {
+    const action = vi.fn();
+    const { unmount } = renderHook(() => useKeyboardShortcuts([{ combo: 'a', action }]));
+
+    dispatch({ key: 'a' });
+    expect(action).toHaveBeenCalledTimes(1);
+
+    unmount();
+    dispatch({ key: 'a' });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips typing targets unless allowInTypingTarget is true', () => {
+    const skipAction = vi.fn();
+    const allowAction = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts([
+        { combo: 'a', action: skipAction },
+        { combo: 'b', action: allowAction, allowInTypingTarget: true },
+      ]),
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const evtA = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
+    input.dispatchEvent(evtA);
+    const evtB = new KeyboardEvent('keydown', { key: 'b', bubbles: true, cancelable: true });
+    input.dispatchEvent(evtB);
+
+    expect(skipAction).not.toHaveBeenCalled();
+    expect(allowAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips when a Radix dialog is open unless allowWhenDialogOpen is true', () => {
+    const skip = vi.fn();
+    const allow = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts([
+        { combo: 'a', action: skip },
+        { combo: 'b', action: allow, allowWhenDialogOpen: true },
+      ]),
+    );
+
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+
+    dispatch({ key: 'a' });
+    dispatch({ key: 'b' });
+
+    expect(skip).not.toHaveBeenCalled();
+    expect(allow).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips when target is within excludeIfTargetWithin selector', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts([
+        { combo: 'r', action, excludeIfTargetWithin: '.session-card' },
+      ]),
+    );
+
+    const card = document.createElement('div');
+    card.className = 'session-card';
+    const inner = document.createElement('button');
+    card.appendChild(inner);
+    document.body.appendChild(card);
+
+    const evt = new KeyboardEvent('keydown', { key: 'r', bubbles: true, cancelable: true });
+    inner.dispatchEvent(evt);
+
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hooks/usePacks.test.tsx
+++ b/tests/hooks/usePacks.test.tsx
@@ -95,3 +95,82 @@ describe('usePacks', () => {
     expect(ids).toEqual(['pack-cloud']);
   });
 });
+
+describe('usePacks (catégories invalides)', () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+    vi.resetModules();
+  });
+
+  it('expose loadError quand le fichier de catégories est invalide', async () => {
+    vi.doMock('../../src/hooks/packDataSource', () => ({
+      getPackSourceEntries: () => [],
+      getCategoriesSource: () => ({ wrong: 'shape' }),
+    }));
+    const { usePacks: usePacksReloaded } = await import('../../src/hooks/usePacks');
+
+    const { result } = renderHook(() => usePacksReloaded());
+    expect(result.current.loadError).toMatch(/invalid/i);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('trie deux packs partageant la même catégorie par nom', async () => {
+    vi.doMock('../../src/hooks/packDataSource', () => ({
+      getPackSourceEntries: () => [
+        {
+          path: '/p2.json',
+          data: {
+            version: 1,
+            pack: { id: 'b-pack', name: 'Beta', categoryId: 'cloud' },
+            domainRules: [validRule],
+          },
+        },
+        {
+          path: '/p1.json',
+          data: {
+            version: 1,
+            pack: { id: 'a-pack', name: 'Alpha', categoryId: 'cloud' },
+            domainRules: [validRule],
+          },
+        },
+      ],
+      getCategoriesSource: () => ({
+        categories: [{ id: 'cloud', label: 'Cloud' }],
+      }),
+    }));
+    const { usePacks: usePacksReloaded } = await import('../../src/hooks/usePacks');
+
+    const { result } = renderHook(() => usePacksReloaded());
+    expect(result.current.packs.map((p) => p.pack.id)).toEqual(['a-pack', 'b-pack']);
+  });
+
+  it('classe en dernier les packs sans categoryId', async () => {
+    vi.doMock('../../src/hooks/packDataSource', () => ({
+      getPackSourceEntries: () => [
+        {
+          path: '/p1.json',
+          data: {
+            version: 1,
+            pack: { id: 'no-cat', name: 'Aaa Pack', category: 'Misc' },
+            domainRules: [validRule],
+          },
+        },
+        {
+          path: '/p2.json',
+          data: {
+            version: 1,
+            pack: { id: 'cloud-pack', name: 'Zeta Pack', categoryId: 'cloud' },
+            domainRules: [validRule],
+          },
+        },
+      ],
+      getCategoriesSource: () => ({
+        categories: [{ id: 'cloud', label: 'Cloud' }],
+      }),
+    }));
+    const { usePacks: usePacksReloaded } = await import('../../src/hooks/usePacks');
+
+    const { result } = renderHook(() => usePacksReloaded());
+    expect(result.current.packs.map((p) => p.pack.id)).toEqual(['cloud-pack', 'no-cat']);
+  });
+});

--- a/tests/hooks/useSettings.test.ts
+++ b/tests/hooks/useSettings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
 import { fakeBrowser } from 'wxt/testing';
 import { useSettings } from '../../src/hooks/useSettings';
@@ -141,5 +141,92 @@ describe('useSettings', () => {
 
     expect(result.current.settings?.globalGroupingEnabled).toBe(false);
     expect(result.current.settings?.domainRules).toHaveLength(1);
+  });
+
+  it('devrait mettre à jour deduplicationKeepStrategy', async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    await act(async () => {
+      await result.current.setDeduplicationKeepStrategy('keep-old');
+    });
+
+    expect(result.current.settings?.deduplicationKeepStrategy).toBe('keep-old');
+  });
+
+  it('devrait mettre à jour les categories', async () => {
+    const { result } = renderHook(() => useSettings());
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    const newCategories = [
+      { id: 'work', emoji: '💼', color: 'blue', label: 'Work', builtIn: false },
+    ] as never;
+
+    await act(async () => {
+      await result.current.setCategories(newCategories);
+    });
+
+    expect(result.current.settings?.categories).toEqual(newCategories);
+  });
+
+  it('migre les wildcards legacy `*.example.com` -> `example.com`', async () => {
+    await fakeBrowser.storage.local.set({
+      domainRules: [
+        { id: 'r1', domainFilter: '*.example.com', label: 'Ex' },
+        { id: 'r2', domainFilter: 'plain.com', label: 'Plain' },
+      ],
+    });
+
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.settings?.domainRules?.[0].domainFilter).toBe('example.com');
+    expect(result.current.settings?.domainRules?.[1].domainFilter).toBe('plain.com');
+
+    // The migration should also have written back the cleaned value.
+    const stored = await fakeBrowser.storage.local.get('domainRules');
+    const filters = (stored.domainRules as Array<{ domainFilter: string }>).map(r => r.domainFilter);
+    expect(filters).toEqual(['example.com', 'plain.com']);
+  });
+
+  describe('listeners onFieldChange', () => {
+    it('exposent toutes une fonction de désinscription', async () => {
+      const { result } = renderHook(() => useSettings());
+      await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+      const cb = vi.fn();
+      const unwatchers = [
+        result.current.onGlobalGroupingEnabledChange(cb),
+        result.current.onGlobalDeduplicationEnabledChange(cb),
+        result.current.onDeduplicateUnmatchedDomainsChange(cb),
+        result.current.onDeduplicationKeepStrategyChange(cb),
+        result.current.onDomainRulesChange(cb),
+        result.current.onCategoriesChange(cb),
+      ];
+      for (const u of unwatchers) {
+        expect(typeof u).toBe('function');
+        expect(() => u()).not.toThrow();
+      }
+    });
+
+    it('déclenche le callback enregistré sur un changement externe', async () => {
+      const { result } = renderHook(() => useSettings());
+      await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+      const cb = vi.fn();
+      let unwatch: () => void;
+      await act(async () => {
+        unwatch = result.current.onGlobalGroupingEnabledChange(cb);
+      });
+
+      await act(async () => {
+        await fakeBrowser.storage.local.set({ globalGroupingEnabled: false });
+      });
+
+      await waitFor(() => expect(cb).toHaveBeenCalledWith(false));
+      unwatch!();
+    });
   });
 });

--- a/tests/schemas/statistics.test.ts
+++ b/tests/schemas/statistics.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { statisticsSchema } from '../../src/schemas/statistics';
+
+describe('statisticsSchema', () => {
+  it('parses an empty object using all defaults', () => {
+    const result = statisticsSchema.parse({});
+    expect(result).toEqual({
+      tabGroupsCreatedCount: 0,
+      tabsDeduplicatedCount: 0,
+      dailyBuckets: {},
+    });
+  });
+
+  it('preserves provided counters', () => {
+    const result = statisticsSchema.parse({
+      tabGroupsCreatedCount: 5,
+      tabsDeduplicatedCount: 12,
+    });
+    expect(result.tabGroupsCreatedCount).toBe(5);
+    expect(result.tabsDeduplicatedCount).toBe(12);
+  });
+
+  it('accepts a populated dailyBuckets structure', () => {
+    const result = statisticsSchema.parse({
+      dailyBuckets: {
+        '2026-05-03': {
+          'rule-1': { grouping: 3, dedup: 1 },
+          'rule-2': { grouping: 0, dedup: 4 },
+        },
+      },
+    });
+    expect(result.dailyBuckets['2026-05-03']['rule-1']).toEqual({
+      grouping: 3,
+      dedup: 1,
+    });
+  });
+
+  it('fills missing rule bucket counts with 0', () => {
+    const result = statisticsSchema.parse({
+      dailyBuckets: {
+        '2026-05-03': {
+          'rule-1': {},
+        },
+      },
+    });
+    expect(result.dailyBuckets['2026-05-03']['rule-1']).toEqual({
+      grouping: 0,
+      dedup: 0,
+    });
+  });
+
+  it('preserves the firstUsedAt timestamp when provided', () => {
+    const result = statisticsSchema.parse({
+      firstUsedAt: '2026-01-01T00:00:00Z',
+    });
+    expect(result.firstUsedAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('rejects negative counters', () => {
+    expect(() => statisticsSchema.parse({ tabGroupsCreatedCount: -1 })).toThrow();
+    expect(() => statisticsSchema.parse({ tabsDeduplicatedCount: -3 })).toThrow();
+  });
+
+  it('rejects non-integer counters', () => {
+    expect(() => statisticsSchema.parse({ tabGroupsCreatedCount: 1.5 })).toThrow();
+  });
+
+  it('rejects negative grouping/dedup values inside a bucket', () => {
+    expect(() =>
+      statisticsSchema.parse({
+        dailyBuckets: { '2026-05-03': { 'rule-1': { grouping: -1, dedup: 0 } } },
+      }),
+    ).toThrow();
+  });
+});

--- a/tests/utils/browserUrls.test.ts
+++ b/tests/utils/browserUrls.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('getShortcutsCustomizeInfo', () => {
+  it('returns the Chromium URL when FIREFOX env is unset/empty', async () => {
+    vi.stubEnv('FIREFOX', '');
+    const { getShortcutsCustomizeInfo } = await import('../../src/utils/browserUrls');
+
+    expect(getShortcutsCustomizeInfo()).toEqual({
+      url: 'chrome://extensions/shortcuts',
+      isDirect: true,
+    });
+  });
+
+  it('returns about:addons with isDirect=false on Firefox', async () => {
+    vi.stubEnv('FIREFOX', '1');
+    const { getShortcutsCustomizeInfo } = await import('../../src/utils/browserUrls');
+
+    expect(getShortcutsCustomizeInfo()).toEqual({
+      url: 'about:addons',
+      isDirect: false,
+    });
+  });
+});
+
+describe('openShortcutsCustomizePage', () => {
+  it('opens chrome://extensions/shortcuts on Chromium', async () => {
+    vi.stubEnv('FIREFOX', '');
+    const createMock = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({} as never);
+    const { openShortcutsCustomizePage } = await import('../../src/utils/browserUrls');
+
+    await openShortcutsCustomizePage();
+
+    expect(createMock).toHaveBeenCalledWith({ url: 'chrome://extensions/shortcuts' });
+  });
+
+  it('opens about:addons on Firefox', async () => {
+    vi.stubEnv('FIREFOX', '1');
+    const createMock = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({} as never);
+    const { openShortcutsCustomizePage } = await import('../../src/utils/browserUrls');
+
+    await openShortcutsCustomizePage();
+
+    expect(createMock).toHaveBeenCalledWith({ url: 'about:addons' });
+  });
+});

--- a/tests/utils/categoriesStore.test.ts
+++ b/tests/utils/categoriesStore.test.ts
@@ -110,6 +110,44 @@ describe('getCategoryLabel', () => {
   });
 });
 
+describe('initCategoriesStore: external storage updates + reset', () => {
+  it('updates the cache when storage changes after init', async () => {
+    await fakeBrowser.storage.local.set({ categories: SAMPLE_CATEGORIES });
+    const { initCategoriesStore, getAllCategories, _resetCategoriesStoreForTests } =
+      await import('../../src/utils/categoriesStore');
+
+    await initCategoriesStore();
+    expect(getAllCategories()).toHaveLength(3);
+
+    // External update
+    const next: RuleCategory[] = [
+      { id: 'gaming', emoji: '🎮', color: 'purple', label: 'Gaming', builtIn: false },
+    ];
+    await fakeBrowser.storage.local.set({ categories: next });
+
+    // Watcher should refresh the cache.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getAllCategories()).toHaveLength(1);
+    expect(getAllCategories()[0].id).toBe('gaming');
+
+    _resetCategoriesStoreForTests();
+    expect(getAllCategories()).toEqual([]);
+  });
+
+  it('falls back to an empty cache when getValue throws', async () => {
+    const mod = await import('../../src/utils/categoriesStore');
+    const { initCategoriesStore, getAllCategories, _resetCategoriesStoreForTests } = mod;
+    const { getActiveScopedItems } = await import('../../src/utils/workspaceContext');
+    const items = await getActiveScopedItems();
+
+    _resetCategoriesStoreForTests();
+    vi.spyOn(items.categoriesItem, 'getValue').mockRejectedValueOnce(new Error('boom'));
+
+    await initCategoriesStore();
+    expect(getAllCategories()).toEqual([]);
+  });
+});
+
 describe('fetchBuiltInCategories', () => {
   it('télécharge et valide le fichier categories.json', async () => {
     vi.stubGlobal(

--- a/tests/utils/openOptions.test.ts
+++ b/tests/utils/openOptions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import { openOptionsWithHash } from '../../src/utils/openOptions';
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.restoreAllMocks();
+});
+
+describe('openOptionsWithHash', () => {
+  it('opens a new tab when no existing options tab is found', async () => {
+    const optionsUrl = 'chrome-extension://abc/options.html';
+    vi.spyOn(fakeBrowser.runtime, 'getURL').mockReturnValue(optionsUrl as ReturnType<typeof fakeBrowser.runtime.getURL>);
+    const queryMock = vi.spyOn(fakeBrowser.tabs, 'query').mockResolvedValue([]);
+    const createMock = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({ id: 1 } as never);
+
+    await openOptionsWithHash('#sessions');
+
+    expect(queryMock).toHaveBeenCalledWith({});
+    expect(createMock).toHaveBeenCalledWith({ url: `${optionsUrl}#sessions` });
+  });
+
+  it('updates and focuses an existing options tab when present', async () => {
+    const optionsUrl = 'chrome-extension://abc/options.html';
+    vi.spyOn(fakeBrowser.runtime, 'getURL').mockReturnValue(optionsUrl as ReturnType<typeof fakeBrowser.runtime.getURL>);
+    vi.spyOn(fakeBrowser.tabs, 'query').mockResolvedValue([
+      { id: 42, url: `${optionsUrl}#oldhash`, windowId: 7 } as never,
+    ]);
+    const updateTab = vi.spyOn(fakeBrowser.tabs, 'update').mockResolvedValue({} as never);
+    const updateWin = vi.spyOn(fakeBrowser.windows, 'update').mockResolvedValue({} as never);
+    const createMock = vi.spyOn(fakeBrowser.tabs, 'create');
+
+    await openOptionsWithHash('#stats');
+
+    expect(updateTab).toHaveBeenCalledWith(42, { url: `${optionsUrl}#stats`, active: true });
+    expect(updateWin).toHaveBeenCalledWith(7, { focused: true });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it('skips windows.update when the existing tab has no windowId', async () => {
+    const optionsUrl = 'chrome-extension://abc/options.html';
+    vi.spyOn(fakeBrowser.runtime, 'getURL').mockReturnValue(optionsUrl as ReturnType<typeof fakeBrowser.runtime.getURL>);
+    vi.spyOn(fakeBrowser.tabs, 'query').mockResolvedValue([
+      { id: 9, url: `${optionsUrl}` } as never,
+    ]);
+    const updateTab = vi.spyOn(fakeBrowser.tabs, 'update').mockResolvedValue({} as never);
+    const updateWin = vi.spyOn(fakeBrowser.windows, 'update').mockResolvedValue({} as never);
+
+    await openOptionsWithHash('#x');
+
+    expect(updateTab).toHaveBeenCalled();
+    expect(updateWin).not.toHaveBeenCalled();
+  });
+
+  it('falls back to creating a tab when the existing tab has no id', async () => {
+    const optionsUrl = 'chrome-extension://abc/options.html';
+    vi.spyOn(fakeBrowser.runtime, 'getURL').mockReturnValue(optionsUrl as ReturnType<typeof fakeBrowser.runtime.getURL>);
+    vi.spyOn(fakeBrowser.tabs, 'query').mockResolvedValue([
+      { url: optionsUrl } as never,
+    ]);
+    const updateTab = vi.spyOn(fakeBrowser.tabs, 'update');
+    const createMock = vi.spyOn(fakeBrowser.tabs, 'create').mockResolvedValue({} as never);
+
+    await openOptionsWithHash('#h');
+
+    expect(updateTab).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledWith({ url: `${optionsUrl}#h` });
+  });
+});

--- a/tests/utils/packLabel.test.ts
+++ b/tests/utils/packLabel.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import {
+  resolveLocalized,
+  resolvePackName,
+  resolvePackDescription,
+  resolvePackParamLabel,
+  resolvePackOptionLabel,
+  resolvePackCategoryLabel,
+} from '../../src/utils/packLabel';
+
+const mockGetUILanguage = vi.fn();
+
+beforeEach(() => {
+  (fakeBrowser as unknown as { i18n: unknown }).i18n = {
+    getUILanguage: mockGetUILanguage,
+  };
+  mockGetUILanguage.mockReset();
+});
+
+afterEach(() => {
+  delete (fakeBrowser as unknown as { i18n?: unknown }).i18n;
+});
+
+describe('resolveLocalized', () => {
+  it('returns a plain string value as-is', () => {
+    expect(resolveLocalized('plain', 'fallback')).toBe('plain');
+  });
+
+  it('uses exact locale match when present', () => {
+    mockGetUILanguage.mockReturnValue('fr-FR');
+    expect(resolveLocalized({ 'fr-FR': 'Bonjour', en: 'Hello' })).toBe('Bonjour');
+  });
+
+  it('falls back to the language base when exact locale is missing', () => {
+    mockGetUILanguage.mockReturnValue('fr-CA');
+    expect(resolveLocalized({ fr: 'Salut', en: 'Hello' })).toBe('Salut');
+  });
+
+  it('falls back to "en" when nothing else matches', () => {
+    mockGetUILanguage.mockReturnValue('de-DE');
+    expect(resolveLocalized({ en: 'Hello', es: 'Hola' })).toBe('Hello');
+  });
+
+  it('falls back to first record entry when no English entry exists', () => {
+    mockGetUILanguage.mockReturnValue('zh');
+    expect(resolveLocalized({ es: 'Hola', it: 'Ciao' })).toBe('Hola');
+  });
+
+  it('returns the fallback when value is undefined', () => {
+    expect(resolveLocalized(undefined, 'default-text')).toBe('default-text');
+  });
+
+  it('returns empty string fallback by default', () => {
+    expect(resolveLocalized(undefined)).toBe('');
+  });
+
+  it('returns the fallback when the record is empty', () => {
+    mockGetUILanguage.mockReturnValue('fr');
+    expect(resolveLocalized({}, 'fallback')).toBe('fallback');
+  });
+
+  it('handles getUILanguage throwing gracefully', () => {
+    mockGetUILanguage.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(resolveLocalized({ en: 'Hello' })).toBe('Hello');
+  });
+
+  it('handles getUILanguage returning empty string', () => {
+    mockGetUILanguage.mockReturnValue('');
+    expect(resolveLocalized({ en: 'Hello' })).toBe('Hello');
+  });
+});
+
+describe('resolvePackName', () => {
+  it('resolves the localized name', () => {
+    mockGetUILanguage.mockReturnValue('fr');
+    expect(resolvePackName({ id: 'p1', name: { fr: 'NomFr', en: 'NameEn' } } as never)).toBe('NomFr');
+  });
+
+  it('falls back to the pack id when name is missing', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(resolvePackName({ id: 'pack-id', name: undefined } as never)).toBe('pack-id');
+  });
+});
+
+describe('resolvePackDescription', () => {
+  it('resolves the description string', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackDescription({ id: 'p', name: 'P', description: { en: 'Desc' } } as never),
+    ).toBe('Desc');
+  });
+
+  it('returns empty string when description is missing', () => {
+    expect(resolvePackDescription({ id: 'p', name: 'P' } as never)).toBe('');
+  });
+});
+
+describe('resolvePackParamLabel', () => {
+  it('resolves the param label', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackParamLabel({ id: 'param-1', label: { en: 'Region' } } as never),
+    ).toBe('Region');
+  });
+
+  it('falls back to the param id when label cannot resolve', () => {
+    expect(
+      resolvePackParamLabel({ id: 'param-1', label: undefined } as never),
+    ).toBe('param-1');
+  });
+});
+
+describe('resolvePackOptionLabel', () => {
+  it('resolves the option label', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackOptionLabel({ value: 'us-east-1', label: { en: 'US East' } } as never),
+    ).toBe('US East');
+  });
+
+  it('falls back to the option value when label is missing', () => {
+    expect(
+      resolvePackOptionLabel({ value: 'us-east-1', label: undefined } as never),
+    ).toBe('us-east-1');
+  });
+});
+
+describe('resolvePackCategoryLabel', () => {
+  it('resolves a PackCategory.label', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackCategoryLabel({ id: 'cloud', label: { en: 'Cloud' } } as never),
+    ).toBe('Cloud');
+  });
+
+  it('returns empty string for a PackCategory whose label is undefined', () => {
+    expect(
+      resolvePackCategoryLabel({ id: 'cloud', label: undefined } as never),
+    ).toBe('');
+  });
+
+  it('uses the category id as fallback when label record is empty', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackCategoryLabel({ id: 'cloud', label: {} } as never),
+    ).toBe('cloud');
+  });
+
+  it('resolves PackManifest.category when set', () => {
+    mockGetUILanguage.mockReturnValue('en');
+    expect(
+      resolvePackCategoryLabel({
+        id: 'p1',
+        name: 'Pack',
+        category: { en: 'Inline' },
+      } as never),
+    ).toBe('Inline');
+  });
+
+  it('returns empty string when manifest has no category', () => {
+    expect(
+      resolvePackCategoryLabel({ id: 'p1', name: 'Pack' } as never),
+    ).toBe('');
+  });
+});

--- a/tests/utils/workspaceContext.test.ts
+++ b/tests/utils/workspaceContext.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+vi.mock('../../src/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('workspaceContext', () => {
+  it('defaults to DEFAULT_WORKSPACE_ID before init', async () => {
+    const { getActiveWsIdSync, _resetWorkspaceContextForTests } = await import(
+      '../../src/utils/workspaceContext'
+    );
+    const { DEFAULT_WORKSPACE_ID, _resetWorkspaceItemsCacheForTests } = await import(
+      '../../src/utils/workspaceStorage'
+    );
+    _resetWorkspaceContextForTests();
+    _resetWorkspaceItemsCacheForTests();
+
+    expect(getActiveWsIdSync()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+
+  it('reads the persisted active workspace id during init', async () => {
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: 'ws-alpha' });
+
+    const { initWorkspaceContext, getActiveWsIdSync, _resetWorkspaceContextForTests } =
+      await import('../../src/utils/workspaceContext');
+    _resetWorkspaceContextForTests();
+
+    await initWorkspaceContext();
+    expect(getActiveWsIdSync()).toBe('ws-alpha');
+  });
+
+  it('only loads once for concurrent init calls', async () => {
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: 'ws-beta' });
+
+    const { initWorkspaceContext, _resetWorkspaceContextForTests } = await import(
+      '../../src/utils/workspaceContext'
+    );
+    const { activeWorkspaceIdItem } = await import('../../src/utils/workspaceStorage');
+    _resetWorkspaceContextForTests();
+
+    const getValueSpy = vi.spyOn(activeWorkspaceIdItem, 'getValue');
+    await Promise.all([initWorkspaceContext(), initWorkspaceContext(), initWorkspaceContext()]);
+
+    expect(getValueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects later writes via the storage watcher', async () => {
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: 'ws-one' });
+
+    const { initWorkspaceContext, getActiveWsIdSync, _resetWorkspaceContextForTests } =
+      await import('../../src/utils/workspaceContext');
+    _resetWorkspaceContextForTests();
+
+    await initWorkspaceContext();
+    expect(getActiveWsIdSync()).toBe('ws-one');
+
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: 'ws-two' });
+    expect(getActiveWsIdSync()).toBe('ws-two');
+  });
+
+  it('falls back to DEFAULT_WORKSPACE_ID when stored value is null', async () => {
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: null });
+
+    const { initWorkspaceContext, getActiveWsIdSync, _resetWorkspaceContextForTests } =
+      await import('../../src/utils/workspaceContext');
+    const { DEFAULT_WORKSPACE_ID } = await import('../../src/utils/workspaceStorage');
+    _resetWorkspaceContextForTests();
+
+    await initWorkspaceContext();
+    expect(getActiveWsIdSync()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+
+  it('getActiveScopedItems resolves scoped items for current workspace', async () => {
+    await fakeBrowser.storage.local.set({ activeWorkspaceId: 'ws-scoped' });
+
+    const { getActiveScopedItems, _resetWorkspaceContextForTests } = await import(
+      '../../src/utils/workspaceContext'
+    );
+    const { _resetWorkspaceItemsCacheForTests } = await import('../../src/utils/workspaceStorage');
+    _resetWorkspaceContextForTests();
+    _resetWorkspaceItemsCacheForTests();
+
+    const items = await getActiveScopedItems();
+    expect(items.domainRulesItem.key).toBe('local:ws:ws-scoped:domainRules');
+    expect(items.statisticsItem.key).toBe('local:ws:ws-scoped:statistics');
+  });
+
+  it('getActiveScopedItemsSync returns items for the cached workspace id', async () => {
+    const { getActiveScopedItemsSync, _resetWorkspaceContextForTests } = await import(
+      '../../src/utils/workspaceContext'
+    );
+    const { _resetWorkspaceItemsCacheForTests } = await import('../../src/utils/workspaceStorage');
+    _resetWorkspaceContextForTests();
+    _resetWorkspaceItemsCacheForTests();
+
+    const items = getActiveScopedItemsSync();
+    expect(items.domainRulesItem.key).toBe('local:domainRules');
+  });
+
+  it('falls back to default when load throws an error', async () => {
+    const { initWorkspaceContext, getActiveWsIdSync, _resetWorkspaceContextForTests } =
+      await import('../../src/utils/workspaceContext');
+    const { activeWorkspaceIdItem, DEFAULT_WORKSPACE_ID } = await import(
+      '../../src/utils/workspaceStorage'
+    );
+    _resetWorkspaceContextForTests();
+
+    vi.spyOn(activeWorkspaceIdItem, 'getValue').mockRejectedValue(new Error('storage down'));
+
+    await initWorkspaceContext();
+    expect(getActiveWsIdSync()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+});


### PR DESCRIPTION
Adds coverage for files that were sitting at 0% (openOptions, packLabel,
schemas/statistics) or below 60% (browserUrls, workspaceContext,
useBrowserCommands, useKeyboardShortcuts, parts of usePacks and
useSettings).

Coverage moves:
  Statements 71.69 -> 73.67
  Branches   65.43 -> 67.47
  Functions  67.85 -> 69.91
  Lines      72.77 -> 74.68