### PR TITLE
fix(a11y): correct color-contrast violations and adopt Radix Avatar/Kbd

### DIFF
--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -1,21 +1,3 @@
-.kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 22px;
-  padding: 2px 6px;
-  font-family: var(--default-font-family);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  color: var(--gray-12);
-  background: var(--gray-a3);
-  border: 1px solid var(--gray-a5);
-  border-bottom-width: 2px;
-  border-radius: var(--radius-2);
-  white-space: nowrap;
-}
-
 .row {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Flex, Text } from '@radix-ui/themes';
+import { Box, Button, Flex, Kbd, Text } from '@radix-ui/themes';
 import { ExternalLink } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { getShortcutsCustomizeInfo, openShortcutsCustomizePage } from '@/utils/browserUrls';
@@ -114,7 +114,7 @@ function KeyCombo({ combo }: { combo: string }) {
       {tokens.map((token, i) => (
         <React.Fragment key={`${token}-${i}`}>
           {i > 0 && <span className={styles.plus} aria-hidden="true">+</span>}
-          <kbd className={styles.kbd}>{token}</kbd>
+          <Kbd size="1">{token}</Kbd>
         </React.Fragment>
       ))}
     </Flex>

--- a/src/components/UI/StatusBar/StatusBar.module.css
+++ b/src/components/UI/StatusBar/StatusBar.module.css
@@ -31,26 +31,8 @@
   outline-offset: 1px;
 }
 
-.kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  padding: 1px 5px;
-  font-family: var(--default-font-family);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  color: var(--gray-12);
-  background: var(--gray-a3);
-  border: 1px solid var(--gray-a5);
-  border-bottom-width: 2px;
-  border-radius: var(--radius-2);
-  white-space: nowrap;
-}
-
 .version {
-  color: var(--gray-10);
+  color: var(--gray-11);
   font-variant-numeric: tabular-nums;
   font-size: 11px;
 }

--- a/src/components/UI/StatusBar/StatusBar.tsx
+++ b/src/components/UI/StatusBar/StatusBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from '@radix-ui/themes';
+import { Kbd, Text } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { useShortcutsControl } from '@/contexts/ShortcutsControlContext';
 import styles from './StatusBar.module.css';
@@ -17,7 +17,7 @@ export function StatusBar() {
         title={getMessage('shortcutsPanelToggleAria')}
         onClick={openShortcuts}
       >
-        <kbd className={styles.kbd}>?</kbd>
+        <Kbd size="1">?</Kbd>
         <Text size="1">{getMessage('statusBarShortcutsLabel')}</Text>
       </button>
       <span data-testid="status-bar-version" className={styles.version}>

--- a/src/components/UI/Workspace/WorkspaceAvatar.tsx
+++ b/src/components/UI/Workspace/WorkspaceAvatar.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Flex, Text } from '@radix-ui/themes';
+import { Avatar } from '@radix-ui/themes';
 import type { WorkspaceAccentColor } from '@/schemas/workspace.js';
 
-const SIZE_TO_PX = {
-  sm: { box: 24, font: '11px' },
-  md: { box: 32, font: '13px' },
-  lg: { box: 44, font: '17px' },
-} as const;
+const SIZE_TO_RADIX = {
+  sm: '1',
+  md: '2',
+  lg: '4',
+} as const satisfies Record<AvatarSize, '1' | '2' | '4'>;
 
-type AvatarSize = keyof typeof SIZE_TO_PX;
+type AvatarSize = 'sm' | 'md' | 'lg';
 
 export function getInitials(name: string): string {
   if (!name) return '?';
@@ -29,35 +29,23 @@ interface WorkspaceAvatarProps {
 }
 
 /**
- * Round badge displaying 1-2 initials of a workspace name on a filled circle
- * tinted with the workspace's Radix accent color. Purely visual; consumers
- * decide whether the avatar acts as a button via wrappers.
+ * Round badge displaying 1-2 initials of a workspace name on a Radix Avatar
+ * tinted with the workspace's accent color. The `soft` variant pairs a tinted
+ * background with `<color>-12` text, guaranteeing WCAG AA contrast for normal
+ * text across every Radix accent (the `solid` variant only meets large-text
+ * thresholds for some scales).
  */
 export function WorkspaceAvatar({ name, accentColor, size = 'md', ariaLabel }: WorkspaceAvatarProps) {
-  const { box, font } = SIZE_TO_PX[size];
   return (
-    <Flex
-      align="center"
-      justify="center"
+    <Avatar
       role={ariaLabel ? 'img' : undefined}
       aria-label={ariaLabel}
-      style={{
-        width: box,
-        height: box,
-        flexShrink: 0,
-        borderRadius: '50%',
-        background: `var(--${accentColor}-9)`,
-        color: 'var(--accent-contrast)',
-        userSelect: 'none',
-      }}
-    >
-      <Text
-        size="2"
-        weight="bold"
-        style={{ fontSize: font, color: 'var(--accent-contrast)', lineHeight: 1 }}
-      >
-        {getInitials(name)}
-      </Text>
-    </Flex>
+      color={accentColor}
+      variant="soft"
+      radius="full"
+      size={SIZE_TO_RADIX[size]}
+      fallback={getInitials(name)}
+      style={{ flexShrink: 0, userSelect: 'none' }}
+    />
   );
 }

--- a/src/components/UI/Workspace/WorkspaceColorPicker.tsx
+++ b/src/components/UI/Workspace/WorkspaceColorPicker.tsx
@@ -50,7 +50,7 @@ export function WorkspaceColorPicker({ value, onChange, ariaLabel }: WorkspaceCo
               display: 'inline-flex',
               alignItems: 'center',
               justifyContent: 'center',
-              color: 'var(--accent-contrast)',
+              color: `var(--${color}-contrast)`,
             }}
           >
             {isActive ? <Check size={14} aria-hidden="true" /> : null}


### PR DESCRIPTION
- WorkspaceAvatar: replace custom solid-9 + accent-contrast with Radix
  Themes Avatar (variant="soft", radius="full"). The solid variant only
  meets large-text contrast (>=3:1) for several scales; soft pairs a
  tinted background with step-12 text, guaranteeing >=4.5:1 for normal
  text across every workspace accent color.
- WorkspaceColorPicker: scope --accent-contrast to per-color
  --<color>-contrast so the active swatch's check icon sits on the
  matching scale's contrast token.
- StatusBar: switch the version label from --gray-10 (designed for
  solid backgrounds) to --gray-11 (low-contrast text token).
- StatusBar + ShortcutsContent: replace hand-rolled <kbd> markup with
  Radix Themes Kbd, removing the duplicated CSS rules. Hero CTA
  shortcut keeps its bespoke style as it sits on a colored background.

Storybook a11y and Playwright a11y E2E both report 0 violations after
the fixes (previously 17 + 6 serious).