### PR TITLE
refactor(dedup): extract shared shells/hooks for top 5 jscpd painpoints

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,6 +4,7 @@
     "jscpd": {
       "source": "kucherenko/jscpd",
       "sourceType": "github",
+      "skillPath": "SKILL.md",
       "computedHash": "80b4c74864717ca5cfaf64a75a0cfd47736c9ebdcab388ee058395365f34f387"
     }
   }

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -211,6 +211,38 @@ function useSessionRename(session: Session, existingSessions: Session[], onRenam
   };
 }
 
+/* ─── SessionNameHoverCard ────────────────────────────────────────────────── */
+
+interface SessionNameHoverCardProps {
+  session: Session;
+  searchQuery: string | undefined;
+  hoverCardContent: React.ReactNode;
+  onDoubleClick?: () => void;
+}
+
+function SessionNameHoverCard({
+  session, searchQuery, hoverCardContent, onDoubleClick,
+}: SessionNameHoverCardProps) {
+  return (
+    <HoverCard.Root>
+      <HoverCard.Trigger>
+        <Text
+          data-testid={`session-card-${session.id}-name`}
+          size="3"
+          weight="medium"
+          onDoubleClick={onDoubleClick}
+          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'default' }}
+        >
+          <AccessibleHighlight text={session.name} searchTerm={searchQuery ?? ''} />
+        </Text>
+      </HoverCard.Trigger>
+      <HoverCard.Content size="2" style={{ maxWidth: 360 }}>
+        {hoverCardContent}
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+}
+
 /* ─── SessionCardSummaryHeader ────────────────────────────────────────────── */
 
 interface SessionCardSummaryHeaderProps {
@@ -233,21 +265,11 @@ function SessionCardSummaryHeader({
         <AlertTriangle size={16} style={{ color: 'var(--orange-9)', flexShrink: 0 }} aria-hidden="true" />
       )}
       <Flex align="center" gap="2" style={{ flex: 1, overflow: 'hidden', minWidth: 0 }}>
-        <HoverCard.Root>
-          <HoverCard.Trigger>
-            <Text
-              data-testid={`session-card-${session.id}-name`}
-              size="3"
-              weight="medium"
-              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'default' }}
-            >
-              <AccessibleHighlight text={session.name} searchTerm={searchQuery ?? ''} />
-            </Text>
-          </HoverCard.Trigger>
-          <HoverCard.Content size="2" style={{ maxWidth: 360 }}>
-            {hoverCardContent}
-          </HoverCard.Content>
-        </HoverCard.Root>
+        <SessionNameHoverCard
+          session={session}
+          searchQuery={searchQuery}
+          hoverCardContent={hoverCardContent}
+        />
         {category && (
           <Tooltip content={getCategoryLabel(category)}>
             <Badge color={getRadixColor(category.color)} size="1" style={{ flexShrink: 0 }}>
@@ -373,22 +395,12 @@ function SessionCardFullHeader({
           </>
         ) : (
           <>
-            <HoverCard.Root>
-              <HoverCard.Trigger>
-                <Text
-                  data-testid={`session-card-${session.id}-name`}
-                  size="3"
-                  weight="medium"
-                  onDoubleClick={() => { setNameValue(session.name); setRenameError(null); setIsRenaming(true); }}
-                  style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'default' }}
-                >
-                  <AccessibleHighlight text={session.name} searchTerm={searchQuery ?? ''} />
-                </Text>
-              </HoverCard.Trigger>
-              <HoverCard.Content size="2" style={{ maxWidth: 360 }}>
-                {hoverCardContent}
-              </HoverCard.Content>
-            </HoverCard.Root>
+            <SessionNameHoverCard
+              session={session}
+              searchQuery={searchQuery}
+              hoverCardContent={hoverCardContent}
+              onDoubleClick={() => { setNameValue(session.name); setRenameError(null); setIsRenaming(true); }}
+            />
             <IconButton
               size="1"
               variant="ghost"

--- a/src/components/Form/FormFields/SearchableInlineList.tsx
+++ b/src/components/Form/FormFields/SearchableInlineList.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useId } from 'react';
 import { Command } from 'cmdk';
-import { Check, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import './SearchableSelect.css';
 import type { SearchableSelectGroup, SearchableSelectOption } from './SearchableSelect';
+import { SearchableSelectItem } from './SearchableSelectItem';
 
 export interface SearchableInlineListProps {
   value: string;
@@ -55,32 +56,14 @@ export function SearchableInlineList({
     return () => clearTimeout(t);
   }, [autoFocus]);
 
-  const renderItem = (option: SearchableSelectOption) => {
-    const isSelected = option.value === value;
-    return (
-      <Command.Item
-        key={option.value}
-        value={`${option.value} ${option.label}`}
-        onSelect={() => {
-          if (!option.disabled) onValueChange(option.value);
-        }}
-        disabled={option.disabled}
-        className={[
-          'ss-item',
-          isSelected ? 'ss-item--selected' : '',
-          option.disabled ? 'ss-item--disabled' : '',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-        aria-selected={isSelected}
-      >
-        <span className="ss-item__check">
-          <Check size={14} aria-hidden="true" />
-        </span>
-        <span className="ss-item__label">{option.label}</span>
-      </Command.Item>
-    );
-  };
+  const renderItem = (option: SearchableSelectOption) => (
+    <SearchableSelectItem
+      key={option.value}
+      option={option}
+      selectedValue={value}
+      onSelect={onValueChange}
+    />
+  );
 
   return (
     <div

--- a/src/components/Form/FormFields/SearchableSelect.tsx
+++ b/src/components/Form/FormFields/SearchableSelect.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect, useCallback, useId } from 'react';
 import { Command } from 'cmdk';
-import { ChevronDown, Check, Search } from 'lucide-react';
+import { ChevronDown, Search } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import './SearchableSelect.css';
+import { SearchableSelectItem } from './SearchableSelectItem';
 
 export interface SearchableSelectOption {
   value: string;
@@ -137,32 +138,14 @@ export function SearchableSelect({
     }
   };
 
-  const renderItem = (option: SearchableSelectOption) => {
-    const isSelected = option.value === value;
-    return (
-      <Command.Item
-        key={option.value}
-        value={`${option.value} ${option.label}`}
-        onSelect={() => {
-          if (!option.disabled) handleSelect(option.value);
-        }}
-        disabled={option.disabled}
-        className={[
-          'ss-item',
-          isSelected ? 'ss-item--selected' : '',
-          option.disabled ? 'ss-item--disabled' : '',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-        aria-selected={isSelected}
-      >
-        <span className="ss-item__check">
-          <Check size={14} aria-hidden="true" />
-        </span>
-        <span className="ss-item__label">{option.label}</span>
-      </Command.Item>
-    );
-  };
+  const renderItem = (option: SearchableSelectOption) => (
+    <SearchableSelectItem
+      key={option.value}
+      option={option}
+      selectedValue={value}
+      onSelect={handleSelect}
+    />
+  );
 
   return (
     <div ref={containerRef} className={['ss-root', className].filter(Boolean).join(' ')}>

--- a/src/components/Form/FormFields/SearchableSelectItem.tsx
+++ b/src/components/Form/FormFields/SearchableSelectItem.tsx
@@ -1,0 +1,44 @@
+import { Command } from 'cmdk';
+import { Check } from 'lucide-react';
+import type { SearchableSelectOption } from './SearchableSelect';
+
+interface SearchableSelectItemProps {
+  option: SearchableSelectOption;
+  selectedValue: string;
+  onSelect: (value: string) => void;
+}
+
+/**
+ * `Command.Item` row shared by `SearchableSelect` and `SearchableInlineList`.
+ * Handles the selected/disabled visual states and skips `onSelect` when the
+ * option is disabled. Callers set `key` at the call site.
+ */
+export function SearchableSelectItem({
+  option,
+  selectedValue,
+  onSelect,
+}: SearchableSelectItemProps) {
+  const isSelected = option.value === selectedValue;
+  return (
+    <Command.Item
+      value={`${option.value} ${option.label}`}
+      onSelect={() => {
+        if (!option.disabled) onSelect(option.value);
+      }}
+      disabled={option.disabled}
+      className={[
+        'ss-item',
+        isSelected ? 'ss-item--selected' : '',
+        option.disabled ? 'ss-item--disabled' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-selected={isSelected}
+    >
+      <span className="ss-item__check">
+        <Check size={14} aria-hidden="true" />
+      </span>
+      <span className="ss-item__label">{option.label}</span>
+    </Command.Item>
+  );
+}

--- a/src/components/UI/DialogShell/DialogCloseButton.tsx
+++ b/src/components/UI/DialogShell/DialogCloseButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Dialog, IconButton } from '@radix-ui/themes';
+import { X } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+
+interface DialogCloseButtonProps {
+  /** Lucide X icon size in px. Default 16. */
+  iconSize?: number;
+  /** Absolute positioning (and any extra) on the IconButton. */
+  style?: React.CSSProperties;
+}
+
+/**
+ * Top-right close button shared by every Radix Dialog variant in the app
+ * (DialogShell, ShortcutsDrawer, ...). Wraps the standard ghost gray
+ * IconButton with the localized close label and an `X` icon.
+ */
+export function DialogCloseButton({ iconSize = 16, style }: DialogCloseButtonProps) {
+  return (
+    <Dialog.Close>
+      <IconButton
+        size="1"
+        variant="ghost"
+        color="gray"
+        aria-label={getMessage('close')}
+        title={getMessage('close')}
+        style={style}
+      >
+        <X size={iconSize} aria-hidden="true" />
+      </IconButton>
+    </Dialog.Close>
+  );
+}

--- a/src/components/UI/DialogShell/DialogShell.tsx
+++ b/src/components/UI/DialogShell/DialogShell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Dialog, Flex, IconButton, Separator } from '@radix-ui/themes';
-import { X, type LucideIcon } from 'lucide-react';
-import { getMessage } from '@/utils/i18n';
+import { Dialog, Flex, Separator } from '@radix-ui/themes';
+import { type LucideIcon } from 'lucide-react';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
+import { DialogCloseButton } from './DialogCloseButton';
 
 type DialogContentProps = React.ComponentProps<typeof Dialog.Content>;
 
@@ -102,18 +102,7 @@ export function DialogShell({
           {showHeaderSeparator && <Separator size="4" mt="3" style={{ opacity: 0.3 }} />}
         </div>
 
-        <Dialog.Close>
-          <IconButton
-            size="1"
-            variant="ghost"
-            color="gray"
-            aria-label={getMessage('close')}
-            title={getMessage('close')}
-            style={closeButtonStyle}
-          >
-            <X size={16} aria-hidden="true" />
-          </IconButton>
-        </Dialog.Close>
+        <DialogCloseButton style={closeButtonStyle} />
 
         {children}
       </Dialog.Content>

--- a/src/components/UI/DialogShell/index.ts
+++ b/src/components/UI/DialogShell/index.ts
@@ -1,1 +1,2 @@
 export { DialogShell } from './DialogShell';
+export { DialogCloseButton } from './DialogCloseButton';

--- a/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
@@ -1,20 +1,13 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { Box, Separator } from '@radix-ui/themes';
+import React, { useCallback, useMemo } from 'react';
+import { Separator } from '@radix-ui/themes';
 import { Archive, FileDown, Pin } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
 import { splitByPinned } from '@/utils/sessionUtils';
 import type { Session } from '@/types/session';
-import { WizardModal } from '@/components/UI/WizardModal';
-import { CountLabel, useDialogReset, useToggleSet } from './Shared';
-import {
-  ExportNoteField,
-  ExportWizardFooter,
-  SelectableListContainer,
-  SelectionToolbar,
-  SessionExportGroupSection,
-  useExportActions,
-} from './Export';
+import { ExportWizardShell } from './ExportWizardShell';
+import { useExportWizardState } from './useExportWizardState';
+import { SessionExportGroupSection } from './Export';
 
 interface ExportSessionsWizardProps {
   open: boolean;
@@ -22,21 +15,18 @@ interface ExportSessionsWizardProps {
 }
 
 export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizardProps) {
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const selection = useToggleSet<string>();
-  const [exportNote, setExportNote] = useState('');
-
-  useDialogReset(open, () => {
-    loadSessions().then((loaded) => {
-      setSessions(loaded);
-      selection.setAll(loaded.map((s) => s.id));
-    });
-    setExportNote('');
+  const state = useExportWizardState<Session>({
+    open,
+    loadItems: loadSessions,
+    payloadKey: 'sessions',
+    filename: 'smarttab_organizer_sessions.json',
+    notifyTitleKey: 'exportSessionsNotificationTitle',
+    notifyMessage: (count) =>
+      getMessage('exportSessionsNotificationMessage').replace('$1', String(count)),
+    onFinish: () => onOpenChange(false),
   });
 
-  const selectAll = useCallback(() => {
-    selection.setAll(sessions.map((s) => s.id));
-  }, [sessions, selection]);
+  const { items: sessions, selection } = state;
 
   const { pinned: pinnedSessions, unpinned: unpinnedSessions } = useMemo(
     () => splitByPinned(sessions),
@@ -62,73 +52,38 @@ export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizar
     return 'indeterminate';
   }, [selection]);
 
-  const selectedSessions = sessions.filter((s) => selection.has(s.id));
-
-  const buildJson = useCallback(() => {
-    const exportData: { note?: string; sessions: Session[] } = { sessions: selectedSessions };
-    if (exportNote.trim()) exportData.note = exportNote.trim();
-    return JSON.stringify(exportData, null, 2);
-  }, [selectedSessions, exportNote]);
-
-  const actions = useExportActions({
-    filename: 'smarttab_organizer_sessions.json',
-    notifyTitleKey: 'exportSessionsNotificationTitle',
-    notifyMessage: (count) =>
-      getMessage('exportSessionsNotificationMessage').replace('$1', String(count)),
-    selected: selectedSessions,
-    note: exportNote,
-    buildJson,
-    onFinish: () => onOpenChange(false),
-  });
-
   return (
-    <WizardModal
+    <ExportWizardShell<Session>
       open={open}
       onOpenChange={onOpenChange}
       icon={FileDown}
       title={getMessage('exportSessionsTitle')}
       description={getMessage('exportSessionsDescription')}
+      state={state}
+      countLabelKey="sessionsSelectedCount"
+      buttonLabelKey="exportSessionsButton"
     >
-      <WizardModal.Body>
-        <Box>
-          <ExportNoteField value={exportNote} onChange={setExportNote} />
-          <SelectionToolbar onSelectAll={selectAll} onDeselectAll={selection.clearAll} />
+      <SessionExportGroupSection
+        sessions={pinnedSessions}
+        titleKey="pinnedSessionsSection"
+        icon={Pin}
+        selection={selection}
+        groupCheckedState={getGroupCheckedState(pinnedSessions)}
+        onToggleGroup={() => toggleGroupSelection(pinnedSessions)}
+      />
 
-          <SelectableListContainer>
-            <SessionExportGroupSection
-              sessions={pinnedSessions}
-              titleKey="pinnedSessionsSection"
-              icon={Pin}
-              selection={selection}
-              groupCheckedState={getGroupCheckedState(pinnedSessions)}
-              onToggleGroup={() => toggleGroupSelection(pinnedSessions)}
-            />
+      {pinnedSessions.length > 0 && unpinnedSessions.length > 0 && (
+        <Separator size="4" my="1" />
+      )}
 
-            {pinnedSessions.length > 0 && unpinnedSessions.length > 0 && (
-              <Separator size="4" my="1" />
-            )}
-
-            <SessionExportGroupSection
-              sessions={unpinnedSessions}
-              titleKey="sessionsSection"
-              icon={Archive}
-              selection={selection}
-              groupCheckedState={getGroupCheckedState(unpinnedSessions)}
-              onToggleGroup={() => toggleGroupSelection(unpinnedSessions)}
-            />
-          </SelectableListContainer>
-
-          <CountLabel messageKey="sessionsSelectedCount" count={selection.size} />
-        </Box>
-      </WizardModal.Body>
-
-      <WizardModal.Footer>
-        <ExportWizardFooter
-          labelKey="exportSessionsButton"
-          actions={actions}
-          disabled={selection.size === 0}
-        />
-      </WizardModal.Footer>
-    </WizardModal>
+      <SessionExportGroupSection
+        sessions={unpinnedSessions}
+        titleKey="sessionsSection"
+        icon={Archive}
+        selection={selection}
+        groupCheckedState={getGroupCheckedState(unpinnedSessions)}
+        onToggleGroup={() => toggleGroupSelection(unpinnedSessions)}
+      />
+    </ExportWizardShell>
   );
 }

--- a/src/components/UI/ImportExportWizards/ExportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizard.tsx
@@ -1,18 +1,11 @@
-import React, { useCallback, useState } from 'react';
-import { Box, Checkbox, Badge } from '@radix-ui/themes';
+import React from 'react';
+import { Badge, Checkbox } from '@radix-ui/themes';
 import { FileDown } from 'lucide-react';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 import { getMessage } from '@/utils/i18n';
-import { WizardModal } from '@/components/UI/WizardModal';
-import { CountLabel, useDialogReset, useToggleSet } from './Shared';
-import {
-  ExportNoteField,
-  ExportWizardFooter,
-  SelectableListContainer,
-  SelectionToolbar,
-  useExportActions,
-} from './Export';
 import { DomainRuleCard } from '@/components/Core/DomainRule/DomainRuleCard';
+import { ExportWizardShell } from './ExportWizardShell';
+import { useExportWizardState } from './useExportWizardState';
 
 interface ExportWizardProps {
   open: boolean;
@@ -21,82 +14,47 @@ interface ExportWizardProps {
 }
 
 export function ExportWizard({ open, onOpenChange, rules }: ExportWizardProps) {
-  const selection = useToggleSet<string>();
-  const [exportNote, setExportNote] = useState('');
-
-  useDialogReset(open, () => {
-    selection.setAll(rules.map((r) => r.id));
-    setExportNote('');
-  });
-
-  const selectAll = useCallback(() => {
-    selection.setAll(rules.map((r) => r.id));
-  }, [rules, selection]);
-
-  const selectedRules = rules.filter((r) => selection.has(r.id));
-
-  const buildJson = useCallback(() => {
-    const exportData: { note?: string; domainRules: DomainRuleSetting[] } = {
-      domainRules: selectedRules,
-    };
-    if (exportNote.trim()) exportData.note = exportNote.trim();
-    return JSON.stringify(exportData, null, 2);
-  }, [selectedRules, exportNote]);
-
-  const actions = useExportActions({
+  const state = useExportWizardState<DomainRuleSetting>({
+    open,
+    items: rules,
+    payloadKey: 'domainRules',
     filename: 'smarttab_organizer_rules.json',
     notifyTitleKey: 'exportNotificationTitle',
     notifyMessage: 'exportNotificationMessage',
-    selected: selectedRules,
-    note: exportNote,
-    buildJson,
     onFinish: () => onOpenChange(false),
   });
 
+  const { selection } = state;
+
   return (
-    <WizardModal
+    <ExportWizardShell<DomainRuleSetting>
       open={open}
       onOpenChange={onOpenChange}
       icon={FileDown}
       title={getMessage('exportRulesTitle')}
       description={getMessage('exportRulesDescription')}
+      state={state}
+      countLabelKey="rulesSelectedCount"
+      buttonLabelKey="exportButton"
+      listRole="list"
     >
-      <WizardModal.Body>
-        <Box>
-          <ExportNoteField value={exportNote} onChange={setExportNote} />
-          <SelectionToolbar onSelectAll={selectAll} onDeselectAll={selection.clearAll} />
-
-          <SelectableListContainer role="list">
-            {rules.map((rule) => (
-              <DomainRuleCard
-                key={rule.id}
-                rule={rule}
-                variant="summary"
-                leading={
-                  <Checkbox
-                    checked={selection.has(rule.id)}
-                    onCheckedChange={() => selection.toggle(rule.id)}
-                    aria-label={rule.label}
-                  />
-                }
-                trailing={rule.enabled ? undefined : (
-                  <Badge color="gray" variant="outline" size="1">{getMessage('disabled')}</Badge>
-                )}
-              />
-            ))}
-          </SelectableListContainer>
-
-          <CountLabel messageKey="rulesSelectedCount" count={selection.size} />
-        </Box>
-      </WizardModal.Body>
-
-      <WizardModal.Footer>
-        <ExportWizardFooter
-          labelKey="exportButton"
-          actions={actions}
-          disabled={selection.size === 0}
+      {rules.map((rule) => (
+        <DomainRuleCard
+          key={rule.id}
+          rule={rule}
+          variant="summary"
+          leading={
+            <Checkbox
+              checked={selection.has(rule.id)}
+              onCheckedChange={() => selection.toggle(rule.id)}
+              aria-label={rule.label}
+            />
+          }
+          trailing={rule.enabled ? undefined : (
+            <Badge color="gray" variant="outline" size="1">{getMessage('disabled')}</Badge>
+          )}
         />
-      </WizardModal.Footer>
-    </WizardModal>
+      ))}
+    </ExportWizardShell>
   );
 }

--- a/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Box } from '@radix-ui/themes';
+import type { LucideIcon } from 'lucide-react';
+import { WizardModal } from '@/components/UI/WizardModal';
+import { CountLabel } from './Shared';
+import {
+  ExportNoteField,
+  ExportWizardFooter,
+  SelectableListContainer,
+  SelectionToolbar,
+} from './Export';
+import type { ExportWizardState } from './useExportWizardState';
+
+interface ExportWizardShellProps<TItem extends { id: string }> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  state: ExportWizardState<TItem>;
+  countLabelKey: string;
+  buttonLabelKey: string;
+  /** Custom rendering of the selectable list (e.g. flat cards or grouped sections). */
+  children: React.ReactNode;
+  /** Forwarded to `SelectableListContainer` (use "list" when children are listitems). */
+  listRole?: string;
+}
+
+/**
+ * Single-step export wizard shell shared by every export flow (rules,
+ * sessions, ...). Owns the WizardModal frame, the note field, the
+ * select-all/none toolbar, the selectable list container, the count label
+ * and the file/clipboard footer split-button. Wizards plug in their list
+ * rendering as children and provide an `ExportWizardState` from
+ * `useExportWizardState`.
+ */
+export function ExportWizardShell<TItem extends { id: string }>({
+  open,
+  onOpenChange,
+  icon,
+  title,
+  description,
+  state,
+  countLabelKey,
+  buttonLabelKey,
+  children,
+  listRole,
+}: ExportWizardShellProps<TItem>) {
+  const { selection, selectAll, exportNote, setExportNote, actions } = state;
+
+  return (
+    <WizardModal
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={icon}
+      title={title}
+      description={description}
+    >
+      <WizardModal.Body>
+        <Box>
+          <ExportNoteField value={exportNote} onChange={setExportNote} />
+          <SelectionToolbar onSelectAll={selectAll} onDeselectAll={selection.clearAll} />
+
+          <SelectableListContainer role={listRole}>
+            {children}
+          </SelectableListContainer>
+
+          <CountLabel messageKey={countLabelKey} count={selection.size} />
+        </Box>
+      </WizardModal.Body>
+
+      <WizardModal.Footer>
+        <ExportWizardFooter
+          labelKey={buttonLabelKey}
+          actions={actions}
+          disabled={selection.size === 0}
+        />
+      </WizardModal.Footer>
+    </WizardModal>
+  );
+}

--- a/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useCallback } from 'react';
-import { Box } from '@radix-ui/themes';
+import React, { useCallback, useState } from 'react';
 import { Upload } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast } from '@/utils/toast';
@@ -7,35 +6,22 @@ import { sessionsArraySchema } from '@/schemas/session';
 import { importSessionsDataSchema } from '@/schemas/importExport';
 import {
   classifyImportedSessions,
-  type SessionClassification,
+  type ConflictingSession,
 } from '@/utils/sessionClassification';
 import { generateUUID } from '@/utils/utils';
 import { loadSessions, saveSessions } from '@/utils/sessionStorage';
 import { SessionRow, ConflictSessionRow } from './SessionImportRows';
 import type { Session } from '@/types/session';
-import { WizardModal } from '@/components/UI/WizardModal';
-import { useDialogReset } from './Shared';
-import { SourceStep, ImportedNoteCallout, useJsonSourceInput } from './Source';
-import { ImportWizardFooter } from './ImportWizardFooter';
+import { ImportWizardShell } from './ImportWizardShell';
 import {
-  useImportClassification,
-  computeImportCount,
-  ClassificationGroup,
-  ClassificationScrollArea,
-  ConflictModeSelector,
-  ConflictWarningCallout,
-  ImportCountLabel,
-} from './Classification';
+  useImportWizardState,
+  type NormalizedClassification,
+} from './useImportWizardState';
 
 interface ImportSessionsWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
-
-const STEP_DESCRIPTION_KEYS = [
-  'importSessionsStepSourceDescription',
-  'importSessionsStepReviewDescription',
-] as const;
 
 function getUniqueName(base: string, takenNames: Set<string>): string {
   if (!takenNames.has(base.toLowerCase())) return base;
@@ -57,37 +43,32 @@ const validateSessionsPayload = (raw: unknown) => {
   };
 };
 
+const classifySessions = (
+  imported: Session[],
+  existing: Session[],
+): NormalizedClassification<Session, ConflictingSession> => {
+  const result = classifyImportedSessions(imported, existing);
+  return {
+    newItems: result.newSessions,
+    conflictingItems: result.conflictingSessions,
+    identicalItems: result.identicalSessions,
+  };
+};
+
 export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizardProps) {
-  const [step, setStep] = useState(0);
-  const source = useJsonSourceInput<Session[]>(validateSessionsPayload);
   const [existingSessions, setExistingSessions] = useState<Session[]>([]);
 
-  const classificationState = useImportClassification<SessionClassification>();
-  const { classification, conflictMode, newSelection: newSessionSelection } = classificationState;
-
-  useDialogReset(open, () => {
-    loadSessions().then((loaded) => setExistingSessions(loaded));
-    setStep(0);
-    source.reset();
-    classificationState.reset();
+  const state = useImportWizardState<Session, ConflictingSession>({
+    open,
+    existingItems: existingSessions,
+    validatePayload: validateSessionsPayload,
+    classify: classifySessions,
+    onReset: () => {
+      loadSessions().then((loaded) => setExistingSessions(loaded));
+    },
   });
 
-  const goToStep1 = useCallback(() => {
-    if (!source.parsedData) return;
-    const result = classifyImportedSessions(source.parsedData, existingSessions);
-    classificationState.setClassification(result);
-    newSessionSelection.setAll(result.newSessions.map((s) => s.id));
-    setStep(1);
-  }, [source.parsedData, existingSessions, classificationState, newSessionSelection]);
-
-  const importCount = classification
-    ? computeImportCount(
-        classification.newSessions,
-        classification.conflictingSessions.length,
-        newSessionSelection,
-        conflictMode,
-      )
-    : 0;
+  const { classification, conflictMode, newSelection } = state;
 
   const executeImport = useCallback(async () => {
     if (!classification) return;
@@ -98,15 +79,15 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
     const takenNames = new Set<string>(existingSessions.map(s => s.name.toLowerCase()));
 
-    for (const session of classification.newSessions) {
-      if (newSessionSelection.has(session.id)) {
+    for (const session of classification.newItems) {
+      if (newSelection.has(session.id)) {
         updatedSessions.push(session);
         takenNames.add(session.name.toLowerCase());
         added++;
       }
     }
 
-    for (const conflict of classification.conflictingSessions) {
+    for (const conflict of classification.conflictingItems) {
       if (conflictMode === 'overwrite') {
         const idx = updatedSessions.findIndex(
           s => s.name.toLowerCase() === conflict.existing.name.toLowerCase()
@@ -129,95 +110,44 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
       getMessage('importSessionsNotificationTitle'),
       getMessage('importSessionsNotificationMessage', [String(added), String(overwritten)]),
     );
-  }, [classification, existingSessions, newSessionSelection, conflictMode, onOpenChange]);
-
-  const hasConflicts = (classification?.conflictingSessions.length ?? 0) > 0;
+  }, [classification, existingSessions, newSelection, conflictMode, onOpenChange]);
 
   return (
-    <WizardModal
+    <ImportWizardShell<Session, ConflictingSession>
       open={open}
       onOpenChange={onOpenChange}
       icon={Upload}
       title={getMessage('importSessionsTitle')}
-      description={getMessage(STEP_DESCRIPTION_KEYS[step])}
-    >
-      <WizardModal.Body>
-        {step === 0 && (
-          <SourceStep
-            source={source}
-            textareaPlaceholder='{"sessions": [{"id": "...", "name": "My Session", ...}]}'
-            successCountMessageKey="sessionsFoundCount"
-          />
-        )}
-
-        {step === 1 && classification && (
-          <Box>
-            <ImportedNoteCallout note={source.importedNote} />
-            <ClassificationScrollArea>
-              <ClassificationGroup
-                titleKey="newSessionsGroup"
-                items={classification.newSessions}
-                renderItem={(session) => (
-                  <SessionRow
-                    key={session.id}
-                    session={session}
-                    checkbox
-                    checked={newSessionSelection.has(session.id)}
-                    onToggle={() => newSessionSelection.toggle(session.id)}
-                  />
-                )}
-              />
-              <ClassificationGroup
-                titleKey="conflictingSessionsGroup"
-                items={classification.conflictingSessions}
-                showSeparator={classification.newSessions.length > 0}
-                beforeList={
-                  <ConflictModeSelector
-                    value={conflictMode}
-                    onChange={classificationState.setConflictMode}
-                  />
-                }
-                renderItem={(conflict) => (
-                  <ConflictSessionRow key={conflict.imported.id} conflict={conflict} />
-                )}
-              />
-              <ClassificationGroup
-                titleKey="identicalSessionsGroup"
-                items={classification.identicalSessions}
-                showSeparator={
-                  classification.newSessions.length > 0
-                  || classification.conflictingSessions.length > 0
-                }
-                renderItem={(session) => (
-                  <SessionRow
-                    key={session.id}
-                    session={session}
-                    dimmed
-                    statusBadge={getMessage('alreadyExists')}
-                  />
-                )}
-              />
-            </ClassificationScrollArea>
-
-            <ImportCountLabel messageKey="sessionsToImportCount" count={importCount} />
-            <ConflictWarningCallout
-              when={hasConflicts && conflictMode === 'overwrite'}
-              messageKey="sessionImportOverwriteWarning"
-            />
-          </Box>
-        )}
-      </WizardModal.Body>
-
-      <WizardModal.Footer>
-        <ImportWizardFooter
-          step={step as 0 | 1}
-          hasParsedData={!!source.parsedData}
-          importCount={importCount}
-          onNext={goToStep1}
-          onBack={() => setStep(0)}
-          onConfirm={executeImport}
+      stepDescriptionKeys={['importSessionsStepSourceDescription', 'importSessionsStepReviewDescription']}
+      textareaPlaceholder='{"sessions": [{"id": "...", "name": "My Session", ...}]}'
+      successCountMessageKey="sessionsFoundCount"
+      newGroupTitleKey="newSessionsGroup"
+      conflictingGroupTitleKey="conflictingSessionsGroup"
+      identicalGroupTitleKey="identicalSessionsGroup"
+      countLabelKey="sessionsToImportCount"
+      overwriteWarningKey="sessionImportOverwriteWarning"
+      state={state}
+      renderNewItem={(session) => (
+        <SessionRow
+          key={session.id}
+          session={session}
+          checkbox
+          checked={newSelection.has(session.id)}
+          onToggle={() => newSelection.toggle(session.id)}
         />
-      </WizardModal.Footer>
-    </WizardModal>
+      )}
+      renderConflictingItem={(conflict) => (
+        <ConflictSessionRow key={conflict.imported.id} conflict={conflict} />
+      )}
+      renderIdenticalItem={(session) => (
+        <SessionRow
+          key={session.id}
+          session={session}
+          dimmed
+          statusBadge={getMessage('alreadyExists')}
+        />
+      )}
+      onConfirm={executeImport}
+    />
   );
 }

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -1,26 +1,19 @@
-import React, { useCallback, useState } from 'react';
-import { Box } from '@radix-ui/themes';
+import React, { useCallback } from 'react';
 import { FileUp } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast } from '@/utils/toast';
 import { importDataSchema } from '@/schemas/importExport';
-import { classifyImportedRules } from '@/utils/importClassification';
+import {
+  classifyImportedRules,
+  type ConflictingRule,
+} from '@/utils/importClassification';
 import { generateUUID } from '@/utils/utils';
 import type { DomainRuleSetting } from '@/types/syncSettings';
-import { WizardModal } from '@/components/UI/WizardModal';
-import { useDialogReset } from './Shared';
-import { SourceStep, ImportedNoteCallout, useJsonSourceInput } from './Source';
-import { ImportWizardFooter } from './ImportWizardFooter';
+import { ImportWizardShell } from './ImportWizardShell';
 import {
-  useImportClassification,
-  computeImportCount,
-  ClassificationGroup,
-  ClassificationScrollArea,
-  ConflictModeSelector,
-  ConflictWarningCallout,
-  ImportCountLabel,
-} from './Classification';
-import type { RuleClassification } from '@/utils/importClassification';
+  useImportWizardState,
+  type NormalizedClassification,
+} from './useImportWizardState';
 import { RuleRow, ConflictRuleRow } from './RuleImportRows';
 
 interface ImportWizardProps {
@@ -30,11 +23,6 @@ interface ImportWizardProps {
   onImport: (updatedRules: DomainRuleSetting[]) => void;
 }
 
-const STEP_DESCRIPTION_KEYS = [
-  'importRulesStepSourceDescription',
-  'importRulesStepReviewDescription',
-] as const;
-
 const validateRulesPayload = (raw: unknown) => {
   const validated = importDataSchema.parse(raw);
   return {
@@ -43,37 +31,28 @@ const validateRulesPayload = (raw: unknown) => {
   };
 };
 
-export function ImportWizard({ open, onOpenChange, existingRules, onImport }: ImportWizardProps) {
-  const [step, setStep] = useState(0);
-  const source = useJsonSourceInput<DomainRuleSetting[]>(validateRulesPayload);
-  const classificationState = useImportClassification<RuleClassification>();
-  const { classification, conflictMode, newSelection: newRuleSelection } = classificationState;
+const classifyRules = (
+  imported: DomainRuleSetting[],
+  existing: DomainRuleSetting[],
+): NormalizedClassification<DomainRuleSetting, ConflictingRule> => {
+  const result = classifyImportedRules(imported, existing);
+  return {
+    newItems: result.newRules,
+    conflictingItems: result.conflictingRules,
+    identicalItems: result.identicalRules,
+  };
+};
 
-  useDialogReset(open, () => {
-    setStep(0);
-    source.reset();
-    classificationState.reset();
+export function ImportWizard({ open, onOpenChange, existingRules, onImport }: ImportWizardProps) {
+  const state = useImportWizardState<DomainRuleSetting, ConflictingRule>({
+    open,
+    existingItems: existingRules,
+    validatePayload: validateRulesPayload,
+    classify: classifyRules,
   });
 
-  // Transition to step 1: classify rules
-  const goToStep1 = useCallback(() => {
-    if (!source.parsedData) return;
-    const result = classifyImportedRules(source.parsedData, existingRules);
-    classificationState.setClassification(result);
-    newRuleSelection.setAll(result.newRules.map((r) => r.id));
-    setStep(1);
-  }, [source.parsedData, existingRules, classificationState, newRuleSelection]);
+  const { classification, conflictMode, newSelection } = state;
 
-  const importCount = classification
-    ? computeImportCount(
-        classification.newRules,
-        classification.conflictingRules.length,
-        newRuleSelection,
-        conflictMode,
-      )
-    : 0;
-
-  // Execute import
   const executeImport = useCallback(() => {
     if (!classification) return;
 
@@ -81,16 +60,14 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
     let added = 0;
     let overwritten = 0;
 
-    // Add new selected rules
-    for (const rule of classification.newRules) {
-      if (newRuleSelection.has(rule.id)) {
+    for (const rule of classification.newItems) {
+      if (newSelection.has(rule.id)) {
         updatedRules.push(rule);
         added++;
       }
     }
 
-    // Handle conflicts
-    for (const conflict of classification.conflictingRules) {
+    for (const conflict of classification.conflictingItems) {
       if (conflictMode === 'overwrite') {
         const idx = updatedRules.findIndex(
           r => r.label.toLowerCase() === conflict.existing.label.toLowerCase()
@@ -103,7 +80,6 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
         updatedRules.push({ ...conflict.imported, id: generateUUID() });
         added++;
       }
-      // 'ignore': do nothing
     }
 
     onImport(updatedRules);
@@ -112,92 +88,44 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
       getMessage('importNotificationTitle'),
       getMessage('importNotificationMessage', [String(added), String(overwritten)]),
     );
-  }, [classification, existingRules, newRuleSelection, conflictMode, onImport, onOpenChange]);
+  }, [classification, existingRules, newSelection, conflictMode, onImport, onOpenChange]);
 
   return (
-    <WizardModal
+    <ImportWizardShell<DomainRuleSetting, ConflictingRule>
       open={open}
       onOpenChange={onOpenChange}
       icon={FileUp}
       title={getMessage('importRulesTitle')}
-      description={getMessage(STEP_DESCRIPTION_KEYS[step])}
-    >
-      <WizardModal.Body>
-        {step === 0 && (
-          <SourceStep
-            source={source}
-            textareaPlaceholder='{"domainRules": [...]}'
-            successCountMessageKey="rulesFoundCount"
-          />
-        )}
-
-        {step === 1 && classification && (
-          <Box>
-            <ImportedNoteCallout note={source.importedNote} />
-            <ClassificationScrollArea>
-              <ClassificationGroup
-                titleKey="newRulesGroup"
-                items={classification.newRules}
-                renderItem={(rule) => (
-                  <RuleRow
-                    key={rule.id}
-                    rule={rule}
-                    checkbox
-                    checked={newRuleSelection.has(rule.id)}
-                    onToggle={() => newRuleSelection.toggle(rule.id)}
-                  />
-                )}
-              />
-              <ClassificationGroup
-                titleKey="conflictingRulesGroup"
-                items={classification.conflictingRules}
-                showSeparator={classification.newRules.length > 0}
-                beforeList={
-                  <ConflictModeSelector
-                    value={conflictMode}
-                    onChange={classificationState.setConflictMode}
-                  />
-                }
-                renderItem={(conflict) => (
-                  <ConflictRuleRow key={conflict.imported.id} conflict={conflict} />
-                )}
-              />
-              <ClassificationGroup
-                titleKey="identicalRulesGroup"
-                items={classification.identicalRules}
-                showSeparator={
-                  classification.newRules.length > 0 || classification.conflictingRules.length > 0
-                }
-                renderItem={(rule) => (
-                  <RuleRow
-                    key={rule.id}
-                    rule={rule}
-                    dimmed
-                    statusBadge={getMessage('alreadyExists')}
-                  />
-                )}
-              />
-            </ClassificationScrollArea>
-
-            <ImportCountLabel messageKey="rulesToImportCount" count={importCount} />
-            <ConflictWarningCallout
-              when={conflictMode === 'overwrite' && classification.conflictingRules.length > 0}
-              messageKey="overwriteWarning"
-            />
-          </Box>
-        )}
-      </WizardModal.Body>
-
-      <WizardModal.Footer>
-        <ImportWizardFooter
-          step={step as 0 | 1}
-          hasParsedData={!!source.parsedData}
-          importCount={importCount}
-          onNext={goToStep1}
-          onBack={() => setStep(0)}
-          onConfirm={executeImport}
+      stepDescriptionKeys={['importRulesStepSourceDescription', 'importRulesStepReviewDescription']}
+      textareaPlaceholder='{"domainRules": [...]}'
+      successCountMessageKey="rulesFoundCount"
+      newGroupTitleKey="newRulesGroup"
+      conflictingGroupTitleKey="conflictingRulesGroup"
+      identicalGroupTitleKey="identicalRulesGroup"
+      countLabelKey="rulesToImportCount"
+      overwriteWarningKey="overwriteWarning"
+      state={state}
+      renderNewItem={(rule) => (
+        <RuleRow
+          key={rule.id}
+          rule={rule}
+          checkbox
+          checked={newSelection.has(rule.id)}
+          onToggle={() => newSelection.toggle(rule.id)}
         />
-      </WizardModal.Footer>
-    </WizardModal>
+      )}
+      renderConflictingItem={(conflict) => (
+        <ConflictRuleRow key={conflict.imported.id} conflict={conflict} />
+      )}
+      renderIdenticalItem={(rule) => (
+        <RuleRow
+          key={rule.id}
+          rule={rule}
+          dimmed
+          statusBadge={getMessage('alreadyExists')}
+        />
+      )}
+      onConfirm={executeImport}
+    />
   );
 }

--- a/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { Box } from '@radix-ui/themes';
+import type { LucideIcon } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { WizardModal } from '@/components/UI/WizardModal';
+import {
+  ClassificationGroup,
+  ClassificationScrollArea,
+  ConflictModeSelector,
+  ConflictWarningCallout,
+  ImportCountLabel,
+} from './Classification';
+import { ImportWizardFooter } from './ImportWizardFooter';
+import { ImportedNoteCallout, SourceStep } from './Source';
+import type { ImportWizardState } from './useImportWizardState';
+
+export interface ImportWizardShellLabels {
+  title: string;
+  /** i18n keys for step 0 and step 1 dialog descriptions. */
+  stepDescriptionKeys: readonly [string, string];
+  textareaPlaceholder: string;
+  successCountMessageKey: string;
+  newGroupTitleKey: string;
+  conflictingGroupTitleKey: string;
+  identicalGroupTitleKey: string;
+  countLabelKey: string;
+  overwriteWarningKey: string;
+}
+
+interface ImportWizardShellProps<TItem extends { id: string }, TConflict>
+  extends ImportWizardShellLabels {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  icon: LucideIcon;
+  state: ImportWizardState<TItem, TConflict>;
+  renderNewItem: (item: TItem) => React.ReactNode;
+  renderConflictingItem: (conflict: TConflict) => React.ReactNode;
+  renderIdenticalItem: (item: TItem) => React.ReactNode;
+  onConfirm: () => void;
+}
+
+/**
+ * Two-step import wizard shell shared by every import flow (rules, sessions,
+ * ...). Owns the WizardModal frame, source step, classification step (3
+ * groups + conflict mode + count + warning) and the footer. Wizards plug in
+ * their classifier, row renderers, and an `executeImport` callback.
+ */
+export function ImportWizardShell<TItem extends { id: string }, TConflict>({
+  open,
+  onOpenChange,
+  icon,
+  title,
+  stepDescriptionKeys,
+  textareaPlaceholder,
+  successCountMessageKey,
+  newGroupTitleKey,
+  conflictingGroupTitleKey,
+  identicalGroupTitleKey,
+  countLabelKey,
+  overwriteWarningKey,
+  state,
+  renderNewItem,
+  renderConflictingItem,
+  renderIdenticalItem,
+  onConfirm,
+}: ImportWizardShellProps<TItem, TConflict>) {
+  const {
+    step,
+    source,
+    classification,
+    conflictMode,
+    setConflictMode,
+    importCount,
+    goToStep0,
+    goToStep1,
+  } = state;
+
+  return (
+    <WizardModal
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={icon}
+      title={title}
+      description={getMessage(stepDescriptionKeys[step])}
+    >
+      <WizardModal.Body>
+        {step === 0 && (
+          <SourceStep
+            source={source}
+            textareaPlaceholder={textareaPlaceholder}
+            successCountMessageKey={successCountMessageKey}
+          />
+        )}
+
+        {step === 1 && classification && (
+          <Box>
+            <ImportedNoteCallout note={source.importedNote} />
+            <ClassificationScrollArea>
+              <ClassificationGroup
+                titleKey={newGroupTitleKey}
+                items={classification.newItems}
+                renderItem={renderNewItem}
+              />
+              <ClassificationGroup
+                titleKey={conflictingGroupTitleKey}
+                items={classification.conflictingItems}
+                showSeparator={classification.newItems.length > 0}
+                beforeList={
+                  <ConflictModeSelector
+                    value={conflictMode}
+                    onChange={setConflictMode}
+                  />
+                }
+                renderItem={renderConflictingItem}
+              />
+              <ClassificationGroup
+                titleKey={identicalGroupTitleKey}
+                items={classification.identicalItems}
+                showSeparator={
+                  classification.newItems.length > 0
+                  || classification.conflictingItems.length > 0
+                }
+                renderItem={renderIdenticalItem}
+              />
+            </ClassificationScrollArea>
+
+            <ImportCountLabel messageKey={countLabelKey} count={importCount} />
+            <ConflictWarningCallout
+              when={conflictMode === 'overwrite' && classification.conflictingItems.length > 0}
+              messageKey={overwriteWarningKey}
+            />
+          </Box>
+        )}
+      </WizardModal.Body>
+
+      <WizardModal.Footer>
+        <ImportWizardFooter
+          step={step}
+          hasParsedData={!!source.parsedData}
+          importCount={importCount}
+          onNext={goToStep1}
+          onBack={goToStep0}
+          onConfirm={onConfirm}
+        />
+      </WizardModal.Footer>
+    </WizardModal>
+  );
+}

--- a/src/components/UI/ImportExportWizards/useExportWizardState.ts
+++ b/src/components/UI/ImportExportWizards/useExportWizardState.ts
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import { useDialogReset, useToggleSet, type ToggleSetState } from './Shared';
+import { useExportActions, type ExportActions } from './Export';
+
+interface UseExportWizardStateOptions<TItem extends { id: string }> {
+  open: boolean;
+  /** Sync items source (e.g. domain rules from props). Mutually exclusive with `loadItems`. */
+  items?: TItem[];
+  /** Async loader called when the dialog opens (e.g. `loadSessions`). */
+  loadItems?: () => Promise<TItem[]>;
+  /** JSON top-level key wrapping the selected items (e.g. "domainRules", "sessions"). */
+  payloadKey: string;
+  filename: string;
+  notifyTitleKey: string;
+  notifyMessage: string | ((count: number) => string);
+  onFinish: () => void;
+}
+
+export interface ExportWizardState<TItem extends { id: string }> {
+  items: TItem[];
+  selection: ToggleSetState<string>;
+  selectedItems: TItem[];
+  exportNote: string;
+  setExportNote: (note: string) => void;
+  selectAll: () => void;
+  actions: ExportActions;
+}
+
+/**
+ * Orchestrates the state shared by every export wizard: selection, optional
+ * note, JSON serialization in the standard `{[payloadKey]: items, note?}`
+ * envelope, and the file/clipboard export actions. Each wizard plugs in its
+ * own list rendering since layouts diverge (flat list vs grouped sections).
+ *
+ * Pass `items` for sync sources or `loadItems` for async ones; the latter
+ * triggers an async load on dialog open and seeds the selection from the
+ * loaded ids.
+ */
+export function useExportWizardState<TItem extends { id: string }>({
+  open,
+  items: providedItems,
+  loadItems,
+  payloadKey,
+  filename,
+  notifyTitleKey,
+  notifyMessage,
+  onFinish,
+}: UseExportWizardStateOptions<TItem>): ExportWizardState<TItem> {
+  const [loadedItems, setLoadedItems] = useState<TItem[]>([]);
+  const items = providedItems ?? loadedItems;
+  const selection = useToggleSet<string>();
+  const [exportNote, setExportNote] = useState('');
+
+  useDialogReset(open, () => {
+    setExportNote('');
+    if (loadItems) {
+      loadItems().then((loaded) => {
+        setLoadedItems(loaded);
+        selection.setAll(loaded.map((item) => item.id));
+      });
+    } else if (providedItems) {
+      selection.setAll(providedItems.map((item) => item.id));
+    }
+  });
+
+  const selectAll = useCallback(() => {
+    selection.setAll(items.map((item) => item.id));
+  }, [items, selection]);
+
+  const selectedItems = items.filter((item) => selection.has(item.id));
+
+  const buildJson = useCallback(() => {
+    const data: Record<string, unknown> = { [payloadKey]: selectedItems };
+    if (exportNote.trim()) data.note = exportNote.trim();
+    return JSON.stringify(data, null, 2);
+  }, [selectedItems, exportNote, payloadKey]);
+
+  const actions = useExportActions({
+    filename,
+    notifyTitleKey,
+    notifyMessage,
+    selected: selectedItems,
+    note: exportNote,
+    buildJson,
+    onFinish,
+  });
+
+  return {
+    items,
+    selection,
+    selectedItems,
+    exportNote,
+    setExportNote,
+    selectAll,
+    actions,
+  };
+}

--- a/src/components/UI/ImportExportWizards/useImportWizardState.ts
+++ b/src/components/UI/ImportExportWizards/useImportWizardState.ts
@@ -1,0 +1,106 @@
+import { useCallback, useState } from 'react';
+import {
+  computeImportCount,
+  useImportClassification,
+  type ConflictMode,
+} from './Classification';
+import { useDialogReset, type ToggleSetState } from './Shared';
+import {
+  useJsonSourceInput,
+  type JsonSourceInputState,
+  type JsonSourceValidationResult,
+} from './Source';
+
+/**
+ * Shape produced by every wizard's classify function. Each concrete classifier
+ * (rules, sessions, ...) should map its native result onto these three buckets
+ * so the shared shell and hook stay item-agnostic.
+ */
+export interface NormalizedClassification<TItem, TConflict> {
+  newItems: TItem[];
+  conflictingItems: TConflict[];
+  identicalItems: TItem[];
+}
+
+interface UseImportWizardStateOptions<TItem extends { id: string }, TConflict> {
+  open: boolean;
+  existingItems: TItem[];
+  validatePayload: (raw: unknown) => JsonSourceValidationResult<TItem[]>;
+  classify: (
+    imported: TItem[],
+    existing: TItem[],
+  ) => NormalizedClassification<TItem, TConflict>;
+  /** Extra reset action triggered when the dialog is opened (e.g. async data load). */
+  onReset?: () => void;
+}
+
+export interface ImportWizardState<TItem extends { id: string }, TConflict> {
+  step: 0 | 1;
+  source: JsonSourceInputState<TItem[]>;
+  classification: NormalizedClassification<TItem, TConflict> | null;
+  conflictMode: ConflictMode;
+  setConflictMode: (mode: ConflictMode) => void;
+  newSelection: ToggleSetState<string>;
+  importCount: number;
+  goToStep0: () => void;
+  goToStep1: () => void;
+}
+
+/**
+ * Orchestrates the state shared by every import wizard: step navigation,
+ * JSON source parsing, classification of imported items against existing
+ * ones, conflict-resolution mode, and selection of new items to import.
+ *
+ * Wizards keep their own `executeImport` since persistence (sync callback vs
+ * async storage write) and conflict handling (uniqueness rules, etc.) differ.
+ */
+export function useImportWizardState<TItem extends { id: string }, TConflict>({
+  open,
+  existingItems,
+  validatePayload,
+  classify,
+  onReset,
+}: UseImportWizardStateOptions<TItem, TConflict>): ImportWizardState<TItem, TConflict> {
+  const [step, setStep] = useState<0 | 1>(0);
+  const source = useJsonSourceInput<TItem[]>(validatePayload);
+  const classificationState = useImportClassification<NormalizedClassification<TItem, TConflict>>();
+  const { classification, conflictMode, newSelection } = classificationState;
+
+  useDialogReset(open, () => {
+    setStep(0);
+    source.reset();
+    classificationState.reset();
+    onReset?.();
+  });
+
+  const goToStep1 = useCallback(() => {
+    if (!source.parsedData) return;
+    const result = classify(source.parsedData, existingItems);
+    classificationState.setClassification(result);
+    newSelection.setAll(result.newItems.map((item) => item.id));
+    setStep(1);
+  }, [source.parsedData, existingItems, classify, classificationState, newSelection]);
+
+  const goToStep0 = useCallback(() => setStep(0), []);
+
+  const importCount = classification
+    ? computeImportCount(
+        classification.newItems,
+        classification.conflictingItems.length,
+        newSelection,
+        conflictMode,
+      )
+    : 0;
+
+  return {
+    step,
+    source,
+    classification,
+    conflictMode,
+    setConflictMode: classificationState.setConflictMode,
+    newSelection,
+    importCount,
+    goToStep0,
+    goToStep1,
+  };
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Box, Dialog, Flex, IconButton } from '@radix-ui/themes';
-import { Keyboard, X } from 'lucide-react';
+import { Box, Dialog, Flex } from '@radix-ui/themes';
+import { Keyboard } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
+import { DialogCloseButton } from '@/components/UI/DialogShell';
 import { ShortcutsContent } from './ShortcutsContent';
 
 interface ShortcutsDrawerProps {
@@ -32,18 +33,7 @@ export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
         <Dialog.Description size="1" color="gray" mb="3">
           {getMessage('shortcutsPanelDescription')}
         </Dialog.Description>
-        <Dialog.Close>
-          <IconButton
-            size="1"
-            variant="ghost"
-            color="gray"
-            aria-label={getMessage('close')}
-            title={getMessage('close')}
-            style={{ position: 'absolute', top: 12, right: 12 }}
-          >
-            <X size={14} aria-hidden="true" />
-          </IconButton>
-        </Dialog.Close>
+        <DialogCloseButton iconSize={14} style={{ position: 'absolute', top: 12, right: 12 }} />
         <Box>
           <ShortcutsContent />
         </Box>


### PR DESCRIPTION
## Summary

Removes the 5 painpoints detected by jscpd in `src/` (top 5 of the code-deduplicator analysis), by extracting shared shells, hooks and components for the import/export wizards, the searchable select, the session card, and the dialog close button.

### Painpoint #1 (commit `996d71b`) : import wizards

`ImportWizard` (rules) and `ImportSessionsWizard` shared ~80 lines of step navigation, JSON source parsing, classification handling, and 2-step JSX frame.

- New hook `useImportWizardState<TItem extends {id:string}, TConflict>` (`src/components/UI/ImportExportWizards/useImportWizardState.ts`) : orchestrates step, source, classification (normalised to `{newItems, conflictingItems, identicalItems}`), conflict mode, selection, and `importCount`.
- New component `ImportWizardShell` (`.../ImportWizardShell.tsx`) : owns the `WizardModal` frame, `SourceStep`, the 3 `ClassificationGroup`s, `ImportCountLabel`, `ConflictWarningCallout` and `ImportWizardFooter`.
- `ImportWizard.tsx` : 203 lignes -> 130. `ImportSessionsWizard.tsx` : 223 -> 154.

### Painpoint #2 (commit `917be1a`) : export wizards

`ExportWizard` (rules) and `ExportSessionsWizard` shared ~50 lines of selection state, note handling, JSON envelope serialization, `useExportActions` wiring, and the modal frame (note field, toolbar, list container, count label, footer).

- New hook `useExportWizardState<TItem extends {id:string}>` (`.../useExportWizardState.ts`) : sync items via `items` prop or async via `loadItems`, selection, `exportNote`, `selectAll`, `buildJson` (standard `{[payloadKey]: items, note?}` envelope), and the `useExportActions` wiring.
- New component `ExportWizardShell` (`.../ExportWizardShell.tsx`) : owns the modal frame and all shared UI. Wizards plug their list rendering as children.
- `ExportWizard.tsx` : 102 -> 57. `ExportSessionsWizard.tsx` : 134 -> 86.

### Painpoint #3 (commit `3acf0e8`) : searchable select item

`SearchableSelect` and `SearchableInlineList` rendered identical `Command.Item` rows (selected/disabled classes, Check icon, label), differing only on the `onSelect` callback.

- New component `SearchableSelectItem` (`src/components/Form/FormFields/SearchableSelectItem.tsx`) shared by both consumers.

### Painpoint #4 (commit `28c7c50`) : session name hover card

`SessionCardSummaryHeader` and `SessionCardFullHeader` rendered the same `HoverCard` around the session name (Trigger Text + AccessibleHighlight, Content with metadata).

- New private component `SessionNameHoverCard` inside `SessionCard.tsx`, with an optional `onDoubleClick` (used in the full header to enter rename mode).

### Painpoint #5 (commit `41d636e`) : dialog close button

`DialogShell` and `ShortcutsDrawer` rendered the same close `IconButton` (Dialog.Close + ghost gray IconButton + X icon + localized label/title), diverging only on icon size and absolute positioning.

- New component `DialogCloseButton` (`src/components/UI/DialogShell/DialogCloseButton.tsx`) with `iconSize` and `style` props.

## Net effect

- Total lines reduced in the touched files (wizards, SessionCard, SearchableSelect/InlineList, DialogShell, ShortcutsDrawer) : large reduction in raw call-site code, partly offset by the extracted shells/hooks/components.
- jscpd duplication ratio sur `src/` : passe de 0.68 % au début de la branche à un niveau attendu proche de 0 % après merge des 5 commits.
- Aucun changement de comportement attendu : tous les chemins (import rules + sessions, export rules + sessions, searchable select dans Inline + Popover, hover card du nom de session en summary + full, close button DialogShell + ShortcutsDrawer) restent identiques.

## Test plan

- [x] `pnpm compile` (TS check)
- [x] `pnpm lint` (0 warning)
- [x] `pnpm test` (1514/1514 unit tests)
- [x] CI E2E (3 shards) sur les commits #1 et #2 : OK
- [ ] CI E2E sur les commits #3, #4, #5 (push groupé) : en cours
- [ ] Smoke manuel : ouvrir wizard d'import rules + sessions, wizard d'export rules + sessions, SearchableSelect dans une options page, SessionCard en mode summary + full (hover + double-click rename), DialogShell + ShortcutsDrawer (close button)

https://claude.ai/code/session_01QFdBrz82Un9y37mKUG2C7d