### PR TITLE
feat(popup): rework help drawer as right-side fullscreen slide

### DIFF
--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -41,7 +41,7 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentP
         </Box>
       )}
       {groups.map((group) => (
-        <Box key={group.titleKey}>
+        <Box key={group.titleKey} data-group-title={group.titleKey}>
           <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
             {getMessage(group.titleKey)}
           </Text>

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.module.css
@@ -1,0 +1,75 @@
+:global(.rt-BaseDialogOverlay):has([data-testid='shortcuts-drawer']) {
+  background: transparent !important;
+}
+
+.drawerContent {
+  position: fixed !important;
+  top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: auto !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: 100% !important;
+  max-height: 100% !important;
+  transform: none !important;
+  border-radius: 0 !important;
+  padding: 0 !important;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -4px 0 12px var(--gray-a4);
+}
+
+.drawerContent[data-state='open'] {
+  animation: slideInFromRight 220ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.drawerContent[data-state='closed'] {
+  animation: slideOutToRight 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+@keyframes slideInFromRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutToRight {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.drawerHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 14px 16px 10px 20px;
+  border-bottom: 1px solid var(--gray-a3);
+  background: var(--color-panel-solid);
+  flex-shrink: 0;
+}
+
+.drawerHeaderTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.drawerBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.stories.tsx
@@ -9,7 +9,17 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <Box style={{ width: 400, minHeight: 500, background: 'var(--gray-a2)', position: 'relative' }}>
+      <Box
+        style={{
+          width: 400,
+          height: 600,
+          background: 'var(--gray-a2)',
+          position: 'relative',
+          overflow: 'hidden',
+          border: '1px solid var(--gray-a4)',
+          borderRadius: 'var(--radius-3)',
+        }}
+      >
         <Story />
       </Box>
     ),
@@ -22,6 +32,13 @@ type Story = StoryObj<typeof meta>;
 export const ShortcutsDrawerOpenInPopup: Story = {
   args: {
     open: true,
+    onOpenChange: () => {},
+  },
+};
+
+export const ShortcutsDrawerClosed: Story = {
+  args: {
+    open: false,
     onOpenChange: () => {},
   },
 };

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Box, Dialog, Flex } from '@radix-ui/themes';
 import { Keyboard } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { DialogCloseButton } from '@/components/UI/DialogShell';
 import { ShortcutsContent } from './ShortcutsContent';
+import { POPUP_SHORTCUT_GROUPS } from './shortcuts';
+import styles from './ShortcutsDrawer.module.css';
 
 interface ShortcutsDrawerProps {
   open: boolean;
@@ -11,31 +13,49 @@ interface ShortcutsDrawerProps {
 }
 
 /**
- * Modal drawer used inside the popup. The Radix Dialog auto-portals to
+ * Slide-from-right drawer used inside the popup. Covers the full popup
+ * viewport (400px x popup height). The Radix Dialog auto-portals to
  * document.body which, in a browser-action popup, is the popup document
- * itself. Sized to fit the typical 400px popup viewport.
+ * itself. Only popup-relevant shortcut groups are displayed.
  */
 export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === '?' && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault();
+        onOpenChange(false);
+      }
+    },
+    [onOpenChange],
+  );
+
+  const preventClose = useCallback((event: Event) => {
+    event.preventDefault();
+  }, []);
+
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
         data-testid="shortcuts-drawer"
-        size="1"
-        maxWidth="92vw"
-        style={{ maxHeight: '90vh', overflow: 'auto' }}
+        className={styles.drawerContent}
+        onPointerDownOutside={preventClose}
+        onInteractOutside={preventClose}
+        onKeyDown={handleKeyDown}
       >
-        <Flex align="center" gap="2" mb="1">
-          <Keyboard size={16} aria-hidden="true" />
-          <Dialog.Title size="3" mb="0">
-            {getMessage('shortcutsPanelTitle')}
-          </Dialog.Title>
-        </Flex>
-        <Dialog.Description size="1" color="gray" mb="3">
-          {getMessage('shortcutsPanelDescription')}
-        </Dialog.Description>
-        <DialogCloseButton iconSize={14} style={{ position: 'absolute', top: 12, right: 12 }} />
-        <Box>
-          <ShortcutsContent />
+        <div className={styles.drawerHeader}>
+          <Flex align="center" gap="2" className={styles.drawerHeaderTitle}>
+            <Keyboard size={16} aria-hidden="true" />
+            <Dialog.Title size="3" mb="0">
+              {getMessage('shortcutsPanelTitle')}
+            </Dialog.Title>
+          </Flex>
+          <DialogCloseButton iconSize={14} />
+        </div>
+        <Box className={styles.drawerBody}>
+          <Dialog.Description size="1" color="gray" mb="3">
+            {getMessage('shortcutsPanelDescription')}
+          </Dialog.Description>
+          <ShortcutsContent groups={POPUP_SHORTCUT_GROUPS} />
         </Box>
       </Dialog.Content>
     </Dialog.Root>

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Box, Dialog, Flex } from '@radix-ui/themes';
 import { Keyboard } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
@@ -19,19 +19,25 @@ interface ShortcutsDrawerProps {
  * itself. Only popup-relevant shortcut groups are displayed.
  */
 export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key === '?' && !event.altKey && !event.ctrlKey && !event.metaKey) {
-        event.preventDefault();
-        onOpenChange(false);
-      }
-    },
-    [onOpenChange],
-  );
-
   const preventClose = useCallback((event: Event) => {
     event.preventDefault();
   }, []);
+
+  // Toggle close on `?` while the drawer is open. Attached at the document
+  // level (capture phase) because the popup-level useKeyboardShortcuts has
+  // `allowWhenDialogOpen: false` and Radix Themes' Dialog.Content can swallow
+  // some bubbling keydowns from focused descendants.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== '?' || event.altKey || event.ctrlKey || event.metaKey) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onOpenChange(false);
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [open, onOpenChange]);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -40,7 +46,6 @@ export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
         className={styles.drawerContent}
         onPointerDownOutside={preventClose}
         onInteractOutside={preventClose}
-        onKeyDown={handleKeyDown}
       >
         <div className={styles.drawerHeader}>
           <Flex align="center" gap="2" className={styles.drawerHeaderTitle}>

--- a/src/components/UI/ShortcutsPanel/index.ts
+++ b/src/components/UI/ShortcutsPanel/index.ts
@@ -1,5 +1,5 @@
 export { ShortcutsContent } from './ShortcutsContent';
 export { ShortcutsDrawer } from './ShortcutsDrawer';
 export { ShortcutsAside } from './ShortcutsAside';
-export { SHORTCUT_GROUPS } from './shortcuts';
+export { SHORTCUT_GROUPS, POPUP_SHORTCUT_GROUPS } from './shortcuts';
 export type { ShortcutDisplay, ShortcutGroup } from './shortcuts';

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -68,3 +68,13 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
 ];
+
+const POPUP_GROUP_KEYS = [
+  'shortcutsGroupGlobal',
+  'shortcutsGroupPopup',
+  'shortcutsGroupSessionCard',
+] as const;
+
+export const POPUP_SHORTCUT_GROUPS: ShortcutGroup[] = POPUP_GROUP_KEYS
+  .map((key) => SHORTCUT_GROUPS.find((g) => g.titleKey === key))
+  .filter((g): g is ShortcutGroup => g !== undefined);

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -65,7 +65,7 @@ export function PopupContent() {
     { combo: 's', action: handlePopupSave, excludeIfTargetWithin: '[data-popup-pinned-card]' },
     { combo: 'r', action: handlePopupRestore, excludeIfTargetWithin: '[data-popup-pinned-card]' },
     { combo: 'o', action: handlePopupOrganize, excludeIfTargetWithin: '[data-popup-pinned-card]' },
-    { combo: '?', action: () => setShortcutsOpen(true), allowWhenDialogOpen: false },
+    { combo: '?', action: () => setShortcutsOpen((open) => !open), allowWhenDialogOpen: false },
   ], [handlePopupSave, handlePopupRestore, handlePopupOrganize]);
 
   useKeyboardShortcuts(shortcuts);

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -47,6 +47,12 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
     });
     await expect(page.getByTestId('shortcuts-content')).toBeVisible();
 
+    // Only the 3 popup-relevant groups must be displayed (Global, Popup,
+    // Session card). Options and Lists groups are hidden in the popup drawer.
+    await expect(
+      page.locator('[data-testid="shortcuts-content"] [data-group-title]'),
+    ).toHaveCount(3);
+
     // Regression guard: the popup.html `.radix-themes` selector used to also
     // match the Theme that Radix Themes wraps around the portaled overlay,
     // forcing it to `height: 0; overflow: hidden`. The drawer kept its own
@@ -58,6 +64,30 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
     expect(overlayHeight).toBeGreaterThan(100);
 
     await page.keyboard.press('Escape');
+    await expect(page.getByTestId('shortcuts-drawer')).toBeHidden({
+      timeout: 5000,
+    });
+
+    await page.close();
+  });
+
+  test('? toggles the shortcuts drawer (re-press closes)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    await expect(page.getByTestId('popup-toolbar')).toBeVisible();
+    await page.getByTestId('popup').click({ position: { x: 5, y: 5 } });
+
+    await page.keyboard.press('Shift+Slash');
+    await expect(page.getByTestId('shortcuts-drawer')).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Re-pressing ? while the drawer is focused must close it.
+    await page.keyboard.press('Shift+Slash');
     await expect(page.getByTestId('shortcuts-drawer')).toBeHidden({
       timeout: 5000,
     });

--- a/tests/popup-shortcut-groups.test.ts
+++ b/tests/popup-shortcut-groups.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  POPUP_SHORTCUT_GROUPS,
+  SHORTCUT_GROUPS,
+} from '../src/components/UI/ShortcutsPanel/shortcuts';
+
+describe('POPUP_SHORTCUT_GROUPS', () => {
+  it('contains exactly 3 groups in the expected order', () => {
+    const titleKeys = POPUP_SHORTCUT_GROUPS.map((g) => g.titleKey);
+    expect(titleKeys).toEqual([
+      'shortcutsGroupGlobal',
+      'shortcutsGroupPopup',
+      'shortcutsGroupSessionCard',
+    ]);
+  });
+
+  it('does not include Options or Lists groups', () => {
+    const titleKeys = POPUP_SHORTCUT_GROUPS.map((g) => g.titleKey);
+    expect(titleKeys).not.toContain('shortcutsGroupOptions');
+    expect(titleKeys).not.toContain('shortcutsGroupLists');
+  });
+
+  it('preserves the full shortcuts list of each retained group', () => {
+    for (const popupGroup of POPUP_SHORTCUT_GROUPS) {
+      const source = SHORTCUT_GROUPS.find((g) => g.titleKey === popupGroup.titleKey);
+      expect(source).toBeDefined();
+      expect(popupGroup.shortcuts).toEqual(source!.shortcuts);
+    }
+  });
+});


### PR DESCRIPTION
The help drawer triggered by `?` in the popup now slides from the right
and covers the full popup viewport (400px x popup height). It also
displays only the popup-relevant shortcut groups (Browser-wide, Popup,
Session card), hiding Options and Lists groups that are not actionable
from the popup. Re-pressing `?` toggles it closed.