### PR TITLE
Make shortcuts panel groups collapsible with context-aware defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *storybook.log
 storybook-static
 playwright-report/
+.playwright-mcp/
 test-results/
 ctrf/
 coverage/

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -646,6 +646,8 @@
   "shortcutDescListNavigate": { "message": "Move focus between cards" },
   "shortcutDescListNew": { "message": "Create new item" },
   "shortcutDescListEdit": { "message": "Edit focused item" },
+  "shortcutDescListToggleSelection": { "message": "Toggle selection on focused rule" },
+  "shortcutDescListToggleEnabled": { "message": "Enable or disable focused rule" },
   "shortcutDescListDelete": { "message": "Delete focused item" },
   "shortcutDescListPin": { "message": "Pin or unpin focused session" },
   "shortcutDescSessionRestoreCustom": { "message": "Custom restore (wizard)" },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -630,7 +630,8 @@
   "shortcutsGroupGlobal": { "message": "Browser-wide" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Options page" },
-  "shortcutsGroupLists": { "message": "Lists (rules and sessions)" },
+  "shortcutsGroupListRules": { "message": "Rules list" },
+  "shortcutsGroupListSessions": { "message": "Sessions list" },
   "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
 
   "shortcutDescOrganize": { "message": "Organize all tabs" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -647,6 +647,8 @@
   "shortcutDescListNavigate": { "message": "Mover el foco entre tarjetas" },
   "shortcutDescListNew": { "message": "Crear nuevo elemento" },
   "shortcutDescListEdit": { "message": "Editar el elemento con foco" },
+  "shortcutDescListToggleSelection": { "message": "Marcar o desmarcar la regla con foco" },
+  "shortcutDescListToggleEnabled": { "message": "Activar o desactivar la regla con foco" },
   "shortcutDescListDelete": { "message": "Eliminar el elemento con foco" },
   "shortcutDescListPin": { "message": "Anclar o desanclar la sesión con foco" },
   "shortcutDescSessionRestoreCustom": { "message": "Restauración personalizada (asistente)" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -631,7 +631,8 @@
   "shortcutsGroupGlobal": { "message": "Globales (navegador)" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Página de opciones" },
-  "shortcutsGroupLists": { "message": "Listas (reglas y sesiones)" },
+  "shortcutsGroupListRules": { "message": "Lista de reglas" },
+  "shortcutsGroupListSessions": { "message": "Lista de sesiones" },
   "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
 
   "shortcutDescOrganize": { "message": "Organizar todas las pestañas" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -631,7 +631,8 @@
   "shortcutsGroupGlobal": { "message": "Globaux navigateur" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Page d'options" },
-  "shortcutsGroupLists": { "message": "Listes (règles et sessions)" },
+  "shortcutsGroupListRules": { "message": "Liste des règles" },
+  "shortcutsGroupListSessions": { "message": "Liste des sessions" },
   "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
 
   "shortcutDescOrganize": { "message": "Organiser tous les onglets" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -647,6 +647,8 @@
   "shortcutDescListNavigate": { "message": "Déplacer le focus entre les cartes" },
   "shortcutDescListNew": { "message": "Créer un nouvel élément" },
   "shortcutDescListEdit": { "message": "Modifier l'élément focus" },
+  "shortcutDescListToggleSelection": { "message": "Cocher ou décocher la règle focus" },
+  "shortcutDescListToggleEnabled": { "message": "Activer ou désactiver la règle focus" },
   "shortcutDescListDelete": { "message": "Supprimer l'élément focus" },
   "shortcutDescListPin": { "message": "Épingler ou désépingler la session focus" },
   "shortcutDescSessionRestoreCustom": { "message": "Restauration personnalisée (assistant)" },

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
@@ -38,24 +38,28 @@ export function SessionRestoreButton({
           label: getMessage('sessionRestoreCurrentWindow'),
           icon: <Monitor size={14} aria-hidden="true" />,
           onClick: () => onRestoreCurrentWindow(session),
+          shortcut: 'Shift+R',
           'data-testid': 'session-restore-menu-current-window',
         },
         {
           label: getMessage('sessionRestoreNewWindow'),
           icon: <Square size={14} aria-hidden="true" />,
           onClick: () => onRestoreNewWindow(session),
+          shortcut: 'Alt+Shift+R',
           'data-testid': 'session-restore-menu-new-window',
         },
         {
           label: getMessage('sessionRestoreReplaceCurrentWindow'),
           icon: <Replace size={14} aria-hidden="true" />,
           onClick: () => onReplaceCurrentWindow(session),
+          shortcut: 'Alt+R',
           'data-testid': 'session-restore-menu-replace-window',
         },
         {
           label: getMessage('sessionRestoreCustomize'),
           icon: <Wrench size={14} aria-hidden="true" />,
           onClick: () => onCustomize(session),
+          shortcut: 'R',
           'data-testid': 'session-restore-menu-customize',
         },
       ]}

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.stories.tsx
@@ -33,3 +33,19 @@ export const ShortcutsAsideClosed: Story = {
     onClose: () => {},
   },
 };
+
+export const ShortcutsAsideOnRules: Story = {
+  args: {
+    open: true,
+    onClose: () => {},
+    pageContext: 'rules',
+  },
+};
+
+export const ShortcutsAsideOnSessions: Story = {
+  args: {
+    open: true,
+    onClose: () => {},
+    pageContext: 'sessions',
+  },
+};

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
@@ -3,11 +3,18 @@ import { Flex, IconButton, Text } from '@radix-ui/themes';
 import { Keyboard, X } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { ShortcutsContent } from './ShortcutsContent';
+import type { PageContext } from './shortcuts';
 import styles from './ShortcutsAside.module.css';
 
 interface ShortcutsAsideProps {
   open: boolean;
   onClose: () => void;
+  /**
+   * Active page in the options surface. Forwarded to ShortcutsContent so
+   * groups irrelevant to the current page start collapsed. Changing the
+   * context resets the open/closed state of every group.
+   */
+  pageContext?: PageContext;
 }
 
 /**
@@ -18,7 +25,7 @@ interface ShortcutsAsideProps {
  * Focus management: when opening, the previously-focused element is captured
  * and the close button takes focus. On close, focus is restored.
  */
-export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
+export function ShortcutsAside({ open, onClose, pageContext }: ShortcutsAsideProps) {
   const asideRef = useRef<HTMLElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
@@ -79,7 +86,7 @@ export function ShortcutsAside({ open, onClose }: ShortcutsAsideProps) {
         </IconButton>
       </div>
       <Flex direction="column" className={styles.body}>
-        <ShortcutsContent />
+        <ShortcutsContent key={pageContext} pageContext={pageContext} />
       </Flex>
     </aside>
   );

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -37,6 +37,33 @@
   margin-bottom: 4px;
 }
 
+.groupTrigger {
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 4px 0;
+  cursor: pointer;
+  border-radius: var(--radius-2);
+}
+
+.groupTrigger:focus-visible {
+  outline: 2px solid var(--focus-8);
+  outline-offset: 2px;
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--gray-11);
+  transition: transform 150ms ease;
+}
+
+.groupTrigger[data-state="open"] .chevron {
+  transform: rotate(180deg);
+}
+
 .firefoxHint {
   margin-top: 4px;
   color: var(--gray-11);

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.stories.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.stories.tsx
@@ -21,6 +21,18 @@ type Story = StoryObj<typeof meta>;
 
 export const ShortcutsContentDefault: Story = {};
 
+export const ShortcutsContentOnRules: Story = {
+  args: { pageContext: 'rules' },
+};
+
+export const ShortcutsContentOnSessions: Story = {
+  args: { pageContext: 'sessions' },
+};
+
+export const ShortcutsContentOnStats: Story = {
+  args: { pageContext: 'stats' },
+};
+
 export const ShortcutsContentSingleGroup: Story = {
   args: {
     groups: [

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -1,15 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
+import * as Collapsible from '@radix-ui/react-collapsible';
 import { Box, Button, Flex, Kbd, Text } from '@radix-ui/themes';
-import { ExternalLink } from 'lucide-react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { getShortcutsCustomizeInfo, openShortcutsCustomizePage } from '@/utils/browserUrls';
 import { useBrowserCommands, type BrowserCommandsMap } from '@/hooks/useBrowserCommands';
-import { SHORTCUT_GROUPS, type ShortcutDisplay, type ShortcutGroup } from './shortcuts';
+import {
+  SHORTCUT_GROUPS,
+  isGroupOpenByDefault,
+  type PageContext,
+  type ShortcutDisplay,
+  type ShortcutGroup,
+} from './shortcuts';
 import styles from './ShortcutsContent.module.css';
 
 interface ShortcutsContentProps {
   /** Optional override of the groups to display (defaults to SHORTCUT_GROUPS). */
   groups?: ShortcutGroup[];
+  /**
+   * When provided, each group's initial expanded state is derived from the
+   * page context (see `isGroupOpenByDefault`). When omitted, all groups start
+   * expanded so non-contextual surfaces (Storybook, popup drawer) keep their
+   * historical behaviour.
+   */
+  pageContext?: PageContext;
 }
 
 function resolveKeys(
@@ -25,7 +39,7 @@ function resolveKeys(
   return { keys: [live], unbound: false };
 }
 
-export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentProps) {
+export function ShortcutsContent({ groups = SHORTCUT_GROUPS, pageContext }: ShortcutsContentProps) {
   const { isDirect } = getShortcutsCustomizeInfo();
   const liveCommands = useBrowserCommands();
   const hasUnbound = !!liveCommands && groups.some((group) =>
@@ -41,20 +55,12 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentP
         </Box>
       )}
       {groups.map((group) => (
-        <Box key={group.titleKey} data-group-title={group.titleKey}>
-          <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
-            {getMessage(group.titleKey)}
-          </Text>
-          <Flex direction="column">
-            {group.shortcuts.map((shortcut) => (
-              <ShortcutRow
-                key={shortcut.descriptionKey}
-                shortcut={shortcut}
-                liveCommands={liveCommands}
-              />
-            ))}
-          </Flex>
-        </Box>
+        <CollapsibleGroup
+          key={group.titleKey}
+          group={group}
+          pageContext={pageContext}
+          liveCommands={liveCommands}
+        />
       ))}
       <Box>
         <Button
@@ -73,6 +79,43 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS }: ShortcutsContentP
         )}
       </Box>
     </Flex>
+  );
+}
+
+function CollapsibleGroup({
+  group,
+  pageContext,
+  liveCommands,
+}: {
+  group: ShortcutGroup;
+  pageContext?: PageContext;
+  liveCommands: BrowserCommandsMap | null;
+}) {
+  const [open, setOpen] = useState(() =>
+    pageContext === undefined ? true : isGroupOpenByDefault(group.titleKey, pageContext),
+  );
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen} data-group-title={group.titleKey}>
+      <Collapsible.Trigger asChild>
+        <button type="button" className={styles.groupTrigger} data-state={open ? 'open' : 'closed'}>
+          <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
+            {getMessage(group.titleKey)}
+          </Text>
+          <ChevronDown size={14} aria-hidden="true" className={styles.chevron} />
+        </button>
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <Flex direction="column">
+          {group.shortcuts.map((shortcut) => (
+            <ShortcutRow
+              key={shortcut.descriptionKey}
+              shortcut={shortcut}
+              liveCommands={liveCommands}
+            />
+          ))}
+        </Flex>
+      </Collapsible.Content>
+    </Collapsible.Root>
   );
 }
 

--- a/src/components/UI/ShortcutsPanel/index.ts
+++ b/src/components/UI/ShortcutsPanel/index.ts
@@ -2,4 +2,5 @@ export { ShortcutsContent } from './ShortcutsContent';
 export { ShortcutsDrawer } from './ShortcutsDrawer';
 export { ShortcutsAside } from './ShortcutsAside';
 export { SHORTCUT_GROUPS, POPUP_SHORTCUT_GROUPS } from './shortcuts';
-export type { ShortcutDisplay, ShortcutGroup } from './shortcuts';
+export { isGroupOpenByDefault } from './shortcuts';
+export type { PageContext, ShortcutDisplay, ShortcutGroup } from './shortcuts';

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -54,6 +54,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
       { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
       { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
+      { keys: ['Space'], descriptionKey: 'shortcutDescListToggleSelection' },
+      { keys: ['t'], descriptionKey: 'shortcutDescListToggleEnabled' },
       { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
       { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
     ],

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -49,13 +49,22 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
-    titleKey: 'shortcutsGroupLists',
+    titleKey: 'shortcutsGroupListRules',
     shortcuts: [
       { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
       { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
       { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
       { keys: ['Space'], descriptionKey: 'shortcutDescListToggleSelection' },
       { keys: ['t'], descriptionKey: 'shortcutDescListToggleEnabled' },
+      { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
+    ],
+  },
+  {
+    titleKey: 'shortcutsGroupListSessions',
+    shortcuts: [
+      { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
+      { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
+      { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
       { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
       { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
     ],
@@ -70,6 +79,39 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
 ];
+
+export type PageContext =
+  | 'rules'
+  | 'sessions'
+  | 'importexport'
+  | 'stats'
+  | 'settings'
+  | 'workspaces';
+
+/**
+ * Defines whether a group is expanded by default given the current page.
+ * Global and Options groups are always open. List/SessionCard groups only
+ * open on the page they pertain to. Popup is implicitly always open since
+ * it is only ever rendered in the popup drawer.
+ */
+export function isGroupOpenByDefault(
+  titleKey: string,
+  pageContext?: PageContext,
+): boolean {
+  switch (titleKey) {
+    case 'shortcutsGroupGlobal':
+    case 'shortcutsGroupOptions':
+    case 'shortcutsGroupPopup':
+      return true;
+    case 'shortcutsGroupListRules':
+      return pageContext === 'rules';
+    case 'shortcutsGroupListSessions':
+    case 'shortcutsGroupSessionCard':
+      return pageContext === 'sessions';
+    default:
+      return false;
+  }
+}
 
 const POPUP_GROUP_KEYS = [
   'shortcutsGroupGlobal',

--- a/src/components/UI/SplitButton/SplitButton.tsx
+++ b/src/components/UI/SplitButton/SplitButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, DropdownMenu, Flex } from '@radix-ui/themes';
+import { Button, DropdownMenu, Flex, Kbd } from '@radix-ui/themes';
 import { ChevronDown } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 
@@ -10,6 +10,8 @@ export interface SplitButtonMenuItem {
   disabled?: boolean;
   /** If true, a separator is rendered before this item */
   separator?: boolean;
+  /** Optional keyboard hint rendered on the right side (e.g. "Shift+R"). */
+  shortcut?: string;
   /** data-testid forwarded to the DropdownMenu.Item */
   'data-testid'?: string;
 }
@@ -104,8 +106,15 @@ export function SplitButton({
                   disabled={item.disabled}
                   data-testid={item['data-testid']}
                 >
-                  {item.icon}
-                  {item.label}
+                  <Flex align="center" justify="between" gap="3" width="100%">
+                    <Flex align="center" gap="2">
+                      {item.icon}
+                      {item.label}
+                    </Flex>
+                    {item.shortcut && (
+                      <Kbd size="1">{item.shortcut}</Kbd>
+                    )}
+                  </Flex>
                 </DropdownMenu.Item>
               </React.Fragment>
             ))}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -213,56 +213,53 @@ export function DomainRulesPage({ syncSettings, updateRules }: DomainRulesPagePr
   const listRef = useRef<HTMLDivElement>(null);
 
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent, rule: DomainRuleSetting, index: number) => {
+    // Only act when the card element itself has focus (not a child input/button).
+    if (e.target !== e.currentTarget) return;
+
     const cards = listRef.current?.querySelectorAll<HTMLElement>('[role="listitem"]');
     if (!cards) return;
 
     switch (e.key) {
-      case 'ArrowDown': {
+      case 'ArrowDown':
         e.preventDefault();
         cards[index + 1]?.focus();
-        break;
-      }
-      case 'ArrowUp': {
+        return;
+      case 'ArrowUp':
         e.preventDefault();
         cards[index - 1]?.focus();
-        break;
-      }
-      case 'Home': {
+        return;
+      case 'Home':
         e.preventDefault();
         cards[0]?.focus();
-        break;
-      }
-      case 'End': {
+        return;
+      case 'End':
         e.preventDefault();
         cards[cards.length - 1]?.focus();
-        break;
-      }
-      case ' ': {
-        const target = e.target as HTMLElement;
-        if (target.getAttribute('role') === 'row') {
-          e.preventDefault();
-          handleRowSelect(rule.id, !selectedIds.has(rule.id));
-        }
-        break;
-      }
-      case 'Enter': {
-        const target = e.target as HTMLElement;
-        if (target.getAttribute('role') === 'row') {
-          e.preventDefault();
-          handleEditRule(rule);
-        }
-        break;
-      }
-      case 'Delete': {
-        const target = e.target as HTMLElement;
-        if (target.getAttribute('role') === 'row') {
-          e.preventDefault();
-          setDeleteTarget({ type: 'single', ruleId: rule.id, focusIndex: index });
-        }
-        break;
-      }
+        return;
+      case ' ':
+        e.preventDefault();
+        handleRowSelect(rule.id, !selectedIds.has(rule.id));
+        return;
+      case 'Enter':
+        e.preventDefault();
+        handleEditRule(rule);
+        return;
+      case 'Delete':
+        e.preventDefault();
+        setDeleteTarget({ type: 'single', ruleId: rule.id, focusIndex: index });
+        return;
     }
-  }, [handleRowSelect, handleEditRule, selectedIds]);
+
+    if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+    const lower = e.key.toLowerCase();
+    if (lower === 'e') {
+      e.preventDefault();
+      handleEditRule(rule);
+    } else if (lower === 't') {
+      e.preventDefault();
+      handleToggleEnabled(rule.id, !rule.enabled);
+    }
+  }, [handleRowSelect, handleEditRule, handleToggleEnabled, selectedIds]);
 
   const handleAddRule = useCallback(() => {
     setEditingRule(undefined);

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -21,7 +21,7 @@ import { Sidebar } from '@/components/UI/Sidebar/Sidebar';
 import type { SidebarItem } from '@/components/UI/Sidebar/Sidebar';
 import { OptionsHeader, OptionsHeaderCollapsed } from '@/components/UI/OptionsLayout/OptionsHeader';
 import { WorkspaceFooter, WorkspaceFooterCollapsed } from '@/components/UI/Workspace/WorkspaceFooter';
-import { ShortcutsAside } from '@/components/UI/ShortcutsPanel';
+import { ShortcutsAside, type PageContext } from '@/components/UI/ShortcutsPanel';
 import { DomainRulesPage } from './DomainRulesPage';
 import { StatisticsPage } from './StatisticsPage';
 import { SettingsPage } from '@/components/UI/SettingsPage/SettingsPage';
@@ -154,7 +154,11 @@ export function OptionsContent() {
                             <WorkspacesPage syncSettings={settings} />
                         )}
                     </main>
-                    <ShortcutsAside open={shortcutsAsideOpen} onClose={() => setShortcutsAsideOpen(false)} />
+                    <ShortcutsAside
+                        open={shortcutsAsideOpen}
+                        onClose={() => setShortcutsAsideOpen(false)}
+                        pageContext={currentTab as PageContext}
+                    />
                 </div>
             </div>
             <ConfirmDialog

--- a/tests/popup-shortcut-groups.test.ts
+++ b/tests/popup-shortcut-groups.test.ts
@@ -14,10 +14,11 @@ describe('POPUP_SHORTCUT_GROUPS', () => {
     ]);
   });
 
-  it('does not include Options or Lists groups', () => {
+  it('does not include Options or List groups', () => {
     const titleKeys = POPUP_SHORTCUT_GROUPS.map((g) => g.titleKey);
     expect(titleKeys).not.toContain('shortcutsGroupOptions');
-    expect(titleKeys).not.toContain('shortcutsGroupLists');
+    expect(titleKeys).not.toContain('shortcutsGroupListRules');
+    expect(titleKeys).not.toContain('shortcutsGroupListSessions');
   });
 
   it('preserves the full shortcuts list of each retained group', () => {

--- a/tests/shortcuts-context.test.ts
+++ b/tests/shortcuts-context.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isGroupOpenByDefault,
+  SHORTCUT_GROUPS,
+  type PageContext,
+} from '../src/components/UI/ShortcutsPanel/shortcuts';
+
+const ALL_CONTEXTS: PageContext[] = [
+  'rules',
+  'sessions',
+  'importexport',
+  'stats',
+  'settings',
+  'workspaces',
+];
+
+describe('isGroupOpenByDefault', () => {
+  it('keeps Global and Options groups open in every context', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('shortcutsGroupGlobal', ctx)).toBe(true);
+      expect(isGroupOpenByDefault('shortcutsGroupOptions', ctx)).toBe(true);
+    }
+  });
+
+  it('opens the rules list group only on the rules page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('shortcutsGroupListRules', ctx)).toBe(ctx === 'rules');
+    }
+  });
+
+  it('opens the sessions list and session card groups only on the sessions page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const expected = ctx === 'sessions';
+      expect(isGroupOpenByDefault('shortcutsGroupListSessions', ctx)).toBe(expected);
+      expect(isGroupOpenByDefault('shortcutsGroupSessionCard', ctx)).toBe(expected);
+    }
+  });
+
+  it('returns false for an unknown title without a context', () => {
+    expect(isGroupOpenByDefault('shortcutsGroupListRules', undefined)).toBe(false);
+    expect(isGroupOpenByDefault('unknown-group', 'rules')).toBe(false);
+  });
+
+  it('covers every group declared in SHORTCUT_GROUPS', () => {
+    for (const group of SHORTCUT_GROUPS) {
+      const opensSomewhere = ALL_CONTEXTS.some((ctx) =>
+        isGroupOpenByDefault(group.titleKey, ctx),
+      );
+      expect(opensSomewhere, `group ${group.titleKey} never opens`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
This PR makes the shortcuts panel groups collapsible using Radix UI's Collapsible component, with intelligent default open/closed states based on the current page context. Groups relevant to the current page start expanded, while irrelevant groups start collapsed, improving UX in the options surface.

## Key Changes

- **Collapsible shortcuts groups**: Converted static shortcut groups to collapsible sections with smooth animations using `@radix-ui/react-collapsible`
  - Added `CollapsibleGroup` component with expand/collapse toggle
  - Added chevron icon that rotates on state change
  - Added focus-visible styling for keyboard navigation

- **Context-aware group defaults**: Introduced `PageContext` type and `isGroupOpenByDefault()` function to determine initial group state
  - Global and Options groups always open
  - List/SessionCard groups only open on their relevant pages (rules/sessions)
  - Popup group always open (only rendered in popup drawer)
  - Backward compatible: when no context provided, all groups start expanded (preserves Storybook/popup behavior)

- **Split shortcuts into page-specific groups**: Separated generic "Lists" group into:
  - `shortcutsGroupListRules` - Rules list keyboard shortcuts
  - `shortcutsGroupListSessions` - Sessions list keyboard shortcuts
  - Updated all locale files (en, es, fr)

- **Enhanced DomainRulesPage keyboard navigation**:
  - Added early return guard to only handle keyboard events when card itself has focus
  - Simplified switch statement with early returns
  - Added support for 'e' (edit) and 't' (toggle enabled) shortcuts
  - Improved code clarity and maintainability

- **SplitButton menu improvements**: Added optional `shortcut` property to display keyboard hints in dropdown menu items (e.g., "Shift+R" for session restore)

- **Updated ShortcutsAside and options.tsx**: Threaded `pageContext` prop through component hierarchy to enable context-aware behavior

- **Added comprehensive tests**: New `shortcuts-context.test.ts` validates that all groups have appropriate default states across all page contexts

## Implementation Details

- The collapsible state is managed per-group using React's `useState` hook
- Initial state is derived from `isGroupOpenByDefault()` which checks the group's title key against the page context
- CSS transitions and transforms provide smooth chevron rotation animation
- The implementation maintains backward compatibility by defaulting to all-expanded when no context is provided

https://claude.ai/code/session_01G1m3X9nPRnVeyLFMDEME9F