### PR TITLE
feat(popup): add P shortcut for options, slim shortcuts drawer

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -640,6 +640,7 @@
   "shortcutDescPopupSave": { "message": "Save snapshot" },
   "shortcutDescPopupRestore": { "message": "Open sessions" },
   "shortcutDescPopupOrganize": { "message": "Organize all tabs" },
+  "shortcutDescPopupOptions": { "message": "Open extension options" },
   "shortcutDescOpenShortcutsHelp": { "message": "Show this shortcuts panel" },
   "shortcutDescNavigateTabs": { "message": "Switch sidebar tab" },
   "shortcutDescFocusSearch": { "message": "Focus the search field" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -641,6 +641,7 @@
   "shortcutDescPopupSave": { "message": "Guardar instantánea" },
   "shortcutDescPopupRestore": { "message": "Abrir sesiones" },
   "shortcutDescPopupOrganize": { "message": "Organizar todas las pestañas" },
+  "shortcutDescPopupOptions": { "message": "Abrir las opciones de la extensión" },
   "shortcutDescOpenShortcutsHelp": { "message": "Mostrar este panel de atajos" },
   "shortcutDescNavigateTabs": { "message": "Cambiar de pestaña en la barra lateral" },
   "shortcutDescFocusSearch": { "message": "Enfocar el campo de búsqueda" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -641,6 +641,7 @@
   "shortcutDescPopupSave": { "message": "Enregistrer un snapshot" },
   "shortcutDescPopupRestore": { "message": "Ouvrir les sessions" },
   "shortcutDescPopupOrganize": { "message": "Organiser tous les onglets" },
+  "shortcutDescPopupOptions": { "message": "Ouvrir les options de l'extension" },
   "shortcutDescOpenShortcutsHelp": { "message": "Afficher ce panneau de raccourcis" },
   "shortcutDescNavigateTabs": { "message": "Changer d'onglet de la barre latérale" },
   "shortcutDescFocusSearch": { "message": "Focus sur le champ de recherche" },

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.module.css
@@ -21,7 +21,7 @@
 }
 
 .drawerContent[data-state='open'] {
-  animation: slideInFromRight 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: slideInFromRight 400ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .drawerContent[data-state='closed'] {

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -36,6 +36,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ['S'], descriptionKey: 'shortcutDescPopupSave' },
       { keys: ['R'], descriptionKey: 'shortcutDescPopupRestore' },
       { keys: ['O'], descriptionKey: 'shortcutDescPopupOrganize' },
+      { keys: ['P'], descriptionKey: 'shortcutDescPopupOptions' },
       { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
     ],
   },
@@ -114,7 +115,6 @@ export function isGroupOpenByDefault(
 }
 
 const POPUP_GROUP_KEYS = [
-  'shortcutsGroupGlobal',
   'shortcutsGroupPopup',
   'shortcutsGroupSessionCard',
 ] as const;

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -65,8 +65,9 @@ export function PopupContent() {
     { combo: 's', action: handlePopupSave, excludeIfTargetWithin: '[data-popup-pinned-card]' },
     { combo: 'r', action: handlePopupRestore, excludeIfTargetWithin: '[data-popup-pinned-card]' },
     { combo: 'o', action: handlePopupOrganize, excludeIfTargetWithin: '[data-popup-pinned-card]' },
+    { combo: 'p', action: openOptionsPage, excludeIfTargetWithin: '[data-popup-pinned-card]' },
     { combo: '?', action: () => setShortcutsOpen((open) => !open), allowWhenDialogOpen: false },
-  ], [handlePopupSave, handlePopupRestore, handlePopupOrganize]);
+  ], [handlePopupSave, handlePopupRestore, handlePopupOrganize, openOptionsPage]);
 
   useKeyboardShortcuts(shortcuts);
 

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -47,11 +47,11 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
     });
     await expect(page.getByTestId('shortcuts-content')).toBeVisible();
 
-    // Only the 3 popup-relevant groups must be displayed (Global, Popup,
-    // Session card). Options and Lists groups are hidden in the popup drawer.
+    // Only the 2 popup-relevant groups must be displayed (Popup, Session
+    // card). Global, Options and Lists groups are hidden in the popup drawer.
     await expect(
       page.locator('[data-testid="shortcuts-content"] [data-group-title]'),
-    ).toHaveCount(3);
+    ).toHaveCount(2);
 
     // Regression guard: the popup.html `.radix-themes` selector used to also
     // match the Theme that Radix Themes wraps around the portaled overlay,

--- a/tests/popup-shortcut-groups.test.ts
+++ b/tests/popup-shortcut-groups.test.ts
@@ -5,17 +5,17 @@ import {
 } from '../src/components/UI/ShortcutsPanel/shortcuts';
 
 describe('POPUP_SHORTCUT_GROUPS', () => {
-  it('contains exactly 3 groups in the expected order', () => {
+  it('contains exactly 2 groups in the expected order', () => {
     const titleKeys = POPUP_SHORTCUT_GROUPS.map((g) => g.titleKey);
     expect(titleKeys).toEqual([
-      'shortcutsGroupGlobal',
       'shortcutsGroupPopup',
       'shortcutsGroupSessionCard',
     ]);
   });
 
-  it('does not include Options or List groups', () => {
+  it('does not include Global, Options or List groups', () => {
     const titleKeys = POPUP_SHORTCUT_GROUPS.map((g) => g.titleKey);
+    expect(titleKeys).not.toContain('shortcutsGroupGlobal');
     expect(titleKeys).not.toContain('shortcutsGroupOptions');
     expect(titleKeys).not.toContain('shortcutsGroupListRules');
     expect(titleKeys).not.toContain('shortcutsGroupListSessions');


### PR DESCRIPTION
- Bind "P" in the popup to open the extension options page (reuses the
  existing settings handler). Documented in the shortcuts cheatsheet.
- Remove the "Browser-wide" group from the popup drawer: Alt+Shift+O/S/P
  are redundant once the popup is open and the section forced a scroll.
  The group is still rendered in the options page aside.
- Bump the drawer open animation from 220ms to 400ms so the slide-in is
  actually perceptible. Close stays at 200ms (snappier dismiss).

https://claude.ai/code/session_01CQahsbbReSkntdBEFnUxMt