### PR TITLE
feat(dnd): expose keyboard drag-and-drop on sessions and domain rules

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -652,6 +652,7 @@
   "shortcutDescListToggleEnabled": { "message": "Enable or disable focused rule" },
   "shortcutDescListDelete": { "message": "Delete focused item" },
   "shortcutDescListPin": { "message": "Pin or unpin focused session" },
+  "shortcutDescListReorderKeyboard": { "message": "Reorder via drag handle (then arrows to move, Esc to cancel)" },
   "shortcutDescSessionRestoreCustom": { "message": "Custom restore (wizard)" },
   "shortcutDescSessionRestoreCurrent": { "message": "Add session to current window" },
   "shortcutDescSessionReplaceCurrent": { "message": "Replace current window tabs" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -653,6 +653,7 @@
   "shortcutDescListToggleEnabled": { "message": "Activar o desactivar la regla con foco" },
   "shortcutDescListDelete": { "message": "Eliminar el elemento con foco" },
   "shortcutDescListPin": { "message": "Anclar o desanclar la sesión con foco" },
+  "shortcutDescListReorderKeyboard": { "message": "Reordenar con el asa (luego flechas para mover, Esc para cancelar)" },
   "shortcutDescSessionRestoreCustom": { "message": "Restauración personalizada (asistente)" },
   "shortcutDescSessionRestoreCurrent": { "message": "Añadir la sesión a la ventana actual" },
   "shortcutDescSessionReplaceCurrent": { "message": "Reemplazar las pestañas de la ventana" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -653,6 +653,7 @@
   "shortcutDescListToggleEnabled": { "message": "Activer ou désactiver la règle focus" },
   "shortcutDescListDelete": { "message": "Supprimer l'élément focus" },
   "shortcutDescListPin": { "message": "Épingler ou désépingler la session focus" },
+  "shortcutDescListReorderKeyboard": { "message": "Réorganiser via la poignée (puis flèches pour déplacer, Échap pour annuler)" },
   "shortcutDescSessionRestoreCustom": { "message": "Restauration personnalisée (assistant)" },
   "shortcutDescSessionRestoreCurrent": { "message": "Ajouter la session à la fenêtre courante" },
   "shortcutDescSessionReplaceCurrent": { "message": "Remplacer les onglets de la fenêtre" },

--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu, Box } from '@radix-ui/themes';
+import { Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu } from '@radix-ui/themes';
 import { Pencil, Trash2, MoreHorizontal, GripVertical, AlertTriangle } from 'lucide-react';
 import { useSortable } from '@dnd-kit/react/sortable';
 
@@ -9,22 +9,12 @@ function getStatusStyle(status: 'default' | 'conflict' | 'identical'): React.CSS
   return {};
 }
 
-function getDragHandleStyle(disabled: boolean): React.CSSProperties {
-  return {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    cursor: disabled ? 'not-allowed' : 'grab',
-    touchAction: 'none',
-    color: disabled ? 'var(--gray-6)' : 'var(--gray-9)',
-    flexShrink: 0,
-  };
-}
 import { RuleDetailPopover } from './RuleDetailPopover';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { getMessage } from '@/utils/i18n';
 import { getRadixColor } from '@/utils/utils';
 import { getRuleCategory } from '@/utils/categoriesStore';
+import { getDragHandleStyle } from '@/utils/dragHandleStyle';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 
 export interface DomainRuleCardProps {
@@ -159,15 +149,21 @@ export function DomainRuleCard({
         /* ── MODE FULL ── */
         <Flex align="center" justify="between" gap="4">
           {/* Drag handle */}
-          <Box
+          <IconButton
             ref={handleRef}
+            type="button"
+            variant="ghost"
+            size="1"
+            color="gray"
+            disabled={isDragDisabled}
             data-testid={`rule-card-${rule.id}-drag-handle`}
             aria-disabled={isDragDisabled}
             aria-label={getMessage('dragHandle')}
+            aria-keyshortcuts="Space Enter ArrowUp ArrowDown Escape"
             style={getDragHandleStyle(isDragDisabled)}
           >
             <GripVertical size={16} aria-hidden="true" />
-          </Box>
+          </IconButton>
 
           {/* Left: Selection + Toggle */}
           <Flex align="center" gap="3">

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -17,6 +17,7 @@ import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/Accessi
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import { getRadixColor } from '@/utils/utils';
+import { getDragHandleStyle } from '@/utils/dragHandleStyle';
 import { SessionPreviewTree } from './SessionPreviewTree';
 import { SessionRestoreButton } from './SessionRestoreButton/SessionRestoreButton';
 import type { Session } from '@/types/session';
@@ -327,23 +328,21 @@ function SessionCardFullHeader({
     <>
       {/* Drag handle */}
       {!isRenaming && (
-        <Box
+        <IconButton
           ref={handleRef}
+          type="button"
+          variant="ghost"
+          size="1"
+          color="gray"
+          disabled={isDragDisabled}
           data-testid={`session-card-${session.id}-drag-handle`}
           aria-disabled={isDragDisabled}
           aria-label={getMessage('dragHandle')}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: isDragDisabled ? 'not-allowed' : 'grab',
-            touchAction: 'none',
-            color: isDragDisabled ? 'var(--gray-6)' : 'var(--gray-9)',
-            flexShrink: 0,
-          }}
+          aria-keyshortcuts="Space Enter ArrowUp ArrowDown Escape"
+          style={getDragHandleStyle(isDragDisabled)}
         >
           <GripVertical size={16} aria-hidden="true" />
-        </Box>
+        </IconButton>
       )}
 
       {/* Pin / Unpin button */}

--- a/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsAside.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { Flex, IconButton, Text } from '@radix-ui/themes';
 import { Keyboard, X } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import { ShortcutsContent } from './ShortcutsContent';
+import { ShortcutsContent, focusFirstOpenTrigger } from './ShortcutsContent';
 import type { PageContext } from './shortcuts';
 import styles from './ShortcutsAside.module.css';
 
@@ -27,7 +27,6 @@ interface ShortcutsAsideProps {
  */
 export function ShortcutsAside({ open, onClose, pageContext }: ShortcutsAsideProps) {
   const asideRef = useRef<HTMLElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const wasOpenRef = useRef(false);
 
@@ -35,7 +34,7 @@ export function ShortcutsAside({ open, onClose, pageContext }: ShortcutsAsidePro
     if (open && !wasOpenRef.current) {
       previousActiveElementRef.current = document.activeElement as HTMLElement | null;
       // Wait one frame so the panel is in the DOM and visible.
-      requestAnimationFrame(() => closeButtonRef.current?.focus());
+      requestAnimationFrame(() => focusFirstOpenTrigger(asideRef.current));
     } else if (!open && wasOpenRef.current) {
       previousActiveElementRef.current?.focus?.();
       previousActiveElementRef.current = null;
@@ -73,7 +72,6 @@ export function ShortcutsAside({ open, onClose, pageContext }: ShortcutsAsidePro
           </Text>
         </div>
         <IconButton
-          ref={closeButtonRef}
           size="1"
           variant="ghost"
           color="gray"

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -39,6 +39,60 @@ function resolveKeys(
   return { keys: [live], unbound: false };
 }
 
+const TRIGGER_SELECTOR = '[data-shortcut-group-trigger]';
+
+function getTriggers(container: HTMLElement | null): HTMLButtonElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLButtonElement>(TRIGGER_SELECTOR));
+}
+
+/**
+ * Focus the first group trigger that is currently open. Falls back to the
+ * very first trigger when no section is open. No-op when the container is
+ * empty or null.
+ */
+export function focusFirstOpenTrigger(container: HTMLElement | null): void {
+  const triggers = getTriggers(container);
+  if (triggers.length === 0) return;
+  const open = triggers.find((t) => t.getAttribute('data-state') === 'open');
+  (open ?? triggers[0]).focus();
+}
+
+function handleTriggerKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
+  const target = event.target as HTMLElement | null;
+  if (!target?.matches(TRIGGER_SELECTOR)) return;
+
+  const triggers = getTriggers(event.currentTarget);
+  if (triggers.length === 0) return;
+  const currentIndex = triggers.indexOf(target as HTMLButtonElement);
+  if (currentIndex === -1) return;
+
+  let nextIndex: number | null = null;
+  switch (event.key) {
+    case 'ArrowDown':
+      nextIndex = Math.min(currentIndex + 1, triggers.length - 1);
+      break;
+    case 'ArrowUp':
+      nextIndex = Math.max(currentIndex - 1, 0);
+      break;
+    case 'Home':
+      nextIndex = 0;
+      break;
+    case 'End':
+      nextIndex = triggers.length - 1;
+      break;
+    default:
+      return;
+  }
+
+  if (nextIndex !== null && nextIndex !== currentIndex) {
+    event.preventDefault();
+    triggers[nextIndex].focus();
+  } else if (nextIndex === currentIndex) {
+    event.preventDefault();
+  }
+}
+
 export function ShortcutsContent({ groups = SHORTCUT_GROUPS, pageContext }: ShortcutsContentProps) {
   const { isDirect } = getShortcutsCustomizeInfo();
   const liveCommands = useBrowserCommands();
@@ -46,7 +100,7 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS, pageContext }: Shor
     group.shortcuts.some((s) => resolveKeys(s, liveCommands).unbound),
   );
   return (
-    <Flex direction="column" gap="4" data-testid="shortcuts-content">
+    <Flex direction="column" gap="4" data-testid="shortcuts-content" onKeyDown={handleTriggerKeyDown}>
       {hasUnbound && (
         <Box className={styles.unboundBanner} data-testid="shortcuts-unbound-banner">
           <Text size="1" as="p">
@@ -97,7 +151,12 @@ function CollapsibleGroup({
   return (
     <Collapsible.Root open={open} onOpenChange={setOpen} data-group-title={group.titleKey}>
       <Collapsible.Trigger asChild>
-        <button type="button" className={styles.groupTrigger} data-state={open ? 'open' : 'closed'}>
+        <button
+          type="button"
+          className={styles.groupTrigger}
+          data-state={open ? 'open' : 'closed'}
+          data-shortcut-group-trigger=""
+        >
           <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
             {getMessage(group.titleKey)}
           </Text>

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -3,7 +3,7 @@ import { Box, Dialog, Flex } from '@radix-ui/themes';
 import { Keyboard } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { DialogCloseButton } from '@/components/UI/DialogShell';
-import { ShortcutsContent } from './ShortcutsContent';
+import { ShortcutsContent, focusFirstOpenTrigger } from './ShortcutsContent';
 import { POPUP_SHORTCUT_GROUPS } from './shortcuts';
 import styles from './ShortcutsDrawer.module.css';
 
@@ -46,6 +46,13 @@ export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
         className={styles.drawerContent}
         onPointerDownOutside={preventClose}
         onInteractOutside={preventClose}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          requestAnimationFrame(() => {
+            const root = document.querySelector('[data-testid="shortcuts-drawer"]');
+            focusFirstOpenTrigger(root as HTMLElement | null);
+          });
+        }}
       >
         <div className={styles.drawerHeader}>
           <Flex align="center" gap="2" className={styles.drawerHeaderTitle}>

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -58,6 +58,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ['Space'], descriptionKey: 'shortcutDescListToggleSelection' },
       { keys: ['t'], descriptionKey: 'shortcutDescListToggleEnabled' },
       { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
+      { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
     ],
   },
   {
@@ -68,6 +69,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
       { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
       { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
+      { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
     ],
   },
   {

--- a/src/utils/dragHandleStyle.ts
+++ b/src/utils/dragHandleStyle.ts
@@ -1,0 +1,13 @@
+import type React from 'react';
+
+export function getDragHandleStyle(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: disabled ? 'not-allowed' : 'grab',
+    touchAction: 'none',
+    color: disabled ? 'var(--gray-6)' : 'var(--gray-9)',
+    flexShrink: 0,
+  };
+}

--- a/tests/e2e/domain-rules-keyboard-dnd.spec.ts
+++ b/tests/e2e/domain-rules-keyboard-dnd.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * E2E tests for keyboard-driven drag-and-drop reordering of domain rules.
+ * Validates that the dnd-kit KeyboardSensor (default Space/Enter to grab,
+ * arrows to move, Escape to cancel) is reachable via Tab now that the
+ * drag handle is rendered as a focusable IconButton.
+ */
+import { test, expect } from './fixtures';
+import { goToDomainRulesSection } from './helpers/navigation';
+
+test.beforeEach(async ({ helpers }) => {
+  await helpers.clearDomainRules();
+});
+
+async function getDomainRuleLabels(helpers: any): Promise<string[]> {
+  const settings = await helpers.getSettings();
+  return (settings.domainRules as any[]).map((r: any) => r.label);
+}
+
+test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
+  test('drag handle is focusable and exposes keyboard shortcuts', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    const handle = page.locator('[data-testid$="-drag-handle"]').first();
+    await expect(handle).toBeVisible();
+
+    const tagName = await handle.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe('button');
+
+    await expect(handle).toHaveAttribute('aria-keyshortcuts', /Space.*Enter.*Arrow/);
+    await expect(handle).toHaveAttribute('aria-label', /reorder|réordonner|reordenar/i);
+
+    await handle.focus();
+    await expect(handle).toBeFocused();
+
+    await page.close();
+  });
+
+  test('keyboard reorders rules via Space + ArrowDown + Space', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+    await helpers.addDomainRule({ label: 'Rule C', domainFilter: 'c.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    const ruleARow = page.getByRole('listitem', { name: /Rule A/i });
+    const handleA = ruleARow.locator('[data-testid$="-drag-handle"]');
+
+    await handleA.focus();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Space');
+
+    await page.waitForFunction(() => {
+      const rows = [...document.querySelectorAll('[role="listitem"]')];
+      const iA = rows.findIndex(r => r.getAttribute('aria-label')?.includes('Rule A'));
+      const iC = rows.findIndex(r => r.getAttribute('aria-label')?.includes('Rule C'));
+      return iA > -1 && iC > -1 && iA > iC;
+    }, { timeout: 5000 });
+
+    await page.close();
+
+    const labels = await getDomainRuleLabels(helpers);
+    const idxA = labels.indexOf('Rule A');
+    const idxB = labels.indexOf('Rule B');
+    expect(idxA).toBeGreaterThan(idxB);
+  });
+
+  test('Escape during keyboard drag cancels the reorder', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'Rule A', domainFilter: 'a.com' });
+    await helpers.addDomainRule({ label: 'Rule B', domainFilter: 'b.com' });
+    await helpers.addDomainRule({ label: 'Rule C', domainFilter: 'c.com' });
+
+    const before = await getDomainRuleLabels(helpers);
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    const handleA = page
+      .getByRole('listitem', { name: /Rule A/i })
+      .locator('[data-testid$="-drag-handle"]');
+
+    await handleA.focus();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Escape');
+    await expect(handleA).toBeFocused();
+    await page.close();
+
+    const after = await getDomainRuleLabels(helpers);
+    expect(after).toEqual(before);
+  });
+
+  test('drag handle is disabled and out of tab order during search', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'GitHub', domainFilter: 'github.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await page.getByTestId('page-rules-search').fill('git');
+
+    const handle = page.locator('[data-testid$="-drag-handle"]').first();
+    await expect(handle).toBeDisabled();
+
+    await page.close();
+  });
+});

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -209,6 +209,82 @@ test.describe('[US-KB-options] Options shortcuts', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Shortcuts panel keyboard navigation
+// ---------------------------------------------------------------------------
+test.describe('[US-KB-panel] Shortcuts panel keyboard navigation', () => {
+  test('drawer opens with focus on the contextual open trigger; Arrow keys roam between triggers', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    await expect(page.getByTestId('popup-toolbar')).toBeVisible();
+    await page.getByTestId('popup').click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press('Shift+Slash');
+
+    const drawer = page.getByTestId('shortcuts-drawer');
+    await expect(drawer).toBeVisible({ timeout: 5000 });
+
+    const triggers = drawer.locator('[data-shortcut-group-trigger]');
+    await expect(triggers).toHaveCount(2);
+
+    // Initial focus must be on a group trigger (the first open one), not the
+    // close button.
+    await expect(triggers.first()).toBeFocused({ timeout: 2000 });
+
+    // ArrowDown moves focus to the next trigger.
+    await page.keyboard.press('ArrowDown');
+    await expect(triggers.nth(1)).toBeFocused();
+
+    // ArrowDown at the last trigger clamps (no wrap).
+    await page.keyboard.press('ArrowDown');
+    await expect(triggers.nth(1)).toBeFocused();
+
+    // ArrowUp goes back.
+    await page.keyboard.press('ArrowUp');
+    await expect(triggers.first()).toBeFocused();
+
+    // Home / End jump to first / last.
+    await page.keyboard.press('End');
+    await expect(triggers.nth(1)).toBeFocused();
+    await page.keyboard.press('Home');
+    await expect(triggers.first()).toBeFocused();
+
+    await page.close();
+  });
+
+  test('aside opens with focus on the first open group trigger, not the close button', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await page.locator('body').click();
+    await page.keyboard.press('Shift+Slash');
+
+    const aside = page.getByTestId('shortcuts-aside');
+    await expect(aside).toHaveAttribute('data-state', 'open');
+
+    const firstOpenTrigger = aside
+      .locator('[data-shortcut-group-trigger][data-state="open"]')
+      .first();
+    await expect(firstOpenTrigger).toBeFocused({ timeout: 2000 });
+
+    // ArrowDown moves to the next trigger.
+    const allTriggers = aside.locator('[data-shortcut-group-trigger]');
+    await page.keyboard.press('ArrowDown');
+    const movedFocus = await allTriggers.evaluateAll(
+      (els) => els.findIndex((el) => el === document.activeElement),
+    );
+    expect(movedFocus).toBeGreaterThan(0);
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Session card restore shortcuts (the user-requested ones)
 // ---------------------------------------------------------------------------
 test.describe('[US-KB-sessions] SessionCard restore shortcuts', () => {

--- a/tests/e2e/sessions-keyboard-dnd.spec.ts
+++ b/tests/e2e/sessions-keyboard-dnd.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * E2E tests for keyboard-driven drag-and-drop reordering of sessions.
+ * Validates that the dnd-kit KeyboardSensor (default Space/Enter to grab,
+ * arrows to move, Escape to cancel) is reachable via Tab now that the
+ * drag handle is rendered as a focusable IconButton.
+ */
+import { test, expect } from './fixtures';
+import { goToSessionsSection } from './helpers/navigation';
+import {
+  seedSessions,
+  clearSessions,
+  getSessionsFromStorage,
+  createTestSession,
+} from './helpers/seed';
+
+test.beforeEach(async ({ extensionContext }) => {
+  await clearSessions(extensionContext);
+});
+
+test.describe('[KBD-DND] Sessions keyboard drag-and-drop', () => {
+  test('drag handle is focusable and exposes keyboard shortcuts', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    await seedSessions(extensionContext, [createTestSession({ name: 'Solo' })]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const handle = page.locator('[data-testid$="-drag-handle"]').first();
+    await expect(handle).toBeVisible();
+
+    const tagName = await handle.evaluate((el) => el.tagName.toLowerCase());
+    expect(tagName).toBe('button');
+
+    await expect(handle).toHaveAttribute('aria-keyshortcuts', /Space.*Enter.*Arrow/);
+
+    await handle.focus();
+    await expect(handle).toBeFocused();
+
+    await page.close();
+  });
+
+  test('keyboard reorders sessions via Space + ArrowDown + Space', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const sA = createTestSession({ name: 'Session A' });
+    const sB = createTestSession({ name: 'Session B' });
+    const sC = createTestSession({ name: 'Session C' });
+    await seedSessions(extensionContext, [sA, sB, sC]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const handleA = page
+      .locator(`[data-testid="session-card-${sA.id}-drag-handle"]`);
+
+    await handleA.focus();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Space');
+
+    await page.waitForFunction((targetId) => {
+      const cards = [...document.querySelectorAll('[data-testid^="session-card-"]')]
+        .filter((el) => /^session-card-[^-]+(-[^-]+){4}$/.test(el.getAttribute('data-testid') ?? ''));
+      const ids = cards.map((c) => c.getAttribute('data-testid'));
+      const targetIdx = ids.indexOf(`session-card-${targetId}`);
+      return targetIdx > 0;
+    }, sA.id, { timeout: 5000 });
+
+    await page.close();
+
+    const stored = await getSessionsFromStorage(extensionContext);
+    const idxA = stored.findIndex((s) => s.id === sA.id);
+    const idxB = stored.findIndex((s) => s.id === sB.id);
+    expect(idxA).toBeGreaterThan(idxB);
+  });
+
+  test('Escape during keyboard drag cancels the reorder', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const sA = createTestSession({ name: 'Session A' });
+    const sB = createTestSession({ name: 'Session B' });
+    const sC = createTestSession({ name: 'Session C' });
+    await seedSessions(extensionContext, [sA, sB, sC]);
+
+    const before = (await getSessionsFromStorage(extensionContext)).map((s) => s.id);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const handleA = page
+      .locator(`[data-testid="session-card-${sA.id}-drag-handle"]`)
+      .first();
+
+    await handleA.focus();
+    await page.keyboard.press('Space');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Escape');
+
+    // Wait until dnd-kit unmounts the drag overlay clone and clears aria-pressed.
+    await page.waitForFunction((id) => {
+      const handles = document.querySelectorAll(
+        `[data-testid="session-card-${id}-drag-handle"]`,
+      );
+      const pressed = Array.from(handles).some(
+        (h) => h.getAttribute('aria-pressed') === 'true',
+      );
+      return !pressed;
+    }, sA.id, { timeout: 5000 });
+
+    await page.close();
+
+    const after = (await getSessionsFromStorage(extensionContext)).map((s) => s.id);
+    expect(after).toEqual(before);
+  });
+});


### PR DESCRIPTION
Convert the GripVertical drag handles from non-focusable Box wrappers to
Radix IconButtons so the dnd-kit KeyboardSensor (already enabled in the
default preset) becomes reachable via Tab. Users can now reorder cards
with Space/Enter to grab, arrows to move, Escape to cancel.

Mutualize the shared handle style in src/utils/dragHandleStyle.ts and add
two Playwright specs covering focus, reorder, cancel and disabled state.

https://claude.ai/code/session_01RFHC3H66tApNV76MR6Qbuc