### PR TITLE
fix(popup,options): reorganize shortcuts and dialog UX issues

### DIFF
--- a/src/components/UI/DialogShell/DialogShell.tsx
+++ b/src/components/UI/DialogShell/DialogShell.tsx
@@ -40,6 +40,25 @@ const closeButtonStyle: React.CSSProperties = {
   right: 16,
 };
 
+/**
+ * Radix's default focuses the first focusable element, which in our shell is
+ * the close X button: pressing Enter then dismisses the dialog instead of
+ * triggering the primary action. When a child marks an element with the
+ * `data-autofocus` attribute (typically the primary action button), focus it
+ * instead. Disabled elements fall through to Radix's default so we never park
+ * focus on something that swallows Enter.
+ */
+function defaultOnOpenAutoFocus(event: Event) {
+  const root = event.currentTarget;
+  if (!(root instanceof HTMLElement)) return;
+  const target = root.querySelector<HTMLElement>('[data-autofocus]');
+  if (!target) return;
+  if (target instanceof HTMLButtonElement && target.disabled) return;
+  if (target.getAttribute('aria-disabled') === 'true') return;
+  event.preventDefault();
+  target.focus();
+}
+
 export function DialogShell({
   open,
   onOpenChange,
@@ -71,6 +90,7 @@ export function DialogShell({
     onInteractOutside ?? (preventOutsideClose ? (event) => event.preventDefault() : undefined);
   const resolvedPointerDownOutside =
     onPointerDownOutside ?? (preventOutsideClose ? (event) => event.preventDefault() : undefined);
+  const resolvedOnOpenAutoFocus = onOpenAutoFocus ?? defaultOnOpenAutoFocus;
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -80,7 +100,7 @@ export function DialogShell({
         onInteractOutside={resolvedInteractOutside}
         onPointerDownOutside={resolvedPointerDownOutside}
         onEscapeKeyDown={onEscapeKeyDown}
-        onOpenAutoFocus={onOpenAutoFocus}
+        onOpenAutoFocus={resolvedOnOpenAutoFocus}
       >
         <div style={{ flexShrink: 0 }}>
           <Dialog.Title>

--- a/src/components/UI/ListToolbar/ListToolbar.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.tsx
@@ -23,6 +23,17 @@ export function ListToolbar({
   onSearchChange,
   action,
 }: ListToolbarProps) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Escape') return;
+    if (searchValue.length > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      onSearchChange('');
+      return;
+    }
+    event.currentTarget.blur();
+  };
+
   return (
     <Flex data-testid={testId} gap="3" mb="4" align="center">
       <Box style={{ flex: 1 }}>
@@ -32,6 +43,7 @@ export function ListToolbar({
           aria-label={searchPlaceholder}
           value={searchValue}
           onChange={(e) => onSearchChange(e.target.value)}
+          onKeyDown={handleKeyDown}
         >
           <TextField.Slot>
             <Search size={16} />

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -299,6 +299,7 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
             </Dialog.Close>
             <Button
               data-testid="wizard-restore-btn-restore"
+              data-autofocus="true"
               onClick={handleRestoreOrNext}
               disabled={selectedTabIds.size === 0 || isAnalyzing || isRestoring}
             >

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -82,3 +82,9 @@
   font-style: italic;
   color: var(--amber-11);
 }
+
+.nestedGroup {
+  margin-top: var(--space-2);
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--gray-a4);
+}

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -43,7 +43,9 @@ const TRIGGER_SELECTOR = '[data-shortcut-group-trigger]';
 
 function getTriggers(container: HTMLElement | null): HTMLButtonElement[] {
   if (!container) return [];
-  return Array.from(container.querySelectorAll<HTMLButtonElement>(TRIGGER_SELECTOR));
+  return Array.from(container.querySelectorAll<HTMLButtonElement>(TRIGGER_SELECTOR)).filter(
+    (el) => el.offsetParent !== null,
+  );
 }
 
 /**
@@ -114,6 +116,7 @@ export function ShortcutsContent({ groups = SHORTCUT_GROUPS, pageContext }: Shor
           group={group}
           pageContext={pageContext}
           liveCommands={liveCommands}
+          nested={false}
         />
       ))}
       <Box>
@@ -140,16 +143,23 @@ function CollapsibleGroup({
   group,
   pageContext,
   liveCommands,
+  nested,
 }: {
   group: ShortcutGroup;
   pageContext?: PageContext;
   liveCommands: BrowserCommandsMap | null;
+  nested: boolean;
 }) {
   const [open, setOpen] = useState(() =>
     pageContext === undefined ? true : isGroupOpenByDefault(group.titleKey, pageContext),
   );
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen} data-group-title={group.titleKey}>
+    <Collapsible.Root
+      open={open}
+      onOpenChange={setOpen}
+      data-group-title={group.titleKey}
+      className={nested ? styles.nestedGroup : undefined}
+    >
       <Collapsible.Trigger asChild>
         <button
           type="button"
@@ -157,7 +167,14 @@ function CollapsibleGroup({
           data-state={open ? 'open' : 'closed'}
           data-shortcut-group-trigger=""
         >
-          <Text size="2" weight="bold" highContrast className={styles.groupTitle} as="div">
+          <Text
+            size={nested ? '1' : '2'}
+            weight="bold"
+            highContrast={!nested}
+            color={nested ? 'gray' : undefined}
+            className={styles.groupTitle}
+            as="div"
+          >
             {getMessage(group.titleKey)}
           </Text>
           <ChevronDown size={14} className={styles.chevron} />
@@ -170,6 +187,15 @@ function CollapsibleGroup({
               key={shortcut.descriptionKey}
               shortcut={shortcut}
               liveCommands={liveCommands}
+            />
+          ))}
+          {group.subgroups?.map((sub) => (
+            <CollapsibleGroup
+              key={sub.titleKey}
+              group={sub}
+              pageContext={pageContext}
+              liveCommands={liveCommands}
+              nested
             />
           ))}
         </Flex>

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -19,68 +19,86 @@ export interface ShortcutDisplay {
 export interface ShortcutGroup {
   titleKey: string;
   shortcuts: ShortcutDisplay[];
+  /**
+   * Optional nested groups, rendered as a collapsible inside the parent's
+   * content. Used on the options-page cheatsheet to scope the focused-card
+   * shortcuts under their list.
+   */
+  subgroups?: ShortcutGroup[];
 }
 
+const groupGlobal: ShortcutGroup = {
+  titleKey: 'shortcutsGroupGlobal',
+  shortcuts: [
+    { keys: ['Alt+Shift+O'], descriptionKey: 'shortcutDescOrganize', commandName: 'organize-all-tabs' },
+    { keys: ['Alt+Shift+S'], descriptionKey: 'shortcutDescSaveSession', commandName: 'save-current-window-session' },
+    { keys: ['Alt+Shift+P'], descriptionKey: 'shortcutDescOpenPopup', commandName: '_execute_action' },
+  ],
+};
+
+const groupListRules: ShortcutGroup = {
+  titleKey: 'shortcutsGroupListRules',
+  shortcuts: [
+    { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
+    { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
+    { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
+    { keys: ['Space'], descriptionKey: 'shortcutDescListToggleSelection' },
+    { keys: ['t'], descriptionKey: 'shortcutDescListToggleEnabled' },
+    { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
+    { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
+  ],
+};
+
+const groupSessionCard: ShortcutGroup = {
+  titleKey: 'shortcutsGroupSessionCard',
+  shortcuts: [
+    { keys: ['R'], descriptionKey: 'shortcutDescSessionRestoreCustom' },
+    { keys: ['Shift+R'], descriptionKey: 'shortcutDescSessionRestoreCurrent' },
+    { keys: ['Alt+R'], descriptionKey: 'shortcutDescSessionReplaceCurrent' },
+    { keys: ['Alt+Shift+R'], descriptionKey: 'shortcutDescSessionRestoreNew' },
+  ],
+};
+
+const groupListSessions: ShortcutGroup = {
+  titleKey: 'shortcutsGroupListSessions',
+  shortcuts: [
+    { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
+    { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
+    { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
+    { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
+    { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
+    { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
+  ],
+  subgroups: [groupSessionCard],
+};
+
+const groupOptions: ShortcutGroup = {
+  titleKey: 'shortcutsGroupOptions',
+  shortcuts: [
+    { keys: ['Alt+1', 'Alt+2', 'Alt+3', 'Alt+4', 'Alt+5'], descriptionKey: 'shortcutDescNavigateTabs' },
+    { keys: ['/'], descriptionKey: 'shortcutDescFocusSearch' },
+    { keys: ['Esc'], descriptionKey: 'shortcutDescClearSearch' },
+    { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
+  ],
+};
+
+const groupPopup: ShortcutGroup = {
+  titleKey: 'shortcutsGroupPopup',
+  shortcuts: [
+    { keys: ['S'], descriptionKey: 'shortcutDescPopupSave' },
+    { keys: ['R'], descriptionKey: 'shortcutDescPopupRestore' },
+    { keys: ['O'], descriptionKey: 'shortcutDescPopupOrganize' },
+    { keys: ['P'], descriptionKey: 'shortcutDescPopupOptions' },
+    { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
+  ],
+};
+
 export const SHORTCUT_GROUPS: ShortcutGroup[] = [
-  {
-    titleKey: 'shortcutsGroupGlobal',
-    shortcuts: [
-      { keys: ['Alt+Shift+O'], descriptionKey: 'shortcutDescOrganize', commandName: 'organize-all-tabs' },
-      { keys: ['Alt+Shift+S'], descriptionKey: 'shortcutDescSaveSession', commandName: 'save-current-window-session' },
-      { keys: ['Alt+Shift+P'], descriptionKey: 'shortcutDescOpenPopup', commandName: '_execute_action' },
-    ],
-  },
-  {
-    titleKey: 'shortcutsGroupPopup',
-    shortcuts: [
-      { keys: ['S'], descriptionKey: 'shortcutDescPopupSave' },
-      { keys: ['R'], descriptionKey: 'shortcutDescPopupRestore' },
-      { keys: ['O'], descriptionKey: 'shortcutDescPopupOrganize' },
-      { keys: ['P'], descriptionKey: 'shortcutDescPopupOptions' },
-      { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
-    ],
-  },
-  {
-    titleKey: 'shortcutsGroupOptions',
-    shortcuts: [
-      { keys: ['Alt+1', 'Alt+2', 'Alt+3', 'Alt+4', 'Alt+5'], descriptionKey: 'shortcutDescNavigateTabs' },
-      { keys: ['/'], descriptionKey: 'shortcutDescFocusSearch' },
-      { keys: ['Esc'], descriptionKey: 'shortcutDescClearSearch' },
-      { keys: ['?'], descriptionKey: 'shortcutDescOpenShortcutsHelp' },
-    ],
-  },
-  {
-    titleKey: 'shortcutsGroupListRules',
-    shortcuts: [
-      { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
-      { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
-      { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
-      { keys: ['Space'], descriptionKey: 'shortcutDescListToggleSelection' },
-      { keys: ['t'], descriptionKey: 'shortcutDescListToggleEnabled' },
-      { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
-      { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
-    ],
-  },
-  {
-    titleKey: 'shortcutsGroupListSessions',
-    shortcuts: [
-      { keys: ['↑', '↓'], descriptionKey: 'shortcutDescListNavigate' },
-      { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
-      { keys: ['e'], descriptionKey: 'shortcutDescListEdit' },
-      { keys: ['Del'], descriptionKey: 'shortcutDescListDelete' },
-      { keys: ['p'], descriptionKey: 'shortcutDescListPin' },
-      { keys: ['Space'], descriptionKey: 'shortcutDescListReorderKeyboard' },
-    ],
-  },
-  {
-    titleKey: 'shortcutsGroupSessionCard',
-    shortcuts: [
-      { keys: ['R'], descriptionKey: 'shortcutDescSessionRestoreCustom' },
-      { keys: ['Shift+R'], descriptionKey: 'shortcutDescSessionRestoreCurrent' },
-      { keys: ['Alt+R'], descriptionKey: 'shortcutDescSessionReplaceCurrent' },
-      { keys: ['Alt+Shift+R'], descriptionKey: 'shortcutDescSessionRestoreNew' },
-    ],
-  },
+  groupGlobal,
+  groupListRules,
+  groupListSessions,
+  groupOptions,
+  groupPopup,
 ];
 
 export type PageContext =
@@ -93,9 +111,10 @@ export type PageContext =
 
 /**
  * Defines whether a group is expanded by default given the current page.
- * Global and Options groups are always open. List/SessionCard groups only
- * open on the page they pertain to. Popup is implicitly always open since
- * it is only ever rendered in the popup drawer.
+ * Global and Options groups are always open on the options cheatsheet.
+ * List/SessionCard groups only open on the page they pertain to. Popup is
+ * collapsed on the options cheatsheet (rarely needed there) but open by
+ * default in the popup drawer / Storybook (where `pageContext` is undefined).
  */
 export function isGroupOpenByDefault(
   titleKey: string,
@@ -104,8 +123,9 @@ export function isGroupOpenByDefault(
   switch (titleKey) {
     case 'shortcutsGroupGlobal':
     case 'shortcutsGroupOptions':
-    case 'shortcutsGroupPopup':
       return true;
+    case 'shortcutsGroupPopup':
+      return pageContext === undefined;
     case 'shortcutsGroupListRules':
       return pageContext === 'rules';
     case 'shortcutsGroupListSessions':
@@ -116,11 +136,4 @@ export function isGroupOpenByDefault(
   }
 }
 
-const POPUP_GROUP_KEYS = [
-  'shortcutsGroupPopup',
-  'shortcutsGroupSessionCard',
-] as const;
-
-export const POPUP_SHORTCUT_GROUPS: ShortcutGroup[] = POPUP_GROUP_KEYS
-  .map((key) => SHORTCUT_GROUPS.find((g) => g.titleKey === key))
-  .filter((g): g is ShortcutGroup => g !== undefined);
+export const POPUP_SHORTCUT_GROUPS: ShortcutGroup[] = [groupPopup, groupSessionCard];

--- a/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
+++ b/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
@@ -6,17 +6,17 @@ import { getMessage } from '@/utils/i18n.js';
 import { WorkspaceAvatar } from '@/components/UI/Workspace/WorkspaceAvatar.js';
 import { WorkspaceSwitcherDropdown } from '@/components/UI/Workspace/WorkspaceSwitcherDropdown.js';
 
-interface PopupWorkspaceFooterProps {
+interface PopupWorkspaceSwitcherProps {
   /** Open the manage page; the popup typically closes itself afterwards. */
   onManage?: () => void;
 }
 
 /**
- * Compact workspace switcher rendered at the bottom of the popup so the user
+ * Compact workspace switcher rendered near the top of the popup so the user
  * always sees which workspace their popup actions target. Mirrors the options
  * sidebar footer but adapted for the 400px popup width.
  */
-export function PopupWorkspaceFooter({ onManage }: PopupWorkspaceFooterProps) {
+export function PopupWorkspaceSwitcher({ onManage }: PopupWorkspaceSwitcherProps) {
   const { active, accentColor } = useActiveWorkspaceContext();
   const name = active?.name ?? getMessage('workspaceDefaultName');
 
@@ -62,7 +62,7 @@ export function PopupWorkspaceFooter({ onManage }: PopupWorkspaceFooterProps) {
   );
 
   return (
-    <Flex data-testid="popup-workspace-footer" align="center" style={{ width: '100%' }}>
+    <Flex data-testid="popup-workspace-switcher" align="center" style={{ width: '100%' }}>
       <WorkspaceSwitcherDropdown trigger={trigger} onManage={onManage} />
     </Flex>
   );

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -9,7 +9,7 @@ import { PopupHeader } from '@/components/UI/PopupHeader/PopupHeader';
 import { SettingsToggles } from '@/components/UI/SettingsToggles/SettingsToggles';
 import { PopupToolbar } from '@/components/UI/PopupToolbar/PopupToolbar';
 import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfilesList';
-import { PopupWorkspaceFooter } from '@/components/UI/Workspace/PopupWorkspaceFooter';
+import { PopupWorkspaceSwitcher } from '@/components/UI/Workspace/PopupWorkspaceSwitcher';
 import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
 import { openOptionsWithHash } from '@/utils/openOptions';
 import { useSettings } from '@/hooks/useSettings';
@@ -82,6 +82,8 @@ export function PopupContent() {
 
           <PopupToolbar />
 
+          <PopupWorkspaceSwitcher onManage={handleManageWorkspaces} />
+
           {isLoaded && !hasRules ? (
             <SettingsToggles
               isLoading={false}
@@ -105,9 +107,6 @@ export function PopupContent() {
               />
             </>
           ) : null}
-
-          <Separator size="4" />
-          <PopupWorkspaceFooter onManage={handleManageWorkspaces} />
         </Flex>
       </Box>
       <StatusBar />

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -6,9 +6,10 @@
  * `Escape`, `?`, `/`. Modifier order does not matter, casing on the key does
  * not matter.
  *
- * For the literal key `?` shift is ignored (most layouts require shift to type
- * it). All other keys require strict modifier match so that `r` and `Shift+r`
- * are distinguishable.
+ * For the literal keys `?` and `/`, shift is ignored: many layouts require
+ * shift to produce them (`?` on QWERTY, `/` on French AZERTY where Shift+: is
+ * the only way to type a slash). All other keys require strict modifier match
+ * so that `r` and `Shift+r` are distinguishable.
  */
 
 export interface ParsedCombo {
@@ -32,13 +33,15 @@ export function parseCombo(combo: string): ParsedCombo {
   };
 }
 
+const SHIFT_INSENSITIVE_KEYS = new Set(['?', '/']);
+
 export function matchesShortcut(event: KeyboardEvent, combo: string): boolean {
   const parsed = parseCombo(combo);
   if (!keyMatches(event, parsed.key)) return false;
   if (event.altKey !== parsed.alt) return false;
   if (event.ctrlKey !== parsed.ctrl) return false;
   if (event.metaKey !== parsed.meta) return false;
-  if (parsed.key !== '?' && event.shiftKey !== parsed.shift) return false;
+  if (!SHIFT_INSENSITIVE_KEYS.has(parsed.key) && event.shiftKey !== parsed.shift) return false;
   return true;
 }
 

--- a/tests/components/WorkspaceFooter.test.tsx
+++ b/tests/components/WorkspaceFooter.test.tsx
@@ -29,7 +29,7 @@ import {
   WorkspaceFooter,
   WorkspaceFooterCollapsed,
 } from '../../src/components/UI/Workspace/WorkspaceFooter';
-import { PopupWorkspaceFooter } from '../../src/components/UI/Workspace/PopupWorkspaceFooter';
+import { PopupWorkspaceSwitcher } from '../../src/components/UI/Workspace/PopupWorkspaceSwitcher';
 
 const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
 
@@ -94,10 +94,10 @@ describe('WorkspaceFooterCollapsed', () => {
   });
 });
 
-describe('PopupWorkspaceFooter', () => {
-  it('renders the popup-specific footer with trigger', () => {
-    wrap(<PopupWorkspaceFooter />);
-    expect(screen.getByTestId('popup-workspace-footer')).toBeInTheDocument();
+describe('PopupWorkspaceSwitcher', () => {
+  it('renders the popup-specific switcher with trigger', () => {
+    wrap(<PopupWorkspaceSwitcher />);
+    expect(screen.getByTestId('popup-workspace-switcher')).toBeInTheDocument();
     expect(screen.getByTestId('popup-workspace-trigger')).toBeInTheDocument();
   });
 
@@ -109,7 +109,7 @@ describe('PopupWorkspaceFooter', () => {
       createdAt: '2025-01-01T00:00:00.000Z',
       updatedAt: '2025-01-01T00:00:00.000Z',
     };
-    wrap(<PopupWorkspaceFooter />);
+    wrap(<PopupWorkspaceSwitcher />);
     expect(screen.getByText('Important')).toBeInTheDocument();
   });
 });

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -77,6 +77,11 @@ test('matchesShortcut: ? ignores shift since most layouts require shift to type 
   assert.strictEqual(matchesShortcut(makeEvent({ key: '?', shiftKey: true }), '?'), true);
 });
 
+test('matchesShortcut: / ignores shift (French AZERTY emits / via Shift+:)', () => {
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '/' }), '/'), true);
+  assert.strictEqual(matchesShortcut(makeEvent({ key: '/', shiftKey: true }), '/'), true);
+});
+
 test('matchesShortcut: Escape and / and named keys', () => {
   assert.strictEqual(matchesShortcut(makeEvent({ key: 'Escape' }), 'Escape'), true);
   assert.strictEqual(matchesShortcut(makeEvent({ key: '/' }), '/'), true);

--- a/tests/popup-shortcut-groups.test.ts
+++ b/tests/popup-shortcut-groups.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest';
 import {
   POPUP_SHORTCUT_GROUPS,
   SHORTCUT_GROUPS,
+  type ShortcutGroup,
 } from '../src/components/UI/ShortcutsPanel/shortcuts';
+
+function flattenGroups(groups: ShortcutGroup[]): ShortcutGroup[] {
+  return groups.flatMap((g) => [g, ...flattenGroups(g.subgroups ?? [])]);
+}
 
 describe('POPUP_SHORTCUT_GROUPS', () => {
   it('contains exactly 2 groups in the expected order', () => {
@@ -22,8 +27,9 @@ describe('POPUP_SHORTCUT_GROUPS', () => {
   });
 
   it('preserves the full shortcuts list of each retained group', () => {
+    const allOptionsGroups = flattenGroups(SHORTCUT_GROUPS);
     for (const popupGroup of POPUP_SHORTCUT_GROUPS) {
-      const source = SHORTCUT_GROUPS.find((g) => g.titleKey === popupGroup.titleKey);
+      const source = allOptionsGroups.find((g) => g.titleKey === popupGroup.titleKey);
       expect(source).toBeDefined();
       expect(popupGroup.shortcuts).toEqual(source!.shortcuts);
     }

--- a/tests/shortcuts-context.test.ts
+++ b/tests/shortcuts-context.test.ts
@@ -3,6 +3,7 @@ import {
   isGroupOpenByDefault,
   SHORTCUT_GROUPS,
   type PageContext,
+  type ShortcutGroup,
 } from '../src/components/UI/ShortcutsPanel/shortcuts';
 
 const ALL_CONTEXTS: PageContext[] = [
@@ -13,6 +14,12 @@ const ALL_CONTEXTS: PageContext[] = [
   'settings',
   'workspaces',
 ];
+
+const ALL_CONTEXTS_AND_DRAWER: (PageContext | undefined)[] = [...ALL_CONTEXTS, undefined];
+
+function flattenGroups(groups: ShortcutGroup[]): ShortcutGroup[] {
+  return groups.flatMap((g) => [g, ...flattenGroups(g.subgroups ?? [])]);
+}
 
 describe('isGroupOpenByDefault', () => {
   it('keeps Global and Options groups open in every context', () => {
@@ -36,14 +43,21 @@ describe('isGroupOpenByDefault', () => {
     }
   });
 
+  it('keeps the popup group collapsed on every options page but open in the popup drawer', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('shortcutsGroupPopup', ctx)).toBe(false);
+    }
+    expect(isGroupOpenByDefault('shortcutsGroupPopup', undefined)).toBe(true);
+  });
+
   it('returns false for an unknown title without a context', () => {
     expect(isGroupOpenByDefault('shortcutsGroupListRules', undefined)).toBe(false);
     expect(isGroupOpenByDefault('unknown-group', 'rules')).toBe(false);
   });
 
-  it('covers every group declared in SHORTCUT_GROUPS', () => {
-    for (const group of SHORTCUT_GROUPS) {
-      const opensSomewhere = ALL_CONTEXTS.some((ctx) =>
+  it('covers every group declared in SHORTCUT_GROUPS (including subgroups)', () => {
+    for (const group of flattenGroups(SHORTCUT_GROUPS)) {
+      const opensSomewhere = ALL_CONTEXTS_AND_DRAWER.some((ctx) =>
         isGroupOpenByDefault(group.titleKey, ctx),
       );
       expect(opensSomewhere, `group ${group.titleKey} never opens`).toBe(true);


### PR DESCRIPTION
## Context

A handful of UX papercuts on the popup and the options page, surfaced during a single session:

1. The popup workspace switcher was at the very bottom even though it scopes every action above it.
2. The options shortcuts cheatsheet ordered groups in an unhelpful way and showed "Carte session (focus)" at the same level as "Liste des sessions".
3. The `/` shortcut documented as "focus search" did nothing on a French AZERTY keyboard, and `Esc` documented as "clear search" was never implemented.
4. Pressing Enter on a freshly opened dialog (e.g. session restore) closed it because focus auto-landed on the close X.

## What changed

### Popup layout
- Move the workspace switcher right below the toolbar (Organize / Save / Restore) so the active workspace is always visible before any action.
- Rename `PopupWorkspaceFooter` to `PopupWorkspaceSwitcher` (component, file, props, `data-testid`, JSDoc, tests) since it is no longer a footer.
- Drop the now-redundant `Separator` above the switcher; the parent `Flex gap` already provides the visual rhythm.

### Shortcuts cheatsheet (options page)
- New order on the options aside: Global, Rules list, Sessions list (with **Session card (focus)** as a nested sub-group), Options page, Popup.
- Add `subgroups?: ShortcutGroup[]` to `ShortcutGroup` and recursive rendering in `CollapsibleGroup`. Nested groups get a smaller gray title and a left border for visual indent.
- The Popup group is collapsed by default on the options page (still open in the popup drawer / Storybook where `pageContext` is undefined).
- `POPUP_SHORTCUT_GROUPS` is now an explicit literal `[Popup, SessionCard]` so the popup drawer is independent of the options-side ordering and nesting.
- Keyboard nav via the existing trigger arrow keys filters out hidden triggers (`offsetParent === null`) so it does not jump into a closed parent's nested children.

### Search shortcuts (options page)
- `/` is added to the shift-insensitive set in `matchesShortcut`. On French AZERTY, `/` is produced via Shift+: ; the strict shift check was blocking the match. Same exemption that already exists for `?`.
- `Esc` to clear search is now handled locally in `ListToolbar`: when the input has content, Esc clears it (preventing the global handler from also firing); when the input is already empty, Esc blurs and lets the global Escape (close shortcuts aside) take over on the next press.

### Dialog primary-button autofocus
- `DialogShell` now provides a default `onOpenAutoFocus` that, when a descendant is marked with `data-autofocus`, focuses it instead of letting Radix land on the close X. Disabled or `aria-disabled="true"` targets fall through to Radix's default so we never park focus on something that swallows Enter. Existing custom `onOpenAutoFocus` handlers (ShortcutsDrawer, SnapshotWizard, SessionEditDialog, RuleWizardModal) keep their priority.
- `RestoreWizard` step 0's "Restore" button is marked `data-autofocus="true"` so pressing Enter right after opening the dialog triggers the restore action instead of dismissing the dialog.

The convention is opt-in on purpose: destructive AlertDialogs (delete, reset stats) keep their safe Cancel-by-default focus, and form wizards keep focusing their first input.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm test` (1524 tests, all green)
- [ ] Manual: open the popup, confirm the workspace switcher sits between the toolbar and pinned sessions.
- [ ] Manual: on the options page, press `?` on each tab and confirm the new group order, the nested "Carte session (focus)" sub-group, and the Popup group collapsed by default.
- [ ] Manual: on Rules / Sessions tabs press `/` (AZERTY) and confirm the search field gets focus; type something then press Esc and confirm the input empties; press Esc again and confirm focus leaves the input.
- [ ] Manual: open "Restaurer une session" from the popup, press Enter immediately and confirm the session restores instead of the wizard closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)