### PR TITLE
Update French translation: change default workspace name

### DIFF
--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1,7 +1,7 @@
 {
   "extensionName": { "message": "SmartTab Organizer" },
   "extensionDescription": { "message": "Organisez automatiquement vos onglets Chrome : regroupement intelligent, déduplication, gestion des sessions. Sans IA, sans suivi. Respect de votre vie privée avant tout." },
-  "workspaceDefaultName": { "message": "Par défaut" },
+  "workspaceDefaultName": { "message": "Principal" },
   "workspaceSwitcherLabel": { "message": "Changer d'espace de travail" },
   "workspaceManageLabel": { "message": "Gérer les espaces de travail" },
   "workspacesTab": { "message": "Espaces de travail" },


### PR DESCRIPTION
## Summary
Updated the French localization for the default workspace name to use a more appropriate term.

## Changes
- Changed the French translation of `workspaceDefaultName` from "Par défaut" (literally "By default") to "Principal" (meaning "Main" or "Primary")

## Details
This change improves the user experience for French-speaking users by using a more intuitive and professional term for the default workspace. "Principal" better conveys that this is the main/primary workspace rather than just a default fallback option.

https://claude.ai/code/session_012A5kiskLtVTm893nBaTpyr