### PR TITLE
test: consolidate redundant Storybook renders in component tests

### DIFF
--- a/tests/components/ConflictResolutionStep.stories.test.tsx
+++ b/tests/components/ConflictResolutionStep.stories.test.tsx
@@ -18,10 +18,14 @@ describe('ConflictResolutionStep — static renders', () => {
     expect(screen.getByText('GitHub PR #42')).toBeInTheDocument();
   });
 
-  it('renders conflicting groups section', () => {
+  it('renders conflicting groups with combobox dropdowns', () => {
     render(<ConflictResolutionGroupsOnly />);
     expect(screen.getByText('Frontend')).toBeInTheDocument();
     expect(screen.getByText('Backend')).toBeInTheDocument();
+    // ConflictResolutionChangeGroupAction uses Radix Select which requires pointer events
+    // not available in happy-dom; verify the comboboxes are rendered statically.
+    const comboboxes = screen.queryAllByRole('combobox');
+    expect(comboboxes.length).toBeGreaterThan(0);
   });
 
   it('renders both sections in mixed mode', () => {
@@ -45,13 +49,5 @@ describe('ConflictResolutionStep — interactions', () => {
     // At least one radio should now be in "checked" state (data-state attribute used by Radix)
     const checkedByDataState = radios.some(r => r.getAttribute('data-state') === 'checked');
     expect(checkedByDataState).toBe(true);
-  });
-
-  it('renders group conflict dropdowns without throwing', () => {
-    // ConflictResolutionChangeGroupAction uses Radix Select which requires pointer events
-    // not available in happy-dom; verify static render instead
-    render(<ConflictResolutionGroupsOnly />);
-    const comboboxes = screen.queryAllByRole('combobox');
-    expect(comboboxes.length).toBeGreaterThan(0);
   });
 });

--- a/tests/components/DomainRulesPage.stories.test.tsx
+++ b/tests/components/DomainRulesPage.stories.test.tsx
@@ -6,27 +6,15 @@ import * as stories from '../../src/pages/DomainRulesPage.stories';
 const { DomainRulesPageDefault, DomainRulesPageEmpty } = composeStories(stories);
 
 describe('DomainRulesPage (portable stories)', () => {
-  it('renders the page with toolbar and rules list', () => {
+  it('renders the page with toolbar, list, and search empty state', async () => {
     render(<DomainRulesPageDefault />);
 
     expect(screen.getByTestId('page-rules')).toBeInTheDocument();
     expect(screen.getByTestId('page-rules-toolbar')).toBeInTheDocument();
     expect(screen.getByTestId('page-rules-btn-add')).toBeInTheDocument();
     expect(screen.getByTestId('page-rules-list')).toBeInTheDocument();
-  });
 
-  it('shows empty state when no rules and hides the toolbar', () => {
-    render(<DomainRulesPageEmpty />);
-    expect(screen.getByTestId('page-rules-empty')).toBeInTheDocument();
-    // Add button is present in the empty placeholder (same testid as the toolbar button, mutually exclusive).
-    expect(screen.getByTestId('page-rules-btn-add')).toBeInTheDocument();
-    // Toolbar is hidden when there are no rules (search is useless, add is already in the placeholder).
-    expect(screen.queryByTestId('page-rules-toolbar')).not.toBeInTheDocument();
-  });
-
-  it("affiche l'état vide compact quand la recherche ne retourne aucun résultat", async () => {
-    render(<DomainRulesPageDefault />);
-
+    // État vide compact quand la recherche ne retourne aucun résultat.
     const searchInput = screen.getByTestId('page-rules-search');
     fireEvent.change(searchInput, { target: { value: 'xyznotexist' } });
 
@@ -39,7 +27,16 @@ describe('DomainRulesPage (portable stories)', () => {
     expect(screen.getByText('No rules found')).toBeInTheDocument();
   });
 
-  it("ouvre la boite de dialogue de suppression unique avec le bon titre", async () => {
+  it('shows empty state when no rules and hides the toolbar', () => {
+    render(<DomainRulesPageEmpty />);
+    expect(screen.getByTestId('page-rules-empty')).toBeInTheDocument();
+    // Add button is present in the empty placeholder (same testid as the toolbar button, mutually exclusive).
+    expect(screen.getByTestId('page-rules-btn-add')).toBeInTheDocument();
+    // Toolbar is hidden when there are no rules (search is useless, add is already in the placeholder).
+    expect(screen.queryByTestId('page-rules-toolbar')).not.toBeInTheDocument();
+  });
+
+  it('single delete: opens dialog with correct title and confirms (handleConfirmDelete - single)', async () => {
     render(<DomainRulesPageDefault />);
 
     // Radix UI DropdownMenu s'ouvre sur pointerDown (pas click)
@@ -54,9 +51,17 @@ describe('DomainRulesPage (portable stories)', () => {
     await waitFor(() => {
       expect(screen.getByText('Delete this rule?')).toBeInTheDocument();
     });
+
+    const confirmBtn = await screen.findByTestId('confirm-dialog-btn-confirm');
+    fireEvent.click(confirmBtn);
+
+    // Le dialog se ferme après confirmation
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
   });
 
-  it("ouvre la boite de dialogue de suppression en masse avec le bon titre", async () => {
+  it('bulk delete: opens dialog with correct title and confirms (handleConfirmDelete - bulk)', async () => {
     render(<DomainRulesPageDefault />);
 
     // Cocher la première règle pour faire apparaître la BulkActionsBar
@@ -71,34 +76,6 @@ describe('DomainRulesPage (portable stories)', () => {
     await waitFor(() => {
       expect(screen.getByText('Delete the selected rules?')).toBeInTheDocument();
     });
-  });
-
-  it('confirme la suppression unique (handleConfirmDelete - single)', async () => {
-    render(<DomainRulesPageDefault />);
-
-    const trigger = screen.getByTestId('rule-card-rule-1-btn-dropdown');
-    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-
-    const deleteItem = await screen.findByTestId('rule-card-rule-1-menu-delete');
-    fireEvent.click(deleteItem);
-
-    const confirmBtn = await screen.findByTestId('confirm-dialog-btn-confirm');
-    fireEvent.click(confirmBtn);
-
-    // Le dialog se ferme après confirmation
-    await waitFor(() => {
-      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
-    });
-  });
-
-  it('confirme la suppression en masse (handleConfirmDelete - bulk)', async () => {
-    render(<DomainRulesPageDefault />);
-
-    const checkboxes = screen.getAllByRole('checkbox');
-    fireEvent.click(checkboxes[0]);
-
-    const deleteSelectedBtn = await screen.findByText('Delete Selected');
-    fireEvent.click(deleteSelectedBtn);
 
     const confirmBtn = await screen.findByTestId('confirm-dialog-btn-confirm');
     fireEvent.click(confirmBtn);

--- a/tests/components/ImportExportPage.stories.test.tsx
+++ b/tests/components/ImportExportPage.stories.test.tsx
@@ -6,7 +6,7 @@ import * as stories from '../../src/pages/ImportExportPage.stories';
 const { ImportExportPageDefault, ImportExportPageWithRules } = composeStories(stories);
 
 describe('ImportExportPage (portable stories)', () => {
-  it('renders the page with four action cards', async () => {
+  it('renders four action cards, disables export-rules without rules, and opens the import dialog', async () => {
     render(<ImportExportPageDefault />);
     await waitFor(() => {
       expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
@@ -15,45 +15,29 @@ describe('ImportExportPage (portable stories)', () => {
     expect(screen.getByTestId('page-import-export-card-import-rules')).toBeInTheDocument();
     expect(screen.getByTestId('page-import-export-card-export-sessions')).toBeInTheDocument();
     expect(screen.getByTestId('page-import-export-card-import-sessions')).toBeInTheDocument();
-  });
 
-  it('désactive le bouton export-rules quand il n\'y a aucune règle', async () => {
-    render(<ImportExportPageDefault />);
-    await waitFor(() => {
-      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
-    });
-    const card = screen.getByTestId('page-import-export-card-export-rules');
-    expect(card.querySelector('button')).toBeDisabled();
-  });
+    const exportCard = screen.getByTestId('page-import-export-card-export-rules');
+    expect(exportCard.querySelector('button')).toBeDisabled();
 
-  it('active le bouton export-rules quand des règles existent', async () => {
-    render(<ImportExportPageWithRules />);
-    await waitFor(() => {
-      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
-    });
-    const card = screen.getByTestId('page-import-export-card-export-rules');
-    expect(card.querySelector('button')).not.toBeDisabled();
-  });
-
-  it('ouvre le dialog d\'export de règles au clic', async () => {
-    render(<ImportExportPageWithRules />);
-    await waitFor(() => {
-      expect(screen.getByTestId('page-import-export-card-export-rules')).toBeInTheDocument();
-    });
-    const exportBtn = screen.getByTestId('page-import-export-card-export-rules').querySelector('button')!;
-    fireEvent.click(exportBtn);
+    const importBtn = screen
+      .getByTestId('page-import-export-card-import-rules')
+      .querySelector('button')!;
+    fireEvent.click(importBtn);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
 
-  it('ouvre le dialog d\'import de règles au clic', async () => {
-    render(<ImportExportPageDefault />);
+  it('active le bouton export-rules quand des règles existent et ouvre le dialog au clic', async () => {
+    render(<ImportExportPageWithRules />);
     await waitFor(() => {
-      expect(screen.getByTestId('page-import-export-card-import-rules')).toBeInTheDocument();
+      expect(screen.getByTestId('page-import-export')).toBeInTheDocument();
     });
-    const importBtn = screen.getByTestId('page-import-export-card-import-rules').querySelector('button')!;
-    fireEvent.click(importBtn);
+    const card = screen.getByTestId('page-import-export-card-export-rules');
+    const exportBtn = card.querySelector('button')!;
+    expect(exportBtn).not.toBeDisabled();
+
+    fireEvent.click(exportBtn);
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });

--- a/tests/components/PackCard.stories.test.tsx
+++ b/tests/components/PackCard.stories.test.tsx
@@ -12,15 +12,12 @@ const {
 } = composed;
 
 describe('PackCard (stories)', () => {
-  it('renders the simple pack with name, description and rule count badge', () => {
+  it('renders the simple pack with metadata and toggles selection on click', () => {
     render(<PackCardSimple />);
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.getByText('GitHub & GitLab grouping')).toBeInTheDocument();
     expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
-  });
 
-  it('toggles selection when the checkbox is clicked', () => {
-    render(<PackCardSimple />);
     const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
     expect(checkbox.getAttribute('aria-checked')).toBe('false');
     fireEvent.click(checkbox);

--- a/tests/components/PackGallery.stories.test.tsx
+++ b/tests/components/PackGallery.stories.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/Core/Pack/PackGallery/PackGallery.stories';
 
@@ -12,11 +12,12 @@ const {
 } = composed;
 
 describe('PackGallery (stories)', () => {
-  it('renders the gallery with packs grouped by category', () => {
+  it('renders the gallery grouped by category and disables the confirm button initially', () => {
     render(<PackGalleryDefault />);
     expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
     expect(screen.getByText('Cloud Console')).toBeInTheDocument();
     expect(screen.getByText('Code Hosting')).toBeInTheDocument();
+    expect(screen.getByTestId('pack-gallery-confirm')).toBeDisabled();
   });
 
   it('shows the empty state when there are no packs', () => {
@@ -32,23 +33,21 @@ describe('PackGallery (stories)', () => {
   it('renders the with-search variant', async () => {
     render(<PackGalleryWithSearch />);
     // The story applies its initialSearch via a setTimeout; wait for it.
-    const { waitFor } = await import('@testing-library/react');
     await waitFor(() => {
       expect(screen.queryByText('Cloud Console')).toBeNull();
     });
     expect(screen.getByText('Code Hosting')).toBeInTheDocument();
   });
 
-  it('disables the confirm button while no pack is selected', () => {
+  it('selecting a pack enables the confirm button and updates the global counter', () => {
     render(<PackGalleryDefault />);
-    expect(screen.getByTestId('pack-gallery-confirm')).toBeDisabled();
-  });
 
-  it('enables the confirm button after selecting a pack', () => {
-    render(<PackGalleryDefault />);
     const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
     fireEvent.click(checkbox);
+
     expect(screen.getByTestId('pack-gallery-confirm')).not.toBeDisabled();
+    const counter = screen.getByTestId('pack-gallery-counter');
+    expect(counter.textContent).not.toBe('packGalleryGlobalCounterEmpty');
   });
 
   it('shows the no-result message when search matches nothing', () => {
@@ -56,13 +55,5 @@ describe('PackGallery (stories)', () => {
     const search = within(screen.getByTestId('pack-gallery')).getByRole('textbox');
     fireEvent.change(search, { target: { value: 'no-match-xyz' } });
     expect(screen.getByTestId('pack-gallery-search-empty')).toBeInTheDocument();
-  });
-
-  it('updates the global counter when packs are toggled on', () => {
-    render(<PackGalleryDefault />);
-    const checkbox = screen.getByTestId('pack-card-pk-github-checkbox');
-    fireEvent.click(checkbox);
-    const counter = screen.getByTestId('pack-gallery-counter');
-    expect(counter.textContent).not.toBe('packGalleryGlobalCounterEmpty');
   });
 });

--- a/tests/components/SessionCard.stories.test.tsx
+++ b/tests/components/SessionCard.stories.test.tsx
@@ -17,7 +17,7 @@ const existingSessions = [
 
 describe('SessionCard (portable stories)', () => {
   describe('SessionCardDefault', () => {
-    it('renders session metadata (name, tab/group counts, color dots)', () => {
+    it('renders metadata, action buttons and collapsed preview', () => {
       const { container } = render(
         <SessionCardDefault existingSessions={existingSessions as any} />,
       );
@@ -34,12 +34,6 @@ describe('SessionCard (portable stories)', () => {
         (el) => (el as HTMLElement).style.borderRadius === '50%',
       );
       expect(colorDots).toHaveLength(2);
-    });
-
-    it('renders action buttons and collapsed preview', () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
 
       expect(screen.getByRole('button', { name: 'Pin' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Rename' })).toBeInTheDocument();
@@ -52,12 +46,63 @@ describe('SessionCard (portable stories)', () => {
         'closed',
       );
     });
+
+    it('rename flow: enter mode, show confirm/cancel, cancel exits', async () => {
+      render(
+        <SessionCardDefault existingSessions={existingSessions as any} />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('textbox', { name: 'Session name' }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: 'Confirm rename' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Cancel' }),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      });
+    });
+
+    it('calls onPin and toggles preview open on trigger click', async () => {
+      const onPin = vi.fn();
+      render(
+        <SessionCardDefault
+          existingSessions={existingSessions as any}
+          onPin={onPin}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Pin' }));
+      expect(onPin).toHaveBeenCalledOnce();
+
+      const toggle = screen.getByTestId('session-card-session-1-preview-toggle');
+      fireEvent.click(toggle);
+
+      await waitFor(() => {
+        const root = toggle.closest('[data-state]');
+        expect(root?.getAttribute('data-state')).toBe('open');
+      });
+    });
   });
 
   describe('SessionCardPinned', () => {
-    it('shows the "Unpin" button instead of "Pin"', () => {
+    it('shows Unpin button (not Pin) and calls onUnpin when clicked', () => {
+      const onUnpin = vi.fn();
       render(
-        <SessionCardPinned existingSessions={existingSessions as any} />,
+        <SessionCardPinned
+          existingSessions={existingSessions as any}
+          onUnpin={onUnpin}
+        />,
       );
 
       expect(
@@ -66,11 +111,14 @@ describe('SessionCard (portable stories)', () => {
       expect(
         screen.queryByRole('button', { name: 'Pin' }),
       ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+      expect(onUnpin).toHaveBeenCalledOnce();
     });
   });
 
   describe('SessionCardWithRelativeDates', () => {
-    it('renders a relative-time text with a <time> element on every card', () => {
+    it('renders <time> elements with "modified"/"created" prefixes', () => {
       const { container } = render(<SessionCardWithRelativeDates />);
 
       const timeElements = container.querySelectorAll('time[datetime]');
@@ -83,20 +131,17 @@ describe('SessionCard (portable stories)', () => {
         );
         expect(el.textContent?.trim().length).toBeGreaterThan(0);
       }
-    });
 
-    it('uses the "modified" prefix when updatedAt differs from createdAt', () => {
-      render(<SessionCardWithRelativeDates />);
       // "Sprint en cours" has updatedAt 5 min ago vs createdAt 30 min ago.
-      const node = screen.getByTestId('session-card-rt-5min-modified-relative-time');
-      expect(node.textContent).toMatch(/modified/);
-    });
-
-    it('uses the "created" prefix when updatedAt equals createdAt', () => {
-      render(<SessionCardWithRelativeDates />);
+      expect(
+        screen.getByTestId('session-card-rt-5min-modified-relative-time')
+          .textContent,
+      ).toMatch(/modified/);
       // "Recherches du matin" passes updatedOffset null -> createdAt === updatedAt.
-      const node = screen.getByTestId('session-card-rt-2h-created-relative-time');
-      expect(node.textContent).toMatch(/created/);
+      expect(
+        screen.getByTestId('session-card-rt-2h-created-relative-time')
+          .textContent,
+      ).toMatch(/created/);
     });
   });
 
@@ -112,95 +157,6 @@ describe('SessionCard (portable stories)', () => {
         .getByTestId('session-card-session-1-preview-toggle')
         .closest('[data-state]');
       expect(collapsibleRoot?.getAttribute('data-state')).toBe('open');
-    });
-  });
-
-  describe('interactions', () => {
-    it('enters rename mode when the rename button is clicked', async () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('textbox', { name: 'Session name' }),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('shows confirm and cancel buttons in rename mode', async () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: 'Confirm rename' }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('button', { name: 'Cancel' }),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('cancels rename mode on cancel click', async () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
-      await waitFor(() => {
-        expect(screen.getByRole('textbox')).toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-      await waitFor(() => {
-        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-      });
-    });
-
-    it('calls onPin when the pin button is clicked', () => {
-      const onPin = vi.fn();
-      render(
-        <SessionCardDefault
-          existingSessions={existingSessions as any}
-          onPin={onPin}
-        />,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Pin' }));
-      expect(onPin).toHaveBeenCalledOnce();
-    });
-
-    it('calls onUnpin when the unpin button is clicked on a pinned card', () => {
-      const onUnpin = vi.fn();
-      render(
-        <SessionCardPinned
-          existingSessions={existingSessions as any}
-          onUnpin={onUnpin}
-        />,
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Unpin' }));
-      expect(onUnpin).toHaveBeenCalledOnce();
-    });
-
-    it('toggles preview open on trigger click', async () => {
-      render(
-        <SessionCardDefault existingSessions={existingSessions as any} />,
-      );
-
-      const toggle = screen.getByTestId('session-card-session-1-preview-toggle');
-      fireEvent.click(toggle);
-
-      await waitFor(() => {
-        const root = toggle.closest('[data-state]');
-        expect(root?.getAttribute('data-state')).toBe('open');
-      });
     });
   });
 });

--- a/tests/components/SessionEditDialog.stories.test.tsx
+++ b/tests/components/SessionEditDialog.stories.test.tsx
@@ -6,7 +6,7 @@ import * as stories from '../../src/components/Core/Session/SessionEditDialog.st
 const { SessionEditDialogOpen, SessionEditDialogClosed } = composeStories(stories);
 
 describe('SessionEditDialog (portable stories)', () => {
-  it('renders the dialog with name input, note, summary and buttons', () => {
+  it('renders the dialog content and closes on cancel without dirty edits', () => {
     render(<SessionEditDialogOpen />);
 
     expect(screen.getByTestId('dialog-session-edit')).toBeInTheDocument();
@@ -17,6 +17,10 @@ describe('SessionEditDialog (portable stories)', () => {
     // 3 tabs (2 grouped + 1 ungrouped), 1 group
     expect(screen.getByText(/3 tabs/)).toBeInTheDocument();
     expect(screen.getByText(/1 group/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('dialog-session-edit-btn-cancel'));
+    // No alert should appear since no changes were made.
+    expect(screen.queryByText(/unsaved/i)).toBeNull();
   });
 
   it('renders nothing when session is null', () => {
@@ -24,22 +28,13 @@ describe('SessionEditDialog (portable stories)', () => {
     expect(container.querySelector('[data-testid="dialog-session-edit"]')).not.toBeInTheDocument();
   });
 
-  it('clicking cancel without dirty edits closes immediately', () => {
+  it('typing in the name and note fields updates their values', () => {
     render(<SessionEditDialogOpen />);
-    fireEvent.click(screen.getByTestId('dialog-session-edit-btn-cancel'));
-    // No alert should appear since no changes were made.
-    expect(screen.queryByText(/unsaved/i)).toBeNull();
-  });
 
-  it('typing in the name field updates the input value', () => {
-    render(<SessionEditDialogOpen />);
     const input = screen.getByTestId('dialog-session-edit-field-name') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'Renamed session' } });
     expect(input.value).toBe('Renamed session');
-  });
 
-  it('typing in the note field updates the textarea value', () => {
-    render(<SessionEditDialogOpen />);
     const textarea = document.getElementById('session-edit-note') as HTMLTextAreaElement;
     fireEvent.change(textarea, { target: { value: 'Some note text' } });
     expect(textarea.value).toBe('Some note text');


### PR DESCRIPTION
Group multiple `it` blocks that re-render the same composed story into
single tests with grouped assertions. Storybook stories are heavy to
mount: each `composeStories` render replays decorators, providers, args
loaders. Reducing renders in 7 files saves significant compute time
during the unit test suite.

Files touched:
- SessionCard: 13 renders -> 6 (SessionCardDefault x7, x3, x2 deduped)
- DomainRulesPage: 8 renders -> 5 (single + bulk delete flows merged)
- PackGallery: 8 renders -> 6 (gallery + confirm-disabled + selection merged)
- SessionEditDialog: 5 renders -> 3 (read + cancel merged, name + note merged)
- ImportExportPage: 5 renders -> 2 (4-cards + disabled + import-click merged,
  WithRules enabled + click merged)
- PackCard: 5 renders -> 4 (PackCardSimple read + click merged)
- ConflictResolutionStep: 5 renders -> 4 (GroupsOnly read + combobox merged)

All 1541 unit tests still pass.

https://claude.ai/code/session_01WjTmixNBQPiiAzLdTmrjY1