### PR TITLE
feat(popup): hide workspace switcher when only the default workspace exists

### DIFF
--- a/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
+++ b/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
@@ -17,7 +17,12 @@ interface PopupWorkspaceSwitcherProps {
  * sidebar footer but adapted for the 400px popup width.
  */
 export function PopupWorkspaceSwitcher({ onManage }: PopupWorkspaceSwitcherProps) {
-  const { active, accentColor } = useActiveWorkspaceContext();
+  const { active, accentColor, workspaces, isLoaded } = useActiveWorkspaceContext();
+
+  if (!isLoaded || workspaces.length <= 1) {
+    return null;
+  }
+
   const name = active?.name ?? getMessage('workspaceDefaultName');
 
   const trigger = (

--- a/tests/components/WorkspaceFooter.test.tsx
+++ b/tests/components/WorkspaceFooter.test.tsx
@@ -36,6 +36,17 @@ const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
 beforeEach(() => {
   ctx.active = null;
   ctx.accentColor = 'indigo';
+  ctx.workspaces = [];
+  ctx.isLoaded = true;
+});
+
+const makeWorkspace = (overrides: Partial<WorkspaceMeta> = {}): WorkspaceMeta => ({
+  id: 'ws-default',
+  name: 'Default',
+  accentColor: 'indigo',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  ...overrides,
 });
 
 describe('WorkspaceFooter', () => {
@@ -95,6 +106,13 @@ describe('WorkspaceFooterCollapsed', () => {
 });
 
 describe('PopupWorkspaceSwitcher', () => {
+  beforeEach(() => {
+    ctx.workspaces = [
+      makeWorkspace({ id: 'default', name: 'Default' }),
+      makeWorkspace({ id: 'ws-2', name: 'Side project', accentColor: 'jade' }),
+    ];
+  });
+
   it('renders the popup-specific switcher with trigger', () => {
     wrap(<PopupWorkspaceSwitcher />);
     expect(screen.getByTestId('popup-workspace-switcher')).toBeInTheDocument();
@@ -111,5 +129,25 @@ describe('PopupWorkspaceSwitcher', () => {
     };
     wrap(<PopupWorkspaceSwitcher />);
     expect(screen.getByText('Important')).toBeInTheDocument();
+  });
+
+  it('renders nothing when only the default workspace exists', () => {
+    ctx.workspaces = [makeWorkspace({ id: 'default', name: 'Default' })];
+    wrap(<PopupWorkspaceSwitcher />);
+    expect(screen.queryByTestId('popup-workspace-switcher')).toBeNull();
+    expect(screen.queryByTestId('popup-workspace-trigger')).toBeNull();
+  });
+
+  it('renders nothing when the workspace list is empty (pre-migration)', () => {
+    ctx.workspaces = [];
+    wrap(<PopupWorkspaceSwitcher />);
+    expect(screen.queryByTestId('popup-workspace-switcher')).toBeNull();
+  });
+
+  it('renders nothing while the workspace list is loading', () => {
+    ctx.isLoaded = false;
+    ctx.workspaces = [];
+    wrap(<PopupWorkspaceSwitcher />);
+    expect(screen.queryByTestId('popup-workspace-switcher')).toBeNull();
   });
 });

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -87,13 +87,17 @@ test.describe('[US-PO01] Toolbar', () => {
     extensionContext,
     extensionId,
   }) => {
-    // Close all existing pages so hasCapturableTabs() sees no capturable tab
-    // (extension pages like chrome-extension:// are already filtered by hasCapturableTabs)
-    for (const p of extensionContext.pages()) {
-      await p.close().catch(() => {});
-    }
-
+    // Snapshot existing pages BEFORE opening the new one. Chromium persistent
+    // contexts with --load-extension can shut down (or refuse subsequent
+    // newPage() calls with "Failed to open a new tab") once their last page
+    // closes, so we keep the new page alive while we close the others.
+    const stalePages = extensionContext.pages();
     const page = await extensionContext.newPage();
+
+    // Close stale pages so hasCapturableTabs() sees no capturable tab.
+    // Extension pages (chrome-extension://) are already filtered by hasCapturableTabs.
+    await Promise.all(stalePages.map((p) => p.close().catch(() => {})));
+
     await goToPopup(page, extensionId);
 
     const saveBtn = page.getByTestId('popup-toolbar-btn-save');


### PR DESCRIPTION
The workspace selector block adds noise to the popup for users who never
created a second workspace. Hide it when the workspace list is loading,
empty (pre-migration), or contains a single entry. Workspace management
remains reachable via the popup settings icon and the options sidebar.

https://claude.ai/code/session_01Te5TvBhFGDaVagrgVYJHEu