### PR TITLE
feat(home): add keyboard navigation and restore shortcuts to HomePage

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -531,6 +531,7 @@
   "shortcutsGroupGlobal": { "message": "Browser-wide" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Options page" },
+  "shortcutsGroupListHome": { "message": "Home page" },
   "shortcutsGroupListRules": { "message": "Rules list" },
   "shortcutsGroupListSessions": { "message": "Sessions list" },
   "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
@@ -558,6 +559,9 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Add session to current window" },
   "shortcutDescSessionReplaceCurrent": { "message": "Replace current window tabs" },
   "shortcutDescSessionRestoreNew": { "message": "Open session in a new window" },
+  "shortcutDescHomeFirstLast": { "message": "Move focus to first or last item" },
+  "shortcutDescHomeNextSection": { "message": "Move focus to the next section" },
+  "shortcutDescHomeActivate": { "message": "Activate the focused item" },
 
   "homeTab": { "message": "Home" },
   "homePageDescription": { "message": "Your SmartTab Organizer dashboard: pinned sessions, shortcuts, and activity." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -532,6 +532,7 @@
   "shortcutsGroupGlobal": { "message": "Globales (navegador)" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Página de opciones" },
+  "shortcutsGroupListHome": { "message": "Página de inicio" },
   "shortcutsGroupListRules": { "message": "Lista de reglas" },
   "shortcutsGroupListSessions": { "message": "Lista de sesiones" },
   "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
@@ -559,6 +560,9 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Añadir la sesión a la ventana actual" },
   "shortcutDescSessionReplaceCurrent": { "message": "Reemplazar las pestañas de la ventana" },
   "shortcutDescSessionRestoreNew": { "message": "Abrir la sesión en una nueva ventana" },
+  "shortcutDescHomeFirstLast": { "message": "Mover el foco al primer o último elemento" },
+  "shortcutDescHomeNextSection": { "message": "Mover el foco a la sección siguiente" },
+  "shortcutDescHomeActivate": { "message": "Activar el elemento con foco" },
 
   "homeTab": { "message": "Inicio" },
   "homePageDescription": { "message": "Tu panel de SmartTab Organizer: sesiones ancladas, accesos rápidos y actividad." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -532,6 +532,7 @@
   "shortcutsGroupGlobal": { "message": "Globaux navigateur" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Page d'options" },
+  "shortcutsGroupListHome": { "message": "Page d'accueil" },
   "shortcutsGroupListRules": { "message": "Liste des règles" },
   "shortcutsGroupListSessions": { "message": "Liste des sessions" },
   "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
@@ -559,6 +560,9 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Ajouter la session à la fenêtre courante" },
   "shortcutDescSessionReplaceCurrent": { "message": "Remplacer les onglets de la fenêtre" },
   "shortcutDescSessionRestoreNew": { "message": "Ouvrir la session dans une nouvelle fenêtre" },
+  "shortcutDescHomeFirstLast": { "message": "Aller au premier ou au dernier élément" },
+  "shortcutDescHomeNextSection": { "message": "Aller à la section suivante" },
+  "shortcutDescHomeActivate": { "message": "Activer l'élément focus" },
 
   "homeTab": { "message": "Accueil" },
   "homePageDescription": { "message": "Votre tableau de bord SmartTab Organizer : sessions épinglées, raccourcis et activité." },

--- a/src/components/HomePage/PinnedSessionTile.tsx
+++ b/src/components/HomePage/PinnedSessionTile.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react';
 import { Box, Card, Flex, Text } from '@radix-ui/themes';
 import { Pin, RotateCcw } from 'lucide-react';
 import type { Session } from '@/types/session';
@@ -9,6 +10,9 @@ import styles from './PinnedSessionsSection.module.css';
 export interface PinnedSessionTileProps {
   session: Session;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
+  tabIndex?: number;
+  onKeyDown?: (e: KeyboardEvent<HTMLElement>) => void;
+  onFocus?: () => void;
 }
 
 function getCounts(session: Session): { groups: number; tabs: number } {
@@ -17,11 +21,25 @@ function getCounts(session: Session): { groups: number; tabs: number } {
   return { groups, tabs: grouped + session.ungroupedTabs.length };
 }
 
-export function PinnedSessionTile({ session, onRestore }: PinnedSessionTileProps) {
+export function PinnedSessionTile({
+  session,
+  onRestore,
+  tabIndex = 0,
+  onKeyDown,
+  onFocus,
+}: PinnedSessionTileProps) {
   const { groups, tabs } = getCounts(session);
 
   return (
-    <Card className={styles.tile} data-testid={`home-pinned-tile-${session.id}`}>
+    <Card
+      className={styles.tile}
+      data-testid={`home-pinned-tile-${session.id}`}
+      data-home-pinned-tile=""
+      tabIndex={tabIndex}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      aria-label={getMessage('homepagePinnedSessionsTileAriaLabel', [session.name])}
+    >
       <Flex direction="column" gap="2" height="100%">
         <Flex align="center" gap="2">
           <Text size="2" weight="medium" truncate className={styles.name}>

--- a/src/components/HomePage/PinnedSessionsSection.tsx
+++ b/src/components/HomePage/PinnedSessionsSection.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useRef, useState, type KeyboardEvent } from 'react';
 import { Badge, Box, Button, Card, Flex, Grid, Heading } from '@radix-ui/themes';
 import { Pin } from 'lucide-react';
 import type { Session } from '@/types/session';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import { getMessage } from '@/utils/i18n';
 import { PinnedSessionTile } from './PinnedSessionTile';
 import type { HomeRestoreTarget } from './types';
@@ -15,8 +17,31 @@ export interface PinnedSessionsSectionProps {
 const MAX_TILES = 6;
 
 export function PinnedSessionsSection({ sessions, onSeeAll, onRestore }: PinnedSessionsSectionProps) {
-  if (sessions.length === 0) return null;
   const visible = sessions.slice(0, MAX_TILES);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [focusIndex, setFocusIndex] = useState(0);
+  const { handleNavigationKey } = useListNavigation(gridRef, '[data-home-pinned-tile]', {
+    axis: 'horizontal',
+    rovingTabIndex: true,
+  });
+
+  const handleTileKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLElement>, index: number, session: Session) => {
+      if (e.target !== e.currentTarget) return;
+      if (handleNavigationKey(e, index)) return;
+      if (e.ctrlKey || e.metaKey) return;
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        if (e.altKey && e.shiftKey) onRestore(session, 'new');
+        else if (e.altKey) onRestore(session, 'replace');
+        else if (e.shiftKey) onRestore(session, 'current');
+        else onRestore(session, 'custom');
+      }
+    },
+    [handleNavigationKey, onRestore],
+  );
+
+  if (visible.length === 0) return null;
 
   return (
     <Card asChild>
@@ -35,9 +60,16 @@ export function PinnedSessionsSection({ sessions, onSeeAll, onRestore }: PinnedS
               {getMessage('homepagePinnedSessionsSeeAll')}
             </Button>
           </Flex>
-          <Grid columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
-            {visible.map((s) => (
-              <PinnedSessionTile key={s.id} session={s} onRestore={onRestore} />
+          <Grid ref={gridRef} columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
+            {visible.map((s, i) => (
+              <PinnedSessionTile
+                key={s.id}
+                session={s}
+                onRestore={onRestore}
+                tabIndex={i === focusIndex ? 0 : -1}
+                onFocus={() => setFocusIndex(i)}
+                onKeyDown={(e) => handleTileKeyDown(e, i, s)}
+              />
             ))}
           </Grid>
         </Flex>

--- a/src/components/HomePage/QuickActionCard.tsx
+++ b/src/components/HomePage/QuickActionCard.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react';
 import { Card, Flex, Heading, Text } from '@radix-ui/themes';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
 import { getMessage } from '@/utils/i18n';
@@ -7,15 +8,28 @@ import styles from './QuickActionsSection.module.css';
 export interface QuickActionCardProps {
   action: QuickActionDef;
   onClick: () => void;
+  tabIndex?: number;
+  onKeyDown?: (e: KeyboardEvent<HTMLElement>) => void;
+  onFocus?: () => void;
 }
 
-export function QuickActionCard({ action, onClick }: QuickActionCardProps) {
+export function QuickActionCard({
+  action,
+  onClick,
+  tabIndex = 0,
+  onKeyDown,
+  onFocus,
+}: QuickActionCardProps) {
   return (
     <button
       type="button"
       className={styles.actionButton}
       onClick={onClick}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      tabIndex={tabIndex}
       data-testid={`home-quick-action-${action.id}`}
+      data-home-quick-action=""
     >
       <Card className={styles.actionCard}>
         <Flex direction="column" gap="2">

--- a/src/components/HomePage/QuickActionsSection.tsx
+++ b/src/components/HomePage/QuickActionsSection.tsx
@@ -1,6 +1,8 @@
+import { useRef, useState } from 'react';
 import { Card, Flex, Grid, Heading } from '@radix-ui/themes';
 import { Zap } from 'lucide-react';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import { getMessage } from '@/utils/i18n';
 import { QUICK_ACTIONS, type QuickActionId } from './data';
 import { QuickActionCard } from './QuickActionCard';
@@ -12,6 +14,12 @@ export interface QuickActionsSectionProps {
 
 export function QuickActionsSection({ count = 5, onAction }: QuickActionsSectionProps) {
   const items = QUICK_ACTIONS.slice(0, count);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [focusIndex, setFocusIndex] = useState(0);
+  const { handleNavigationKey } = useListNavigation(gridRef, '[data-home-quick-action]', {
+    axis: 'horizontal',
+    rovingTabIndex: true,
+  });
 
   return (
     <Card asChild>
@@ -23,9 +31,16 @@ export function QuickActionsSection({ count = 5, onAction }: QuickActionsSection
               {getMessage('homepageQuickActionsTitle')}
             </Heading>
           </Flex>
-          <Grid columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
-            {items.map((a) => (
-              <QuickActionCard key={a.id} action={a} onClick={() => onAction(a.id)} />
+          <Grid ref={gridRef} columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
+            {items.map((a, i) => (
+              <QuickActionCard
+                key={a.id}
+                action={a}
+                onClick={() => onAction(a.id)}
+                tabIndex={i === focusIndex ? 0 : -1}
+                onFocus={() => setFocusIndex(i)}
+                onKeyDown={(e) => handleNavigationKey(e, i)}
+              />
             ))}
           </Grid>
         </Flex>

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -11,6 +11,7 @@ import { showSuccessNotification } from '@/utils/notifications';
 import { getRuleCategory } from '@/utils/categoriesStore';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import type { Session } from '@/types/session';
 import styles from './PopupProfilesList.module.css';
 
@@ -108,30 +109,11 @@ export function PopupProfilesList() {
       .catch(() => {});
   }, []);
 
+  const { handleNavigationKey } = useListNavigation(listRef, '[data-popup-pinned-card]');
+
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, session: Session, index: number) => {
     if (e.target !== e.currentTarget) return;
-    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-popup-pinned-card]');
-    if (!cards) return;
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      cards[index + 1]?.focus();
-      return;
-    }
-    if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      cards[index - 1]?.focus();
-      return;
-    }
-    if (e.key === 'Home') {
-      e.preventDefault();
-      cards[0]?.focus();
-      return;
-    }
-    if (e.key === 'End') {
-      e.preventDefault();
-      cards[cards.length - 1]?.focus();
-      return;
-    }
+    if (handleNavigationKey(e, index)) return;
     if (e.key.toLowerCase() === 'r' && !e.ctrlKey && !e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
@@ -145,7 +127,7 @@ export function PopupProfilesList() {
         void openCustomizeRestore(session);
       }
     }
-  }, [handleRestore]);
+  }, [handleNavigationKey, handleRestore]);
 
   const handleToggleEmptyCollapsed = useCallback((nextOpen: boolean) => {
     const nextCollapsed = !nextOpen;

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -72,6 +72,17 @@ const groupListSessions: ShortcutGroup = {
   subgroups: [groupSessionCard],
 };
 
+const groupListHome: ShortcutGroup = {
+  titleKey: 'shortcutsGroupListHome',
+  shortcuts: [
+    { keys: ['←', '→'], descriptionKey: 'shortcutDescListNavigate' },
+    { keys: ['Home', 'End'], descriptionKey: 'shortcutDescHomeFirstLast' },
+    { keys: ['Tab'], descriptionKey: 'shortcutDescHomeNextSection' },
+    { keys: ['Enter'], descriptionKey: 'shortcutDescHomeActivate' },
+  ],
+  subgroups: [groupSessionCard],
+};
+
 const groupOptions: ShortcutGroup = {
   titleKey: 'shortcutsGroupOptions',
   shortcuts: [
@@ -95,6 +106,7 @@ const groupPopup: ShortcutGroup = {
 
 export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   groupGlobal,
+  groupListHome,
   groupListRules,
   groupListSessions,
   groupOptions,
@@ -102,6 +114,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
 ];
 
 export type PageContext =
+  | 'home'
   | 'rules'
   | 'sessions'
   | 'importexport'
@@ -126,11 +139,14 @@ export function isGroupOpenByDefault(
       return true;
     case 'shortcutsGroupPopup':
       return pageContext === undefined;
+    case 'shortcutsGroupListHome':
+      return pageContext === 'home';
     case 'shortcutsGroupListRules':
       return pageContext === 'rules';
     case 'shortcutsGroupListSessions':
-    case 'shortcutsGroupSessionCard':
       return pageContext === 'sessions';
+    case 'shortcutsGroupSessionCard':
+      return pageContext === 'sessions' || pageContext === 'home';
     default:
       return false;
   }

--- a/src/components/UI/Sidebar/SidebarItems.tsx
+++ b/src/components/UI/Sidebar/SidebarItems.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef, useState } from 'react';
 import { Flex, Text, Button, Box } from '@radix-ui/themes';
 import { SidebarItem } from './Sidebar';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
+import { useListNavigation } from '@/hooks/useListNavigation';
 
 interface SidebarItemsProps {
   isCollapsed?: boolean;
@@ -131,6 +133,20 @@ export function SidebarItems({
   onItemClick,
   items
 }: SidebarItemsProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const activeIndex = items.findIndex((it) => it.id === activeItem);
+  const [focusIndex, setFocusIndex] = useState(activeIndex >= 0 ? activeIndex : 0);
+  const { handleNavigationKey } = useListNavigation(listRef, '[data-sidebar-nav-item]', {
+    axis: 'vertical',
+    rovingTabIndex: true,
+  });
+
+  // Keep the roving tabstop aligned with the active route so a fresh Tab into
+  // the sidebar lands on the current page rather than on a stale position.
+  useEffect(() => {
+    if (activeIndex >= 0) setFocusIndex(activeIndex);
+  }, [activeIndex]);
+
   const handleItemClick = (itemId: string, onClick?: () => void) => {
     if (onClick) {
       onClick();
@@ -140,8 +156,8 @@ export function SidebarItems({
   };
 
   return (
-    <Flex direction="column" gap="2">
-      {items.map((item) => {
+    <Flex direction="column" gap="2" ref={listRef}>
+      {items.map((item, index) => {
         const isActive = activeItem === item.id;
         const accent = resolveAccentTokens(item.accentColor);
 
@@ -149,9 +165,13 @@ export function SidebarItems({
           <Button
             key={item.id}
             data-testid={`sidebar-nav-item-${item.id}`}
+            data-sidebar-nav-item=""
             variant="ghost"
             size="3"
             onClick={() => handleItemClick(item.id, item.onClick)}
+            onFocus={() => setFocusIndex(index)}
+            onKeyDown={(e) => handleNavigationKey(e, index)}
+            tabIndex={index === focusIndex ? 0 : -1}
             aria-label={isCollapsed ? item.label : undefined}
             title={isCollapsed ? item.label : undefined}
             style={computeButtonStyle(isCollapsed, isActive, accent, item.accentColor)}

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -1,0 +1,85 @@
+import { useCallback, type RefObject, type KeyboardEvent } from 'react';
+
+export type NavigationAxis = 'vertical' | 'horizontal' | 'both';
+
+export interface UseListNavigationOptions {
+  /** Axis along which arrow keys move focus. Default `'vertical'`. */
+  axis?: NavigationAxis;
+  /**
+   * When true, the hook also rewrites `tabindex` on every matched item so that
+   * only the focused one is reachable via Tab (roving tabindex pattern).
+   */
+  rovingTabIndex?: boolean;
+}
+
+export interface ListNavigationApi {
+  /**
+   * Returns true when the key was consumed (caller should stop processing).
+   * `index` is the position of the element receiving the event among its
+   * siblings matching `itemSelector`.
+   */
+  handleNavigationKey: (e: KeyboardEvent<HTMLElement>, index: number) => boolean;
+}
+
+/**
+ * Shared keyboard navigation helper for card lists / grids.
+ *
+ * The list container is referenced by `listRef`; the navigable items are
+ * looked up via `itemSelector` at call time so additions/removals are picked
+ * up without re-binding the hook.
+ */
+export function useListNavigation<T extends HTMLElement>(
+  listRef: RefObject<T | null>,
+  itemSelector: string,
+  options: UseListNavigationOptions = {},
+): ListNavigationApi {
+  const { axis = 'vertical', rovingTabIndex = false } = options;
+
+  const handleNavigationKey = useCallback(
+    (e: KeyboardEvent<HTMLElement>, index: number): boolean => {
+      const items = listRef.current?.querySelectorAll<HTMLElement>(itemSelector);
+      if (!items || items.length === 0) return false;
+
+      const focusAt = (next: number) => {
+        const clamped = Math.max(0, Math.min(items.length - 1, next));
+        const target = items[clamped];
+        if (!target) return;
+        if (rovingTabIndex) {
+          items.forEach((el) => el.setAttribute('tabindex', el === target ? '0' : '-1'));
+        }
+        target.focus();
+      };
+
+      const v = axis === 'vertical' || axis === 'both';
+      const h = axis === 'horizontal' || axis === 'both';
+
+      switch (e.key) {
+        case 'ArrowDown':
+          if (v) { e.preventDefault(); focusAt(index + 1); return true; }
+          return false;
+        case 'ArrowUp':
+          if (v) { e.preventDefault(); focusAt(index - 1); return true; }
+          return false;
+        case 'ArrowRight':
+          if (h) { e.preventDefault(); focusAt(index + 1); return true; }
+          return false;
+        case 'ArrowLeft':
+          if (h) { e.preventDefault(); focusAt(index - 1); return true; }
+          return false;
+        case 'Home':
+          e.preventDefault();
+          focusAt(0);
+          return true;
+        case 'End':
+          e.preventDefault();
+          focusAt(items.length - 1);
+          return true;
+        default:
+          return false;
+      }
+    },
+    [listRef, itemSelector, axis, rovingTabIndex],
+  );
+
+  return { handleNavigationKey };
+}

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -15,6 +15,7 @@ import { foldAccents } from '@/utils/stringUtils';
 import { generateUUID } from '@/utils/utils';
 import { DomainRuleCard } from '@/components/Core/DomainRule/DomainRuleCard';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import {
   moveToFirst,
@@ -228,30 +229,15 @@ export function DomainRulesPage({
 
   const listRef = useRef<HTMLDivElement>(null);
 
+  const { handleNavigationKey } = useListNavigation(listRef, '[role="listitem"]');
+
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent, rule: DomainRuleSetting, index: number) => {
     // Only act when the card element itself has focus (not a child input/button).
     if (e.target !== e.currentTarget) return;
 
-    const cards = listRef.current?.querySelectorAll<HTMLElement>('[role="listitem"]');
-    if (!cards) return;
+    if (handleNavigationKey(e as React.KeyboardEvent<HTMLElement>, index)) return;
 
     switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        cards[index + 1]?.focus();
-        return;
-      case 'ArrowUp':
-        e.preventDefault();
-        cards[index - 1]?.focus();
-        return;
-      case 'Home':
-        e.preventDefault();
-        cards[0]?.focus();
-        return;
-      case 'End':
-        e.preventDefault();
-        cards[cards.length - 1]?.focus();
-        return;
       case ' ':
         e.preventDefault();
         handleRowSelect(rule.id, !selectedIds.has(rule.id));
@@ -275,7 +261,7 @@ export function DomainRulesPage({
       e.preventDefault();
       handleToggleEnabled(rule.id, !rule.enabled);
     }
-  }, [handleRowSelect, handleEditRule, handleToggleEnabled, selectedIds]);
+  }, [handleNavigationKey, handleRowSelect, handleEditRule, handleToggleEnabled, selectedIds]);
 
   const handleAddRule = useCallback(() => {
     setEditingRule(undefined);

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -19,6 +19,7 @@ import { matchSessionSearch, splitByPinned } from '@/utils/sessionUtils';
 import { moveSessionToFirstInGroup, moveSessionToLastInGroup } from '@/utils/sessionOrderUtils';
 import { useSessions } from '@/hooks/useSessions';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { updateSession } from '@/utils/sessionStorage';
 import { showSuccessNotification } from '@/utils/notifications';
@@ -184,30 +185,7 @@ function SessionSection({
     }
   }, [handleRestoreCurrentWindow, handleRestoreNewWindow, handleReplaceCurrentWindow, onOpenRestoreWizard]);
 
-  const handleNavigationKey = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number): boolean => {
-    const cards = listRef.current?.querySelectorAll<HTMLElement>('[data-session-card]');
-    if (!cards) return false;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        cards[index + 1]?.focus();
-        return true;
-      case 'ArrowUp':
-        e.preventDefault();
-        cards[index - 1]?.focus();
-        return true;
-      case 'Home':
-        e.preventDefault();
-        cards[0]?.focus();
-        return true;
-      case 'End':
-        e.preventDefault();
-        cards[cards.length - 1]?.focus();
-        return true;
-      default:
-        return false;
-    }
-  }, []);
+  const { handleNavigationKey } = useListNavigation(listRef, '[data-session-card]');
 
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number, session: Session) => {
     // Only act when the card element itself has focus (not a child input/button).

--- a/tests/hooks/useListNavigation.test.tsx
+++ b/tests/hooks/useListNavigation.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRef, type ReactNode } from 'react';
+import { render, renderHook } from '@testing-library/react';
+import {
+  useListNavigation,
+  type UseListNavigationOptions,
+} from '../../src/hooks/useListNavigation';
+
+interface SetupResult {
+  list: HTMLDivElement;
+  items: HTMLButtonElement[];
+  api: ReturnType<typeof useListNavigation>;
+}
+
+function setup(itemCount: number, options?: UseListNavigationOptions): SetupResult {
+  const list = document.createElement('div');
+  const items: HTMLButtonElement[] = [];
+  for (let i = 0; i < itemCount; i++) {
+    const btn = document.createElement('button');
+    btn.setAttribute('data-item', '');
+    btn.setAttribute('tabindex', i === 0 ? '0' : '-1');
+    btn.textContent = `Item ${i}`;
+    list.appendChild(btn);
+    items.push(btn);
+  }
+  document.body.appendChild(list);
+
+  const { result } = renderHook(() => {
+    const ref = useRef<HTMLDivElement | null>(list);
+    return useListNavigation(ref, '[data-item]', options);
+  });
+
+  return { list, items, api: result.current };
+}
+
+function pressKey(target: HTMLElement, key: string): React.KeyboardEvent<HTMLElement> {
+  // Build a minimal React-like keyboard event the hook can consume.
+  let prevented = false;
+  const event = {
+    key,
+    target,
+    currentTarget: target,
+    preventDefault: () => { prevented = true; },
+    get defaultPrevented() { return prevented; },
+  } as unknown as React.KeyboardEvent<HTMLElement>;
+  return event;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('useListNavigation', () => {
+  it('moves focus down on ArrowDown when axis is vertical (default)', () => {
+    const { items, api } = setup(3);
+    items[0].focus();
+    const consumed = api.handleNavigationKey(pressKey(items[0], 'ArrowDown'), 0);
+    expect(consumed).toBe(true);
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('moves focus up on ArrowUp when axis is vertical', () => {
+    const { items, api } = setup(3);
+    items[2].focus();
+    api.handleNavigationKey(pressKey(items[2], 'ArrowUp'), 2);
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('does not consume horizontal arrows when axis is vertical', () => {
+    const { items, api } = setup(3);
+    items[0].focus();
+    const consumed = api.handleNavigationKey(pressKey(items[0], 'ArrowRight'), 0);
+    expect(consumed).toBe(false);
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('moves on horizontal arrows when axis is horizontal', () => {
+    const { items, api } = setup(3, { axis: 'horizontal' });
+    items[0].focus();
+    api.handleNavigationKey(pressKey(items[0], 'ArrowRight'), 0);
+    expect(document.activeElement).toBe(items[1]);
+    api.handleNavigationKey(pressKey(items[1], 'ArrowLeft'), 1);
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('handles both axes when axis is "both"', () => {
+    const { items, api } = setup(3, { axis: 'both' });
+    items[0].focus();
+    api.handleNavigationKey(pressKey(items[0], 'ArrowRight'), 0);
+    expect(document.activeElement).toBe(items[1]);
+    api.handleNavigationKey(pressKey(items[1], 'ArrowDown'), 1);
+    expect(document.activeElement).toBe(items[2]);
+  });
+
+  it('clamps Home to the first and End to the last item', () => {
+    const { items, api } = setup(4);
+    items[2].focus();
+    api.handleNavigationKey(pressKey(items[2], 'Home'), 2);
+    expect(document.activeElement).toBe(items[0]);
+    api.handleNavigationKey(pressKey(items[0], 'End'), 0);
+    expect(document.activeElement).toBe(items[3]);
+  });
+
+  it('does not move past the boundaries', () => {
+    const { items, api } = setup(2);
+    items[0].focus();
+    api.handleNavigationKey(pressKey(items[0], 'ArrowUp'), 0);
+    expect(document.activeElement).toBe(items[0]);
+    items[1].focus();
+    api.handleNavigationKey(pressKey(items[1], 'ArrowDown'), 1);
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('rewrites tabindex on focused item when rovingTabIndex is true', () => {
+    const { items, api } = setup(3, { rovingTabIndex: true });
+    items[0].focus();
+    api.handleNavigationKey(pressKey(items[0], 'ArrowDown'), 0);
+    expect(items[0].getAttribute('tabindex')).toBe('-1');
+    expect(items[1].getAttribute('tabindex')).toBe('0');
+    expect(items[2].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('returns false when no items match the selector', () => {
+    const empty = document.createElement('div');
+    document.body.appendChild(empty);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(empty);
+      return useListNavigation(ref, '[data-item]');
+    });
+    const fakeTarget = document.createElement('button');
+    const consumed = result.current.handleNavigationKey(pressKey(fakeTarget, 'ArrowDown'), 0);
+    expect(consumed).toBe(false);
+  });
+
+  // Sanity check: hook can be consumed inside a real component without throwing.
+  it('integrates with React refs', () => {
+    function Harness({ children }: { children: ReactNode }) {
+      const ref = useRef<HTMLDivElement>(null);
+      const { handleNavigationKey } = useListNavigation(ref, '[data-item]');
+      return (
+        <div ref={ref} data-testid="list" onKeyDown={(e) => handleNavigationKey(e, 0)}>
+          {children}
+        </div>
+      );
+    }
+    const { getByTestId } = render(
+      <Harness>
+        <button data-item type="button">A</button>
+        <button data-item type="button">B</button>
+      </Harness>,
+    );
+    expect(getByTestId('list')).toBeDefined();
+  });
+});

--- a/tests/shortcuts-context.test.ts
+++ b/tests/shortcuts-context.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/components/UI/ShortcutsPanel/shortcuts';
 
 const ALL_CONTEXTS: PageContext[] = [
+  'home',
   'rules',
   'sessions',
   'importexport',
@@ -35,11 +36,22 @@ describe('isGroupOpenByDefault', () => {
     }
   });
 
-  it('opens the sessions list and session card groups only on the sessions page', () => {
+  it('opens the sessions list group only on the sessions page', () => {
     for (const ctx of ALL_CONTEXTS) {
-      const expected = ctx === 'sessions';
-      expect(isGroupOpenByDefault('shortcutsGroupListSessions', ctx)).toBe(expected);
+      expect(isGroupOpenByDefault('shortcutsGroupListSessions', ctx)).toBe(ctx === 'sessions');
+    }
+  });
+
+  it('opens the session card group on both the sessions page and the home page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const expected = ctx === 'sessions' || ctx === 'home';
       expect(isGroupOpenByDefault('shortcutsGroupSessionCard', ctx)).toBe(expected);
+    }
+  });
+
+  it('opens the home list group only on the home page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('shortcutsGroupListHome', ctx)).toBe(ctx === 'home');
     }
   });
 


### PR DESCRIPTION
Pinned session tiles and quick actions now use a roving tabindex with
Arrow Left/Right and Home/End for intra-section navigation, while Tab
moves focus across sections. Pinned tiles also accept R / Shift+R /
Alt+R / Alt+Shift+R to mirror SessionCard restore combos (custom wizard,
current window, replace, new window).

Extracted useListNavigation hook to share the arrow/Home/End pattern
between SessionsPage, DomainRulesPage, PopupProfilesList and HomePage.
Added a "Home page" group to the shortcuts cheatsheet (en/fr/es).

https://claude.ai/code/session_01WXe7mcjR13sGf7q12H59X9