### PR TITLE
feat(packs): bootstrap PackGallery catalog with 13 categories and 38 packs

### DIFF
--- a/public/data/presets.json
+++ b/public/data/presets.json
@@ -325,6 +325,15 @@
           "description": "Extrait une référence d'issue GitHub (#123) dans le titre, quel que soit le domaine. Utile pour les onglets qui référencent une issue par son numéro."
         },
         {
+          "id": "servicenow-record-in-title",
+          "name": "ServiceNow - Record dans le titre (cross-domaine)",
+          "domainFilters": ["*"],
+          "titleRegex": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+          "groupNameSource": "smart_preset",
+          "titleExample": "Titre: 'Fix login outage INC0012345' ou '[CHG0006789] Deploy update' → Groupe: 'INC0012345'",
+          "description": "Extrait un identifiant d'enregistrement ServiceNow (INC, CHG, REQ, RITM, PRB) dans le titre, quel que soit le domaine. Utile pour les PR GitHub/GitLab, cartes Trello ou tâches Asana qui référencent un incident ou changement ServiceNow."
+        },
+        {
           "id": "trello-board",
           "name": "Trello - Boards",
           "domainFilters": ["trello.com"],

--- a/src/data/packs/_categories.json
+++ b/src/data/packs/_categories.json
@@ -17,6 +17,105 @@
         "es": "Cloud y DevOps"
       },
       "icon": "☁️"
+    },
+    {
+      "id": "productivity",
+      "label": {
+        "en": "Productivity",
+        "fr": "Productivité",
+        "es": "Productividad"
+      },
+      "icon": "📋"
+    },
+    {
+      "id": "communication",
+      "label": {
+        "en": "Communication",
+        "fr": "Communication",
+        "es": "Comunicación"
+      },
+      "icon": "💬"
+    },
+    {
+      "id": "ai",
+      "label": {
+        "en": "AI assistants",
+        "fr": "Assistants IA",
+        "es": "Asistentes de IA"
+      },
+      "icon": "🤖"
+    },
+    {
+      "id": "search",
+      "label": {
+        "en": "Search",
+        "fr": "Recherche",
+        "es": "Búsqueda"
+      },
+      "icon": "🔍"
+    },
+    {
+      "id": "media",
+      "label": {
+        "en": "Media & Streaming",
+        "fr": "Médias & Streaming",
+        "es": "Medios y Streaming"
+      },
+      "icon": "🎬"
+    },
+    {
+      "id": "social",
+      "label": {
+        "en": "Social",
+        "fr": "Réseaux sociaux",
+        "es": "Redes sociales"
+      },
+      "icon": "🗣️"
+    },
+    {
+      "id": "commerce",
+      "label": {
+        "en": "Commerce",
+        "fr": "Commerce",
+        "es": "Comercio"
+      },
+      "icon": "🛍️"
+    },
+    {
+      "id": "travel",
+      "label": {
+        "en": "Travel",
+        "fr": "Voyage",
+        "es": "Viajes"
+      },
+      "icon": "✈️"
+    },
+    {
+      "id": "finance",
+      "label": {
+        "en": "Finance",
+        "fr": "Finance",
+        "es": "Finanzas"
+      },
+      "icon": "💰"
+    },
+    {
+      "id": "news",
+      "label": {
+        "en": "News",
+        "fr": "Actualités",
+        "es": "Actualidad"
+      },
+      "icon": "📰"
+    },
+    {
+      "id": "education",
+      "label": {
+        "en": "Learning",
+        "fr": "Apprentissage",
+        "es": "Aprendizaje"
+      },
+      "icon": "🎓"
     }
   ]
 }

--- a/src/data/packs/_categories.json
+++ b/src/data/packs/_categories.json
@@ -8,6 +8,15 @@
         "es": "Desarrollo"
       },
       "icon": "💻"
+    },
+    {
+      "id": "cloud",
+      "label": {
+        "en": "Cloud & DevOps",
+        "fr": "Cloud & DevOps",
+        "es": "Cloud y DevOps"
+      },
+      "icon": "☁️"
     }
   ]
 }

--- a/src/data/packs/_categories.json
+++ b/src/data/packs/_categories.json
@@ -1,3 +1,13 @@
 {
-  "categories": []
+  "categories": [
+    {
+      "id": "development",
+      "label": {
+        "en": "Development",
+        "fr": "Développement",
+        "es": "Desarrollo"
+      },
+      "icon": "💻"
+    }
+  ]
 }

--- a/src/data/packs/pk-ai-assistants.json
+++ b/src/data/packs/pk-ai-assistants.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-ai-assistants",
+    "name": {
+      "en": "AI assistants",
+      "fr": "Assistants IA",
+      "es": "Asistentes de IA"
+    },
+    "description": {
+      "en": "Keep ChatGPT, Claude and Gemini conversations grouped together by tool.",
+      "fr": "Regroupe les conversations ChatGPT, Claude et Gemini par outil.",
+      "es": "Agrupa las conversaciones de ChatGPT, Claude y Gemini por herramienta."
+    },
+    "categoryId": "ai"
+  },
+  "domainRules": [
+    {
+      "id": "pk-ai-chatgpt",
+      "enabled": true,
+      "domainFilter": "chatgpt.com",
+      "label": "ChatGPT",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-ai-claude",
+      "enabled": true,
+      "domainFilter": "claude.ai",
+      "label": "Claude",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-ai-gemini",
+      "enabled": true,
+      "domainFilter": "gemini.google.com",
+      "label": "Gemini",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-ai-huggingface.json
+++ b/src/data/packs/pk-ai-huggingface.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-ai-huggingface",
+    "name": {
+      "en": "Hugging Face",
+      "fr": "Hugging Face",
+      "es": "Hugging Face"
+    },
+    "description": {
+      "en": "Group Hugging Face tabs by model or dataset slug.",
+      "fr": "Regroupe les onglets Hugging Face par slug de modèle ou de dataset.",
+      "es": "Agrupa las pestañas de Hugging Face por slug de modelo o conjunto de datos."
+    },
+    "categoryId": "ai"
+  },
+  "domainRules": [
+    {
+      "id": "pk-ai-hf-model",
+      "enabled": true,
+      "domainFilter": "huggingface.co",
+      "label": "Hugging Face: Model",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "huggingface\\.co/(?!datasets|spaces)([^/?#]+/[^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-ai-hf-dataset",
+      "enabled": true,
+      "domainFilter": "huggingface.co",
+      "label": "Hugging Face: Dataset",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "huggingface\\.co/datasets/([^/?#]+/[^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-ai-search.json
+++ b/src/data/packs/pk-ai-search.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-ai-search",
+    "name": {
+      "en": "AI search engines",
+      "fr": "Moteurs de recherche IA",
+      "es": "Motores de búsqueda con IA"
+    },
+    "description": {
+      "en": "Group AI search tabs by query on Perplexity, Phind and You.com.",
+      "fr": "Regroupe les onglets de recherche IA par requête sur Perplexity, Phind et You.com.",
+      "es": "Agrupa las pestañas de búsqueda IA por consulta en Perplexity, Phind y You.com."
+    },
+    "categoryId": "ai"
+  },
+  "domainRules": [
+    {
+      "id": "pk-ai-perplexity",
+      "enabled": true,
+      "domainFilter": "*.perplexity.ai",
+      "label": "Perplexity: Thread",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/search/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-ai-phind",
+      "enabled": true,
+      "domainFilter": "*.phind.com",
+      "label": "Phind: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-ai-youcom",
+      "enabled": true,
+      "domainFilter": "you.com",
+      "label": "You.com: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    }
+  ]
+}

--- a/src/data/packs/pk-cloud-aws.json
+++ b/src/data/packs/pk-cloud-aws.json
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-cloud-aws",
+    "name": {
+      "en": "AWS Console",
+      "fr": "Console AWS",
+      "es": "Consola AWS"
+    },
+    "description": {
+      "en": "Group AWS console tabs around the service you focus on most.",
+      "fr": "Regroupe les onglets de la console AWS selon le service que vous utilisez le plus.",
+      "es": "Agrupa las pestañas de la consola AWS según el servicio que más utilice."
+    },
+    "categoryId": "cloud",
+    "configurable": {
+      "rulePattern": "aws/{service}/",
+      "params": [
+        {
+          "id": "service",
+          "label": {
+            "en": "AWS service",
+            "fr": "Service AWS",
+            "es": "Servicio AWS"
+          },
+          "default": "ec2",
+          "options": [
+            { "value": "ec2", "label": "EC2 (Compute)" },
+            { "value": "s3", "label": "S3 (Storage)" },
+            { "value": "lambda", "label": "Lambda (Functions)" },
+            { "value": "rds", "label": "RDS (Databases)" },
+            { "value": "cloudwatch", "label": "CloudWatch (Monitoring)" },
+            { "value": "iam", "label": "IAM (Identity)" },
+            { "value": "dynamodb", "label": "DynamoDB (NoSQL)" },
+            { "value": "ecs", "label": "ECS (Containers)" }
+          ]
+        }
+      ]
+    }
+  },
+  "domainRules": [
+    {
+      "id": "pk-cloud-aws-ec2",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/ec2/by region",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "region"
+    },
+    {
+      "id": "pk-cloud-aws-s3",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/s3/buckets",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/s3/buckets/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-aws-lambda",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/lambda/functions",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "#/functions/([^/?]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-aws-rds",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/rds/databases",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "database:id=([^;&]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-aws-cloudwatch",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/cloudwatch/by region",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "region"
+    },
+    {
+      "id": "pk-cloud-aws-iam",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/iam/by section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/iam[v0-9]*/home#/?([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-aws-dynamodb",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/dynamodb/tables",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "[?&#]name=([^&;]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-aws-ecs",
+      "enabled": true,
+      "domainFilter": "*.console.aws.amazon.com",
+      "label": "aws/ecs/clusters",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/ecs/(?:v2/)?clusters/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-cloud-azure.json
+++ b/src/data/packs/pk-cloud-azure.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-cloud-azure",
+    "name": {
+      "en": "Azure Portal",
+      "fr": "Portail Azure",
+      "es": "Portal Azure"
+    },
+    "description": {
+      "en": "Group Azure portal tabs by subscription or by Microsoft service provider.",
+      "fr": "Regroupe les onglets du portail Azure par abonnement ou par fournisseur de service Microsoft.",
+      "es": "Agrupa las pestañas del portal Azure por suscripción o por proveedor de servicio Microsoft."
+    },
+    "categoryId": "cloud",
+    "configurable": {
+      "rulePattern": "azure/{scope}/",
+      "params": [
+        {
+          "id": "scope",
+          "label": {
+            "en": "Group by",
+            "fr": "Grouper par",
+            "es": "Agrupar por"
+          },
+          "default": "subscription",
+          "options": [
+            {
+              "value": "subscription",
+              "label": {
+                "en": "Subscription",
+                "fr": "Abonnement",
+                "es": "Suscripción"
+              }
+            },
+            {
+              "value": "service",
+              "label": {
+                "en": "Service",
+                "fr": "Service",
+                "es": "Servicio"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "domainRules": [
+    {
+      "id": "pk-cloud-azure-subscription",
+      "enabled": true,
+      "domainFilter": "portal.azure.com",
+      "label": "azure/subscription/by subscription",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "subscriptions/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-azure-service",
+      "enabled": true,
+      "domainFilter": "portal.azure.com",
+      "label": "azure/service/by service",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "providers/Microsoft\\.([A-Za-z0-9]+)/",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-cloud-gcp.json
+++ b/src/data/packs/pk-cloud-gcp.json
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-cloud-gcp",
+    "name": {
+      "en": "Google Cloud Console",
+      "fr": "Console Google Cloud",
+      "es": "Consola Google Cloud"
+    },
+    "description": {
+      "en": "Group Google Cloud console tabs by project or by product family.",
+      "fr": "Regroupe les onglets de la console Google Cloud par projet ou par famille de produit.",
+      "es": "Agrupa las pestañas de la consola Google Cloud por proyecto o por familia de producto."
+    },
+    "categoryId": "cloud",
+    "configurable": {
+      "rulePattern": "gcp/{scope}/",
+      "params": [
+        {
+          "id": "scope",
+          "label": {
+            "en": "Group by",
+            "fr": "Grouper par",
+            "es": "Agrupar por"
+          },
+          "default": "project",
+          "options": [
+            {
+              "value": "project",
+              "label": {
+                "en": "Project",
+                "fr": "Projet",
+                "es": "Proyecto"
+              }
+            },
+            {
+              "value": "product",
+              "label": {
+                "en": "Product family",
+                "fr": "Famille de produit",
+                "es": "Familia de producto"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "domainRules": [
+    {
+      "id": "pk-cloud-gcp-project",
+      "enabled": true,
+      "domainFilter": "console.cloud.google.com",
+      "label": "gcp/project/by project",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "project"
+    },
+    {
+      "id": "pk-cloud-gcp-product",
+      "enabled": true,
+      "domainFilter": "console.cloud.google.com",
+      "label": "gcp/product/by product",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "console\\.cloud\\.google\\.com/([a-z0-9-]+)(?:/|\\?|$)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-cloud-platforms.json
+++ b/src/data/packs/pk-cloud-platforms.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-cloud-platforms",
+    "name": {
+      "en": "Deployment platforms",
+      "fr": "Plateformes de déploiement",
+      "es": "Plataformas de despliegue"
+    },
+    "description": {
+      "en": "Group dashboards on Cloudflare, Vercel, Netlify and Render by site or project.",
+      "fr": "Regroupe les tableaux de bord Cloudflare, Vercel, Netlify et Render par site ou projet.",
+      "es": "Agrupa los paneles de Cloudflare, Vercel, Netlify y Render por sitio o proyecto."
+    },
+    "categoryId": "cloud"
+  },
+  "domainRules": [
+    {
+      "id": "pk-cloud-platforms-cloudflare",
+      "enabled": true,
+      "domainFilter": "dash.cloudflare.com",
+      "label": "Cloudflare: Domain",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "dash\\.cloudflare\\.com/[0-9a-f]+/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-platforms-vercel",
+      "enabled": true,
+      "domainFilter": "vercel.com",
+      "label": "Vercel: Project",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "vercel\\.com/[^/]+/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "vercel-dashboard",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-platforms-netlify",
+      "enabled": true,
+      "domainFilter": "app.netlify.com",
+      "label": "Netlify: Site",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/sites/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-cloud-platforms-render",
+      "enabled": true,
+      "domainFilter": "dashboard.render.com",
+      "label": "Render: Service",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/(srv-[a-z0-9]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "cloud",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-comm-discord.json
+++ b/src/data/packs/pk-comm-discord.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-comm-discord",
+    "name": {
+      "en": "Discord",
+      "fr": "Discord",
+      "es": "Discord"
+    },
+    "description": {
+      "en": "Group Discord tabs by server identifier.",
+      "fr": "Regroupe les onglets Discord par identifiant de serveur.",
+      "es": "Agrupa las pestañas de Discord por identificador de servidor."
+    },
+    "categoryId": "communication"
+  },
+  "domainRules": [
+    {
+      "id": "pk-comm-discord-server",
+      "enabled": true,
+      "domainFilter": "discord.com",
+      "label": "Discord: Server",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/channels/(\\d+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-comm-meetings.json
+++ b/src/data/packs/pk-comm-meetings.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-comm-meetings",
+    "name": {
+      "en": "Video meetings",
+      "fr": "Visioconférences",
+      "es": "Videoconferencias"
+    },
+    "description": {
+      "en": "Group meeting tabs by meeting ID across Zoom, Google Meet and Microsoft Teams.",
+      "fr": "Regroupe les onglets de réunion par identifiant sur Zoom, Google Meet et Microsoft Teams.",
+      "es": "Agrupa las pestañas de reunión por identificador en Zoom, Google Meet y Microsoft Teams."
+    },
+    "categoryId": "communication"
+  },
+  "domainRules": [
+    {
+      "id": "pk-comm-zoom",
+      "enabled": true,
+      "domainFilter": "*.zoom.us",
+      "label": "Zoom: Meeting",
+      "titleParsingRegEx": "Zoom Meeting ID: (\\d+)",
+      "urlParsingRegEx": "zoom\\.us/j/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "zoom-meeting",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-comm-google-meet",
+      "enabled": true,
+      "domainFilter": "meet.google.com",
+      "label": "Google Meet: Meeting",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "meet\\.google\\.com/([a-z]{3,4}-[a-z]{3,4}-[a-z]{3,4})",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-comm-teams",
+      "enabled": true,
+      "domainFilter": "teams.microsoft.com",
+      "label": "Teams: Meeting",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/meetup-join/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-comm-slack.json
+++ b/src/data/packs/pk-comm-slack.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-comm-slack",
+    "name": {
+      "en": "Slack",
+      "fr": "Slack",
+      "es": "Slack"
+    },
+    "description": {
+      "en": "Group Slack tabs by workspace.",
+      "fr": "Regroupe les onglets Slack par espace de travail.",
+      "es": "Agrupa las pestañas de Slack por espacio de trabajo."
+    },
+    "categoryId": "communication"
+  },
+  "domainRules": [
+    {
+      "id": "pk-comm-slack-workspace",
+      "enabled": true,
+      "domainFilter": "*.slack.com",
+      "label": "Slack: Workspace",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "://([^.]+)\\.slack\\.com",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "slack-workspace",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-cross-tool-servicenow.json
+++ b/src/data/packs/pk-dev-cross-tool-servicenow.json
@@ -1,0 +1,131 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-cross-tool-servicenow",
+    "name": {
+      "en": "Cross-tool ServiceNow records",
+      "fr": "Enregistrements ServiceNow inter-outils",
+      "es": "Registros ServiceNow entre herramientas"
+    },
+    "description": {
+      "en": "Group tabs across ServiceNow, GitHub, GitLab, Gitea, Bitbucket, Trello and Asana by the ServiceNow record identifier (INC, CHG, REQ, RITM, PRB) referenced in their title. Pull requests, merge requests, cards and tasks that mention the same incident or change land in the same group as the ServiceNow record itself.",
+      "fr": "Regroupe les onglets ServiceNow, GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par l'identifiant de record ServiceNow (INC, CHG, REQ, RITM, PRB) référencé dans leur titre. Les pull requests, merge requests, cartes et tâches qui mentionnent le même incident ou changement atterrissent dans le même groupe que le record ServiceNow lui-même.",
+      "es": "Agrupa las pestañas de ServiceNow, GitHub, GitLab, Gitea, Bitbucket, Trello y Asana por el identificador de registro ServiceNow (INC, CHG, REQ, RITM, PRB) referenciado en su título. Las pull requests, merge requests, tarjetas y tareas que mencionan el mismo incidente o cambio acaban en el mismo grupo que el registro ServiceNow."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-snow-self",
+      "enabled": true,
+      "domainFilter": "*.service-now.com",
+      "label": "ServiceNow: Record",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-github",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-gitlab",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-gitea",
+      "enabled": true,
+      "domainFilter": "*.gitea.io",
+      "label": "Gitea: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-bitbucket",
+      "enabled": true,
+      "domainFilter": "*.bitbucket.org",
+      "label": "Bitbucket: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-trello",
+      "enabled": true,
+      "domainFilter": "trello.com",
+      "label": "Trello: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-snow-asana",
+      "enabled": true,
+      "domainFilter": "app.asana.com",
+      "label": "Asana: ServiceNow ref in title",
+      "titleParsingRegEx": "(INC\\d+|CHG\\d+|REQ\\d+|RITM\\d+|PRB\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "servicenow-record-in-title",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-cross-tool-tickets.json
+++ b/src/data/packs/pk-dev-cross-tool-tickets.json
@@ -3,14 +3,14 @@
   "pack": {
     "id": "pk-dev-cross-tool-tickets",
     "name": {
-      "en": "Cross-tool Jira references",
-      "fr": "Références Jira inter-outils",
-      "es": "Referencias Jira entre herramientas"
+      "en": "Cross-tool ticket references",
+      "fr": "Références ticket inter-outils",
+      "es": "Referencias de ticket entre herramientas"
     },
     "description": {
-      "en": "Group tabs across GitHub, GitLab, Gitea, Bitbucket, Trello and Asana by the Jira ticket key (PROJ-123) referenced in their title. Pull requests, merge requests, cards and tasks that mention the same ticket end up in the same group as the Jira ticket itself.",
-      "fr": "Regroupe les onglets GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par la clé de ticket Jira (PROJ-123) référencée dans leur titre. Les pull requests, merge requests, cartes et tâches qui mentionnent le même ticket atterrissent dans le même groupe que le ticket Jira lui-même.",
-      "es": "Agrupa las pestañas de GitHub, GitLab, Gitea, Bitbucket, Trello y Asana por la clave de ticket Jira (PROJ-123) referenciada en su título. Las pull requests, merge requests, tarjetas y tareas que mencionan el mismo ticket acaban en el mismo grupo que el ticket Jira."
+      "en": "Group tabs across GitHub, GitLab, Gitea, Bitbucket, Trello and Asana by the ticket key (PROJ-123) referenced in their title. Works with any tracker that uses a PREFIX-NUMBER scheme: Jira, Linear, Shortcut, YouTrack, Plane, ClickUp custom IDs. Pull requests, merge requests, cards and tasks that mention the same ticket land in the same group as the ticket itself.",
+      "fr": "Regroupe les onglets GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par la clé de ticket (PROJ-123) référencée dans leur titre. Fonctionne avec tout gestionnaire qui utilise un schéma PRÉFIXE-NUMÉRO : Jira, Linear, Shortcut, YouTrack, Plane, identifiants personnalisés ClickUp. Les pull requests, merge requests, cartes et tâches qui mentionnent le même ticket atterrissent dans le même groupe que le ticket lui-même.",
+      "es": "Agrupa las pestañas de GitHub, GitLab, Gitea, Bitbucket, Trello y Asana por la clave de ticket (PROJ-123) referenciada en su título. Compatible con cualquier gestor que use un esquema PREFIJO-NÚMERO: Jira, Linear, Shortcut, YouTrack, Plane, identificadores personalizados de ClickUp. Las pull requests, merge requests, tarjetas y tareas que mencionan el mismo ticket acaban en el mismo grupo que el ticket."
     },
     "categoryId": "development"
   },
@@ -19,7 +19,7 @@
       "id": "pk-dev-cross-github",
       "enabled": true,
       "domainFilter": "github.com",
-      "label": "GitHub: Jira ref in title",
+      "label": "GitHub: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",
@@ -35,7 +35,7 @@
       "id": "pk-dev-cross-gitlab",
       "enabled": true,
       "domainFilter": "gitlab.com",
-      "label": "GitLab: Jira ref in title",
+      "label": "GitLab: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",
@@ -51,7 +51,7 @@
       "id": "pk-dev-cross-gitea",
       "enabled": true,
       "domainFilter": "*.gitea.io",
-      "label": "Gitea: Jira ref in title",
+      "label": "Gitea: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",
@@ -67,7 +67,7 @@
       "id": "pk-dev-cross-bitbucket",
       "enabled": true,
       "domainFilter": "*.bitbucket.org",
-      "label": "Bitbucket: Jira ref in title",
+      "label": "Bitbucket: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",
@@ -83,7 +83,7 @@
       "id": "pk-dev-cross-trello",
       "enabled": true,
       "domainFilter": "trello.com",
-      "label": "Trello: Jira ref in title",
+      "label": "Trello: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",
@@ -99,7 +99,7 @@
       "id": "pk-dev-cross-asana",
       "enabled": true,
       "domainFilter": "app.asana.com",
-      "label": "Asana: Jira ref in title",
+      "label": "Asana: Ticket ref in title",
       "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
       "urlParsingRegEx": "",
       "groupNameSource": "smart_preset",

--- a/src/data/packs/pk-dev-cross-tool-tickets.json
+++ b/src/data/packs/pk-dev-cross-tool-tickets.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-cross-tool-tickets",
+    "name": {
+      "en": "Cross-tool Jira references",
+      "fr": "Références Jira inter-outils",
+      "es": "Referencias Jira entre herramientas"
+    },
+    "description": {
+      "en": "Group tabs across GitHub, GitLab, Gitea, Bitbucket, Trello and Asana by the Jira ticket key (PROJ-123) referenced in their title. Pull requests, merge requests, cards and tasks that mention the same ticket end up in the same group as the Jira ticket itself.",
+      "fr": "Regroupe les onglets GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par la clé de ticket Jira (PROJ-123) référencée dans leur titre. Les pull requests, merge requests, cartes et tâches qui mentionnent le même ticket atterrissent dans le même groupe que le ticket Jira lui-même.",
+      "es": "Agrupa las pestañas de GitHub, GitLab, Gitea, Bitbucket, Trello y Asana por la clave de ticket Jira (PROJ-123) referenciada en su título. Las pull requests, merge requests, tarjetas y tareas que mencionan el mismo ticket acaban en el mismo grupo que el ticket Jira."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-cross-github",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-cross-gitlab",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-cross-gitea",
+      "enabled": true,
+      "domainFilter": "*.gitea.io",
+      "label": "Gitea: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-cross-bitbucket",
+      "enabled": true,
+      "domainFilter": "*.bitbucket.org",
+      "label": "Bitbucket: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-cross-trello",
+      "enabled": true,
+      "domainFilter": "trello.com",
+      "label": "Trello: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-cross-asana",
+      "enabled": true,
+      "domainFilter": "app.asana.com",
+      "label": "Asana: Jira ref in title",
+      "titleParsingRegEx": "([A-Z][A-Z0-9_]+-\\d+)",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket-in-title",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-github.json
+++ b/src/data/packs/pk-dev-github.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-github",
+    "name": {
+      "en": "GitHub",
+      "fr": "GitHub",
+      "es": "GitHub"
+    },
+    "description": {
+      "en": "Group GitHub tabs by repository, issue, pull request and discussion.",
+      "fr": "Regroupe les onglets GitHub par dépôt, issue, pull request et discussion.",
+      "es": "Agrupa las pestañas de GitHub por repositorio, issue, pull request y discusión."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-github-repo",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: Repository",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*", "ref", "ref_src"],
+      "presetId": "github-repo",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-github-issue",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: Issue",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": "github-issue",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-github-pr",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: Pull Request",
+      "titleParsingRegEx": "·\\s*Pull Request\\s*#(\\d+)",
+      "urlParsingRegEx": "pull/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-github-discussion",
+      "enabled": true,
+      "domainFilter": "github.com",
+      "label": "GitHub: Discussion",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "discussions/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "blue",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-gitlab.json
+++ b/src/data/packs/pk-dev-gitlab.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-gitlab",
+    "name": {
+      "en": "GitLab",
+      "fr": "GitLab",
+      "es": "GitLab"
+    },
+    "description": {
+      "en": "Group GitLab tabs by project, issue and merge request.",
+      "fr": "Regroupe les onglets GitLab par projet, issue et merge request.",
+      "es": "Agrupa las pestañas de GitLab por proyecto, issue y merge request."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-gitlab-project",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab: Project",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "orange",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*", "ref"],
+      "presetId": "gitlab-project",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-gitlab-issue",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab: Issue",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/-/issues/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "orange",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-gitlab-mr",
+      "enabled": true,
+      "domainFilter": "gitlab.com",
+      "label": "GitLab: Merge Request",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/-/merge_requests/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "orange",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-package-registries.json
+++ b/src/data/packs/pk-dev-package-registries.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-package-registries",
+    "name": {
+      "en": "Package registries",
+      "fr": "Registres de paquets",
+      "es": "Registros de paquetes"
+    },
+    "description": {
+      "en": "Group package pages on npm, PyPI and Docker Hub by package name.",
+      "fr": "Regroupe les pages de paquets sur npm, PyPI et Docker Hub par nom de paquet.",
+      "es": "Agrupa las páginas de paquetes en npm, PyPI y Docker Hub por nombre de paquete."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-pkg-npm",
+      "enabled": true,
+      "domainFilter": "*.npmjs.com",
+      "label": "npm: Package",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*", "activeTab"],
+      "presetId": "npm-package",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-pkg-pypi",
+      "enabled": true,
+      "domainFilter": "pypi.org",
+      "label": "PyPI: Package",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "pypi\\.org/project/([^/?#]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-pkg-docker-hub",
+      "enabled": true,
+      "domainFilter": "hub.docker.com",
+      "label": "Docker Hub: Image",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "hub\\.docker\\.com/(?:r|_)/([^/?#]+(?:/[^/?#]+)?)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "red",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-dev-stackoverflow.json
+++ b/src/data/packs/pk-dev-stackoverflow.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-dev-stackoverflow",
+    "name": {
+      "en": "Stack Overflow & Stack Exchange",
+      "fr": "Stack Overflow & Stack Exchange",
+      "es": "Stack Overflow & Stack Exchange"
+    },
+    "description": {
+      "en": "Group Q&A tabs across Stack Overflow, Server Fault, Super User and Stack Exchange sites.",
+      "fr": "Regroupe les onglets Q/R sur Stack Overflow, Server Fault, Super User et les sites Stack Exchange.",
+      "es": "Agrupa las pestañas de Q&R en Stack Overflow, Server Fault, Super User y los sitios Stack Exchange."
+    },
+    "categoryId": "development"
+  },
+  "domainRules": [
+    {
+      "id": "pk-dev-stackoverflow-question",
+      "enabled": true,
+      "domainFilter": "stackoverflow.com",
+      "label": "Stack Overflow: Question",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_preset",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "yellow",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*", "noredirect", "newreg"],
+      "presetId": "stackoverflow-question",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-dev-stackoverflow-tag",
+      "enabled": true,
+      "domainFilter": "stackoverflow.com",
+      "label": "Stack Overflow: Tag",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/questions/tagged/([^/?#]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact_ignore_params",
+      "color": "yellow",
+      "categoryId": "development",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_*", "tab", "page"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-edu-mooc.json
+++ b/src/data/packs/pk-edu-mooc.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-edu-mooc",
+    "name": {
+      "en": "Online courses & docs",
+      "fr": "Cours en ligne & docs",
+      "es": "Cursos en línea y documentación"
+    },
+    "description": {
+      "en": "Group Coursera, Udemy, edX and MDN Web Docs tabs by course or section.",
+      "fr": "Regroupe les onglets Coursera, Udemy, edX et MDN Web Docs par cours ou section.",
+      "es": "Agrupa las pestañas de Coursera, Udemy, edX y MDN Web Docs por curso o sección."
+    },
+    "categoryId": "education"
+  },
+  "domainRules": [
+    {
+      "id": "pk-edu-coursera",
+      "enabled": true,
+      "domainFilter": "*.coursera.org",
+      "label": "Coursera: Course",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Coursera",
+      "urlParsingRegEx": "coursera\\.org/learn/([^/?#]+)",
+      "groupNameSource": "smart",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "coursera-course",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-udemy",
+      "enabled": true,
+      "domainFilter": "*.udemy.com",
+      "label": "Udemy: Course",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Udemy",
+      "urlParsingRegEx": "udemy\\.com/course/([^/?#]+)",
+      "groupNameSource": "smart",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "udemy-course",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-edx",
+      "enabled": true,
+      "domainFilter": "*.edx.org",
+      "label": "edX: Course",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "edx\\.org/(?:learn|course)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-mdn",
+      "enabled": true,
+      "domainFilter": "developer.mozilla.org",
+      "label": "MDN: Web docs section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "docs/Web/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "mdn-docs",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-finance-crypto.json
+++ b/src/data/packs/pk-finance-crypto.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-finance-crypto",
+    "name": {
+      "en": "Crypto exchanges",
+      "fr": "Plateformes crypto",
+      "es": "Exchanges crypto"
+    },
+    "description": {
+      "en": "Group Coinbase and Binance tabs by crypto asset or trading pair.",
+      "fr": "Regroupe les onglets Coinbase et Binance par actif crypto ou paire de trading.",
+      "es": "Agrupa las pestañas de Coinbase y Binance por activo crypto o par de trading."
+    },
+    "categoryId": "finance"
+  },
+  "domainRules": [
+    {
+      "id": "pk-finance-coinbase",
+      "enabled": true,
+      "domainFilter": "*.coinbase.com",
+      "label": "Coinbase: Price",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "coinbase\\.com/price/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "coinbase-crypto",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-binance",
+      "enabled": true,
+      "domainFilter": "*.binance.com",
+      "label": "Binance: Trading pair",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/trade/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-finance-markets.json
+++ b/src/data/packs/pk-finance-markets.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-finance-markets",
+    "name": {
+      "en": "Markets & tickers",
+      "fr": "Marchés & tickers",
+      "es": "Mercados y tickers"
+    },
+    "description": {
+      "en": "Group Yahoo Finance, TradingView and Investing.com tabs by ticker symbol.",
+      "fr": "Regroupe les onglets Yahoo Finance, TradingView et Investing.com par symbole ticker.",
+      "es": "Agrupa las pestañas de Yahoo Finance, TradingView e Investing.com por símbolo de ticker."
+    },
+    "categoryId": "finance"
+  },
+  "domainRules": [
+    {
+      "id": "pk-finance-yahoo",
+      "enabled": true,
+      "domainFilter": "finance.yahoo.com",
+      "label": "Yahoo Finance: Ticker",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/quote/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-tradingview",
+      "enabled": true,
+      "domainFilter": "*.tradingview.com",
+      "label": "TradingView: Symbol",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "symbol=([^&]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "tradingview-chart",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-investing",
+      "enabled": true,
+      "domainFilter": "*.investing.com",
+      "label": "Investing.com: Instrument",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "investing\\.com/(?:equities|etfs|currencies|indices|commodities)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-media-spotify.json
+++ b/src/data/packs/pk-media-spotify.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-media-spotify",
+    "name": {
+      "en": "Spotify",
+      "fr": "Spotify",
+      "es": "Spotify"
+    },
+    "description": {
+      "en": "Group Spotify tabs by artist, album and playlist.",
+      "fr": "Regroupe les onglets Spotify par artiste, album et playlist.",
+      "es": "Agrupa las pestañas de Spotify por artista, álbum y lista de reproducción."
+    },
+    "categoryId": "media"
+  },
+  "domainRules": [
+    {
+      "id": "pk-media-spotify-artist",
+      "enabled": true,
+      "domainFilter": "open.spotify.com",
+      "label": "Spotify: Artist",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "spotify\\.com/artist/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-spotify-album",
+      "enabled": true,
+      "domainFilter": "open.spotify.com",
+      "label": "Spotify: Album",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "spotify\\.com/album/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-spotify-playlist",
+      "enabled": true,
+      "domainFilter": "open.spotify.com",
+      "label": "Spotify: Playlist",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "spotify\\.com/playlist/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-media-svod.json
+++ b/src/data/packs/pk-media-svod.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-media-svod",
+    "name": {
+      "en": "SVOD platforms",
+      "fr": "Plateformes SVOD",
+      "es": "Plataformas SVOD"
+    },
+    "description": {
+      "en": "Group Netflix, Disney+ and Prime Video tabs by title.",
+      "fr": "Regroupe les onglets Netflix, Disney+ et Prime Video par titre.",
+      "es": "Agrupa las pestañas de Netflix, Disney+ y Prime Video por título."
+    },
+    "categoryId": "media"
+  },
+  "domainRules": [
+    {
+      "id": "pk-media-netflix",
+      "enabled": true,
+      "domainFilter": "*.netflix.com",
+      "label": "Netflix: Title",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Netflix",
+      "urlParsingRegEx": "netflix\\.com/(?:[a-z-]+/)?title/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "netflix-title",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-disney",
+      "enabled": true,
+      "domainFilter": "*.disneyplus.com",
+      "label": "Disney+: Title",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Disney\\+?",
+      "urlParsingRegEx": "/(?:movies|series|browse)/[^/]+/([^/?#]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-prime",
+      "enabled": true,
+      "domainFilter": "*.primevideo.com",
+      "label": "Prime Video: Title",
+      "titleParsingRegEx": "(.+?)\\s*[-|]\\s*Prime Video",
+      "urlParsingRegEx": "/(?:detail|gp/video)/([^/?#]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-media-youtube.json
+++ b/src/data/packs/pk-media-youtube.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-media-youtube",
+    "name": {
+      "en": "YouTube",
+      "fr": "YouTube",
+      "es": "YouTube"
+    },
+    "description": {
+      "en": "Group YouTube tabs by channel and search query.",
+      "fr": "Regroupe les onglets YouTube par chaîne et par requête de recherche.",
+      "es": "Agrupa las pestañas de YouTube por canal y por consulta de búsqueda."
+    },
+    "categoryId": "media"
+  },
+  "domainRules": [
+    {
+      "id": "pk-media-youtube-channel",
+      "enabled": true,
+      "domainFilter": "*.youtube.com",
+      "label": "YouTube: Channel",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "youtube\\.com/(?:@|c/|user/|channel/)([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "youtube-channel",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-youtube-search",
+      "enabled": true,
+      "domainFilter": "*.youtube.com",
+      "label": "YouTube: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-youtube",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "search_query"
+    }
+  ]
+}

--- a/src/data/packs/pk-news-fr.json
+++ b/src/data/packs/pk-news-fr.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-news-fr",
+    "name": {
+      "en": "French press",
+      "fr": "Presse française",
+      "es": "Prensa francesa"
+    },
+    "description": {
+      "en": "Group Le Monde, Le Figaro and Libération tabs by section.",
+      "fr": "Regroupe les onglets Le Monde, Le Figaro et Libération par rubrique.",
+      "es": "Agrupa las pestañas de Le Monde, Le Figaro y Libération por sección."
+    },
+    "categoryId": "news"
+  },
+  "domainRules": [
+    {
+      "id": "pk-news-lemonde",
+      "enabled": true,
+      "domainFilter": "*.lemonde.fr",
+      "label": "Le Monde: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "lemonde\\.fr/([^/?#]+)/",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["xtor"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-news-lefigaro",
+      "enabled": true,
+      "domainFilter": "*.lefigaro.fr",
+      "label": "Le Figaro: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "lefigaro\\.fr/([^/?#]+)/",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-news-liberation",
+      "enabled": true,
+      "domainFilter": "*.liberation.fr",
+      "label": "Libération: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "liberation\\.fr/([^/?#]+)/",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-news-international.json
+++ b/src/data/packs/pk-news-international.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-news-international",
+    "name": {
+      "en": "International press",
+      "fr": "Presse internationale",
+      "es": "Prensa internacional"
+    },
+    "description": {
+      "en": "Group The Guardian, NYT and BBC News tabs by section.",
+      "fr": "Regroupe les onglets The Guardian, NYT et BBC News par rubrique.",
+      "es": "Agrupa las pestañas de The Guardian, NYT y BBC News por sección."
+    },
+    "categoryId": "news"
+  },
+  "domainRules": [
+    {
+      "id": "pk-news-guardian",
+      "enabled": true,
+      "domainFilter": "*.theguardian.com",
+      "label": "The Guardian: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "theguardian\\.com/([^/?#]+)/",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["CMP"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-news-nytimes",
+      "enabled": true,
+      "domainFilter": "*.nytimes.com",
+      "label": "The New York Times: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "nytimes\\.com/(?:section|topic|by)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["smid", "smtyp"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-news-bbc",
+      "enabled": true,
+      "domainFilter": "*.bbc.com",
+      "label": "BBC News: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "bbc\\.com/(?:news/)?([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": null,
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-prod-google-workspace.json
+++ b/src/data/packs/pk-prod-google-workspace.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-prod-google-workspace",
+    "name": {
+      "en": "Google Workspace",
+      "fr": "Google Workspace",
+      "es": "Google Workspace"
+    },
+    "description": {
+      "en": "Group Google Docs, Sheets and Slides tabs by document title.",
+      "fr": "Regroupe les onglets Google Docs, Sheets et Slides par titre de document.",
+      "es": "Agrupa las pestañas de Google Docs, Sheets y Slides por título de documento."
+    },
+    "categoryId": "productivity"
+  },
+  "domainRules": [
+    {
+      "id": "pk-prod-google-docs",
+      "enabled": true,
+      "domainFilter": "docs.google.com",
+      "label": "Google Docs: Document",
+      "titleParsingRegEx": "(.+?)\\s*-\\s*Google Docs",
+      "urlParsingRegEx": "",
+      "groupNameSource": "title",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-prod-google-sheets",
+      "enabled": true,
+      "domainFilter": "docs.google.com",
+      "label": "Google Sheets: Spreadsheet",
+      "titleParsingRegEx": "(.+?)\\s*-\\s*Google Sheets",
+      "urlParsingRegEx": "",
+      "groupNameSource": "title",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-prod-google-slides",
+      "enabled": true,
+      "domainFilter": "docs.google.com",
+      "label": "Google Slides: Presentation",
+      "titleParsingRegEx": "(.+?)\\s*-\\s*Google Slides",
+      "urlParsingRegEx": "",
+      "groupNameSource": "title",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-prod-jira.json
+++ b/src/data/packs/pk-prod-jira.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-prod-jira",
+    "name": {
+      "en": "Jira",
+      "fr": "Jira",
+      "es": "Jira"
+    },
+    "description": {
+      "en": "Group Jira tabs by ticket key (PROJ-123) across all Atlassian Cloud workspaces.",
+      "fr": "Regroupe les onglets Jira par clé de ticket (PROJ-123) sur tous les espaces Atlassian Cloud.",
+      "es": "Agrupa las pestañas de Jira por clave de ticket (PROJ-123) en todos los espacios Atlassian Cloud."
+    },
+    "categoryId": "productivity"
+  },
+  "domainRules": [
+    {
+      "id": "pk-prod-jira-ticket",
+      "enabled": true,
+      "domainFilter": "*.atlassian.net",
+      "label": "Jira: Ticket",
+      "titleParsingRegEx": "([A-Z]+-\\d+)",
+      "urlParsingRegEx": "browse/([A-Z]+-\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "jira-ticket",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-prod-linear.json
+++ b/src/data/packs/pk-prod-linear.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-prod-linear",
+    "name": {
+      "en": "Linear",
+      "fr": "Linear",
+      "es": "Linear"
+    },
+    "description": {
+      "en": "Group Linear tabs by issue identifier (TEAM-123).",
+      "fr": "Regroupe les onglets Linear par identifiant d'issue (TEAM-123).",
+      "es": "Agrupa las pestañas de Linear por identificador de issue (TEAM-123)."
+    },
+    "categoryId": "productivity"
+  },
+  "domainRules": [
+    {
+      "id": "pk-prod-linear-issue",
+      "enabled": true,
+      "domainFilter": "linear.app",
+      "label": "Linear: Issue",
+      "titleParsingRegEx": "([A-Z]+-\\d+)",
+      "urlParsingRegEx": "/issue/([A-Z]+-\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-prod-notion.json
+++ b/src/data/packs/pk-prod-notion.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-prod-notion",
+    "name": {
+      "en": "Notion",
+      "fr": "Notion",
+      "es": "Notion"
+    },
+    "description": {
+      "en": "Group Notion tabs by page title.",
+      "fr": "Regroupe les onglets Notion par titre de page.",
+      "es": "Agrupa las pestañas de Notion por título de página."
+    },
+    "categoryId": "productivity"
+  },
+  "domainRules": [
+    {
+      "id": "pk-prod-notion-page",
+      "enabled": true,
+      "domainFilter": "*.notion.so",
+      "label": "Notion: Page",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Notion",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "notion-page",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-prod-trello-asana.json
+++ b/src/data/packs/pk-prod-trello-asana.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-prod-trello-asana",
+    "name": {
+      "en": "Trello, Asana & ClickUp",
+      "fr": "Trello, Asana & ClickUp",
+      "es": "Trello, Asana y ClickUp"
+    },
+    "description": {
+      "en": "Group project boards across Trello, Asana and ClickUp.",
+      "fr": "Regroupe les tableaux de projet sur Trello, Asana et ClickUp.",
+      "es": "Agrupa los tableros de proyecto en Trello, Asana y ClickUp."
+    },
+    "categoryId": "productivity"
+  },
+  "domainRules": [
+    {
+      "id": "pk-prod-trello-board",
+      "enabled": true,
+      "domainFilter": "trello.com",
+      "label": "Trello: Board",
+      "titleParsingRegEx": "(.+?)\\s*\\|\\s*Trello",
+      "urlParsingRegEx": "trello\\.com/b/[^/]+/(.+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "trello-board",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-prod-asana-task",
+      "enabled": true,
+      "domainFilter": "app.asana.com",
+      "label": "Asana: Project",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "app\\.asana\\.com/0/([^/]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "asana-task",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-prod-clickup-task",
+      "enabled": true,
+      "domainFilter": "app.clickup.com",
+      "label": "ClickUp: Workspace",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "app\\.clickup\\.com/(\\d+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "productivity",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-search-engines.json
+++ b/src/data/packs/pk-search-engines.json
@@ -1,0 +1,104 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-search-engines",
+    "name": {
+      "en": "Search engines",
+      "fr": "Moteurs de recherche",
+      "es": "Motores de búsqueda"
+    },
+    "description": {
+      "en": "Group search result tabs by query across Google, Bing, DuckDuckGo, Brave and Kagi.",
+      "fr": "Regroupe les onglets de résultats par requête sur Google, Bing, DuckDuckGo, Brave et Kagi.",
+      "es": "Agrupa las pestañas de resultados por consulta en Google, Bing, DuckDuckGo, Brave y Kagi."
+    },
+    "categoryId": "search"
+  },
+  "domainRules": [
+    {
+      "id": "pk-search-google",
+      "enabled": true,
+      "domainFilter": "*.google.com",
+      "label": "Google: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-google",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-search-bing",
+      "enabled": true,
+      "domainFilter": "bing.com",
+      "label": "Bing: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-bing",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-search-ddg",
+      "enabled": true,
+      "domainFilter": "duckduckgo.com",
+      "label": "DuckDuckGo: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-duckduckgo",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-search-brave",
+      "enabled": true,
+      "domainFilter": "search.brave.com",
+      "label": "Brave: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-search-kagi",
+      "enabled": true,
+      "domainFilter": "kagi.com",
+      "label": "Kagi: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    }
+  ]
+}

--- a/src/data/packs/pk-search-wikipedia.json
+++ b/src/data/packs/pk-search-wikipedia.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-search-wikipedia",
+    "name": {
+      "en": "Wikipedia",
+      "fr": "Wikipédia",
+      "es": "Wikipedia"
+    },
+    "description": {
+      "en": "Group Wikipedia tabs by article title across language editions.",
+      "fr": "Regroupe les onglets Wikipédia par titre d'article toutes langues confondues.",
+      "es": "Agrupa las pestañas de Wikipedia por título de artículo en todas las ediciones lingüísticas."
+    },
+    "categoryId": "search"
+  },
+  "domainRules": [
+    {
+      "id": "pk-search-wikipedia-article",
+      "enabled": true,
+      "domainFilter": "*.wikipedia.org",
+      "label": "Wikipedia: Article",
+      "titleParsingRegEx": "(.+?)\\s*-\\s*Wikipedia",
+      "urlParsingRegEx": "wiki/([^#?]+)",
+      "groupNameSource": "smart",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "search",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "wikipedia-article",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-shop-amazon.json
+++ b/src/data/packs/pk-shop-amazon.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-shop-amazon",
+    "name": {
+      "en": "Amazon",
+      "fr": "Amazon",
+      "es": "Amazon"
+    },
+    "description": {
+      "en": "Group Amazon tabs by ASIN product code and search query (FR, COM, ES, DE).",
+      "fr": "Regroupe les onglets Amazon par code produit ASIN et par requête (FR, COM, ES, DE).",
+      "es": "Agrupa las pestañas de Amazon por código de producto ASIN y por consulta (FR, COM, ES, DE)."
+    },
+    "categoryId": "commerce"
+  },
+  "domainRules": [
+    {
+      "id": "pk-shop-amazon-product",
+      "enabled": true,
+      "domainFilter": "*.amazon.*",
+      "label": "Amazon: Product",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/dp/([A-Z0-9]{10})",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["ref", "ref_", "tag", "linkCode"],
+      "presetId": "amazon-product",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-shop-amazon-search",
+      "enabled": true,
+      "domainFilter": "*.amazon.*",
+      "label": "Amazon: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["ref", "ref_"],
+      "presetId": "serp-amazon",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "k"
+    }
+  ]
+}

--- a/src/data/packs/pk-shop-fr.json
+++ b/src/data/packs/pk-shop-fr.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-shop-fr",
+    "name": {
+      "en": "French marketplaces",
+      "fr": "Places de marché françaises",
+      "es": "Marketplaces franceses"
+    },
+    "description": {
+      "en": "Group Leboncoin, Backmarket and Cdiscount tabs by listing or search query.",
+      "fr": "Regroupe les onglets Leboncoin, Backmarket et Cdiscount par annonce ou requête.",
+      "es": "Agrupa las pestañas de Leboncoin, Backmarket y Cdiscount por anuncio o consulta."
+    },
+    "categoryId": "commerce"
+  },
+  "domainRules": [
+    {
+      "id": "pk-shop-leboncoin-search",
+      "enabled": true,
+      "domainFilter": "*.leboncoin.fr",
+      "label": "Leboncoin: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "text"
+    },
+    {
+      "id": "pk-shop-leboncoin-ad",
+      "enabled": true,
+      "domainFilter": "*.leboncoin.fr",
+      "label": "Leboncoin: Ad",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "leboncoin\\.fr/(?:ad/[^/]+|annonces)/(\\d+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-shop-backmarket-product",
+      "enabled": true,
+      "domainFilter": "*.backmarket.*",
+      "label": "Back Market: Product",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/p/[^/]+/([a-f0-9-]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["utm_source", "utm_medium", "utm_campaign"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-shop-cdiscount-search",
+      "enabled": true,
+      "domainFilter": "*.cdiscount.com",
+      "label": "Cdiscount: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "search"
+    }
+  ]
+}

--- a/src/data/packs/pk-shop-marketplaces.json
+++ b/src/data/packs/pk-shop-marketplaces.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-shop-marketplaces",
+    "name": {
+      "en": "Marketplaces",
+      "fr": "Places de marché",
+      "es": "Marketplaces"
+    },
+    "description": {
+      "en": "Group eBay, AliExpress, Etsy and Vinted tabs by item ID or search query.",
+      "fr": "Regroupe les onglets eBay, AliExpress, Etsy et Vinted par identifiant d'article ou requête.",
+      "es": "Agrupa las pestañas de eBay, AliExpress, Etsy y Vinted por identificador o consulta."
+    },
+    "categoryId": "commerce"
+  },
+  "domainRules": [
+    {
+      "id": "pk-shop-ebay-item",
+      "enabled": true,
+      "domainFilter": "*.ebay.*",
+      "label": "eBay: Item",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/itm/(?:[^/]+/)?(\\d+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["hash", "_trkparms"],
+      "presetId": "ebay-item",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-shop-ebay-search",
+      "enabled": true,
+      "domainFilter": "*.ebay.*",
+      "label": "eBay: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-ebay",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "_nkw"
+    },
+    {
+      "id": "pk-shop-aliexpress-item",
+      "enabled": true,
+      "domainFilter": "*.aliexpress.com",
+      "label": "AliExpress: Item",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/item/(\\d+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": ["spm", "scm"],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-shop-etsy-search",
+      "enabled": true,
+      "domainFilter": "*.etsy.com",
+      "label": "Etsy: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    },
+    {
+      "id": "pk-shop-vinted",
+      "enabled": true,
+      "domainFilter": "*.vinted.*",
+      "label": "Vinted: Item",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/items/(\\d+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "commerce",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-social-linkedin.json
+++ b/src/data/packs/pk-social-linkedin.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-social-linkedin",
+    "name": {
+      "en": "LinkedIn",
+      "fr": "LinkedIn",
+      "es": "LinkedIn"
+    },
+    "description": {
+      "en": "Group LinkedIn tabs by profile, company and job search query.",
+      "fr": "Regroupe les onglets LinkedIn par profil, entreprise et requête d'offre d'emploi.",
+      "es": "Agrupa las pestañas de LinkedIn por perfil, empresa y consulta de oferta de empleo."
+    },
+    "categoryId": "social"
+  },
+  "domainRules": [
+    {
+      "id": "pk-social-linkedin-profile",
+      "enabled": true,
+      "domainFilter": "*.linkedin.com",
+      "label": "LinkedIn: Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "linkedin\\.com/in/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "linkedin-profile",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-linkedin-company",
+      "enabled": true,
+      "domainFilter": "*.linkedin.com",
+      "label": "LinkedIn: Company",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "linkedin\\.com/company/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-linkedin-jobs",
+      "enabled": true,
+      "domainFilter": "*.linkedin.com",
+      "label": "LinkedIn: Jobs search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "keywords"
+    }
+  ]
+}

--- a/src/data/packs/pk-social-reddit.json
+++ b/src/data/packs/pk-social-reddit.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-social-reddit",
+    "name": {
+      "en": "Reddit",
+      "fr": "Reddit",
+      "es": "Reddit"
+    },
+    "description": {
+      "en": "Group Reddit tabs by subreddit and by search query.",
+      "fr": "Regroupe les onglets Reddit par subreddit et par requête de recherche.",
+      "es": "Agrupa las pestañas de Reddit por subreddit y por consulta de búsqueda."
+    },
+    "categoryId": "social"
+  },
+  "domainRules": [
+    {
+      "id": "pk-social-reddit-subreddit",
+      "enabled": true,
+      "domainFilter": "*.reddit.com",
+      "label": "Reddit: Subreddit",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "reddit\\.com/r/([^/]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "reddit-subreddit",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-reddit-search",
+      "enabled": true,
+      "domainFilter": "*.reddit.com",
+      "label": "Reddit: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "serp-reddit",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "q"
+    }
+  ]
+}

--- a/src/data/packs/pk-social-x.json
+++ b/src/data/packs/pk-social-x.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-social-x",
+    "name": {
+      "en": "X (Twitter)",
+      "fr": "X (Twitter)",
+      "es": "X (Twitter)"
+    },
+    "description": {
+      "en": "Group X / Twitter tabs by handle.",
+      "fr": "Regroupe les onglets X / Twitter par identifiant.",
+      "es": "Agrupa las pestañas de X / Twitter por identificador."
+    },
+    "categoryId": "social"
+  },
+  "domainRules": [
+    {
+      "id": "pk-social-x-user",
+      "enabled": true,
+      "domainFilter": "*.x.com",
+      "label": "X: User",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "(?:twitter|x)\\.com/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "twitter-user",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-twitter-user",
+      "enabled": true,
+      "domainFilter": "*.twitter.com",
+      "label": "Twitter: User",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "(?:twitter|x)\\.com/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "twitter-user",
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-travel-flights.json
+++ b/src/data/packs/pk-travel-flights.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-travel-flights",
+    "name": {
+      "en": "Flights",
+      "fr": "Vols",
+      "es": "Vuelos"
+    },
+    "description": {
+      "en": "Group Skyscanner, Google Flights and Kayak tabs by route.",
+      "fr": "Regroupe les onglets Skyscanner, Google Flights et Kayak par itinéraire.",
+      "es": "Agrupa las pestañas de Skyscanner, Google Flights y Kayak por ruta."
+    },
+    "categoryId": "travel"
+  },
+  "domainRules": [
+    {
+      "id": "pk-travel-skyscanner",
+      "enabled": true,
+      "domainFilter": "*.skyscanner.*",
+      "label": "Skyscanner: Route",
+      "titleParsingRegEx": "(?:.+?)\\s*to\\s*(.+?)\\s*-",
+      "urlParsingRegEx": "(?:flights|vols)/([^/]+)/([^/?#]+)",
+      "groupNameSource": "smart_manual",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "skyscanner-flights",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-travel-google-flights",
+      "enabled": true,
+      "domainFilter": "*.google.*",
+      "label": "Google Flights: Search",
+      "titleParsingRegEx": "(.+?)\\s*-\\s*Google\\s+(?:Flights|Vols)",
+      "urlParsingRegEx": "google\\.[a-z.]+/(travel|flights)/",
+      "groupNameSource": "title",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-travel-kayak",
+      "enabled": true,
+      "domainFilter": "*.kayak.*",
+      "label": "Kayak: Route",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "/flights/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-travel-stays.json
+++ b/src/data/packs/pk-travel-stays.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-travel-stays",
+    "name": {
+      "en": "Hotels & rentals",
+      "fr": "Hôtels & locations",
+      "es": "Hoteles y alquileres"
+    },
+    "description": {
+      "en": "Group Booking, Airbnb and Hotels.com tabs by destination or listing.",
+      "fr": "Regroupe les onglets Booking, Airbnb et Hotels.com par destination ou annonce.",
+      "es": "Agrupa las pestañas de Booking, Airbnb y Hotels.com por destino o anuncio."
+    },
+    "categoryId": "travel"
+  },
+  "domainRules": [
+    {
+      "id": "pk-travel-booking",
+      "enabled": true,
+      "domainFilter": "*.booking.com",
+      "label": "Booking: Destination",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_manual",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "booking-hotel",
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "ss"
+    },
+    {
+      "id": "pk-travel-airbnb",
+      "enabled": true,
+      "domainFilter": "*.airbnb.*",
+      "label": "Airbnb: Listing",
+      "titleParsingRegEx": "(?:.+?)\\s*-\\s*(.+?)\\s*-\\s*Airbnb",
+      "urlParsingRegEx": "rooms/(\\d+)",
+      "groupNameSource": "smart_manual",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": "airbnb-listing",
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-travel-hotels-com",
+      "enabled": true,
+      "domainFilter": "*.hotels.com",
+      "label": "Hotels.com: Search",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_manual",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "query_param",
+      "urlQueryParamName": "destination"
+    }
+  ]
+}

--- a/src/data/packs/pk-travel-trains-fr.json
+++ b/src/data/packs/pk-travel-trains-fr.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-travel-trains-fr",
+    "name": {
+      "en": "Train tickets (FR/EU)",
+      "fr": "Billets de train (FR/EU)",
+      "es": "Billetes de tren (FR/EU)"
+    },
+    "description": {
+      "en": "Group SNCF Connect and Trainline tabs by route or destination.",
+      "fr": "Regroupe les onglets SNCF Connect et Trainline par itinéraire ou destination.",
+      "es": "Agrupa las pestañas de SNCF Connect y Trainline por ruta o destino."
+    },
+    "categoryId": "travel"
+  },
+  "domainRules": [
+    {
+      "id": "pk-travel-sncf-connect",
+      "enabled": true,
+      "domainFilter": "*.sncf-connect.com",
+      "label": "SNCF Connect",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-travel-trainline",
+      "enabled": true,
+      "domainFilter": "*.trainline.*",
+      "label": "Trainline: Route",
+      "titleParsingRegEx": "(.+?)\\s*[-|]\\s*Trainline",
+      "urlParsingRegEx": "/trains?/([^/?#]+)",
+      "groupNameSource": "smart_label",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "travel",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/tests/packs-validate.test.ts
+++ b/tests/packs-validate.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { packCategoriesFileSchema, packFileSchema } from '@/schemas/pack';
+
+const PACKS_DIR = path.resolve(__dirname, '../src/data/packs');
+
+describe('packs data files', () => {
+  const files = fs.readdirSync(PACKS_DIR).filter(f => f.endsWith('.json'));
+
+  it('_categories.json validates against schema', () => {
+    const data = JSON.parse(
+      fs.readFileSync(path.join(PACKS_DIR, '_categories.json'), 'utf8'),
+    );
+    const r = packCategoriesFileSchema.safeParse(data);
+    if (!r.success) console.error(JSON.stringify(r.error.issues, null, 2));
+    expect(r.success).toBe(true);
+  });
+
+  for (const f of files.filter(f => !f.startsWith('_'))) {
+    it(`${f} validates against schema`, () => {
+      const data = JSON.parse(
+        fs.readFileSync(path.join(PACKS_DIR, f), 'utf8'),
+      );
+      const r = packFileSchema.safeParse(data);
+      if (!r.success) console.error(f, JSON.stringify(r.error.issues, null, 2));
+      expect(r.success).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Boostrap le catalogue de la `PackGallery` (qui était implémentée et testée
mais sans contenu autre que le tableau vide `_categories.json`). Le composant
est maintenant alimenté par 13 catégories et 38 packs représentatifs (105
règles au total), localisés en EN/FR/ES via `LocalizedString`.

### Couverture

| Catégorie | Packs | Exemples |
|-----------|-------|----------|
| Development | 4 | GitHub, GitLab, Stack Overflow, package registries (npm/PyPI/Docker Hub) |
| Cloud & DevOps | 4 | AWS *(config 8 services)*, GCP *(config)*, Azure *(config)*, plateformes deploy (Cloudflare, Vercel, Netlify, Render) |
| Productivity | 5 | Jira, Linear, Notion, Trello/Asana/ClickUp, Google Workspace |
| Communication | 3 | Slack, Discord, visio (Zoom + Meet + Teams) |
| AI assistants | 3 | ChatGPT/Claude/Gemini, Perplexity/Phind/You.com, Hugging Face |
| Search | 2 | Google/Bing/DuckDuckGo/Brave/Kagi, Wikipedia |
| Media | 3 | YouTube, Spotify, SVOD (Netflix/Disney+/Prime) |
| Social | 3 | Reddit, X/Twitter, LinkedIn |
| Commerce | 3 | Amazon FR/COM/ES/DE, marketplaces, sites FR (Leboncoin, Back Market, Cdiscount) |
| Travel | 3 | Booking/Airbnb/Hotels.com, Skyscanner/Google Flights/Kayak, SNCF Connect/Trainline |
| Finance | 2 | Yahoo Finance/TradingView/Investing, Coinbase/Binance |
| News | 2 | Le Monde/Le Figaro/Libération, Guardian/NYT/BBC |
| Learning | 1 | Coursera/Udemy/edX/MDN |

### Choix techniques

- Critère d'inclusion : seul un site dont l'URL ou le titre porte un fragment
  sémantique stable (issue#, repo, ticket, query, ticker, destination,
  slug d'article, etc.) est éligible. Sites vitrine sans pattern réutilisable
  écartés.
- 3 packs configurables (AWS, GCP, Azure) tirent parti du moteur
  `packResolution.ts` déjà implémenté. Les labels suivent le préfixe imposé
  par `rulePattern` (ex: `aws/ec2/`) suivi d'un suffixe court non redondant.
- Réutilise massivement les presets existants de `public/data/presets.json`
  (`github-issue`, `github-repo`, `jira-ticket`, `serp-google`,
  `youtube-channel`, `amazon-product`, `coursera-course`, etc.) plutôt que
  de dupliquer les regex.
- Localisation EN/FR/ES embarquée dans les manifests (résolution gérée par
  `src/utils/packLabel.ts`, fallback `en` puis première entrée).
- Mix FR/international demandé : forte présence FR sur commerce (Leboncoin,
  Back Market), voyage (SNCF Connect), news (Le Monde, Le Figaro,
  Libération), équilibrée par les classiques internationaux.

### Garde-fou

Ajout d'un test Vitest `tests/packs-validate.test.ts` qui valide chaque
fichier pack contre `packFileSchema` au runtime, pour catcher les erreurs
de structure dès la PR sur les futurs packs.

## Test plan

- [x] `pnpm compile` passe (tsc --noEmit)
- [x] `pnpm test --run` passe (1595 tests, 129 fichiers)
- [x] `pnpm test --run tests/packs-validate.test.ts` valide tous les packs
      contre `packFileSchema` (39 tests)
- [ ] Vérification manuelle Storybook (`pnpm storybook` -> `Components/Core/Pack/PackGallery`) :
  - 13 catégories visibles, ordre conforme à `_categories.json`
  - badge `CONFIG` sur AWS, GCP, Azure
  - filtrage de la recherche (essayer `aws`, `jira`, `youtube`, `presse`)
  - compteur global affichant `~105 rules in 38 packs` quand tout est sélectionné

## Hors scope

- Intégration de `PackGallery` dans un wizard d'onboarding ou la page Import.
  Le composant reste accessible uniquement via Storybook tant que cette
  intégration UX n'est pas réalisée (à traiter dans une PR dédiée).
- UI permettant à un utilisateur de **créer** ses propres packs.

https://claude.ai/code/session_01HdjUprH35hVPK7zrXzmbhG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdjUprH35hVPK7zrXzmbhG)_