### PR TITLE
feat(importexport): add referrer tracking to import/export deeplinks

### DIFF
--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -1,4 +1,25 @@
 import { useState, useEffect } from 'react';
+import { logger } from '@/utils/logger';
+
+export const VALID_IMPORTEXPORT_ACTIONS = [
+  'import-rules',
+  'export-rules',
+  'import-sessions',
+  'export-sessions',
+  'import-workspace',
+  'export-workspace',
+] as const;
+
+export const VALID_FROM_VALUES = [
+  'home',
+  'rules',
+  'sessions',
+  'workspaces',
+  'popup',
+] as const;
+
+export type ImportExportAction = typeof VALID_IMPORTEXPORT_ACTIONS[number];
+export type ImportExportFrom = typeof VALID_FROM_VALUES[number];
 
 interface DeepLinkState {
   currentTab: string;
@@ -6,6 +27,8 @@ interface DeepLinkState {
   openRuleWizard: boolean;
   snapshotGroupId: number | null;
   restoreSessionId: string | null;
+  importExportAction: ImportExportAction | null;
+  importExportFrom: ImportExportFrom | null;
 }
 
 const VALID_SECTIONS = ['home', 'rules', 'importexport', 'sessions', 'stats', 'settings', 'workspaces'] as const;
@@ -34,12 +57,16 @@ export function useDeepLinking(): DeepLinkState & {
   setOpenRuleWizard: (open: boolean) => void;
   setSnapshotGroupId: (id: number | null) => void;
   setRestoreSessionId: (id: string | null) => void;
+  setImportExportAction: (action: ImportExportAction | null) => void;
+  setImportExportFrom: (from: ImportExportFrom | null) => void;
 } {
   const [currentTab, setCurrentTab] = useState<string>('home');
   const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
   const [openRuleWizard, setOpenRuleWizard] = useState(false);
   const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
   const [restoreSessionId, setRestoreSessionId] = useState<string | null>(null);
+  const [importExportAction, setImportExportAction] = useState<ImportExportAction | null>(null);
+  const [importExportFrom, setImportExportFrom] = useState<ImportExportFrom | null>(null);
 
   useEffect(() => {
     function applySessionsAction(params: URLSearchParams) {
@@ -60,12 +87,36 @@ export function useDeepLinking(): DeepLinkState & {
       }
     }
 
+    function applyImportExportAction(params: URLSearchParams) {
+      const rawAction = params.get('action');
+      const rawFrom = params.get('from');
+
+      if (rawAction && (VALID_IMPORTEXPORT_ACTIONS as readonly string[]).includes(rawAction)) {
+        setImportExportAction(rawAction as ImportExportAction);
+      } else {
+        if (rawAction) {
+          logger.debug('[DEEPLINK] Unknown importexport action ignored:', rawAction);
+        }
+        setImportExportAction(null);
+      }
+
+      if (rawFrom && (VALID_FROM_VALUES as readonly string[]).includes(rawFrom)) {
+        setImportExportFrom(rawFrom as ImportExportFrom);
+      } else {
+        if (rawFrom) {
+          logger.debug('[DEEPLINK] Unknown importexport from ignored:', rawFrom);
+        }
+        setImportExportFrom(null);
+      }
+    }
+
     function handleHash() {
       const parsed = parseHash(window.location.hash);
       if (!parsed) return;
       setCurrentTab(parsed.section);
       if (parsed.section === 'sessions') applySessionsAction(parsed.params);
       else if (parsed.section === 'rules') applyRulesAction(parsed.params);
+      else if (parsed.section === 'importexport') applyImportExportAction(parsed.params);
     }
 
     handleHash();
@@ -84,5 +135,9 @@ export function useDeepLinking(): DeepLinkState & {
     setSnapshotGroupId,
     restoreSessionId,
     setRestoreSessionId,
+    importExportAction,
+    setImportExportAction,
+    importExportFrom,
+    setImportExportFrom,
   };
 }

--- a/src/pages/DomainRulesPage.stories.tsx
+++ b/src/pages/DomainRulesPage.stories.tsx
@@ -53,6 +53,7 @@ const meta: Meta<typeof DomainRulesPage> = {
   args: {
     syncSettings: mockSyncSettings,
     updateRules: () => {},
+    onOpenImportRules: () => {},
   },
 };
 

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -7,7 +7,6 @@ import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { EmptyState } from '@/components/UI/EmptyState';
 import { RuleWizardModal } from '@/components/Core/DomainRule/RuleWizardModal';
-import { ImportWizard } from '@/components/UI/ImportExportWizards/ImportWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { ListToolbar } from '@/components/UI/ListToolbar';
 import { getMessage } from '@/utils/i18n';
@@ -55,6 +54,8 @@ interface DomainRulesPageProps {
   openRuleWizard?: boolean;
   /** Notifies the parent when the modal opens or closes. */
   onOpenRuleWizardChange?: (open: boolean) => void;
+  /** Opens the rules import wizard via deep-link with from=rules. */
+  onOpenImportRules: () => void;
 }
 
 /* ─── Local presentation components ──────────────────────────────────────── */
@@ -114,9 +115,9 @@ export function DomainRulesPage({
   updateRules,
   openRuleWizard,
   onOpenRuleWizardChange,
+  onOpenImportRules,
 }: DomainRulesPageProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isImportOpen, setIsImportOpen] = useState(false);
   const [editingRule, setEditingRule] = useState<DomainRule | undefined>(undefined);
   const [dragItems, setDragItems] = useState<DomainRuleSetting[] | null>(null);
 
@@ -366,7 +367,7 @@ export function DomainRulesPage({
                       <Plus size={14} />
                       {getMessage('addRule')}
                     </Button>
-                    <Button variant="soft" onClick={() => setIsImportOpen(true)}>
+                    <Button variant="soft" onClick={onOpenImportRules}>
                       <Upload size={14} />
                       {getMessage('importRulesButton')}
                     </Button>
@@ -427,12 +428,6 @@ export function DomainRulesPage({
         description={confirmDeleteDescription(deleteTarget, syncSettings.domainRules)}
       />
 
-      <ImportWizard
-        open={isImportOpen}
-        onOpenChange={setIsImportOpen}
-        existingRules={syncSettings.domainRules}
-        onImport={updateRules}
-      />
     </>
   );
 }

--- a/src/pages/HomePage.stories.tsx
+++ b/src/pages/HomePage.stories.tsx
@@ -94,6 +94,7 @@ const meta: Meta<typeof HomePage> = {
     onNavigate: () => {},
     onOpenSnapshotWizard: () => {},
     onOpenRuleWizard: () => {},
+    onOpenImportRules: () => {},
     onOpenShortcutsAside: () => {},
     onRestore: () => {},
   },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,6 +25,8 @@ export interface HomePageProps {
   onNavigate: (tab: string) => void;
   onOpenSnapshotWizard: () => void;
   onOpenRuleWizard: () => void;
+  /** Opens the rules import wizard via deep-link with from=home. */
+  onOpenImportRules: () => void;
   onOpenShortcutsAside: () => void;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
   /** Locale used by mini-stats for thousand-separator formatting. */
@@ -45,6 +47,7 @@ export function HomePage({
   onNavigate,
   onOpenSnapshotWizard,
   onOpenRuleWizard,
+  onOpenImportRules,
   onOpenShortcutsAside,
   onRestore,
   locale,
@@ -119,7 +122,7 @@ export function HomePage({
             <Flex direction="column" gap="5">
               {isEmpty && (
                 <HeroOnboarding
-                  onImportPack={() => onNavigate('importexport')}
+                  onImportPack={onOpenImportRules}
                   onCreateRule={onOpenRuleWizard}
                 />
               )}

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Grid } from '@radix-ui/themes';
 import { Download, Upload, FileText, Layers } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
@@ -11,20 +11,39 @@ import { ImportExportActionCard } from '@/components/UI/ImportExportWizards/Impo
 import { ExportWorkspaceDialog } from '@/components/UI/Workspace/ExportWorkspaceDialog';
 import { ImportWorkspaceDialog } from '@/components/UI/Workspace/ImportWorkspaceDialog';
 import { useSessions } from '@/hooks/useSessions';
+import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinking';
 import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
 
 interface ImportExportPageProps {
   syncSettings: AppSettings;
   onSettingsUpdate: (settings: AppSettings) => void;
+  /** When set, opens the matching wizard automatically (deep-link entry). */
+  deepLinkAction?: ImportExportAction | null;
+  /** Origin of the deep-link, used to navigate back when the wizard closes. */
+  deepLinkFrom?: ImportExportFrom | null;
+  /** Called once the deep-link has been consumed so the parent can clear its state. */
+  onDeepLinkConsumed?: () => void;
+  /** Section navigator used to return to the referrer once the wizard closes. */
+  onNavigate?: (tab: string) => void;
 }
 
-export function ImportExportPage({ syncSettings, onSettingsUpdate }: ImportExportPageProps) {
+export function ImportExportPage({
+  syncSettings,
+  onSettingsUpdate,
+  deepLinkAction,
+  deepLinkFrom,
+  onDeepLinkConsumed,
+  onNavigate,
+}: ImportExportPageProps) {
   const [exportOpen, setExportOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [exportSessionsOpen, setExportSessionsOpen] = useState(false);
   const [importSessionsOpen, setImportSessionsOpen] = useState(false);
   const [exportWorkspaceOpen, setExportWorkspaceOpen] = useState(false);
   const [importWorkspaceOpen, setImportWorkspaceOpen] = useState(false);
+
+  const [triggeredByDeepLink, setTriggeredByDeepLink] = useState(false);
+  const [pendingFrom, setPendingFrom] = useState<ImportExportFrom | null>(null);
 
   const { sessions } = useSessions();
 
@@ -34,6 +53,41 @@ export function ImportExportPage({ syncSettings, onSettingsUpdate }: ImportExpor
       domainRules: updatedRules
     });
   }, [syncSettings, onSettingsUpdate]);
+
+  useEffect(() => {
+    if (!deepLinkAction) return;
+
+    setPendingFrom(deepLinkFrom ?? null);
+    setTriggeredByDeepLink(true);
+
+    const action: ImportExportAction = deepLinkAction;
+    if (action === 'import-rules') setImportOpen(true);
+    else if (action === 'export-rules') setExportOpen(true);
+    else if (action === 'import-sessions') setImportSessionsOpen(true);
+    else if (action === 'export-sessions') setExportSessionsOpen(true);
+    else if (action === 'import-workspace') setImportWorkspaceOpen(true);
+    else if (action === 'export-workspace') setExportWorkspaceOpen(true);
+
+    if (typeof window !== 'undefined') {
+      window.history.replaceState(null, '', `${window.location.pathname}#importexport`);
+    }
+    onDeepLinkConsumed?.();
+  }, [deepLinkAction, deepLinkFrom, onDeepLinkConsumed]);
+
+  const makeCloseHandler = useCallback(
+    (setter: (open: boolean) => void) => (open: boolean) => {
+      setter(open);
+      if (open) return;
+      if (!triggeredByDeepLink) return;
+      const from = pendingFrom;
+      setTriggeredByDeepLink(false);
+      setPendingFrom(null);
+      if (from && from !== 'popup' && onNavigate) {
+        onNavigate(from);
+      }
+    },
+    [triggeredByDeepLink, pendingFrom, onNavigate],
+  );
 
   return (
     <PageLayout
@@ -107,35 +161,35 @@ export function ImportExportPage({ syncSettings, onSettingsUpdate }: ImportExpor
 
           <ExportWizard
             open={exportOpen}
-            onOpenChange={setExportOpen}
+            onOpenChange={makeCloseHandler(setExportOpen)}
             rules={syncSettings.domainRules}
           />
 
           <ImportWizard
             open={importOpen}
-            onOpenChange={setImportOpen}
+            onOpenChange={makeCloseHandler(setImportOpen)}
             existingRules={syncSettings.domainRules}
             onImport={handleImport}
           />
 
           <ExportSessionsWizard
             open={exportSessionsOpen}
-            onOpenChange={setExportSessionsOpen}
+            onOpenChange={makeCloseHandler(setExportSessionsOpen)}
           />
 
           <ImportSessionsWizard
             open={importSessionsOpen}
-            onOpenChange={setImportSessionsOpen}
+            onOpenChange={makeCloseHandler(setImportSessionsOpen)}
           />
 
           <ExportWorkspaceDialog
             open={exportWorkspaceOpen}
-            onOpenChange={setExportWorkspaceOpen}
+            onOpenChange={makeCloseHandler(setExportWorkspaceOpen)}
           />
 
           <ImportWorkspaceDialog
             open={importWorkspaceOpen}
-            onOpenChange={setImportWorkspaceOpen}
+            onOpenChange={makeCloseHandler(setImportWorkspaceOpen)}
           />
         </Box>
       )}

--- a/src/pages/SessionsPage.stories.tsx
+++ b/src/pages/SessionsPage.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta<typeof SessionsPage> = {
   parameters: { layout: 'fullscreen' },
   args: {
     syncSettings: mockSyncSettings,
+    onOpenImportSessions: () => {},
   },
 };
 

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -6,7 +6,6 @@ import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { move } from '@dnd-kit/helpers';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { EmptyState } from '@/components/UI/EmptyState';
-import { ImportSessionsWizard } from '@/components/UI/ImportExportWizards/ImportSessionsWizard';
 import { SessionCard } from '@/components/Core/Session/SessionCard';
 import { SessionEditDialog } from '@/components/Core/Session/SessionEditDialog';
 import { SnapshotWizard } from '@/components/UI/SessionWizards/SnapshotWizard';
@@ -43,6 +42,8 @@ interface SessionsPageProps {
   restoreSessionId?: string | null;
   /** Called to clear the restore deep-link once consumed. */
   onRestoreSessionIdChange?: (id: string | null) => void;
+  /** Opens the sessions import wizard via deep-link with from=sessions. */
+  onOpenImportSessions: () => void;
 }
 
 function SectionHeader({ icon: Icon, titleKey, count }: { icon: LucideIcon; titleKey: string; count: number }) {
@@ -293,11 +294,11 @@ export function SessionsPage({
   onSnapshotGroupIdChange,
   restoreSessionId,
   onRestoreSessionIdChange,
+  onOpenImportSessions,
 }: SessionsPageProps) {
   const { sessions, isLoaded, createSession, renameSession, removeSession, reload, updateOrder } = useSessions();
   // Internal open state; initialized from external prop so the wizard opens immediately on mount.
   const [snapshotOpen, setSnapshotOpen] = useState(snapshotWizardOpen);
-  const [importSessionsOpen, setImportSessionsOpen] = useState(false);
 
   // Sync: if the external prop becomes true after mount (e.g. user already on sessions tab),
   // open the wizard.
@@ -450,7 +451,7 @@ export function SessionsPage({
                     <Camera size={14} />
                     {getMessage('sessionSnapshotButton')}
                   </Button>
-                  <Button variant="soft" onClick={() => setImportSessionsOpen(true)}>
+                  <Button variant="soft" onClick={onOpenImportSessions}>
                     <Upload size={14} />
                     {getMessage('importSessionsButton')}
                   </Button>
@@ -504,11 +505,6 @@ export function SessionsPage({
               />
             </Flex>
           )}
-
-          <ImportSessionsWizard
-            open={importSessionsOpen}
-            onOpenChange={setImportSessionsOpen}
-          />
 
           <SnapshotWizard
             open={snapshotOpen}

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -13,6 +13,7 @@ import { ShortcutsControlProvider } from '@/contexts/ShortcutsControlContext';
 import { useSettings } from '@/hooks/useSettings.js';
 import { useStatistics } from '@/hooks/useStatistics.js';
 import { useDeepLinking } from '@/hooks/useDeepLinking.js';
+import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinking.js';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts.js';
 import { getMessage } from '@/utils/i18n';
 import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
@@ -48,6 +49,8 @@ export function OptionsContent() {
         openRuleWizard, setOpenRuleWizard,
         snapshotGroupId, setSnapshotGroupId,
         restoreSessionId, setRestoreSessionId,
+        importExportAction, setImportExportAction,
+        importExportFrom, setImportExportFrom,
     } = useDeepLinking();
 
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
@@ -74,6 +77,28 @@ export function OptionsContent() {
         setOpenSnapshotWizard(true);
         handleTabChange('sessions');
     }, [setOpenSnapshotWizard, handleTabChange]);
+
+    const navigateToImportExportAction = useCallback((action: ImportExportAction, from: ImportExportFrom) => {
+        window.location.hash = `importexport?action=${action}&from=${from}`;
+        setCurrentTab('importexport');
+    }, [setCurrentTab]);
+
+    const handleOpenImportRulesFromHome = useCallback(() => {
+        navigateToImportExportAction('import-rules', 'home');
+    }, [navigateToImportExportAction]);
+
+    const handleOpenImportRulesFromRules = useCallback(() => {
+        navigateToImportExportAction('import-rules', 'rules');
+    }, [navigateToImportExportAction]);
+
+    const handleOpenImportSessionsFromSessions = useCallback(() => {
+        navigateToImportExportAction('import-sessions', 'sessions');
+    }, [navigateToImportExportAction]);
+
+    const handleImportExportConsumed = useCallback(() => {
+        setImportExportAction(null);
+        setImportExportFrom(null);
+    }, [setImportExportAction, setImportExportFrom]);
 
     const handleRestoreFromHome = useCallback(async (session: Session, target: HomeRestoreTarget) => {
         if (target === 'custom') {
@@ -159,6 +184,7 @@ export function OptionsContent() {
                                 onNavigate={handleTabChange}
                                 onOpenSnapshotWizard={handleOpenSnapshotWizardFromHome}
                                 onOpenRuleWizard={handleOpenRuleWizardFromHome}
+                                onOpenImportRules={handleOpenImportRulesFromHome}
                                 onOpenShortcutsAside={openShortcuts}
                                 onRestore={handleRestoreFromHome}
                             />
@@ -169,10 +195,18 @@ export function OptionsContent() {
                                 updateRules={updateRules}
                                 openRuleWizard={openRuleWizard}
                                 onOpenRuleWizardChange={setOpenRuleWizard}
+                                onOpenImportRules={handleOpenImportRulesFromRules}
                             />
                         )}
                         {currentTab === 'importexport' && (
-                            <ImportExportPage syncSettings={settings} onSettingsUpdate={updateSettings} />
+                            <ImportExportPage
+                                syncSettings={settings}
+                                onSettingsUpdate={updateSettings}
+                                deepLinkAction={importExportAction}
+                                deepLinkFrom={importExportFrom}
+                                onDeepLinkConsumed={handleImportExportConsumed}
+                                onNavigate={handleTabChange}
+                            />
                         )}
                         {currentTab === 'sessions' && (
                             <SessionsPage
@@ -183,6 +217,7 @@ export function OptionsContent() {
                                 onSnapshotGroupIdChange={setSnapshotGroupId}
                                 restoreSessionId={restoreSessionId}
                                 onRestoreSessionIdChange={setRestoreSessionId}
+                                onOpenImportSessions={handleOpenImportSessionsFromSessions}
                             />
                         )}
                         {currentTab === 'stats' && (

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -970,7 +970,9 @@ test.describe('Import / Export', () => {
       await page.goto(`chrome-extension://${extensionId}/options.html#rules`);
       await page.waitForLoadState('domcontentloaded');
 
-      const importBtn = page.getByTestId('page-rules-empty').getByRole('button', { name: /import/i });
+      const emptyState = page.getByTestId('page-rules-empty');
+      await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
+      const importBtn = emptyState.getByRole('button', { name: /import/i });
       await importBtn.click();
 
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
@@ -991,7 +993,9 @@ test.describe('Import / Export', () => {
       await page.goto(`chrome-extension://${extensionId}/options.html#sessions`);
       await page.waitForLoadState('domcontentloaded');
 
-      const importBtn = page.getByTestId('page-sessions-empty').getByRole('button', { name: /import/i });
+      const emptyState = page.getByTestId('page-sessions-empty');
+      await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
+      const importBtn = emptyState.getByRole('button', { name: /import/i });
       await importBtn.click();
 
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
@@ -1013,7 +1017,9 @@ test.describe('Import / Export', () => {
       await page.goto(`chrome-extension://${extensionId}/options.html#home`);
       await page.waitForLoadState('domcontentloaded');
 
-      await page.getByTestId('home-hero-import').click();
+      const heroImport = page.getByTestId('home-hero-import');
+      await heroImport.waitFor({ state: 'visible', timeout: 10_000 });
+      await heroImport.click();
 
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
       await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -874,4 +874,155 @@ test.describe('Import / Export', () => {
       await page.close();
     });
   });
+
+  // ── Deep-link referrer (#importexport?action=...&from=...) ───────────────
+
+  test.describe('Deep-link referrer', () => {
+    test('opens the rules import wizard when navigating with action=import-rules', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#importexport?action=import-rules&from=home`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      // The wizard's "File" radio is part of the source step.
+      await expect(page.getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
+
+      // Hash should be cleaned of the action/from params after consumption.
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+
+      await page.close();
+    });
+
+    test('returns to the referrer section when the wizard closes (from=home)', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#importexport?action=import-rules&from=home`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+
+      // Close the wizard via Escape.
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#home');
+      await expect(page.getByTestId('page-home')).toBeVisible();
+
+      await page.close();
+    });
+
+    test('stays on importexport when from=popup', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#importexport?action=import-rules&from=popup`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+      await expect(page.getByTestId('page-import-export')).toBeVisible();
+
+      await page.close();
+    });
+
+    test('does not re-open the wizard after a refresh on #importexport', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(
+        `chrome-extension://${extensionId}/options.html#importexport?action=import-rules&from=home`,
+      );
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+
+      // Navigate back to importexport without params and reload.
+      await page.evaluate(() => { window.location.hash = '#importexport'; });
+      await page.reload();
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page.getByTestId('page-import-export')).toBeVisible();
+      await expect(page.getByRole('dialog')).toBeHidden();
+
+      await page.close();
+    });
+
+    test('rules empty-state Import button uses the deep-link mechanism', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(`chrome-extension://${extensionId}/options.html#rules`);
+      await page.waitForLoadState('domcontentloaded');
+
+      const importBtn = page.getByTestId('page-rules-empty').getByRole('button', { name: /import/i });
+      await importBtn.click();
+
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#rules');
+
+      await page.close();
+    });
+
+    test('sessions empty-state Import button uses the deep-link mechanism', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      const page = await extensionContext.newPage();
+      await page.goto(`chrome-extension://${extensionId}/options.html#sessions`);
+      await page.waitForLoadState('domcontentloaded');
+
+      const importBtn = page.getByTestId('page-sessions-empty').getByRole('button', { name: /import/i });
+      await importBtn.click();
+
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#sessions');
+
+      await page.close();
+    });
+
+    test('home onboarding "Import pack" button opens the rules wizard with from=home', async ({
+      extensionContext,
+      extensionId,
+    }) => {
+      // No rules seeded -> hero is shown.
+      const page = await extensionContext.newPage();
+      await page.goto(`chrome-extension://${extensionId}/options.html#home`);
+      await page.waitForLoadState('domcontentloaded');
+
+      await page.getByTestId('home-hero-import').click();
+
+      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog')).toBeHidden();
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#home');
+
+      await page.close();
+    });
+  });
 });

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -78,6 +78,17 @@ async function clearDomainRules(extensionContext: any): Promise<void> {
   await new Promise(r => setTimeout(r, 200));
 }
 
+/** Clear all sessions from storage. Used by deep-link tests that rely on the
+ *  sessions empty state appearing. Without this a prior spec may have left
+ *  sessions in chrome.storage.local. */
+async function clearSessions(extensionContext: any): Promise<void> {
+  const sw = extensionContext.serviceWorkers()[0];
+  await sw.evaluate(async () => {
+    await chrome.storage.local.set({ sessions: [] });
+  });
+  await new Promise(r => setTimeout(r, 200));
+}
+
 /** Open the Import wizard dialog from the Import/Export page. */
 async function openImportWizard(page: any): Promise<void> {
   await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
@@ -989,6 +1000,8 @@ test.describe('Import / Export', () => {
       extensionContext,
       extensionId,
     }) => {
+      await clearSessions(extensionContext);
+
       const page = await extensionContext.newPage();
       await page.goto(`chrome-extension://${extensionId}/options.html#sessions`);
       await page.waitForLoadState('domcontentloaded');

--- a/tests/hooks/useDeepLinking.test.ts
+++ b/tests/hooks/useDeepLinking.test.ts
@@ -40,7 +40,7 @@ describe('useDeepLinking — hash on mount', () => {
     expect(result.current.currentTab).toBe('importexport');
   });
 
-  it.each(['home', 'rules', 'sessions', 'stats', 'settings', 'importexport'])(
+  it.each(['home', 'rules', 'sessions', 'stats', 'settings', 'importexport', 'workspaces'])(
     'accepts the valid section %s',
     (section) => {
       window.location.hash = `#${section}`;
@@ -179,6 +179,81 @@ describe('useDeepLinking — restore deep link', () => {
     expect(result.current.restoreSessionId).toBe('s-1');
     act(() => result.current.setRestoreSessionId(null));
     expect(result.current.restoreSessionId).toBeNull();
+  });
+});
+
+describe('useDeepLinking — import/export deep link', () => {
+  it('starts with both fields null when there is no hash', () => {
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.importExportAction).toBeNull();
+    expect(result.current.importExportFrom).toBeNull();
+  });
+
+  it.each([
+    'import-rules',
+    'export-rules',
+    'import-sessions',
+    'export-sessions',
+    'import-workspace',
+    'export-workspace',
+  ] as const)('parses valid action %s', (action) => {
+    window.location.hash = `#importexport?action=${action}&from=home`;
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('importexport');
+    expect(result.current.importExportAction).toBe(action);
+    expect(result.current.importExportFrom).toBe('home');
+  });
+
+  it.each(['home', 'rules', 'sessions', 'workspaces', 'popup'] as const)(
+    'parses valid from %s',
+    (from) => {
+      window.location.hash = `#importexport?action=import-rules&from=${from}`;
+      const { result } = renderHook(() => useDeepLinking());
+      expect(result.current.importExportFrom).toBe(from);
+    },
+  );
+
+  it('treats an unknown action as null', () => {
+    window.location.hash = '#importexport?action=bogus&from=home';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.importExportAction).toBeNull();
+    expect(result.current.importExportFrom).toBe('home');
+  });
+
+  it('treats a spoofed from as null', () => {
+    window.location.hash = '#importexport?action=import-rules&from=evil';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.importExportAction).toBe('import-rules');
+    expect(result.current.importExportFrom).toBeNull();
+  });
+
+  it('returns both fields null when params are missing', () => {
+    window.location.hash = '#importexport';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('importexport');
+    expect(result.current.importExportAction).toBeNull();
+    expect(result.current.importExportFrom).toBeNull();
+  });
+
+  it('reacts to a hashchange after mount', () => {
+    const { result } = renderHook(() => useDeepLinking());
+    act(() => setHash('#importexport?action=export-sessions&from=sessions'));
+    expect(result.current.currentTab).toBe('importexport');
+    expect(result.current.importExportAction).toBe('export-sessions');
+    expect(result.current.importExportFrom).toBe('sessions');
+  });
+
+  it('exposes setters to clear both fields', () => {
+    window.location.hash = '#importexport?action=import-rules&from=home';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.importExportAction).toBe('import-rules');
+    expect(result.current.importExportFrom).toBe('home');
+    act(() => {
+      result.current.setImportExportAction(null);
+      result.current.setImportExportFrom(null);
+    });
+    expect(result.current.importExportAction).toBeNull();
+    expect(result.current.importExportFrom).toBeNull();
   });
 });
 

--- a/tests/pages/HomePage.test.tsx
+++ b/tests/pages/HomePage.test.tsx
@@ -81,6 +81,7 @@ const baseHandlers = {
   onNavigate: vi.fn(),
   onOpenSnapshotWizard: vi.fn(),
   onOpenRuleWizard: vi.fn(),
+  onOpenImportRules: vi.fn(),
   onOpenShortcutsAside: vi.fn(),
   onRestore: vi.fn(),
 };
@@ -216,6 +217,19 @@ describe('HomePage interactions', () => {
     );
     fireEvent.click(screen.getByTestId('home-hero-create-rule'));
     expect(baseHandlers.onOpenRuleWizard).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the rules import wizard when "import pack" is clicked from the onboarding hero', () => {
+    wrap(
+      <HomePage
+        syncSettings={baseSettings}
+        statisticsAggregates={baseAggregates}
+        {...baseHandlers}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('home-hero-import'));
+    expect(baseHandlers.onOpenImportRules).toHaveBeenCalledTimes(1);
+    expect(baseHandlers.onNavigate).not.toHaveBeenCalled();
   });
 
   it('navigates to sessions when clicking on the sessions mini-stat', () => {


### PR DESCRIPTION
Deep-link the import/export wizards from outside the I/O page so that
closing the wizard returns the user to where they came from.

Hash form: #importexport?action=<action>&from=<from> where action is one
of import-rules, export-rules, import-sessions, export-sessions,
import-workspace, export-workspace and from is one of home, rules,
sessions, workspaces, popup. Unknown values are ignored. The action
param is stripped from the URL once consumed (replaceState) so a refresh
will not re-open the wizard.

The empty-state Import buttons in DomainRulesPage and SessionsPage and
the HeroOnboarding "Import pack" CTA on HomePage now route through this
mechanism; their local wizard mounts have been removed and ImportExportPage
is the single mount point. from=popup keeps the user on the I/O page,
matching the existing openOptionsWithHash flow.