### PR TITLE
feat(import): integrate PackGallery as third source mode in ImportWizard

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -255,6 +255,8 @@
 
   "sourceFile": { "message": "File" },
   "sourceText": { "message": "Text" },
+  "sourcePack": { "message": "Pack" },
+  "importRulesStepSourcePackDescription": { "message": "Select one or more packs from the built-in catalog." },
   "packGallerySearchPlaceholder": { "message": "Search for a pack..." },
   "packGalleryEmptyState": { "message": "No pack available" },
   "packGallerySearchNoResult": { "message": "No pack matches your search" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -255,6 +255,8 @@
 
   "sourceFile": { "message": "Archivo" },
   "sourceText": { "message": "Texto" },
+  "sourcePack": { "message": "Pack" },
+  "importRulesStepSourcePackDescription": { "message": "Seleccione uno o varios packs del catálogo integrado." },
   "packGallerySearchPlaceholder": { "message": "Buscar un pack..." },
   "packGalleryEmptyState": { "message": "Ningún pack disponible" },
   "packGallerySearchNoResult": { "message": "Ningún pack coincide con tu búsqueda" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -255,6 +255,8 @@
 
   "sourceFile": { "message": "Fichier" },
   "sourceText": { "message": "Texte" },
+  "sourcePack": { "message": "Pack" },
+  "importRulesStepSourcePackDescription": { "message": "Sélectionnez un ou plusieurs packs depuis le catalogue intégré." },
   "packGallerySearchPlaceholder": { "message": "Rechercher un pack..." },
   "packGalleryEmptyState": { "message": "Aucun pack disponible" },
   "packGallerySearchNoResult": { "message": "Aucun pack ne correspond à votre recherche" },

--- a/src/components/UI/ImportExportWizards/ImportWizard.stories.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.stories.tsx
@@ -112,3 +112,18 @@ export const ImportWizardConflictDuplicate: Story = {
     if (dupOption) await userEvent.click(dupOption);
   },
 };
+
+// Opens the wizard pre-selected on the Pack tab in the wider 960px dialog.
+export const ImportWizardLargeWithPack: Story = {
+  args: { open: true, initialSourceMode: 'pack' },
+};
+
+// Opens the wider dialog on the File tab to verify the layout still feels balanced.
+export const ImportWizardSizeFile: Story = {
+  args: { open: true, initialSourceMode: 'file' },
+};
+
+// Opens the wider dialog on the Text tab to verify the textarea behaviour.
+export const ImportWizardSizeText: Story = {
+  args: { open: true, initialSourceMode: 'text' },
+};

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -9,18 +9,25 @@ import {
 } from '@/utils/importClassification';
 import { generateUUID } from '@/utils/utils';
 import type { DomainRuleSetting } from '@/types/syncSettings';
+import { PackGallery } from '@/components/Core/Pack/PackGallery/PackGallery';
+import { usePacks } from '@/hooks/usePacks';
 import { ImportWizardShell } from './ImportWizardShell';
 import {
   useImportWizardState,
   type NormalizedClassification,
 } from './useImportWizardState';
+import type { SourceMode } from './Source';
 import { RuleRow, ConflictRuleRow } from './RuleImportRows';
+
+const RULES_AVAILABLE_MODES: readonly SourceMode[] = ['file', 'text', 'pack'];
 
 interface ImportWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   existingRules: DomainRuleSetting[];
   onImport: (updatedRules: DomainRuleSetting[]) => void;
+  /** When provided, the wizard opens on this source mode instead of `'file'`. */
+  initialSourceMode?: SourceMode;
 }
 
 const validateRulesPayload = (raw: unknown) => {
@@ -43,15 +50,23 @@ const classifyRules = (
   };
 };
 
-export function ImportWizard({ open, onOpenChange, existingRules, onImport }: ImportWizardProps) {
+export function ImportWizard({
+  open,
+  onOpenChange,
+  existingRules,
+  onImport,
+  initialSourceMode,
+}: ImportWizardProps) {
   const state = useImportWizardState<DomainRuleSetting, ConflictingRule>({
     open,
     existingItems: existingRules,
     validatePayload: validateRulesPayload,
     classify: classifyRules,
+    initialSourceMode,
   });
 
-  const { classification, conflictMode, newSelection } = state;
+  const { packs, categories } = usePacks();
+  const { classification, conflictMode, newSelection, source } = state;
 
   const executeImport = useCallback(() => {
     if (!classification) return;
@@ -105,6 +120,12 @@ export function ImportWizard({ open, onOpenChange, existingRules, onImport }: Im
       countLabelKey="rulesToImportCount"
       overwriteWarningKey="overwriteWarning"
       state={state}
+      maxWidth="min(960px, 95vw)"
+      fillHeight
+      availableModes={RULES_AVAILABLE_MODES}
+      packGalleryNode={
+        <PackGallery packs={packs} categories={categories} source={source} />
+      }
       renderNewItem={(rule) => (
         <RuleRow
           key={rule.id}

--- a/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
@@ -11,7 +11,7 @@ import {
   ImportCountLabel,
 } from './Classification';
 import { ImportWizardFooter } from './ImportWizardFooter';
-import { ImportedNoteCallout, SourceStep } from './Source';
+import { ImportedNoteCallout, SourceStep, type SourceMode } from './Source';
 import type { ImportWizardState } from './useImportWizardState';
 
 export interface ImportWizardShellLabels {
@@ -37,6 +37,14 @@ interface ImportWizardShellProps<TItem extends { id: string }, TConflict>
   renderConflictingItem: (conflict: TConflict) => React.ReactNode;
   renderIdenticalItem: (item: TItem) => React.ReactNode;
   onConfirm: () => void;
+  /** Override the dialog max width forwarded to `WizardModal`. */
+  maxWidth?: number | string;
+  /** When true, force the dialog to a fixed height so inner content can size deterministically. */
+  fillHeight?: boolean;
+  /** Source modes exposed in the segmented control. Defaults to `['file', 'text']`. */
+  availableModes?: readonly SourceMode[];
+  /** Optional gallery node rendered when `sourceMode === 'pack'`. */
+  packGalleryNode?: React.ReactNode;
 }
 
 /**
@@ -63,6 +71,10 @@ export function ImportWizardShell<TItem extends { id: string }, TConflict>({
   renderConflictingItem,
   renderIdenticalItem,
   onConfirm,
+  maxWidth,
+  fillHeight,
+  availableModes,
+  packGalleryNode,
 }: ImportWizardShellProps<TItem, TConflict>) {
   const {
     step,
@@ -82,6 +94,8 @@ export function ImportWizardShell<TItem extends { id: string }, TConflict>({
       icon={icon}
       title={title}
       description={getMessage(stepDescriptionKeys[step])}
+      maxWidth={maxWidth}
+      fillHeight={fillHeight}
     >
       <WizardModal.Body>
         {step === 0 && (
@@ -89,6 +103,8 @@ export function ImportWizardShell<TItem extends { id: string }, TConflict>({
             source={source}
             textareaPlaceholder={textareaPlaceholder}
             successCountMessageKey={successCountMessageKey}
+            availableModes={availableModes}
+            packGalleryNode={packGalleryNode}
           />
         )}
 

--- a/src/components/UI/ImportExportWizards/Source/SourceModeSegmented.tsx
+++ b/src/components/UI/ImportExportWizards/Source/SourceModeSegmented.tsx
@@ -3,19 +3,34 @@ import { SegmentedControl } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import type { JsonSourceInputState, SourceMode } from './useJsonSourceInput';
 
+const DEFAULT_AVAILABLE_MODES: readonly SourceMode[] = ['file', 'text'];
+
+const MODE_LABEL_KEYS: Record<SourceMode, string> = {
+  file: 'sourceFile',
+  text: 'sourceText',
+  pack: 'sourcePack',
+};
+
 interface SourceModeSegmentedProps<T> {
   source: JsonSourceInputState<T>;
+  availableModes?: readonly SourceMode[];
 }
 
-export function SourceModeSegmented<T>({ source }: SourceModeSegmentedProps<T>) {
+export function SourceModeSegmented<T>({
+  source,
+  availableModes = DEFAULT_AVAILABLE_MODES,
+}: SourceModeSegmentedProps<T>) {
   return (
     <SegmentedControl.Root
       value={source.sourceMode}
       onValueChange={(v: string) => source.setSourceMode(v as SourceMode)}
       size="2"
     >
-      <SegmentedControl.Item value="file">{getMessage('sourceFile')}</SegmentedControl.Item>
-      <SegmentedControl.Item value="text">{getMessage('sourceText')}</SegmentedControl.Item>
+      {availableModes.map((mode) => (
+        <SegmentedControl.Item key={mode} value={mode}>
+          {getMessage(MODE_LABEL_KEYS[mode])}
+        </SegmentedControl.Item>
+      ))}
     </SegmentedControl.Root>
   );
 }

--- a/src/components/UI/ImportExportWizards/Source/SourceStep.tsx
+++ b/src/components/UI/ImportExportWizards/Source/SourceStep.tsx
@@ -5,31 +5,37 @@ import { FileDropZone } from './FileDropZone';
 import { JsonTextArea } from './JsonTextArea';
 import { ImportErrorCallout } from './ImportErrorCallout';
 import { ImportSuccessCallout } from './ImportSuccessCallout';
-import type { JsonSourceInputState } from './useJsonSourceInput';
+import type { JsonSourceInputState, SourceMode } from './useJsonSourceInput';
 
 interface SourceStepProps<T extends readonly unknown[]> {
   source: JsonSourceInputState<T>;
   textareaPlaceholder: string;
   successCountMessageKey: string;
+  availableModes?: readonly SourceMode[];
+  packGalleryNode?: React.ReactNode;
 }
 
 /**
- * Step 0 of an import wizard: mode segmented control + either file drop zone
- * or JSON textarea, followed by success / error callouts.
+ * Step 0 of an import wizard: mode segmented control + either file drop zone,
+ * JSON textarea, or pack gallery, followed by success / error callouts.
  */
 export function SourceStep<T extends readonly unknown[]>({
   source,
   textareaPlaceholder,
   successCountMessageKey,
+  availableModes,
+  packGalleryNode,
 }: SourceStepProps<T>) {
   return (
     <Box mt="4">
-      <SourceModeSegmented source={source} />
+      <SourceModeSegmented source={source} availableModes={availableModes} />
 
       <Box mt="3">
-        {source.sourceMode === 'file'
-          ? <FileDropZone source={source} />
-          : <JsonTextArea source={source} placeholder={textareaPlaceholder} />}
+        {source.sourceMode === 'file' && <FileDropZone source={source} />}
+        {source.sourceMode === 'text' && (
+          <JsonTextArea source={source} placeholder={textareaPlaceholder} />
+        )}
+        {source.sourceMode === 'pack' && packGalleryNode}
       </Box>
 
       <ImportErrorCallout source={source} />

--- a/src/components/UI/ImportExportWizards/Source/useJsonSourceInput.ts
+++ b/src/components/UI/ImportExportWizards/Source/useJsonSourceInput.ts
@@ -35,8 +35,9 @@ export interface JsonSourceInputState<T> {
  */
 export function useJsonSourceInput<T>(
   validate: (raw: unknown) => JsonSourceValidationResult<T>,
+  initialSourceMode: SourceMode = 'file',
 ): JsonSourceInputState<T> {
-  const [sourceMode, setSourceMode] = useState<SourceMode>('file');
+  const [sourceMode, setSourceMode] = useState<SourceMode>(initialSourceMode);
   const [jsonText, setJsonText] = useState('');
   const [parsedData, setParsedData] = useState<T | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -121,14 +122,14 @@ export function useJsonSourceInput<T>(
   }, [handleFileRead]);
 
   const reset = useCallback(() => {
-    setSourceMode('file');
+    setSourceMode(initialSourceMode);
     setJsonText('');
     setParsedData(null);
     setParseError(null);
     setImportedNote(null);
     setFileName(null);
     setIsDragOver(false);
-  }, []);
+  }, [initialSourceMode]);
 
   return {
     sourceMode,

--- a/src/components/UI/ImportExportWizards/useImportWizardState.ts
+++ b/src/components/UI/ImportExportWizards/useImportWizardState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   computeImportCount,
   useImportClassification,
@@ -9,6 +9,7 @@ import {
   useJsonSourceInput,
   type JsonSourceInputState,
   type JsonSourceValidationResult,
+  type SourceMode,
 } from './Source';
 
 /**
@@ -32,6 +33,8 @@ interface UseImportWizardStateOptions<TItem extends { id: string }, TConflict> {
   ) => NormalizedClassification<TItem, TConflict>;
   /** Extra reset action triggered when the dialog is opened (e.g. async data load). */
   onReset?: () => void;
+  /** Initial source mode forwarded to `useJsonSourceInput`. Defaults to `'file'`. */
+  initialSourceMode?: SourceMode;
 }
 
 export interface ImportWizardState<TItem extends { id: string }, TConflict> {
@@ -60,16 +63,20 @@ export function useImportWizardState<TItem extends { id: string }, TConflict>({
   validatePayload,
   classify,
   onReset,
+  initialSourceMode,
 }: UseImportWizardStateOptions<TItem, TConflict>): ImportWizardState<TItem, TConflict> {
   const [step, setStep] = useState<0 | 1>(0);
-  const source = useJsonSourceInput<TItem[]>(validatePayload);
+  const source = useJsonSourceInput<TItem[]>(validatePayload, initialSourceMode);
   const classificationState = useImportClassification<NormalizedClassification<TItem, TConflict>>();
   const { classification, conflictMode, newSelection } = classificationState;
+
+  const previousParsedDataRef = useRef<TItem[] | null>(null);
 
   useDialogReset(open, () => {
     setStep(0);
     source.reset();
     classificationState.reset();
+    previousParsedDataRef.current = null;
     onReset?.();
   });
 
@@ -82,6 +89,16 @@ export function useImportWizardState<TItem extends { id: string }, TConflict>({
   }, [source.parsedData, existingItems, classify, classificationState, newSelection]);
 
   const goToStep0 = useCallback(() => setStep(0), []);
+
+  useEffect(() => {
+    const previousParsedData = previousParsedDataRef.current;
+    previousParsedDataRef.current = source.parsedData;
+    if (source.sourceMode !== 'pack') return;
+    if (!source.parsedData) return;
+    if (step !== 0) return;
+    if (previousParsedData === source.parsedData) return;
+    goToStep1();
+  }, [source.sourceMode, source.parsedData, step, goToStep1]);
 
   const importCount = classification
     ? computeImportCount(

--- a/src/hooks/packDataSource.ts
+++ b/src/hooks/packDataSource.ts
@@ -7,7 +7,7 @@ import categoriesData from '@/data/packs/_categories.json';
  * Files matching `_*.json` (notably `_categories.json`) are filtered out by
  * convention so they never show up as packs.
  */
-const rawPackModules = import.meta.glob('@/data/packs/*.json', {
+const rawPackModules = import.meta.glob('../data/packs/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, unknown>;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { browser } from 'wxt/browser';
 import { Box, Flex } from '@radix-ui/themes';
 import { Home } from 'lucide-react';
@@ -6,6 +6,7 @@ import { useSessions } from '@/hooks/useSessions';
 import type { AppSettings } from '@/types/syncSettings';
 import type { Session } from '@/types/session';
 import type { StatisticsAggregates } from '@/types/statistics';
+import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { HeroOnboarding } from '@/components/HomePage/HeroOnboarding';
 import { PinnedSessionsSection } from '@/components/HomePage/PinnedSessionsSection';
@@ -26,7 +27,7 @@ export interface HomePageProps {
   onOpenSnapshotWizard: () => void;
   onOpenRuleWizard: () => void;
   /** Opens the rules import wizard via deep-link with from=home. */
-  onOpenImportRules: () => void;
+  onOpenImportRules: (initialSourceMode?: SourceMode) => void;
   onOpenShortcutsAside: () => void;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
   /** Locale used by mini-stats for thousand-separator formatting. */
@@ -107,6 +108,10 @@ export function HomePage({
     onNavigate('sessions');
   };
 
+  const handleHeroImportPack = useCallback(() => {
+    onOpenImportRules('pack');
+  }, [onOpenImportRules]);
+
   return (
     <PageLayout
       titleKey="homeTab"
@@ -122,7 +127,7 @@ export function HomePage({
             <Flex direction="column" gap="5">
               {isEmpty && (
                 <HeroOnboarding
-                  onImportPack={onOpenImportRules}
+                  onImportPack={handleHeroImportPack}
                   onCreateRule={onOpenRuleWizard}
                 />
               )}

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -12,6 +12,7 @@ import { ExportWorkspaceDialog } from '@/components/UI/Workspace/ExportWorkspace
 import { ImportWorkspaceDialog } from '@/components/UI/Workspace/ImportWorkspaceDialog';
 import { useSessions } from '@/hooks/useSessions';
 import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinking';
+import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
 
 interface ImportExportPageProps {
@@ -25,6 +26,10 @@ interface ImportExportPageProps {
   onDeepLinkConsumed?: () => void;
   /** Section navigator used to return to the referrer once the wizard closes. */
   onNavigate?: (tab: string) => void;
+  /** Initial source mode forwarded to the rules import wizard (e.g. `'pack'` from the home hero). */
+  importRulesInitialMode?: SourceMode | null;
+  /** Called when the rules import wizard closes so the parent can clear `importRulesInitialMode`. */
+  onImportRulesClosed?: () => void;
 }
 
 export function ImportExportPage({
@@ -34,6 +39,8 @@ export function ImportExportPage({
   deepLinkFrom,
   onDeepLinkConsumed,
   onNavigate,
+  importRulesInitialMode,
+  onImportRulesClosed,
 }: ImportExportPageProps) {
   const [exportOpen, setExportOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
@@ -167,9 +174,13 @@ export function ImportExportPage({
 
           <ImportWizard
             open={importOpen}
-            onOpenChange={makeCloseHandler(setImportOpen)}
+            onOpenChange={(open) => {
+              makeCloseHandler(setImportOpen)(open);
+              if (!open) onImportRulesClosed?.();
+            }}
             existingRules={syncSettings.domainRules}
             onImport={handleImport}
+            initialSourceMode={importRulesInitialMode ?? undefined}
           />
 
           <ExportSessionsWizard

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -17,6 +17,7 @@ import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinkin
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts.js';
 import { getMessage } from '@/utils/i18n';
 import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
+import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 
 import { Sidebar } from '@/components/UI/Sidebar/Sidebar';
 import type { SidebarItem } from '@/components/UI/Sidebar/Sidebar';
@@ -56,6 +57,7 @@ export function OptionsContent() {
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
     const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
     const [shortcutsAsideOpen, setShortcutsAsideOpen] = useState(false);
+    const [importInitialMode, setImportInitialMode] = useState<SourceMode | null>(null);
 
     const updateRules = useCallback((newRules: DomainRuleSettings) => {
         updateSettings({ domainRules: newRules });
@@ -83,11 +85,13 @@ export function OptionsContent() {
         setCurrentTab('importexport');
     }, [setCurrentTab]);
 
-    const handleOpenImportRulesFromHome = useCallback(() => {
+    const handleOpenImportRulesFromHome = useCallback((initialSourceMode?: SourceMode) => {
+        setImportInitialMode(initialSourceMode ?? null);
         navigateToImportExportAction('import-rules', 'home');
     }, [navigateToImportExportAction]);
 
     const handleOpenImportRulesFromRules = useCallback(() => {
+        setImportInitialMode(null);
         navigateToImportExportAction('import-rules', 'rules');
     }, [navigateToImportExportAction]);
 
@@ -99,6 +103,10 @@ export function OptionsContent() {
         setImportExportAction(null);
         setImportExportFrom(null);
     }, [setImportExportAction, setImportExportFrom]);
+
+    const handleImportRulesClosed = useCallback(() => {
+        setImportInitialMode(null);
+    }, []);
 
     const handleRestoreFromHome = useCallback(async (session: Session, target: HomeRestoreTarget) => {
         if (target === 'custom') {
@@ -206,6 +214,8 @@ export function OptionsContent() {
                                 deepLinkFrom={importExportFrom}
                                 onDeepLinkConsumed={handleImportExportConsumed}
                                 onNavigate={handleTabChange}
+                                importRulesInitialMode={importInitialMode}
+                                onImportRulesClosed={handleImportRulesClosed}
                             />
                         )}
                         {currentTab === 'sessions' && (

--- a/tests/components/ImportWizard.integration.test.tsx
+++ b/tests/components/ImportWizard.integration.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { DomainRuleSetting } from '../../src/types/syncSettings';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string, subs?: string[]) =>
+    subs?.length ? `${key}(${subs.join(',')})` : key,
+  ),
+  getPluralMessage: vi.fn((count: number, oneKey: string, manyKey: string) =>
+    count === 1 ? oneKey : manyKey,
+  ),
+}));
+
+vi.mock('@/utils/toast', () => ({
+  showSuccessToast: vi.fn(),
+}));
+
+const samplePackRule = {
+  id: 'pack-rule-1',
+  domainFilter: 'example.com',
+  label: 'Sample',
+  titleParsingRegEx: '(.+)',
+  urlParsingRegEx: '',
+  groupNameSource: 'title',
+  deduplicationMatchMode: 'exact',
+  presetId: null,
+  enabled: true,
+};
+
+const samplePack = {
+  version: 1,
+  pack: { id: 'pack-sample', name: 'Sample pack', categoryId: 'cloud' },
+  domainRules: [samplePackRule],
+};
+
+vi.mock('../../src/hooks/packDataSource', () => ({
+  getPackSourceEntries: () => [
+    { path: '/src/data/packs/sample.json', data: samplePack },
+  ],
+  getCategoriesSource: () => ({
+    categories: [{ id: 'cloud', label: 'Cloud' }],
+  }),
+}));
+
+import { ImportWizard } from '../../src/components/UI/ImportExportWizards/ImportWizard';
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ImportWizard integration : mode pack', () => {
+  it('rend la PackGallery quand initialSourceMode=pack', () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+        initialSourceMode="pack"
+      />,
+    );
+    expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
+  });
+
+  it("avance à l'étape 1 quand l'utilisateur sélectionne un pack et confirme", () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+        initialSourceMode="pack"
+      />,
+    );
+
+    const checkbox = screen.getByTestId('pack-card-pack-sample-checkbox');
+    fireEvent.click(checkbox);
+
+    const confirmBtn = screen.getByTestId('pack-gallery-confirm');
+    fireEvent.click(confirmBtn);
+
+    expect(screen.getByText('newRulesGroup')).toBeInTheDocument();
+    expect(screen.queryByTestId('pack-gallery')).not.toBeInTheDocument();
+  });
+
+  it("permet de revenir à l'étape 0 via Précédent en gardant la galerie visible", () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+        initialSourceMode="pack"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('pack-card-pack-sample-checkbox'));
+    fireEvent.click(screen.getByTestId('pack-gallery-confirm'));
+    expect(screen.getByText('newRulesGroup')).toBeInTheDocument();
+
+    const previousBtn = screen.getByText('previous').closest('button')!;
+    fireEvent.click(previousBtn);
+
+    expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
+  });
+
+  it('ne touche pas au mode par défaut quand initialSourceMode est absent', () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('pack-gallery')).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/SourceModeSegmented.test.tsx
+++ b/tests/components/SourceModeSegmented.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { JsonSourceInputState, SourceMode } from '../../src/components/UI/ImportExportWizards/Source';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+import { SourceModeSegmented } from '../../src/components/UI/ImportExportWizards/Source/SourceModeSegmented';
+
+function makeSource(
+  overrides: Partial<JsonSourceInputState<unknown[]>> = {},
+): JsonSourceInputState<unknown[]> {
+  return {
+    sourceMode: 'file',
+    setSourceMode: vi.fn(),
+    jsonText: '',
+    parsedData: null,
+    parseError: null,
+    importedNote: null,
+    fileName: null,
+    isDragOver: false,
+    fileInputRef: { current: null },
+    handleTextChange: vi.fn(),
+    handleDrop: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleBrowse: vi.fn(),
+    handleFileSelect: vi.fn(),
+    reset: vi.fn(),
+    ...overrides,
+  };
+}
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+describe('SourceModeSegmented', () => {
+  it('affiche les 3 onglets quand availableModes inclut pack', () => {
+    const source = makeSource();
+    wrap(
+      <SourceModeSegmented
+        source={source}
+        availableModes={['file', 'text', 'pack']}
+      />,
+    );
+    expect(screen.getAllByText('i18n(sourceFile)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('i18n(sourceText)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('i18n(sourcePack)').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("affiche 2 onglets quand availableModes est omis (compatibilité ascendante)", () => {
+    const source = makeSource();
+    wrap(<SourceModeSegmented source={source} />);
+    expect(screen.getAllByText('i18n(sourceFile)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('i18n(sourceText)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('i18n(sourcePack)')).not.toBeInTheDocument();
+  });
+
+  it("appelle setSourceMode('pack') au clic sur l'onglet Pack", () => {
+    const setSourceMode = vi.fn<(mode: SourceMode) => void>();
+    const source = makeSource({ setSourceMode });
+    wrap(
+      <SourceModeSegmented
+        source={source}
+        availableModes={['file', 'text', 'pack']}
+      />,
+    );
+    const packLabels = screen.getAllByText('i18n(sourcePack)');
+    fireEvent.click(packLabels[0]);
+    expect(setSourceMode).toHaveBeenCalledWith('pack');
+  });
+});

--- a/tests/components/SourceStep.test.tsx
+++ b/tests/components/SourceStep.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import type { JsonSourceInputState, SourceMode } from '../../src/components/UI/ImportExportWizards/Source';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+import { SourceStep } from '../../src/components/UI/ImportExportWizards/Source/SourceStep';
+
+function makeSource(
+  overrides: Partial<JsonSourceInputState<unknown[]>> = {},
+): JsonSourceInputState<unknown[]> {
+  return {
+    sourceMode: 'file',
+    setSourceMode: vi.fn<(mode: SourceMode) => void>(),
+    jsonText: '',
+    parsedData: null,
+    parseError: null,
+    importedNote: null,
+    fileName: null,
+    isDragOver: false,
+    fileInputRef: { current: null },
+    handleTextChange: vi.fn(),
+    handleDrop: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleBrowse: vi.fn(),
+    handleFileSelect: vi.fn(),
+    reset: vi.fn(),
+    ...overrides,
+  };
+}
+
+const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+
+const PACK_TESTID = 'pack-gallery-mock';
+const PACK_NODE = <div data-testid={PACK_TESTID}>pack gallery</div>;
+
+describe('SourceStep', () => {
+  it('rend le packGalleryNode quand le mode est pack', () => {
+    const source = makeSource({ sourceMode: 'pack' });
+    wrap(
+      <SourceStep
+        source={source}
+        textareaPlaceholder="placeholder"
+        successCountMessageKey="rulesFoundCount"
+        availableModes={['file', 'text', 'pack']}
+        packGalleryNode={PACK_NODE}
+      />,
+    );
+    expect(screen.getByTestId(PACK_TESTID)).toBeInTheDocument();
+  });
+
+  it('ignore packGalleryNode quand le mode est file', () => {
+    const source = makeSource({ sourceMode: 'file' });
+    wrap(
+      <SourceStep
+        source={source}
+        textareaPlaceholder="placeholder"
+        successCountMessageKey="rulesFoundCount"
+        availableModes={['file', 'text', 'pack']}
+        packGalleryNode={PACK_NODE}
+      />,
+    );
+    expect(screen.queryByTestId(PACK_TESTID)).not.toBeInTheDocument();
+  });
+
+  it('ignore packGalleryNode quand le mode est text', () => {
+    const source = makeSource({ sourceMode: 'text' });
+    wrap(
+      <SourceStep
+        source={source}
+        textareaPlaceholder="placeholder"
+        successCountMessageKey="rulesFoundCount"
+        availableModes={['file', 'text', 'pack']}
+        packGalleryNode={PACK_NODE}
+      />,
+    );
+    expect(screen.queryByTestId(PACK_TESTID)).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/useImportWizardState.test.tsx
+++ b/tests/components/useImportWizardState.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { JsonSourceValidationResult } from '../../src/components/UI/ImportExportWizards/Source';
+
+vi.mock('@/utils/i18n', () => ({
+  getMessage: vi.fn((key: string) => `i18n(${key})`),
+}));
+
+import { useImportWizardState } from '../../src/components/UI/ImportExportWizards/useImportWizardState';
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const validate = (raw: unknown): JsonSourceValidationResult<Item[]> => {
+  const items = (raw as { items?: Item[] }).items ?? [];
+  return { data: items, note: null };
+};
+
+const classify = (imported: Item[]) => ({
+  newItems: imported,
+  conflictingItems: [],
+  identicalItems: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useImportWizardState', () => {
+  it('transmet initialSourceMode à useJsonSourceInput', () => {
+    const { result } = renderHook(() =>
+      useImportWizardState<Item, never>({
+        open: true,
+        existingItems: [],
+        validatePayload: validate,
+        classify,
+        initialSourceMode: 'pack',
+      }),
+    );
+    expect(result.current.source.sourceMode).toBe('pack');
+  });
+
+  it("avance automatiquement à l'étape 1 quand mode=pack et parsedData devient non-null", () => {
+    const { result } = renderHook(() =>
+      useImportWizardState<Item, never>({
+        open: true,
+        existingItems: [],
+        validatePayload: validate,
+        classify,
+        initialSourceMode: 'pack',
+      }),
+    );
+    expect(result.current.step).toBe(0);
+    act(() => {
+      result.current.source.handleTextChange('{"items":[{"id":"1","label":"a"}]}');
+    });
+    expect(result.current.source.parsedData).toEqual([{ id: '1', label: 'a' }]);
+    expect(result.current.step).toBe(1);
+  });
+
+  it("reste à l'étape 0 quand mode=file et parsedData devient non-null", () => {
+    const { result } = renderHook(() =>
+      useImportWizardState<Item, never>({
+        open: true,
+        existingItems: [],
+        validatePayload: validate,
+        classify,
+      }),
+    );
+    expect(result.current.source.sourceMode).toBe('file');
+    act(() => {
+      result.current.source.handleTextChange('{"items":[{"id":"1","label":"a"}]}');
+    });
+    expect(result.current.source.parsedData).toEqual([{ id: '1', label: 'a' }]);
+    expect(result.current.step).toBe(0);
+  });
+});

--- a/tests/components/useJsonSourceInput.test.tsx
+++ b/tests/components/useJsonSourceInput.test.tsx
@@ -129,4 +129,17 @@ describe('useJsonSourceInput', () => {
     act(() => result.current.setSourceMode('pack'));
     expect(result.current.sourceMode).toBe('pack');
   });
+
+  it('initialSourceMode positionne le mode initial', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate, 'pack'));
+    expect(result.current.sourceMode).toBe('pack');
+  });
+
+  it('reset() restaure initialSourceMode et non file en dur', () => {
+    const { result } = renderHook(() => useJsonSourceInput(validate, 'pack'));
+    act(() => result.current.setSourceMode('text'));
+    expect(result.current.sourceMode).toBe('text');
+    act(() => result.current.reset());
+    expect(result.current.sourceMode).toBe('pack');
+  });
 });

--- a/tests/pages/HomePage.test.tsx
+++ b/tests/pages/HomePage.test.tsx
@@ -219,7 +219,7 @@ describe('HomePage interactions', () => {
     expect(baseHandlers.onOpenRuleWizard).toHaveBeenCalledTimes(1);
   });
 
-  it('opens the rules import wizard when "import pack" is clicked from the onboarding hero', () => {
+  it('opens the rules import wizard with initialSourceMode=pack from the onboarding hero', () => {
     wrap(
       <HomePage
         syncSettings={baseSettings}
@@ -229,6 +229,7 @@ describe('HomePage interactions', () => {
     );
     fireEvent.click(screen.getByTestId('home-hero-import'));
     expect(baseHandlers.onOpenImportRules).toHaveBeenCalledTimes(1);
+    expect(baseHandlers.onOpenImportRules).toHaveBeenCalledWith('pack');
     expect(baseHandlers.onNavigate).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Wires the existing PackGallery into the rules ImportWizard so users can
import rules from the built-in pack catalog without manipulating JSON.
The home onboarding hero now opens the wizard pre-selected on the Pack
tab, the dialog widens to min(960px, 95vw) with fillHeight, and the
PackGallery confirm button auto-advances to the classification step.

Closes #254