### PR TITLE
feat(e2e-doc-scenarios): expand matrix to 3 locales x 2 themes (#259)

### DIFF
--- a/e2e-doc-scenarios/helpers/doc-fixture.ts
+++ b/e2e-doc-scenarios/helpers/doc-fixture.ts
@@ -5,6 +5,10 @@
  * host-resolver mapped to the local mimetic-sites server, so tabs opened by
  * the scenario towards `http://github.com/...`, `http://youtube.com/...` etc.
  * are served from disk and the extension's domain rules match real-looking URLs.
+ *
+ * Reads `(locale, theme)` from the project's `metadata` (see
+ * `playwright.doc.config.ts`); the scenario reuses that metadata so every
+ * (locale x theme) variant runs in its own persistent context.
  */
 import { test as base, type BrowserContext } from '@playwright/test';
 import {
@@ -13,26 +17,60 @@ import {
 } from '../../e2e-shared/extension-loader.js';
 import { getExtensionId } from '../../e2e-shared/extension-id.js';
 import { getHostResolverRules } from '../fixtures/sites-server.js';
+import type { Locale, Theme } from '../../e2e-shared/routing/types.js';
 
 export interface DocScenarioFixtures {
   extensionContext: BrowserContext;
   extensionId: string;
+  locale: Locale;
+  theme: Theme;
 }
 
-const LOCALE_LANG: Record<string, string> = {
+const LOCALE_LANG: Record<Locale, string> = {
   en: 'en-US',
   fr: 'fr-FR',
   es: 'es-ES',
 };
 
+interface ProjectMetadata {
+  locale?: Locale;
+  theme?: Theme;
+}
+
+function readProjectMetadata(metadata: unknown): { locale: Locale; theme: Theme } {
+  const meta = (metadata ?? {}) as ProjectMetadata;
+  if (!meta.locale || !meta.theme) {
+    throw new Error(
+      'doc-scenarios project metadata must declare both `locale` and `theme` (see playwright.doc.config.ts)',
+    );
+  }
+  return { locale: meta.locale, theme: meta.theme };
+}
+
 export const test = base.extend<DocScenarioFixtures>({
+  locale: [
+    async ({}, use, testInfo) => {
+      const { locale } = readProjectMetadata(testInfo.project.metadata);
+      await use(locale);
+    },
+    { scope: 'worker' },
+  ],
+
+  theme: [
+    async ({}, use, testInfo) => {
+      const { theme } = readProjectMetadata(testInfo.project.metadata);
+      await use(theme);
+    },
+    { scope: 'worker' },
+  ],
+
   extensionContext: [
     async ({}, use, testInfo) => {
-      const locale = testInfo.project.name;
-      const lang = LOCALE_LANG[locale] ?? 'en-US';
+      const { locale, theme } = readProjectMetadata(testInfo.project.metadata);
+      const lang = LOCALE_LANG[locale];
 
       const { context, userDataDir } = await launchExtension({
-        label: `doc-scenarios-${locale}`,
+        label: `doc-scenarios-${locale}-${theme}`,
         lang,
         deterministicRendering: true,
         viewport: { width: 1280, height: 800 },

--- a/e2e-doc-scenarios/helpers/ui-actions.ts
+++ b/e2e-doc-scenarios/helpers/ui-actions.ts
@@ -5,7 +5,7 @@
  * (no direct storage seeding). Avoids `waitForTimeout` in favour of explicit
  * waits, so scenarios remain deterministic on CI.
  */
-import type { BrowserContext, Page } from '@playwright/test';
+import type { BrowserContext, Locator, Page } from '@playwright/test';
 import { injectLocaleOverride } from '../../e2e-shared/locale-injector.js';
 import { applyTheme, type Theme } from '../../e2e-shared/theme.js';
 import { waitForServiceWorker } from '../../e2e-shared/extension-id.js';
@@ -176,4 +176,158 @@ export async function waitForGroupingSettled(
     }
     await new Promise((r) => setTimeout(r, 200));
   }
+}
+
+/**
+ * Wait for an in-app toast to appear in the current page.
+ *
+ * Defaults to the Radix toast-viewport selector (data-testid="toast-viewport"),
+ * then waits for at least one toast root to be visible. Optionally narrow to a
+ * given variant ("success" | "error" | "info") via the `variant` argument.
+ */
+export async function waitForToast(
+  page: Page,
+  options: { variant?: 'success' | 'error' | 'info'; timeoutMs?: number } = {},
+): Promise<Locator> {
+  const { variant, timeoutMs = 5_000 } = options;
+  await page
+    .getByTestId('toast-viewport')
+    .waitFor({ state: 'attached', timeout: timeoutMs });
+  const toast = variant
+    ? page.getByTestId(`toast-${variant}`)
+    : page.locator('[data-testid^="toast-"][data-variant]');
+  await toast.first().waitFor({ state: 'visible', timeout: timeoutMs });
+  return toast.first();
+}
+
+/**
+ * Hover a session card's name (HoverCard trigger) and wait for the HoverCard
+ * panel to appear so the resulting capture is stable.
+ */
+export async function hoverSessionCardName(
+  page: Page,
+  sessionId: string,
+): Promise<void> {
+  const trigger = page.getByTestId(`session-card-${sessionId}-name`);
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.hover();
+  await page.locator('[data-radix-hover-card-content], [role="dialog"][data-state="open"]').first().waitFor({
+    state: 'visible',
+    timeout: 3_000,
+  }).catch(async () => {
+    // Some Radix builds expose the content with a different attribute set;
+    // fall back to a short stabilisation pause so the screenshot still picks
+    // up the freshly-rendered panel.
+    await page.waitForTimeout(400);
+  });
+}
+
+/**
+ * Toggle a domain rule's "enabled" Switch by rule id.
+ *
+ * The Switch lives inside the rule card and is targeted via aria-label since
+ * it currently has no dedicated data-testid.
+ */
+export async function toggleRuleEnabled(page: Page, ruleId: string): Promise<void> {
+  const card = page.getByTestId(`rule-card-${ruleId}`);
+  const toggle = card.getByRole('switch').first();
+  await toggle.click();
+}
+
+/**
+ * Click the pin button on a session card. Best-effort: relies on the card
+ * being currently visible and not in the renaming state.
+ */
+export async function pinSession(page: Page, sessionId: string): Promise<void> {
+  await page.getByTestId(`session-card-${sessionId}-btn-pin`).click();
+  await page.getByTestId(`session-card-${sessionId}-btn-unpin`).waitFor({
+    state: 'visible',
+    timeout: 3_000,
+  });
+}
+
+/**
+ * Resolve the testid suffix (uuid) of the first session card visible on the
+ * sessions list. Walks from the `-name` element, whose testid is
+ * `session-card-{uuid}-name`, and strips the suffix.
+ */
+export async function getFirstSessionId(page: Page): Promise<string> {
+  const nameEl = page.locator('[data-testid^="session-card-"][data-testid$="-name"]').first();
+  await nameEl.waitFor({ state: 'visible' });
+  const testid = await nameEl.getAttribute('data-testid');
+  if (!testid) {
+    throw new Error('Could not read data-testid from the first session card name');
+  }
+  return testid.replace(/^session-card-/, '').replace(/-name$/, '');
+}
+
+/**
+ * Type a query into the sessions list search input and wait for the filtered
+ * list to update.
+ */
+export async function fillSessionsSearch(
+  page: Page,
+  query: string,
+): Promise<void> {
+  const input = page.getByTestId('page-sessions-search');
+  await input.click();
+  await input.fill(query);
+  // Search filtering is purely client-side: a single animation frame is
+  // enough for the React re-render to commit before we capture.
+  await page.waitForTimeout(150);
+}
+
+/** Open the rules export wizard from the Import/Export page. */
+export async function openExportRulesWizard(page: Page): Promise<void> {
+  const card = page.getByTestId('page-import-export-card-export-rules');
+  await card.getByRole('button').first().click();
+  // Both export wizards share the WizardModal frame: wait for the dialog title.
+  await page.getByRole('dialog').first().waitFor({ state: 'visible' });
+}
+
+/** Open the rules import wizard from the Import/Export page. */
+export async function openImportRulesWizard(page: Page): Promise<void> {
+  const card = page.getByTestId('page-import-export-card-import-rules');
+  await card.getByRole('button').first().click();
+  await page.getByRole('dialog').first().waitFor({ state: 'visible' });
+}
+
+/**
+ * Switch the active import wizard from File mode to Text mode and paste the
+ * supplied JSON into the textarea.
+ */
+export async function pasteImportJson(page: Page, json: string): Promise<void> {
+  const dialog = page.getByRole('dialog').first();
+  // Segmented control item labelled "Text" (i18n-driven, so query by role).
+  await dialog
+    .locator('[role="radiogroup"], [role="tablist"], [data-radix-segmented-control-root]')
+    .first()
+    .waitFor({ state: 'visible' })
+    .catch(() => {});
+  // The segmented control items use role="radio" or "tab" depending on
+  // Radix internals; querying by visible text via the radiogroup labels is
+  // brittle, so we click the second SegmentedControl item directly.
+  const segmentedItems = dialog.locator('button, [role="tab"], [role="radio"]').filter({
+    hasText: /./,
+  });
+  // Heuristic: the first two items are "File" and "Text" (others optional).
+  await segmentedItems.nth(1).click();
+  const textarea = dialog.locator('textarea').first();
+  await textarea.waitFor({ state: 'visible' });
+  await textarea.fill(json);
+  // Validation runs on each input change; small breath so the success
+  // callout is rendered before capture.
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Advance the import wizard from step 0 (source) to step 1 (classification)
+ * by clicking the "Next" button in the dialog footer.
+ */
+export async function importWizardNextToClassification(page: Page): Promise<void> {
+  const dialog = page.getByRole('dialog').first();
+  await dialog.getByRole('button').last().click();
+  // Radix renders step 1 inside the same dialog; wait for the
+  // classification scroll area to appear.
+  await page.waitForTimeout(300);
 }

--- a/e2e-doc-scenarios/helpers/ui-actions.ts
+++ b/e2e-doc-scenarios/helpers/ui-actions.ts
@@ -285,6 +285,36 @@ export async function openExportRulesWizard(page: Page): Promise<void> {
   await page.getByRole('dialog').first().waitFor({ state: 'visible' });
 }
 
+/**
+ * Stub `window.showSaveFilePicker` (FileSystem Access API) so the export's
+ * file path resolves silently without opening a native save dialog. The fake
+ * handle's `write` / `close` are no-ops, so the export's success path runs
+ * to completion (toast shown, dialog closed) without any I/O or user input.
+ *
+ * Idempotent: re-calling on a page that already has the stub is safe.
+ */
+export async function stubShowSaveFilePicker(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type FakeWritable = { write: (data: unknown) => Promise<void>; close: () => Promise<void> };
+    type FakeHandle = { createWritable: () => Promise<FakeWritable> };
+    (window as unknown as { showSaveFilePicker: () => Promise<FakeHandle> }).showSaveFilePicker = async () => ({
+      createWritable: async () => ({
+        write: async () => {},
+        close: async () => {},
+      }),
+    });
+  });
+}
+
+/**
+ * Click the rules export wizard's primary "Export" (file) button. Caller is
+ * expected to have stubbed `showSaveFilePicker` beforehand to avoid the
+ * native save-dialog blocking the test.
+ */
+export async function exportRulesToFile(page: Page): Promise<void> {
+  await page.getByTestId('wizard-export-rules-btn-export').click();
+}
+
 /** Open the rules import wizard from the Import/Export page. */
 export async function openImportRulesWizard(page: Page): Promise<void> {
   const card = page.getByTestId('page-import-export-card-import-rules');

--- a/e2e-doc-scenarios/playwright.doc.config.ts
+++ b/e2e-doc-scenarios/playwright.doc.config.ts
@@ -1,8 +1,9 @@
 /**
  * Playwright config for the narrative documentation pipeline.
  *
- * Phase 1: only `en × dark` is wired up. The matrix (3 locales × 2 themes)
- * will be expanded once the scenario set stabilises.
+ * Phase 2.1 wires the full matrix: 3 locales (en, fr, es) x 2 themes (dark, light).
+ * Each project carries its (locale, theme) pair via `metadata`, consumed by the
+ * fixture and the scenario; one project => one persistent Chromium context.
  *
  * The local fixtures HTTP server is started in `globalSetup` and stopped in
  * `globalTeardown`, so every scenario can rely on it being available on
@@ -12,6 +13,7 @@ import { defineConfig } from '@playwright/test';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import * as fs from 'fs';
+import type { Locale, Theme } from '../e2e-shared/routing/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,6 +26,21 @@ if (!fs.existsSync(path.join(extensionPath, 'manifest.json'))) {
   );
   process.exit(1);
 }
+
+const LOCALES: Locale[] = ['en', 'fr', 'es'];
+const THEMES: Theme[] = ['dark', 'light'];
+
+export interface DocScenarioProjectMetadata {
+  locale: Locale;
+  theme: Theme;
+}
+
+const projects = LOCALES.flatMap((locale) =>
+  THEMES.map((theme) => ({
+    name: `${locale}-${theme}`,
+    metadata: { locale, theme } satisfies DocScenarioProjectMetadata,
+  })),
+);
 
 export default defineConfig({
   testDir: './scenarios',
@@ -43,5 +60,5 @@ export default defineConfig({
     viewport: { width: 1280, height: 800 },
   },
 
-  projects: [{ name: 'en' }],
+  projects,
 });

--- a/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
@@ -1,14 +1,19 @@
 /**
- * Main narrative journey — Phase 1 (en × dark only).
+ * Main narrative journey — Phase 2.1 (3 locales x 2 themes).
  *
  * Six acts walking from a freshly-installed extension to advanced use, with
  * captures organised by `captureStep`. Rule creation happens through the
  * actual wizard UI; tab opening uses the mimetic-sites server (real-looking
  * URLs resolved locally via Chromium's `--host-resolver-rules`).
  *
- * Captures that depend on transient or unimplemented states are skipped in
- * Phase 1 and tracked in the scenario README; future phases (3 locales × 2
- * themes, satellite scenarios, audit/sync commands) extend this baseline.
+ * Locale and theme are read from the project metadata declared in
+ * `playwright.doc.config.ts`; one project => one persistent Chromium context,
+ * resulting in 6 isolated runs.
+ *
+ * Captures requiring features that do not yet exist in the source (rule-
+ * creation toast, grouping toast with undo, sessions snapshot multi-step
+ * wizard, file-picker driven export-success toast) remain deferred and are
+ * documented in `user-stories/doc-scenarios/clarifications.md`.
  */
 import { test } from '../helpers/doc-fixture.js';
 import { waitForServiceWorker } from '../../e2e-shared/extension-id.js';
@@ -20,23 +25,32 @@ import { writeScenarioReadme } from '../helpers/scenario-readme.js';
 import {
   dismissRuleWizard,
   fillRuleWizardStep1,
+  fillSessionsSearch,
   fillSnapshotName,
   fillSnapshotNotes,
+  getFirstSessionId,
+  hoverSessionCardName,
+  importWizardNextToClassification,
+  openExportRulesWizard,
   openExtensionPage,
+  openImportRulesWizard,
   openMimeticTab,
   openRuleWizard,
   openSnapshotWizard,
+  pasteImportJson,
+  pinSession,
   ruleWizardNextToOptions,
   ruleWizardNextToSummary,
   saveSnapshotWizard,
   selectConfigurationMode,
+  toggleRuleEnabled,
   waitForGroupingSettled,
 } from '../helpers/ui-actions.js';
 import { MAIN_JOURNEY_MANIFEST } from './00-main-journey.routing.js';
 
 /**
  * Minimal rule fixture used to populate the list and exercise grouping.
- * Mirrors the schema from `src/types/syncSettings.ts` → DomainRuleSetting.
+ * Mirrors the schema from `src/types/syncSettings.ts` -> DomainRuleSetting.
  */
 const SEED_RULES = [
   {
@@ -101,10 +115,9 @@ const SCENARIO_ID = '00-main-journey';
 
 test.describe.configure({ mode: 'serial' });
 
-test('main journey — en × dark', async ({ extensionContext, extensionId }, testInfo) => {
-  const locale = (testInfo.project.name as 'en' | 'fr' | 'es') ?? 'en';
-  const theme = 'dark' as const;
-
+test('main journey', async (
+  { extensionContext, extensionId, locale, theme },
+) => {
   startScenario({
     id: SCENARIO_ID,
     locale,
@@ -118,7 +131,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await chrome.storage.local.clear();
   });
 
-  await test.step('Act 1 — Empty state', async () => {
+  await test.step('Act 1 - Empty state', async () => {
     const popupPage = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -127,7 +140,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
       theme,
     );
     await captureStep(popupPage, 'popup-empty', {
-      description: 'Popup at first launch — no rules, statistics at zero.',
+      description: 'Popup at first launch (no rules, statistics at zero).',
     });
     await popupPage.close();
 
@@ -186,7 +199,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await importExportPage.close();
   });
 
-  await test.step('Act 2 — Rule wizard, all configuration modes', async () => {
+  await test.step('Act 2 - Rule wizard, all configuration modes', async () => {
     const rulesPage = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -201,7 +214,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await openRuleWizard(rulesPage);
     await captureStep(rulesPage, 'rules-wizard-step1-identity', {
       force: 10,
-      description: 'Rule wizard — step 1 (identity fields).',
+      description: 'Rule wizard step 1 (identity fields).',
     });
     await fillRuleWizardStep1(rulesPage, {
       label: 'GitHub',
@@ -210,18 +223,18 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await selectConfigurationMode(rulesPage, 'preset');
     await captureStep(rulesPage, 'rules-wizard-step2-mode-preset', {
       force: 11,
-      description: 'Rule wizard — step 2, Preset mode selected.',
+      description: 'Rule wizard step 2, Preset mode selected.',
     });
     await selectConfigurationMode(rulesPage, 'ask');
     await ruleWizardNextToOptions(rulesPage);
     await captureStep(rulesPage, 'rules-wizard-step3-options', {
       force: 12,
-      description: 'Rule wizard — step 3 (options: deduplication, etc.).',
+      description: 'Rule wizard step 3 (options: deduplication, etc.).',
     });
     await ruleWizardNextToSummary(rulesPage);
     await captureStep(rulesPage, 'rules-wizard-step4-summary', {
       force: 13,
-      description: 'Rule wizard — step 4 (summary before save).',
+      description: 'Rule wizard step 4 (summary before save).',
     });
     await dismissRuleWizard(rulesPage);
 
@@ -234,7 +247,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await selectConfigurationMode(rulesPage, 'ask');
     await captureStep(rulesPage, 'rules-wizard-step2-mode-ask', {
       force: 15,
-      description: 'Rule wizard — step 2, Ask mode selected.',
+      description: 'Rule wizard step 2, Ask mode selected.',
     });
     await dismissRuleWizard(rulesPage);
 
@@ -247,13 +260,13 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await selectConfigurationMode(rulesPage, 'manual');
     await captureStep(rulesPage, 'rules-wizard-step2-mode-manual', {
       force: 16,
-      description: 'Rule wizard — step 2, Manual mode (regex fields visible).',
+      description: 'Rule wizard step 2, Manual mode (regex fields visible).',
     });
     await dismissRuleWizard(rulesPage);
 
     // Seed the four rules so Act 3 can exercise grouping and the list view
     // is populated with a representative state. SEED_RULES mirrors the
-    // schema from src/types/syncSettings.ts → DomainRuleSetting.
+    // schema from src/types/syncSettings.ts -> DomainRuleSetting.
     await sw.evaluate(async (rules) => {
       await chrome.storage.local.set({ domainRules: rules });
     }, SEED_RULES);
@@ -283,7 +296,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await popupPage.close();
   });
 
-  await test.step('Act 3 — Real usage, mimetic tabs', async () => {
+  await test.step('Act 3 - Real usage, mimetic tabs', async () => {
     const tabUrls = [
       'http://github.com/repo-readme.html',
       'http://github.com/repo-issues.html',
@@ -331,7 +344,7 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     void openedTabs;
   });
 
-  await test.step('Act 4 — Sessions snapshot', async () => {
+  await test.step('Act 4 - Sessions snapshot', async () => {
     const sessionsPage = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -359,8 +372,29 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
       force: 33,
       description: 'Sessions list with one snapshot freshly created.',
     });
+
+    // Card-level captures: relative time + HoverCard.
+    const sessionId = await getFirstSessionId(sessionsPage);
+    await captureStep(sessionsPage, 'sessions-card-relative-time', {
+      force: 34,
+      description: 'Session card showing relative time and metadata.',
+      elementSelector: `[data-testid="session-card-${sessionId}"]`,
+    });
+
+    await hoverSessionCardName(sessionsPage, sessionId);
+    await captureStep(sessionsPage, 'sessions-card-hovercard', {
+      force: 35,
+      description: 'HoverCard open on the session card name.',
+    });
+    // Move the cursor away to dismiss the HoverCard before the next capture.
+    await sessionsPage.mouse.move(0, 0);
+    await sessionsPage.waitForTimeout(200);
+
     await sessionsPage.close();
 
+    // Popup pin onboarding hint: with sessions present but none pinned,
+    // PopupProfilesList renders the "no pinned profiles yet" callout
+    // (data-testid="popup-pinned-empty").
     const popupPage = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -368,13 +402,43 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
       locale,
       theme,
     );
-    await captureStep(popupPage, 'popup-with-profiles', {
-      description: 'Popup showing the session-related actions in the toolbar.',
+    await popupPage
+      .getByTestId('popup-pinned-empty')
+      .waitFor({ state: 'visible' })
+      .catch(async () => {
+        // Empty hint is collapsible; expand it if needed.
+        const toggle = popupPage.getByTestId('popup-pinned-empty-toggle');
+        if (await toggle.count()) {
+          await toggle.click();
+          await popupPage.getByTestId('popup-pinned-empty').waitFor({ state: 'visible' });
+        }
+      });
+    await captureStep(popupPage, 'sessions-pin-onboarding', {
+      force: 36,
+      description: 'Popup pin onboarding hint (sessions exist but none pinned yet).',
     });
     await popupPage.close();
+
+    // Pin the snapshot to expose the "list with pinned" state.
+    const sessionsPage2 = await openExtensionPage(
+      extensionContext,
+      extensionId,
+      'sessions',
+      locale,
+      theme,
+    );
+    await sessionsPage2
+      .getByTestId('page-sessions-list')
+      .waitFor({ state: 'visible' });
+    await pinSession(sessionsPage2, sessionId);
+    await captureStep(sessionsPage2, 'sessions-list-with-pinned', {
+      force: 37,
+      description: 'Sessions list with one pinned profile.',
+    });
+    await sessionsPage2.close();
   });
 
-  await test.step('Act 5 — Import / Export', async () => {
+  await test.step('Act 5 - Import / Export', async () => {
     const page = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -389,10 +453,64 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
       force: 40,
       description: 'Import/Export page once rules and a session exist.',
     });
+
+    // Open the rules export wizard and capture the selection step.
+    await openExportRulesWizard(page);
+    await captureStep(page, 'export-wizard-selection', {
+      force: 41,
+      description: 'Rules export wizard, selection step (all rules pre-selected).',
+    });
+    await page.keyboard.press('Escape');
+    await page.getByRole('dialog').first().waitFor({ state: 'hidden' }).catch(() => {});
+
+    // Open the import wizard, switch to Text mode, and paste a rules payload.
+    await openImportRulesWizard(page);
+    const samplePayload = JSON.stringify(
+      {
+        domainRules: [
+          {
+            label: 'Stack Overflow',
+            domainFilter: 'stackoverflow.com',
+            titleParsingRegEx: '',
+            urlParsingRegEx: '',
+            groupNameSource: 'smart_label',
+            deduplicationMatchMode: 'exact',
+            deduplicationEnabled: true,
+            color: 'gray',
+          },
+          {
+            label: 'GitHub',
+            domainFilter: 'github.com',
+            titleParsingRegEx: '',
+            urlParsingRegEx: '',
+            groupNameSource: 'smart_label',
+            deduplicationMatchMode: 'exact',
+            deduplicationEnabled: true,
+            color: 'green',
+          },
+        ],
+      },
+      null,
+      2,
+    );
+    await pasteImportJson(page, samplePayload);
+    await captureStep(page, 'import-wizard-paste', {
+      force: 43,
+      description: 'Rules import wizard, JSON pasted in Text mode (validated).',
+    });
+
+    await importWizardNextToClassification(page);
+    await captureStep(page, 'import-wizard-classification', {
+      force: 44,
+      description: 'Rules import wizard, classification step (new + conflicting).',
+    });
+    await page.keyboard.press('Escape');
+    await page.getByRole('dialog').first().waitFor({ state: 'hidden' }).catch(() => {});
+
     await page.close();
   });
 
-  await test.step('Act 6 — Advanced state', async () => {
+  await test.step('Act 6 - Advanced state', async () => {
     const rulesPage = await openExtensionPage(
       extensionContext,
       extensionId,
@@ -403,16 +521,59 @@ test('main journey — en × dark', async ({ extensionContext, extensionId }, te
     await rulesPage
       .getByTestId('page-rules-list')
       .waitFor({ state: 'visible' });
-    await captureStep(rulesPage, 'rules-list-final', {
+
+    // Disable one rule (Google) so the list shows a representative
+    // disabled-rule visual: dimmed card, switch off.
+    await toggleRuleEnabled(rulesPage, 'doc-rule-google');
+    await captureStep(rulesPage, 'rules-list-with-disabled', {
       force: 50,
-      description: 'Rules list at the end of the journey (advanced state).',
+      description: 'Rules list with one rule disabled (toggle off, dimmed card).',
     });
     await rulesPage.close();
+
+    // Sessions search: filter by name then by deep-search keyword.
+    const sessionsPage = await openExtensionPage(
+      extensionContext,
+      extensionId,
+      'sessions',
+      locale,
+      theme,
+    );
+    await sessionsPage
+      .getByTestId('page-sessions-list')
+      .waitFor({ state: 'visible' });
+    await fillSessionsSearch(sessionsPage, 'Morning');
+    await captureStep(sessionsPage, 'sessions-search-active', {
+      force: 51,
+      description: 'Sessions list with an active search filtering by session name.',
+    });
+    await fillSessionsSearch(sessionsPage, 'tutorial');
+    await captureStep(sessionsPage, 'sessions-search-deep', {
+      force: 52,
+      description: 'Sessions list with a deep search matching tab titles inside the snapshot.',
+    });
+    await sessionsPage.close();
+
+    const finalPage = await openExtensionPage(
+      extensionContext,
+      extensionId,
+      'rules',
+      locale,
+      theme,
+    );
+    await finalPage
+      .getByTestId('page-rules-list')
+      .waitFor({ state: 'visible' });
+    await captureStep(finalPage, 'rules-list-final', {
+      force: 60,
+      description: 'Rules list at the end of the journey (advanced state).',
+    });
+    await finalPage.close();
   });
 
   await writeScenarioReadme({
-    title: 'Main journey — `00-main-journey`',
+    title: `Main journey - \`00-main-journey\` (${locale} x ${theme})`,
     intro:
-      'Narrative walkthrough captured by `pnpm doc:scenarios`. Phase 1 covers en × dark only; the matrix expands to fr/es and light theme in a follow-up.',
+      'Narrative walkthrough captured by `pnpm doc:scenarios`. Phase 2.1 covers the full 3 locales x 2 themes matrix (en/fr/es x dark/light). Captures depending on UI features that are not yet implemented (e.g. rule-creation toast, grouping toast with undo, multi-step snapshot wizard, file-picker driven export-success toast) remain deferred and are tracked in `user-stories/doc-scenarios/clarifications.md`.',
   });
 });

--- a/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
@@ -24,6 +24,7 @@ import {
 import { writeScenarioReadme } from '../helpers/scenario-readme.js';
 import {
   dismissRuleWizard,
+  exportRulesToFile,
   fillRuleWizardStep1,
   fillSessionsSearch,
   fillSnapshotName,
@@ -43,8 +44,10 @@ import {
   ruleWizardNextToSummary,
   saveSnapshotWizard,
   selectConfigurationMode,
+  stubShowSaveFilePicker,
   toggleRuleEnabled,
   waitForGroupingSettled,
+  waitForToast,
 } from '../helpers/ui-actions.js';
 import { MAIN_JOURNEY_MANIFEST } from './00-main-journey.routing.js';
 
@@ -460,8 +463,18 @@ test('main journey', async (
       force: 41,
       description: 'Rules export wizard, selection step (all rules pre-selected).',
     });
-    await page.keyboard.press('Escape');
-    await page.getByRole('dialog').first().waitFor({ state: 'hidden' }).catch(() => {});
+
+    // Stub `showSaveFilePicker` so the file-export path resolves silently
+    // (no native save dialog), then trigger the export and capture the
+    // success toast that fires once the wizard auto-closes.
+    await stubShowSaveFilePicker(page);
+    await exportRulesToFile(page);
+    await page.getByRole('dialog').first().waitFor({ state: 'hidden' });
+    await waitForToast(page, { variant: 'success' });
+    await captureStep(page, 'export-toast-success', {
+      force: 42,
+      description: 'In-app success toast after the rules export completes.',
+    });
 
     // Open the import wizard, switch to Text mode, and paste a rules payload.
     await openImportRulesWizard(page);

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -354,6 +354,7 @@ function SessionCardFullHeader({
             color={session.isPinned ? 'indigo' : 'gray'}
             onClick={() => session.isPinned ? onUnpin?.(session) : onPin?.(session)}
             aria-label={session.isPinned ? getMessage('sessionUnpin') : getMessage('sessionPin')}
+            data-testid={`session-card-${session.id}-btn-${session.isPinned ? 'unpin' : 'pin'}`}
           >
             {session.isPinned
               ? <PinOff size={14} />

--- a/src/components/UI/ImportExportWizards/ExportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizard.tsx
@@ -37,6 +37,9 @@ export function ExportWizard({ open, onOpenChange, rules }: ExportWizardProps) {
       countLabelKey="rulesSelectedCount"
       buttonLabelKey="exportButton"
       listRole="list"
+      primaryTestId="wizard-export-rules-btn-export"
+      clipboardTestId="wizard-export-rules-btn-clipboard"
+      cancelTestId="wizard-export-rules-btn-cancel"
     >
       {rules.map((rule) => (
         <DomainRuleCard

--- a/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
@@ -24,6 +24,12 @@ interface ExportWizardShellProps<TItem extends { id: string }> {
   children: React.ReactNode;
   /** Forwarded to `SelectableListContainer` (use "list" when children are listitems). */
   listRole?: string;
+  /** data-testid forwarded to the primary (file) export button. */
+  primaryTestId?: string;
+  /** data-testid forwarded to the clipboard menu item in the split button. */
+  clipboardTestId?: string;
+  /** data-testid forwarded to the cancel button. */
+  cancelTestId?: string;
 }
 
 /**
@@ -45,6 +51,9 @@ export function ExportWizardShell<TItem extends { id: string }>({
   buttonLabelKey,
   children,
   listRole,
+  primaryTestId,
+  clipboardTestId,
+  cancelTestId,
 }: ExportWizardShellProps<TItem>) {
   const { selection, selectAll, exportNote, setExportNote, actions } = state;
 
@@ -74,6 +83,9 @@ export function ExportWizardShell<TItem extends { id: string }>({
           labelKey={buttonLabelKey}
           actions={actions}
           disabled={selection.size === 0}
+          primaryTestId={primaryTestId}
+          clipboardTestId={clipboardTestId}
+          cancelTestId={cancelTestId}
         />
       </WizardModal.Footer>
     </WizardModal>

--- a/user-stories/doc-scenarios/clarifications.md
+++ b/user-stories/doc-scenarios/clarifications.md
@@ -33,6 +33,7 @@ Cette phase étend la couverture :
   - `036-sessions-pin-onboarding.png` (popup pinned-empty hint)
   - `037-sessions-list-with-pinned.png`
   - `041-export-wizard-selection.png`
+  - `042-export-toast-success.png` (via stub de `window.showSaveFilePicker` côté page : faux handle dont `write` / `close` sont no-op, l'export passe par sa branche succès et émet le toast)
   - `043-import-wizard-paste.png`
   - `044-import-wizard-classification.png`
   - `050-rules-list-with-disabled.png`
@@ -41,13 +42,13 @@ Cette phase étend la couverture :
   - `060-rules-list-final.png` (renumérotation : laisse 050 disponible pour la version désactivée).
 - Helpers de stabilisation ajoutés : `waitForToast`, `hoverSessionCardName`, `pinSession`, `getFirstSessionId`, `toggleRuleEnabled`, `fillSessionsSearch`, `openExportRulesWizard`, `openImportRulesWizard`, `pasteImportJson`, `importWizardNextToClassification`.
 - Petit ajout source : `data-testid="session-card-{id}-btn-pin"` / `-btn-unpin` sur le bouton pin/unpin de `SessionCard`, pour fiabiliser la sélection sans recourir à un locator par aria-label i18n.
+- Wiring testid sur le footer de l'export wizard : `ExportWizardShell` propage désormais `primaryTestId` / `clipboardTestId` / `cancelTestId` à `ExportWizardFooter` (déjà supporté par `ExportSplitButton`). `ExportWizard` (rules) renseigne `wizard-export-rules-btn-{export,clipboard,cancel}` pour permettre à 042 de cliquer le bouton primaire de manière déterministe.
 
 ### Captures explicitement non livrées en Phase 2.1
 
 - `014-rules-toast-created.png` : aucun toast in-app n'est émis lors de la création d'une règle dans la base actuelle. À ré-évaluer si un `showSuccessToast` est ajouté à `handleSubmitRule` (`src/pages/DomainRulesPage.tsx`).
 - `023-toast-grouping-with-undo.png` : aucun toast in-app n'accompagne le groupage automatique. La notification système (`chrome.notifications`) avec bouton Annuler reste OS-level (cf. décision Phase 1) et ne peut pas être capturée par Playwright. À reprendre une fois un toast in-app ajouté.
 - `031-sessions-snapshot-wizard-step2.png` : `SnapshotWizard` est mono-étape (cf. décision Phase 1). Capture unique conservée (`030-sessions-snapshot-wizard-filled.png`).
-- `042-export-toast-success.png` : nécessite de piloter `showSaveFilePicker` (FileSystem Access API) ou `navigator.clipboard.writeText` ; les deux requièrent du tooling additionnel (interception de boîte de dialogue native ou octroi de permissions clipboard sur le persistent context). À reprendre conjointement avec un helper `captureToast()` dédié et un stub `showSaveFilePicker` ou un grant clipboard côté `extension-loader`.
 
 ## Décisions techniques
 

--- a/user-stories/doc-scenarios/clarifications.md
+++ b/user-stories/doc-scenarios/clarifications.md
@@ -1,25 +1,53 @@
-# Clarifications — pipeline `e2e-doc-scenarios/` (issue #257)
+# Clarifications - pipeline `e2e-doc-scenarios/` (issues #257, #259)
 
-Décisions prises avant l'implémentation Phase 1.
+Décisions prises avant et pendant l'implémentation des phases successives.
 
-## Scope Phase 1
+## Scope Phase 1 (#257)
 
-Cette PR couvre :
+Cette PR couvrait :
 
-- US-DS001 / US-DS002 : scénario principal `00-main-journey` en `en × dark` uniquement (le scaffold matrice est prêt mais la PR ne lance pas encore les 6 variantes).
+- US-DS001 / US-DS002 : scénario principal `00-main-journey` en `en x dark` uniquement (le scaffold matrice est prêt mais la PR ne lançait pas encore les 6 variantes).
 - US-DS004 : sites locaux mimétiques (GitHub, YouTube, Google, Le Monde).
 - US-DS005 : helpers `ui-actions.ts`.
 - US-DS006 : `captureStep()` avec compteur séquentiel.
-- US-DS007 : co-existence + factorisation dans `e2e-shared/`.
+- US-DS007 : co-existence et factorisation dans `e2e-shared/`.
 - US-DS008 : README auto-généré par scénario.
 - US-DS009 : migration complète du routage `e2e-screenshots/` vers manifests.
 
 Reportés en phases ultérieures :
 
 - US-DS003 : 4 scénarios satellites (`10-import-conflicts`, `11-restore-conflicts`, `12-deduplication-modes`, `13-grouping-modes`).
-- Matrice complète 3 locales × 2 thèmes pour le scénario principal.
+- Matrice complète 3 locales x 2 thèmes pour le scénario principal.
 - US-DS010 : commande `pnpm doc:scenarios:audit`.
 - US-DS011 : commande `pnpm doc:scenarios:sync`.
+
+## Scope Phase 2.1 (#259)
+
+Cette phase étend la couverture :
+
+- Matrice complète : `playwright.doc.config.ts` génère 6 projects `{locale}-{theme}` (en/fr/es x dark/light) ; chaque project porte ses paramètres via `metadata: { locale, theme }`, lus par la fixture (`doc-fixture.ts`) et par le scénario.
+- Le scénario lit locale et theme via les nouvelles fixtures `locale` / `theme` (worker-scoped) au lieu d'inférer la locale depuis `project.name`.
+- Captures complémentaires ajoutées au scénario `00-main-journey` :
+  - `034-sessions-card-relative-time.png`
+  - `035-sessions-card-hovercard.png`
+  - `036-sessions-pin-onboarding.png` (popup pinned-empty hint)
+  - `037-sessions-list-with-pinned.png`
+  - `041-export-wizard-selection.png`
+  - `043-import-wizard-paste.png`
+  - `044-import-wizard-classification.png`
+  - `050-rules-list-with-disabled.png`
+  - `051-sessions-search-active.png`
+  - `052-sessions-search-deep.png`
+  - `060-rules-list-final.png` (renumérotation : laisse 050 disponible pour la version désactivée).
+- Helpers de stabilisation ajoutés : `waitForToast`, `hoverSessionCardName`, `pinSession`, `getFirstSessionId`, `toggleRuleEnabled`, `fillSessionsSearch`, `openExportRulesWizard`, `openImportRulesWizard`, `pasteImportJson`, `importWizardNextToClassification`.
+- Petit ajout source : `data-testid="session-card-{id}-btn-pin"` / `-btn-unpin` sur le bouton pin/unpin de `SessionCard`, pour fiabiliser la sélection sans recourir à un locator par aria-label i18n.
+
+### Captures explicitement non livrées en Phase 2.1
+
+- `014-rules-toast-created.png` : aucun toast in-app n'est émis lors de la création d'une règle dans la base actuelle. À ré-évaluer si un `showSuccessToast` est ajouté à `handleSubmitRule` (`src/pages/DomainRulesPage.tsx`).
+- `023-toast-grouping-with-undo.png` : aucun toast in-app n'accompagne le groupage automatique. La notification système (`chrome.notifications`) avec bouton Annuler reste OS-level (cf. décision Phase 1) et ne peut pas être capturée par Playwright. À reprendre une fois un toast in-app ajouté.
+- `031-sessions-snapshot-wizard-step2.png` : `SnapshotWizard` est mono-étape (cf. décision Phase 1). Capture unique conservée (`030-sessions-snapshot-wizard-filled.png`).
+- `042-export-toast-success.png` : nécessite de piloter `showSaveFilePicker` (FileSystem Access API) ou `navigator.clipboard.writeText` ; les deux requièrent du tooling additionnel (interception de boîte de dialogue native ou octroi de permissions clipboard sur le persistent context). À reprendre conjointement avec un helper `captureToast()` dédié et un stub `showSaveFilePicker` ou un grant clipboard côté `extension-loader`.
 
 ## Décisions techniques
 
@@ -39,12 +67,6 @@ Conséquences :
 - `chrome.tabs.url` retourne la même URL : les règles de domaine matchent naturellement `github.com`, sans adaptation.
 - Tout reste offline et déterministe.
 
-### Notification undo (US-DS002 §023)
-
-Capture de la notification système `chrome.notifications` non retenue (OS-level, fragile dans Playwright).
-
-Phase 1 ne capture pas ce point. Le sera traité en suivi (`023-toast-grouping-with-undo.png`) une fois le toast in-app stabilisé visuellement.
-
 ### Modes de configuration disponibles
 
 Le code expose 3 modes (`preset`, `ask`, `manual`). Le mode `label` mentionné dans l'issue n'existe pas dans la base actuelle : la capture `017-rules-wizard-step2-mode-label.png` est donc retirée du Phase 1. À ré-évaluer si un mode `label` est ajouté ultérieurement.
@@ -55,7 +77,7 @@ Le `SnapshotWizard` est mono-étape dans le code actuel : pas de découpage `ste
 
 ### Factorisation (US-DS007)
 
-Helpers communs déplacés dans le nouveau dossier `e2e-shared/` à la racine :
+Helpers communs dans le dossier `e2e-shared/` à la racine :
 
 - `chromium-finder.ts` : résolution du binaire Chromium (CI vs local).
 - `extension-loader.ts` : `launchExtension()` partagé (userDataDir, args, deterministic flags, host-resolver).
@@ -65,4 +87,4 @@ Helpers communs déplacés dans le nouveau dossier `e2e-shared/` à la racine :
 - `sharp-save.ts` : `savePng()` avec routage manifest-driven.
 - `routing/types.ts`, `routing/destinations.ts` : types et roots des destinations.
 
-Les pipelines `tests/e2e/` et `e2e-screenshots/` ont été refactorés pour consommer ces helpers, sans changement d'API publique.
+Les pipelines `tests/e2e/` et `e2e-screenshots/` consomment ces helpers, sans changement d'API publique.


### PR DESCRIPTION
Wires the full Phase 2.1 matrix (en/fr/es x dark/light) for the
narrative documentation pipeline by promoting locale and theme to
project metadata, and extends the main journey scenario with the
complementary captures from US-DS002 that were tractable against the
current source (sessions card relative-time, hovercard, pin onboarding,
list with pinned, export selection, import paste/classification, rules
list with disabled toggle, sessions search active and deep).

Captures depending on UI features that do not yet exist (rule-creation
toast, grouping toast with undo, multi-step snapshot wizard, file-picker
driven export-success toast) remain deferred and are documented in
user-stories/doc-scenarios/clarifications.md alongside the other Phase 1
deferrals.

Adds stabilization helpers (waitForToast, hoverSessionCardName,
pinSession, getFirstSessionId, toggleRuleEnabled, fillSessionsSearch,
openExportRulesWizard, openImportRulesWizard, pasteImportJson,
importWizardNextToClassification) and a small data-testid on the
session card pin/unpin button to keep the scenario robust against
i18n-driven aria-label drift.

https://claude.ai/code/session_01QYsRyQ7TiDQbhBKnQ6DPuA