### PR TITLE
feat(e2e-doc-scenarios): add satellite scenarios (US-DS003)

### DIFF
--- a/e2e-doc-scenarios/helpers/doc-fixture.ts
+++ b/e2e-doc-scenarios/helpers/doc-fixture.ts
@@ -22,8 +22,8 @@ import type { Locale, Theme } from '../../e2e-shared/routing/types.js';
 export interface DocScenarioFixtures {
   extensionContext: BrowserContext;
   extensionId: string;
-  locale: Locale;
-  theme: Theme;
+  docLocale: Locale;
+  docTheme: Theme;
 }
 
 const LOCALE_LANG: Record<Locale, string> = {
@@ -48,7 +48,7 @@ function readProjectMetadata(metadata: unknown): { locale: Locale; theme: Theme 
 }
 
 export const test = base.extend<DocScenarioFixtures>({
-  locale: [
+  docLocale: [
     async ({}, use, testInfo) => {
       const { locale } = readProjectMetadata(testInfo.project.metadata);
       await use(locale);
@@ -56,7 +56,7 @@ export const test = base.extend<DocScenarioFixtures>({
     { scope: 'worker' },
   ],
 
-  theme: [
+  docTheme: [
     async ({}, use, testInfo) => {
       const { theme } = readProjectMetadata(testInfo.project.metadata);
       await use(theme);

--- a/e2e-doc-scenarios/helpers/ui-actions.ts
+++ b/e2e-doc-scenarios/helpers/ui-actions.ts
@@ -325,22 +325,15 @@ export async function openImportRulesWizard(page: Page): Promise<void> {
 /**
  * Switch the active import wizard from File mode to Text mode and paste the
  * supplied JSON into the textarea.
+ *
+ * Targets the Radix Themes SegmentedControl items via their stable
+ * `.rt-SegmentedControlItem` class. The wizard exposes File / Text (and
+ * optionally Pack); "Text" is always the second item.
  */
 export async function pasteImportJson(page: Page, json: string): Promise<void> {
   const dialog = page.getByRole('dialog').first();
-  // Segmented control item labelled "Text" (i18n-driven, so query by role).
-  await dialog
-    .locator('[role="radiogroup"], [role="tablist"], [data-radix-segmented-control-root]')
-    .first()
-    .waitFor({ state: 'visible' })
-    .catch(() => {});
-  // The segmented control items use role="radio" or "tab" depending on
-  // Radix internals; querying by visible text via the radiogroup labels is
-  // brittle, so we click the second SegmentedControl item directly.
-  const segmentedItems = dialog.locator('button, [role="tab"], [role="radio"]').filter({
-    hasText: /./,
-  });
-  // Heuristic: the first two items are "File" and "Text" (others optional).
+  const segmentedItems = dialog.locator('button.rt-SegmentedControlItem');
+  await segmentedItems.first().waitFor({ state: 'visible' });
   await segmentedItems.nth(1).click();
   const textarea = dialog.locator('textarea').first();
   await textarea.waitFor({ state: 'visible' });
@@ -360,4 +353,158 @@ export async function importWizardNextToClassification(page: Page): Promise<void
   // Radix renders step 1 inside the same dialog; wait for the
   // classification scroll area to appear.
   await page.waitForTimeout(300);
+}
+
+// ─── Storage seeding ──────────────────────────────────────────────────────────
+
+/** Reset extension storage before a satellite scenario starts. */
+export async function clearExtensionStorage(context: BrowserContext): Promise<void> {
+  const sw = await waitForServiceWorker(context);
+  await sw.evaluate(async () => {
+    await chrome.storage.local.clear();
+  });
+}
+
+/** Seed `domainRules` directly into chrome.storage.local. */
+export async function seedDomainRules<T>(
+  context: BrowserContext,
+  rules: T[],
+): Promise<void> {
+  const sw = await waitForServiceWorker(context);
+  await sw.evaluate(async (data) => {
+    await chrome.storage.local.set({ domainRules: data });
+  }, rules as unknown as Parameters<typeof sw.evaluate>[1]);
+}
+
+/** Seed `sessions` directly into chrome.storage.local. */
+export async function seedSessions<T>(
+  context: BrowserContext,
+  sessions: T[],
+): Promise<void> {
+  const sw = await waitForServiceWorker(context);
+  await sw.evaluate(async (data) => {
+    await chrome.storage.local.set({ sessions: data });
+  }, sessions as unknown as Parameters<typeof sw.evaluate>[1]);
+}
+
+// ─── Import wizard ───────────────────────────────────────────────────────────
+
+/**
+ * Click an item in the conflict-mode SegmentedControl on the import wizard's
+ * classification step. The control renders Radix `SegmentedControl.Item` as
+ * `button.rt-SegmentedControlItem` in the order overwrite / duplicate / ignore.
+ */
+export async function setImportConflictMode(
+  page: Page,
+  mode: 'overwrite' | 'duplicate' | 'ignore',
+): Promise<void> {
+  const dialog = page.getByRole('dialog').first();
+  const index = mode === 'overwrite' ? 0 : mode === 'duplicate' ? 1 : 2;
+  // Two SegmentedControls may exist in the wizard (source-mode on step 0, conflict-mode
+  // on step 1) but only one is visible at a time. Filter by visibility just in case.
+  const items = dialog.locator('.rt-SegmentedControlItem');
+  await items.nth(index).waitFor({ state: 'visible' });
+  await items.nth(index).click();
+  await page.waitForTimeout(150);
+}
+
+/** Dismiss the currently-open dialog (Escape closes any Radix dialog). */
+export async function dismissDialog(page: Page): Promise<void> {
+  await page.keyboard.press('Escape');
+  await page.getByRole('dialog').first().waitFor({ state: 'hidden' }).catch(() => {});
+}
+
+// ─── Edit rule wizard ────────────────────────────────────────────────────────
+
+/** Open the rule edit wizard via the rule card's dropdown menu. */
+export async function openEditRuleWizard(page: Page, ruleId: string): Promise<void> {
+  await page.getByTestId(`rule-card-${ruleId}-btn-dropdown`).click();
+  await page.getByTestId(`rule-card-${ruleId}-menu-edit`).click();
+  await page.getByTestId('wizard-rule').waitFor({ state: 'visible' });
+}
+
+/** Expand the Options collapsible inside the EditSummaryView, if not already. */
+export async function expandEditWizardOptions(page: Page): Promise<void> {
+  const trigger = page.getByTestId('wizard-rule-edit-toggle-options');
+  await trigger.waitFor({ state: 'visible' });
+  const state = await trigger.getAttribute('data-state');
+  if (state !== 'open') {
+    await trigger.click();
+    await page.waitForTimeout(200);
+  }
+}
+
+/** Pick a deduplication match mode in the Step 3 Options radio group. */
+export async function selectDeduplicationMode(
+  page: Page,
+  mode: 'exact' | 'includes' | 'exact_ignore_params',
+): Promise<void> {
+  // Radix RadioGroup.Item exposes its value via the `value` attribute on the
+  // rendered button[role="radio"]. Scope to the visible dialog so we never
+  // hit a hidden radio from a stale Collapsible state.
+  const dialog = page.getByRole('dialog').first();
+  await dialog.locator(`[role="radio"][value="${mode}"]`).first().click();
+  await page.waitForTimeout(100);
+}
+
+// ─── Restore wizard ──────────────────────────────────────────────────────────
+
+/**
+ * Open the customize-restore wizard for a given session by clicking the
+ * SplitButton chevron on its card and selecting the "Customize" item.
+ */
+export async function openCustomizeRestoreWizard(
+  page: Page,
+  sessionId: string,
+): Promise<void> {
+  const card = page.getByTestId(`session-card-${sessionId}`);
+  await card.locator('button:has(svg.lucide-chevron-down)').first().click();
+  await page.locator('[role="menu"]').waitFor({ state: 'visible', timeout: 5_000 });
+  await page.getByTestId('session-restore-menu-customize').click();
+  await page.getByTestId('wizard-restore').waitFor({ state: 'visible' });
+}
+
+/**
+ * Click the primary "Restore" button on step 0 of the restore wizard. When
+ * conflicts are detected the wizard advances to step 1 (ConflictResolutionStep);
+ * otherwise the dialog closes.
+ */
+export async function clickRestoreInWizard(page: Page): Promise<void> {
+  await page.getByTestId('wizard-restore-btn-restore').click();
+}
+
+/**
+ * Create a live tab group in the same window as the supplied page so that the
+ * RestoreWizard's `analyzeConflicts()` flags it as conflicting with a seeded
+ * session group sharing the same `(title, color)`.
+ */
+export async function createLiveTabGroup(
+  context: BrowserContext,
+  windowOwnerPage: Page,
+  title: string,
+  color: 'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan' | 'orange',
+): Promise<void> {
+  const sw = await waitForServiceWorker(context);
+  const windowId = await windowOwnerPage.evaluate(
+    () =>
+      new Promise<number>((resolve) => {
+        chrome.windows.getCurrent((w) => resolve(w.id!));
+      }),
+  );
+  await sw.evaluate(
+    async ({ wid, gtitle, gcolor }: { wid: number; gtitle: string; gcolor: string }) => {
+      const tab = await chrome.tabs.create({
+        url: 'about:blank',
+        windowId: wid,
+        active: false,
+      });
+      const groupId = await chrome.tabs.group({ tabIds: [tab.id!] });
+      await chrome.tabGroups.update(groupId, {
+        title: gtitle,
+        color: gcolor as chrome.tabGroups.ColorEnum,
+      });
+    },
+    { wid: windowId, gtitle: title, gcolor: color },
+  );
+  await windowOwnerPage.waitForTimeout(300);
 }

--- a/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/00-main-journey.scenario.ts
@@ -119,7 +119,7 @@ const SCENARIO_ID = '00-main-journey';
 test.describe.configure({ mode: 'serial' });
 
 test('main journey', async (
-  { extensionContext, extensionId, locale, theme },
+  { extensionContext, extensionId, docLocale: locale, docTheme: theme },
 ) => {
   startScenario({
     id: SCENARIO_ID,

--- a/e2e-doc-scenarios/scenarios/10-import-conflicts.routing.ts
+++ b/e2e-doc-scenarios/scenarios/10-import-conflicts.routing.ts
@@ -1,0 +1,11 @@
+/**
+ * Routing manifest for `10-import-conflicts`.
+ *
+ * Captures land in `output/{locale}/{theme}/10-import-conflicts/` only.
+ * Routes can be added incrementally once visual review is complete.
+ */
+import type { Manifest } from '../../e2e-shared/routing/types.js';
+
+export const IMPORT_CONFLICTS_MANIFEST: Manifest = {
+  routes: [],
+};

--- a/e2e-doc-scenarios/scenarios/10-import-conflicts.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/10-import-conflicts.scenario.ts
@@ -1,0 +1,88 @@
+/**
+ * Satellite scenario `10-import-conflicts`.
+ *
+ * Starts with 4 seeded rules (reused from `e2e-screenshots/fixtures/rules-seed.ts`),
+ * opens the rules import wizard, pastes a JSON crafted to produce one new,
+ * one conflicting and one identical rule (`buildConflictJson()`), and
+ * captures every step of the classification + conflict-mode resolution.
+ */
+import { test } from '../helpers/doc-fixture.js';
+import { captureStep, startScenario } from '../helpers/doc-capture.js';
+import { writeScenarioReadme } from '../helpers/scenario-readme.js';
+import {
+  clearExtensionStorage,
+  dismissDialog,
+  importWizardNextToClassification,
+  openExtensionPage,
+  openImportRulesWizard,
+  pasteImportJson,
+  seedDomainRules,
+  setImportConflictMode,
+} from '../helpers/ui-actions.js';
+import { SCREENSHOT_RULES } from '../../e2e-screenshots/fixtures/rules-seed.js';
+import { buildConflictJson } from '../../e2e-screenshots/fixtures/conflicts-seed.js';
+import { IMPORT_CONFLICTS_MANIFEST } from './10-import-conflicts.routing.js';
+
+const SCENARIO_ID = '10-import-conflicts';
+
+test.describe.configure({ mode: 'serial' });
+
+test('import conflicts', async (
+  { extensionContext, extensionId, docLocale: locale, docTheme: theme },
+) => {
+  startScenario({
+    id: SCENARIO_ID,
+    locale,
+    theme,
+    manifests: [IMPORT_CONFLICTS_MANIFEST],
+  });
+
+  await clearExtensionStorage(extensionContext);
+  // Reuse the screenshot pipeline's 6-rule seed: covers preset, smart_label,
+  // title-regex, smart_manual, disabled, and another smart_label rule. The
+  // crafted import JSON targets labels "GitHub" (conflicting), "Slack" (new),
+  // and "Linear" (identical) so all three classification buckets are populated.
+  await seedDomainRules(extensionContext, SCREENSHOT_RULES);
+
+  const page = await openExtensionPage(
+    extensionContext,
+    extensionId,
+    'importexport',
+    locale,
+    theme,
+  );
+  await page.getByTestId('page-import-export').waitFor({ state: 'visible' });
+  await captureStep(page, 'import-export-with-rules', {
+    description: 'Import/Export page with four seeded rules ready to be imported on top of.',
+  });
+
+  await openImportRulesWizard(page);
+  await pasteImportJson(page, buildConflictJson());
+  await captureStep(page, 'import-wizard-paste', {
+    description: 'Import wizard step 0, JSON pasted in Text mode (validation succeeded).',
+  });
+
+  await importWizardNextToClassification(page);
+  await captureStep(page, 'import-wizard-classification-overwrite', {
+    description: 'Classification step with conflict mode "overwrite" (default): one new, one conflicting, one identical.',
+  });
+
+  await setImportConflictMode(page, 'duplicate');
+  await captureStep(page, 'import-wizard-classification-duplicate', {
+    description: 'Classification step with conflict mode set to "duplicate".',
+  });
+
+  await setImportConflictMode(page, 'ignore');
+  await captureStep(page, 'import-wizard-classification-ignore', {
+    description: 'Classification step with conflict mode set to "ignore".',
+  });
+
+  await dismissDialog(page);
+  await page.close();
+
+  await writeScenarioReadme({
+    title: `Import conflicts - \`${SCENARIO_ID}\` (${locale} x ${theme})`,
+    intro:
+      'Satellite scenario that imports a JSON containing identical, conflicting and new rules on top of a four-rule seed, capturing the classification step under each conflict-resolution mode.',
+  });
+});

--- a/e2e-doc-scenarios/scenarios/11-restore-conflicts.routing.ts
+++ b/e2e-doc-scenarios/scenarios/11-restore-conflicts.routing.ts
@@ -1,0 +1,11 @@
+/**
+ * Routing manifest for `11-restore-conflicts`.
+ *
+ * Captures land in `output/{locale}/{theme}/11-restore-conflicts/` only.
+ * Routes can be added incrementally once visual review is complete.
+ */
+import type { Manifest } from '../../e2e-shared/routing/types.js';
+
+export const RESTORE_CONFLICTS_MANIFEST: Manifest = {
+  routes: [],
+};

--- a/e2e-doc-scenarios/scenarios/11-restore-conflicts.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/11-restore-conflicts.scenario.ts
@@ -1,0 +1,81 @@
+/**
+ * Satellite scenario `11-restore-conflicts`.
+ *
+ * Seeds a single session whose first group is `(title: "Work", color: "blue")`,
+ * spawns a live tab group with the same `(title, color)` in the current
+ * window, then opens the customize-restore wizard so `analyzeConflicts()`
+ * detects a conflict and the wizard moves to the ConflictResolutionStep.
+ */
+import { test } from '../helpers/doc-fixture.js';
+import { captureStep, startScenario } from '../helpers/doc-capture.js';
+import { writeScenarioReadme } from '../helpers/scenario-readme.js';
+import {
+  clearExtensionStorage,
+  clickRestoreInWizard,
+  createLiveTabGroup,
+  dismissDialog,
+  openCustomizeRestoreWizard,
+  openExtensionPage,
+  seedSessions,
+} from '../helpers/ui-actions.js';
+import { SESSION_FOR_CONFLICT } from '../../e2e-screenshots/fixtures/sessions-seed.js';
+import { RESTORE_CONFLICTS_MANIFEST } from './11-restore-conflicts.routing.js';
+
+const SCENARIO_ID = '11-restore-conflicts';
+
+test.describe.configure({ mode: 'serial' });
+
+test('restore conflicts', async (
+  { extensionContext, extensionId, docLocale: locale, docTheme: theme },
+) => {
+  startScenario({
+    id: SCENARIO_ID,
+    locale,
+    theme,
+    manifests: [RESTORE_CONFLICTS_MANIFEST],
+  });
+
+  await clearExtensionStorage(extensionContext);
+  // SESSION_FOR_CONFLICT contains a "Work" (blue) group whose live counterpart
+  // we will create below to trigger the conflict-resolution step.
+  await seedSessions(extensionContext, [SESSION_FOR_CONFLICT]);
+
+  const sessionsPage = await openExtensionPage(
+    extensionContext,
+    extensionId,
+    'sessions',
+    locale,
+    theme,
+  );
+  await sessionsPage.getByTestId('page-sessions-list').waitFor({ state: 'visible' });
+
+  // Create the live "Work" blue group in the current window so that the
+  // RestoreWizard's analyzeConflicts() detects a conflicting group.
+  await createLiveTabGroup(extensionContext, sessionsPage, 'Work', 'blue');
+
+  await captureStep(sessionsPage, 'sessions-list-with-live-conflict', {
+    description: 'Sessions page with one seeded snapshot and a live "Work" tab group already open in the same window.',
+  });
+
+  await openCustomizeRestoreWizard(sessionsPage, SESSION_FOR_CONFLICT.id);
+  await captureStep(sessionsPage, 'restore-wizard-step0', {
+    description: 'Restore wizard step 0 (destination + tab selection) before triggering conflict analysis.',
+  });
+
+  await clickRestoreInWizard(sessionsPage);
+  await sessionsPage
+    .getByTestId('wizard-restore-step-1')
+    .waitFor({ state: 'visible', timeout: 10_000 });
+  await captureStep(sessionsPage, 'restore-wizard-conflict-resolution', {
+    description: 'Restore wizard step 1 (ConflictResolutionStep) showing detected conflicting group and per-group actions.',
+  });
+
+  await dismissDialog(sessionsPage);
+  await sessionsPage.close();
+
+  await writeScenarioReadme({
+    title: `Restore conflicts - \`${SCENARIO_ID}\` (${locale} x ${theme})`,
+    intro:
+      'Satellite scenario that seeds a session and an opposing live tab group sharing the same title and colour, then opens the restore wizard so the ConflictResolutionStep is captured with a real conflict.',
+  });
+});

--- a/e2e-doc-scenarios/scenarios/12-deduplication-modes.routing.ts
+++ b/e2e-doc-scenarios/scenarios/12-deduplication-modes.routing.ts
@@ -1,0 +1,11 @@
+/**
+ * Routing manifest for `12-deduplication-modes`.
+ *
+ * Captures land in `output/{locale}/{theme}/12-deduplication-modes/` only.
+ * Routes can be added incrementally once visual review is complete.
+ */
+import type { Manifest } from '../../e2e-shared/routing/types.js';
+
+export const DEDUPLICATION_MODES_MANIFEST: Manifest = {
+  routes: [],
+};

--- a/e2e-doc-scenarios/scenarios/12-deduplication-modes.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/12-deduplication-modes.scenario.ts
@@ -1,0 +1,83 @@
+/**
+ * Satellite scenario `12-deduplication-modes`.
+ *
+ * Seeds a single rule, opens its edit wizard, expands the Options collapsible
+ * and captures the form once for each deduplication match mode (`exact`,
+ * `includes`, `exact_ignore_params`).
+ */
+import { test } from '../helpers/doc-fixture.js';
+import { captureStep, startScenario } from '../helpers/doc-capture.js';
+import { writeScenarioReadme } from '../helpers/scenario-readme.js';
+import {
+  clearExtensionStorage,
+  dismissDialog,
+  expandEditWizardOptions,
+  openEditRuleWizard,
+  openExtensionPage,
+  seedDomainRules,
+  selectDeduplicationMode,
+} from '../helpers/ui-actions.js';
+import { DEDUPLICATION_MODES_MANIFEST } from './12-deduplication-modes.routing.js';
+
+const SCENARIO_ID = '12-deduplication-modes';
+
+const SEED_RULE = {
+  id: 'doc-rule-dedup',
+  domainFilter: 'github.com',
+  label: 'GitHub',
+  titleParsingRegEx: '',
+  urlParsingRegEx: '',
+  groupNameSource: 'smart_label',
+  deduplicationMatchMode: 'exact',
+  deduplicationEnabled: true,
+  color: 'grey',
+  categoryId: 'development',
+  presetId: null,
+  enabled: true,
+};
+
+const MODES = ['exact', 'includes', 'exact_ignore_params'] as const;
+
+test.describe.configure({ mode: 'serial' });
+
+test('deduplication modes', async (
+  { extensionContext, extensionId, docLocale: locale, docTheme: theme },
+) => {
+  startScenario({
+    id: SCENARIO_ID,
+    locale,
+    theme,
+    manifests: [DEDUPLICATION_MODES_MANIFEST],
+  });
+
+  await clearExtensionStorage(extensionContext);
+  await seedDomainRules(extensionContext, [SEED_RULE]);
+
+  const rulesPage = await openExtensionPage(
+    extensionContext,
+    extensionId,
+    'rules',
+    locale,
+    theme,
+  );
+  await rulesPage.getByTestId('page-rules-list').waitFor({ state: 'visible' });
+
+  await openEditRuleWizard(rulesPage, SEED_RULE.id);
+  await expandEditWizardOptions(rulesPage);
+
+  for (const mode of MODES) {
+    await selectDeduplicationMode(rulesPage, mode);
+    await captureStep(rulesPage, `edit-wizard-options-${mode.replace(/_/g, '-')}`, {
+      description: `Edit wizard, Options section expanded with deduplication mode "${mode}" selected.`,
+    });
+  }
+
+  await dismissDialog(rulesPage);
+  await rulesPage.close();
+
+  await writeScenarioReadme({
+    title: `Deduplication modes - \`${SCENARIO_ID}\` (${locale} x ${theme})`,
+    intro:
+      'Satellite scenario that opens the edit wizard for an existing rule and captures the Options step once per deduplication match mode (exact, includes, exact_ignore_params).',
+  });
+});

--- a/e2e-doc-scenarios/scenarios/13-grouping-modes.routing.ts
+++ b/e2e-doc-scenarios/scenarios/13-grouping-modes.routing.ts
@@ -1,0 +1,11 @@
+/**
+ * Routing manifest for `13-grouping-modes`.
+ *
+ * Captures land in `output/{locale}/{theme}/13-grouping-modes/` only.
+ * Routes can be added incrementally once visual review is complete.
+ */
+import type { Manifest } from '../../e2e-shared/routing/types.js';
+
+export const GROUPING_MODES_MANIFEST: Manifest = {
+  routes: [],
+};

--- a/e2e-doc-scenarios/scenarios/13-grouping-modes.scenario.ts
+++ b/e2e-doc-scenarios/scenarios/13-grouping-modes.scenario.ts
@@ -1,0 +1,74 @@
+/**
+ * Satellite scenario `13-grouping-modes`.
+ *
+ * Opens the rule creation wizard, walks step 1 once, and captures step 2 with
+ * each configuration mode selected (`preset`, `ask`, `manual`). The
+ * `config-mode-description` paragraph rendered next to the mode list provides
+ * the contextual explanation requested by US-DS003.
+ */
+import { test } from '../helpers/doc-fixture.js';
+import { captureStep, startScenario } from '../helpers/doc-capture.js';
+import { writeScenarioReadme } from '../helpers/scenario-readme.js';
+import {
+  clearExtensionStorage,
+  dismissRuleWizard,
+  fillRuleWizardStep1,
+  openExtensionPage,
+  openRuleWizard,
+  selectConfigurationMode,
+  type ConfigMode,
+} from '../helpers/ui-actions.js';
+import { GROUPING_MODES_MANIFEST } from './13-grouping-modes.routing.js';
+
+const SCENARIO_ID = '13-grouping-modes';
+
+const MODES: ConfigMode[] = ['preset', 'ask', 'manual'];
+
+test.describe.configure({ mode: 'serial' });
+
+test('grouping modes', async (
+  { extensionContext, extensionId, docLocale: locale, docTheme: theme },
+) => {
+  startScenario({
+    id: SCENARIO_ID,
+    locale,
+    theme,
+    manifests: [GROUPING_MODES_MANIFEST],
+  });
+
+  await clearExtensionStorage(extensionContext);
+
+  const rulesPage = await openExtensionPage(
+    extensionContext,
+    extensionId,
+    'rules',
+    locale,
+    theme,
+  );
+
+  await openRuleWizard(rulesPage);
+  await fillRuleWizardStep1(rulesPage, {
+    label: 'GitHub',
+    domainFilter: 'github.com',
+  });
+
+  for (const mode of MODES) {
+    await selectConfigurationMode(rulesPage, mode);
+    // The right column carries the contextual description for the active mode.
+    await rulesPage
+      .getByTestId('config-mode-description')
+      .waitFor({ state: 'visible' });
+    await captureStep(rulesPage, `rules-wizard-step2-mode-${mode}`, {
+      description: `Rule wizard step 2 with configuration mode "${mode}" selected and its contextual description visible.`,
+    });
+  }
+
+  await dismissRuleWizard(rulesPage);
+  await rulesPage.close();
+
+  await writeScenarioReadme({
+    title: `Grouping modes - \`${SCENARIO_ID}\` (${locale} x ${theme})`,
+    intro:
+      'Satellite scenario that walks the rule wizard up to step 2 and captures the form once per configuration mode (preset, ask, manual) so the contextual description is visible for each.',
+  });
+});

--- a/src/components/Core/DomainRule/EditSummaryView.tsx
+++ b/src/components/Core/DomainRule/EditSummaryView.tsx
@@ -161,7 +161,7 @@ export function EditSummaryView({
       {/* ── Zone 3 : Options (Collapsible) ── */}
       <Collapsible.Root open={isOptionsOpen} onOpenChange={setIsOptionsOpen}>
         <Collapsible.Trigger asChild>
-          <Button type="button" variant="ghost" size="2" style={{ width: '100%', justifyContent: 'flex-start', '--button-ghost-padding-x': '0px' } as React.CSSProperties}>
+          <Button data-testid="wizard-rule-edit-toggle-options" type="button" variant="ghost" size="2" style={{ width: '100%', justifyContent: 'flex-start', '--button-ghost-padding-x': '0px' } as React.CSSProperties}>
             <Flex align="center" gap="2" style={{ width: '100%' }}>
               {isOptionsOpen
                 ? <ChevronDown size={14} />


### PR DESCRIPTION
Implements the four V1 satellite scenarios required by Phase 2.2:

- 10-import-conflicts: classification step with new/conflicting/identical
  rules, captured once per conflict-mode (overwrite, duplicate, ignore).
- 11-restore-conflicts: restore wizard's ConflictResolutionStep against a
  seeded session colliding with a live tab group.
- 12-deduplication-modes: edit wizard Options collapsible captured once
  per deduplication mode (exact, includes, exact_ignore_params).
- 13-grouping-modes: rule wizard step 2 captured once per configuration
  mode (preset, ask, manual) with the contextual description visible.

Each scenario starts from a pre-seeded state, drives the real UI, and
runs across the full 3 locales x 2 themes matrix (#259).

Notable changes:

- ui-actions: add storage seed helpers (clearExtensionStorage,
  seedDomainRules, seedSessions), edit-wizard helpers (openEditRuleWizard,
  expandEditWizardOptions, selectDeduplicationMode), restore-wizard
  helpers (openCustomizeRestoreWizard, clickRestoreInWizard,
  createLiveTabGroup), and import-wizard conflict-mode helper.
- ui-actions: tighten pasteImportJson to target the SegmentedControl via
  its stable rt-SegmentedControlItem class so the Pack source mode does
  not throw off the heuristic.
- doc-fixture: rename the locale/theme worker fixtures to
  docLocale/docTheme to avoid colliding with Playwright 1.59's built-in
  test-scoped locale fixture.
- EditSummaryView: expose the Options collapsible trigger as
  data-testid="wizard-rule-edit-toggle-options" so doc scenarios can
  drive the edit flow without relying on i18n labels.

Closes #260

https://claude.ai/code/session_01H9PapsxEnw1qPwZ17kgA8J