### PR TITLE
feat(e2e-doc-scenarios): add routing audit command (US-DS010)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ e2e-doc-scenarios/output/
 ctrf/
 coverage/
 reports/a11y/
+reports/routing-audit.md
 .jscpd-report/
 design-system-bundle/
 design-system-bundle.zip

--- a/e2e-shared/routing/audit.ts
+++ b/e2e-shared/routing/audit.ts
@@ -1,0 +1,333 @@
+/**
+ * Pure routing-audit logic.
+ *
+ * Diffs the captures actually produced by each pipeline against the
+ * destinations declared in their manifests, plus the files currently sitting
+ * in destination directories. Filesystem access lives in the wrapping script
+ * (`scripts/doc-scenarios-audit.mjs`); this module only manipulates plain
+ * data so it can be unit-tested in isolation.
+ */
+import type { DestinationTarget, Locale, Manifest, Theme } from './types.js';
+
+export const ALL_DESTINATION_TARGETS: DestinationTarget[] = [
+  'starlight',
+  'readme',
+  'chrome-web-store',
+];
+
+/** A capture file actually present in a pipeline's source output. */
+export interface CapturePresence {
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+}
+
+/** A pipeline groups one manifest with the captures it actually produces. */
+export interface Pipeline {
+  /** Display label used in the report (for example `e2e-screenshots` or `00-main-journey`). */
+  id: string;
+  manifest: Manifest;
+  /** Captures emitted by the pipeline, keyed implicitly by (locale, theme). */
+  capturesPresent: CapturePresence[];
+  /** Locales the pipeline runs through. Used to expand routes that omit `locales`. */
+  locales: Locale[];
+  /** Themes the pipeline runs through. Used to expand routes that omit `themes`. */
+  themes: Theme[];
+  /**
+   * If set, every present capture also lands directly in this destination
+   * (used for `e2e-screenshots`, whose primary outputDir is `docs/src/assets/screenshots/`).
+   */
+  primaryDestination?: DestinationTarget;
+}
+
+export interface OrphanCapture {
+  pipeline: string;
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+}
+
+export interface ObsoleteReference {
+  pipeline: string;
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+  destination: DestinationTarget;
+  destinationPath: string;
+}
+
+export interface OrphanDestinationFile {
+  destination: DestinationTarget;
+  relativePath: string;
+}
+
+export interface MissingDestinationFile {
+  destination: DestinationTarget;
+  relativePath: string;
+}
+
+export interface DestinationSummary {
+  destination: DestinationTarget;
+  expected: number;
+  present: number;
+  missing: number;
+  orphan: number;
+}
+
+export interface AuditReport {
+  orphanCaptures: OrphanCapture[];
+  obsoleteReferences: ObsoleteReference[];
+  orphanDestinationFiles: OrphanDestinationFile[];
+  missingDestinationFiles: MissingDestinationFile[];
+  destinationSummaries: DestinationSummary[];
+  /** True when at least one manifest references a capture absent from the pipeline output. */
+  hasErrors: boolean;
+}
+
+export interface AuditInput {
+  pipelines: Pipeline[];
+  /** Filenames present under each destination root, expressed relative to the root (with `.png`). */
+  destinationFiles: Map<DestinationTarget, Set<string>>;
+}
+
+/**
+ * Resolve a destination route to a relative `.png` filename under the
+ * destination root. Mirrors `formatDestinationPath()` in `e2e-shared/sharp-save.ts`,
+ * with the implicit `.png` suffix the actual destination tree carries.
+ */
+export function resolveDestinationPath(
+  templatePath: string,
+  locale: Locale,
+  theme: Theme,
+): string {
+  const stem =
+    templatePath.includes('{locale}') || templatePath.includes('{theme}')
+      ? templatePath.replace(/\{locale\}/g, locale).replace(/\{theme\}/g, theme)
+      : `${locale}-${theme}-${templatePath}`;
+  return stem.endsWith('.png') ? stem : `${stem}.png`;
+}
+
+function key(locale: Locale, theme: Theme): string {
+  return `${locale}/${theme}`;
+}
+
+function sortBy<T>(items: T[], by: (item: T) => string): T[] {
+  return [...items].sort((a, b) => {
+    const ka = by(a);
+    const kb = by(b);
+    if (ka < kb) return -1;
+    if (ka > kb) return 1;
+    return 0;
+  });
+}
+
+export function runAudit(input: AuditInput): AuditReport {
+  const orphanCaptures: OrphanCapture[] = [];
+  const obsoleteReferences: ObsoleteReference[] = [];
+  const expected: Record<DestinationTarget, Set<string>> = {
+    starlight: new Set<string>(),
+    readme: new Set<string>(),
+    'chrome-web-store': new Set<string>(),
+  };
+
+  for (const pipeline of input.pipelines) {
+    const presentByCombo = new Map<string, Set<string>>();
+    for (const cap of pipeline.capturesPresent) {
+      const k = key(cap.locale, cap.theme);
+      let set = presentByCombo.get(k);
+      if (!set) {
+        set = new Set<string>();
+        presentByCombo.set(k, set);
+      }
+      set.add(cap.capture);
+    }
+
+    const referencedByCombo = new Map<string, Set<string>>();
+
+    for (const route of pipeline.manifest.routes) {
+      for (const dest of route.destinations) {
+        const localesForDest = dest.locales ?? pipeline.locales;
+        const themesForDest = dest.themes ?? pipeline.themes;
+        for (const locale of localesForDest) {
+          for (const theme of themesForDest) {
+            const k = key(locale, theme);
+            let refs = referencedByCombo.get(k);
+            if (!refs) {
+              refs = new Set<string>();
+              referencedByCombo.set(k, refs);
+            }
+            refs.add(route.capture);
+
+            const destPath = resolveDestinationPath(dest.path, locale, theme);
+            const isPresent = presentByCombo.get(k)?.has(route.capture) ?? false;
+            if (!isPresent) {
+              obsoleteReferences.push({
+                pipeline: pipeline.id,
+                capture: route.capture,
+                locale,
+                theme,
+                destination: dest.target,
+                destinationPath: destPath,
+              });
+            } else {
+              expected[dest.target].add(destPath);
+            }
+          }
+        }
+      }
+    }
+
+    if (pipeline.primaryDestination) {
+      for (const cap of pipeline.capturesPresent) {
+        const filename = `${cap.locale}-${cap.theme}-${cap.capture}.png`;
+        expected[pipeline.primaryDestination].add(filename);
+      }
+    } else {
+      for (const cap of pipeline.capturesPresent) {
+        const refs = referencedByCombo.get(key(cap.locale, cap.theme));
+        if (!refs?.has(cap.capture)) {
+          orphanCaptures.push({
+            pipeline: pipeline.id,
+            capture: cap.capture,
+            locale: cap.locale,
+            theme: cap.theme,
+          });
+        }
+      }
+    }
+  }
+
+  const orphanDestinationFiles: OrphanDestinationFile[] = [];
+  const missingDestinationFiles: MissingDestinationFile[] = [];
+  const destinationSummaries: DestinationSummary[] = [];
+
+  for (const target of ALL_DESTINATION_TARGETS) {
+    const exp = expected[target];
+    const present = input.destinationFiles.get(target) ?? new Set<string>();
+
+    let missingCount = 0;
+    for (const file of exp) {
+      if (!present.has(file)) {
+        missingCount += 1;
+        missingDestinationFiles.push({ destination: target, relativePath: file });
+      }
+    }
+    let orphanCount = 0;
+    for (const file of present) {
+      if (!exp.has(file)) {
+        orphanCount += 1;
+        orphanDestinationFiles.push({ destination: target, relativePath: file });
+      }
+    }
+    destinationSummaries.push({
+      destination: target,
+      expected: exp.size,
+      present: present.size,
+      missing: missingCount,
+      orphan: orphanCount,
+    });
+  }
+
+  return {
+    orphanCaptures: sortBy(orphanCaptures, (c) => `${c.pipeline}/${c.locale}/${c.theme}/${c.capture}`),
+    obsoleteReferences: sortBy(
+      obsoleteReferences,
+      (r) => `${r.pipeline}/${r.locale}/${r.theme}/${r.capture}/${r.destination}`,
+    ),
+    orphanDestinationFiles: sortBy(orphanDestinationFiles, (f) => `${f.destination}/${f.relativePath}`),
+    missingDestinationFiles: sortBy(missingDestinationFiles, (f) => `${f.destination}/${f.relativePath}`),
+    destinationSummaries,
+    hasErrors: obsoleteReferences.length > 0,
+  };
+}
+
+export interface FormatAuditMarkdownOptions {
+  /** ISO timestamp injected at the top of the report. Defaults to `new Date().toISOString()`. */
+  generatedAt?: string;
+}
+
+export function formatAuditMarkdown(
+  report: AuditReport,
+  options: FormatAuditMarkdownOptions = {},
+): string {
+  const lines: string[] = [];
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  lines.push('# Routing audit report');
+  lines.push('');
+  lines.push(`Generated: ${generatedAt}`);
+  lines.push('');
+
+  lines.push('## Summary by destination');
+  lines.push('');
+  lines.push('| Destination | Expected | Present | Missing | Orphan |');
+  lines.push('|-------------|---------:|--------:|--------:|-------:|');
+  for (const summary of report.destinationSummaries) {
+    lines.push(
+      `| \`${summary.destination}\` | ${summary.expected} | ${summary.present} | ${summary.missing} | ${summary.orphan} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Obsolete references');
+  lines.push('');
+  lines.push('Captures referenced by a manifest but missing from the pipeline output.');
+  lines.push('');
+  if (report.obsoleteReferences.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Pipeline | Capture | Locale | Theme | Destination | Path |');
+    lines.push('|----------|---------|--------|-------|-------------|------|');
+    for (const ref of report.obsoleteReferences) {
+      lines.push(
+        `| \`${ref.pipeline}\` | \`${ref.capture}\` | ${ref.locale} | ${ref.theme} | \`${ref.destination}\` | \`${ref.destinationPath}\` |`,
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Orphan captures');
+  lines.push('');
+  lines.push('Captures produced by a pipeline but referenced in no manifest.');
+  lines.push('');
+  if (report.orphanCaptures.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Pipeline | Capture | Locale | Theme |');
+    lines.push('|----------|---------|--------|-------|');
+    for (const cap of report.orphanCaptures) {
+      lines.push(`| \`${cap.pipeline}\` | \`${cap.capture}\` | ${cap.locale} | ${cap.theme} |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Orphan destination files');
+  lines.push('');
+  lines.push('Files present in a destination directory that the routing no longer produces.');
+  lines.push('');
+  if (report.orphanDestinationFiles.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Destination | File |');
+    lines.push('|-------------|------|');
+    for (const file of report.orphanDestinationFiles) {
+      lines.push(`| \`${file.destination}\` | \`${file.relativePath}\` |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Missing destination files');
+  lines.push('');
+  lines.push('Files declared by routing but absent from the destination directory.');
+  lines.push('');
+  if (report.missingDestinationFiles.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push('| Destination | File |');
+    lines.push('|-------------|------|');
+    for (const file of report.missingDestinationFiles) {
+      lines.push(`| \`${file.destination}\` | \`${file.relativePath}\` |`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "a11y": "pnpm a11y:storybook && pnpm a11y:e2e && pnpm a11y:report",
     "screenshots": "pnpm build && xvfb-maybe playwright test --config=e2e-screenshots/playwright.screenshots.config.ts",
     "doc:scenarios": "pnpm build && xvfb-maybe playwright test --config=e2e-doc-scenarios/playwright.doc.config.ts",
+    "doc:scenarios:audit": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/doc-scenarios-audit.mjs",
     "docs:dev": "pnpm --dir docs dev",
     "docs:build": "pnpm --dir docs build",
     "docs:preview": "pnpm --dir docs preview",

--- a/scripts/doc-scenarios-audit.mjs
+++ b/scripts/doc-scenarios-audit.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Routing audit (US-DS010, sub-issue of #257).
+ *
+ * Cross-checks every manifest declared under `e2e-screenshots/` and
+ * `e2e-doc-scenarios/scenarios/` against:
+ *   1. the captures actually written by each pipeline,
+ *   2. the files currently sitting under each destination root.
+ *
+ * Writes `reports/routing-audit.md` and exits with a non-zero status when at
+ * least one manifest references a capture missing from the pipeline output.
+ *
+ * Read-only: no file is ever deleted.
+ *
+ * Run via:
+ *   pnpm doc:scenarios:audit
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+import { DESTINATION_ROOTS } from '../e2e-shared/routing/destinations.ts';
+import {
+  ALL_DESTINATION_TARGETS,
+  formatAuditMarkdown,
+  runAudit,
+} from '../e2e-shared/routing/audit.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+const SCREENSHOTS_OUTPUT_DIR = path.join(PROJECT_ROOT, 'docs/src/assets/screenshots');
+const SCENARIOS_OUTPUT_ROOT = path.join(PROJECT_ROOT, 'e2e-doc-scenarios/output');
+const SCENARIOS_DIR = path.join(PROJECT_ROOT, 'e2e-doc-scenarios/scenarios');
+const SCREENSHOTS_ROUTING = path.join(PROJECT_ROOT, 'e2e-screenshots/routing.ts');
+const REPORT_PATH = path.join(PROJECT_ROOT, 'reports/routing-audit.md');
+
+const ALL_LOCALES = ['en', 'fr', 'es'];
+const ALL_THEMES = ['light', 'dark'];
+
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+async function importManifest(absolutePath, exportNames) {
+  const url = pathToFileURL(absolutePath).href;
+  const mod = await import(url);
+  for (const name of exportNames) {
+    if (mod[name]) return mod[name];
+  }
+  const candidate = Object.values(mod).find(
+    (value) => value && typeof value === 'object' && Array.isArray(value.routes),
+  );
+  if (candidate) return candidate;
+  throw new Error(`No manifest export found in ${absolutePath}`);
+}
+
+function listScreenshotCaptures(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const captures = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.png')) continue;
+    const base = entry.name.slice(0, -'.png'.length);
+    const parts = base.split('-');
+    if (parts.length < 3) continue;
+    const [locale, theme, ...rest] = parts;
+    if (!ALL_LOCALES.includes(locale)) continue;
+    if (!ALL_THEMES.includes(theme)) continue;
+    captures.push({ locale, theme, capture: rest.join('-') });
+  }
+  return captures;
+}
+
+function listScenarioCaptures(scenarioId) {
+  const captures = [];
+  if (!fs.existsSync(SCENARIOS_OUTPUT_ROOT)) return captures;
+  for (const locale of ALL_LOCALES) {
+    for (const theme of ALL_THEMES) {
+      const dir = path.join(SCENARIOS_OUTPUT_ROOT, locale, theme, scenarioId);
+      if (!fs.existsSync(dir)) continue;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.png')) continue;
+        const base = entry.name.slice(0, -'.png'.length);
+        const idx = base.indexOf('-');
+        if (idx < 0) continue;
+        const capture = base.slice(idx + 1);
+        if (!capture) continue;
+        captures.push({ locale, theme, capture });
+      }
+    }
+  }
+  return captures;
+}
+
+function walkDestination(root) {
+  const files = new Set();
+  if (!fs.existsSync(root)) return files;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith('.png')) {
+        const rel = path.relative(root, full).split(path.sep).join('/');
+        files.add(rel);
+      }
+    }
+  }
+  return files;
+}
+
+async function loadPipelines() {
+  const pipelines = [];
+
+  const screenshotsManifest = await importManifest(SCREENSHOTS_ROUTING, [
+    'SCREENSHOTS_MANIFEST',
+  ]);
+  pipelines.push({
+    id: 'e2e-screenshots',
+    manifest: screenshotsManifest,
+    capturesPresent: listScreenshotCaptures(SCREENSHOTS_OUTPUT_DIR),
+    locales: ALL_LOCALES,
+    themes: ALL_THEMES,
+    primaryDestination: 'starlight',
+  });
+
+  if (fs.existsSync(SCENARIOS_DIR)) {
+    const scenarioFiles = fs
+      .readdirSync(SCENARIOS_DIR)
+      .filter((name) => name.endsWith('.routing.ts'))
+      .sort();
+
+    for (const file of scenarioFiles) {
+      const scenarioId = file.slice(0, -'.routing.ts'.length);
+      const manifest = await importManifest(path.join(SCENARIOS_DIR, file), []);
+      pipelines.push({
+        id: scenarioId,
+        manifest,
+        capturesPresent: listScenarioCaptures(scenarioId),
+        locales: ALL_LOCALES,
+        themes: ALL_THEMES,
+      });
+    }
+  }
+
+  return pipelines;
+}
+
+function collectDestinationFiles() {
+  const map = new Map();
+  for (const target of ALL_DESTINATION_TARGETS) {
+    map.set(target, walkDestination(DESTINATION_ROOTS[target]));
+  }
+  return map;
+}
+
+async function main() {
+  log('• Loading manifests…');
+  const pipelines = await loadPipelines();
+  log(`  ${pipelines.length} pipeline(s) discovered.`);
+
+  log('• Scanning destination directories…');
+  const destinationFiles = collectDestinationFiles();
+
+  const report = runAudit({ pipelines, destinationFiles });
+  const markdown = formatAuditMarkdown(report);
+
+  fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
+  fs.writeFileSync(REPORT_PATH, markdown, 'utf-8');
+  log(`• Report written to ${path.relative(PROJECT_ROOT, REPORT_PATH)}`);
+
+  log('');
+  log('Summary:');
+  for (const summary of report.destinationSummaries) {
+    log(
+      `  - ${summary.destination.padEnd(18)} expected=${summary.expected} present=${summary.present} missing=${summary.missing} orphan=${summary.orphan}`,
+    );
+  }
+  log(`  obsolete references: ${report.obsoleteReferences.length}`);
+  log(`  orphan captures:     ${report.orphanCaptures.length}`);
+
+  if (report.hasErrors) {
+    log('');
+    log('✗ Obsolete references detected — see the report.');
+    process.exit(1);
+  }
+
+  log('');
+  log('✓ Routing graph is consistent.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(2);
+});

--- a/tests/routingAudit.test.ts
+++ b/tests/routingAudit.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatAuditMarkdown,
+  resolveDestinationPath,
+  runAudit,
+  type AuditInput,
+  type Pipeline,
+} from '../e2e-shared/routing/audit.js';
+import type { DestinationTarget, Manifest } from '../e2e-shared/routing/types.js';
+
+const ALL_LOCALES = ['en', 'fr', 'es'] as const;
+const ALL_THEMES = ['light', 'dark'] as const;
+
+function emptyDestinationFiles(): Map<DestinationTarget, Set<string>> {
+  return new Map<DestinationTarget, Set<string>>([
+    ['starlight', new Set()],
+    ['readme', new Set()],
+    ['chrome-web-store', new Set()],
+  ]);
+}
+
+function pipeline(overrides: Partial<Pipeline> & { id: string; manifest: Manifest }): Pipeline {
+  return {
+    capturesPresent: [],
+    locales: [...ALL_LOCALES],
+    themes: [...ALL_THEMES],
+    ...overrides,
+  };
+}
+
+describe('resolveDestinationPath', () => {
+  it('appends locale-theme prefix when no template placeholder is used', () => {
+    expect(resolveDestinationPath('rules-list', 'en', 'dark')).toBe('en-dark-rules-list.png');
+  });
+
+  it('substitutes {locale} and {theme} placeholders', () => {
+    expect(resolveDestinationPath('features/{locale}/{theme}/rules', 'fr', 'light')).toBe(
+      'features/fr/light/rules.png',
+    );
+  });
+
+  it('keeps an explicit .png suffix as is', () => {
+    expect(resolveDestinationPath('rules.png', 'en', 'dark')).toBe('en-dark-rules.png');
+  });
+});
+
+describe('runAudit', () => {
+  it('returns an empty report when manifests, captures and destinations are empty', () => {
+    const input: AuditInput = {
+      pipelines: [],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const report = runAudit(input);
+    expect(report.hasErrors).toBe(false);
+    expect(report.obsoleteReferences).toEqual([]);
+    expect(report.orphanCaptures).toEqual([]);
+    expect(report.orphanDestinationFiles).toEqual([]);
+    expect(report.missingDestinationFiles).toEqual([]);
+    expect(report.destinationSummaries.map((s) => s.destination)).toEqual([
+      'starlight',
+      'readme',
+      'chrome-web-store',
+    ]);
+    for (const summary of report.destinationSummaries) {
+      expect(summary).toMatchObject({ expected: 0, present: 0, missing: 0, orphan: 0 });
+    }
+  });
+
+  it('flags an obsolete reference when a manifest cites a missing capture', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [
+            { target: 'readme', path: 'rules-list', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: AuditInput = {
+      pipelines: [pipeline({ id: 'demo', manifest })],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const report = runAudit(input);
+    expect(report.hasErrors).toBe(true);
+    expect(report.obsoleteReferences).toHaveLength(1);
+    expect(report.obsoleteReferences[0]).toMatchObject({
+      pipeline: 'demo',
+      capture: 'rules-list',
+      locale: 'en',
+      theme: 'dark',
+      destination: 'readme',
+      destinationPath: 'en-dark-rules-list.png',
+    });
+  });
+
+  it('flags an orphan capture when no manifest references it', () => {
+    const manifest: Manifest = { routes: [] };
+    const input: AuditInput = {
+      pipelines: [
+        pipeline({
+          id: 'scenario-x',
+          manifest,
+          capturesPresent: [{ capture: 'leftover', locale: 'fr', theme: 'dark' }],
+        }),
+      ],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const report = runAudit(input);
+    expect(report.hasErrors).toBe(false);
+    expect(report.orphanCaptures).toHaveLength(1);
+    expect(report.orphanCaptures[0]).toMatchObject({
+      pipeline: 'scenario-x',
+      capture: 'leftover',
+      locale: 'fr',
+      theme: 'dark',
+    });
+  });
+
+  it('does not flag captures as orphan when the pipeline writes them to a primary destination', () => {
+    const manifest: Manifest = { routes: [] };
+    const input: AuditInput = {
+      pipelines: [
+        pipeline({
+          id: 'screenshots',
+          manifest,
+          capturesPresent: [{ capture: 'popup', locale: 'en', theme: 'dark' }],
+          primaryDestination: 'starlight',
+        }),
+      ],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set(['en-dark-popup.png'])],
+        ['readme', new Set()],
+        ['chrome-web-store', new Set()],
+      ]),
+    };
+    const report = runAudit(input);
+    expect(report.orphanCaptures).toEqual([]);
+    expect(report.missingDestinationFiles).toEqual([]);
+    expect(report.orphanDestinationFiles).toEqual([]);
+    const starlight = report.destinationSummaries.find((s) => s.destination === 'starlight');
+    expect(starlight).toMatchObject({ expected: 1, present: 1, missing: 0, orphan: 0 });
+  });
+
+  it('reports missing and orphan files per destination, plus a summary', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [
+            { target: 'readme', path: 'rules-list', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: AuditInput = {
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          capturesPresent: [{ capture: 'rules-list', locale: 'en', theme: 'dark' }],
+        }),
+      ],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set()],
+        ['readme', new Set(['legacy.png'])],
+        ['chrome-web-store', new Set()],
+      ]),
+    };
+    const report = runAudit(input);
+    expect(report.hasErrors).toBe(false);
+    expect(report.missingDestinationFiles).toHaveLength(1);
+    expect(report.missingDestinationFiles[0]).toMatchObject({
+      destination: 'readme',
+      relativePath: 'en-dark-rules-list.png',
+    });
+    expect(report.orphanDestinationFiles).toHaveLength(1);
+    expect(report.orphanDestinationFiles[0]).toMatchObject({
+      destination: 'readme',
+      relativePath: 'legacy.png',
+    });
+    const readmeSummary = report.destinationSummaries.find((s) => s.destination === 'readme');
+    expect(readmeSummary).toMatchObject({ expected: 1, present: 1, missing: 1, orphan: 1 });
+  });
+
+  it('expands route destinations across pipeline locales and themes when filters are omitted', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [{ target: 'starlight', path: 'rules-list' }],
+        },
+      ],
+    };
+    const presentCombos = ALL_LOCALES.flatMap((locale) =>
+      ALL_THEMES.map((theme) => ({ capture: 'rules-list', locale, theme })),
+    );
+    const input: AuditInput = {
+      pipelines: [pipeline({ id: 'demo', manifest, capturesPresent: presentCombos })],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const report = runAudit(input);
+    expect(report.obsoleteReferences).toEqual([]);
+    const starlight = report.destinationSummaries.find((s) => s.destination === 'starlight');
+    expect(starlight?.expected).toBe(ALL_LOCALES.length * ALL_THEMES.length);
+  });
+});
+
+describe('formatAuditMarkdown', () => {
+  it('produces a deterministic markdown report when given a fixed timestamp', () => {
+    const report = runAudit({
+      pipelines: [],
+      destinationFiles: emptyDestinationFiles(),
+    });
+    const md = formatAuditMarkdown(report, { generatedAt: '2026-05-08T00:00:00Z' });
+    expect(md).toContain('# Routing audit report');
+    expect(md).toContain('Generated: 2026-05-08T00:00:00Z');
+    expect(md).toContain('## Summary by destination');
+    expect(md).toContain('## Obsolete references');
+    expect(md).toContain('## Orphan captures');
+    expect(md).toContain('## Orphan destination files');
+    expect(md).toContain('## Missing destination files');
+  });
+
+  it('renders an obsolete reference row in the table', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [
+            { target: 'readme', path: 'rules-list', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const report = runAudit({
+      pipelines: [pipeline({ id: 'demo', manifest })],
+      destinationFiles: emptyDestinationFiles(),
+    });
+    const md = formatAuditMarkdown(report, { generatedAt: 'fixed' });
+    expect(md).toContain('| `demo` | `rules-list` | en | dark | `readme` | `en-dark-rules-list.png` |');
+  });
+});


### PR DESCRIPTION
Detects drifts between manifests, pipeline outputs and destination
directories without re-running captures. The new `pnpm doc:scenarios:audit`
emits `reports/routing-audit.md` and exits non-zero when a manifest
references a capture missing from the pipeline output.

Closes #261