### PR TITLE
feat(e2e-doc-scenarios): add on-demand routing sync command (US-DS011)

### DIFF
--- a/e2e-shared/routing/sync.ts
+++ b/e2e-shared/routing/sync.ts
@@ -1,0 +1,224 @@
+/**
+ * Pure on-demand sync logic (US-DS011, sub-issue of #257).
+ *
+ * Computes the set of copy and (optional) prune operations needed to bring the
+ * declared destination roots back in line with the existing pipeline captures
+ * cached under `e2e-doc-scenarios/output/` (or `docs/src/assets/screenshots/`),
+ * without ever re-running Playwright. Filesystem access lives in the wrapping
+ * script (`scripts/doc-scenarios-sync.mjs`); this module only manipulates plain
+ * data so it can be unit-tested in isolation.
+ */
+import type { DestinationTarget, Locale, Manifest, Theme } from './types.js';
+import { ALL_DESTINATION_TARGETS, resolveDestinationPath } from './audit.ts';
+
+/** A capture file actually sitting in a pipeline's source output. */
+export interface SyncSourceCapture {
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+  /** Absolute path to the source PNG. Copied verbatim into the plan. */
+  sourcePath: string;
+}
+
+/** A pipeline groups one manifest with the captures actually on disk. */
+export interface SyncPipeline {
+  /** Display label used in logs (e.g. `e2e-screenshots` or `00-main-journey`). */
+  id: string;
+  manifest: Manifest;
+  /** Captures present on disk for this pipeline. */
+  capturesPresent: SyncSourceCapture[];
+  /** Locales the pipeline runs through. Used to expand routes that omit `locales`. */
+  locales: Locale[];
+  /** Themes the pipeline runs through. Used to expand routes that omit `themes`. */
+  themes: Theme[];
+  /**
+   * If set, every present capture also lands directly in this destination
+   * (used for `e2e-screenshots`, whose primary outputDir is `docs/src/assets/screenshots/`).
+   */
+  primaryDestination?: DestinationTarget;
+}
+
+export interface SyncCopyOp {
+  pipeline: string;
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+  sourcePath: string;
+  destination: DestinationTarget;
+  /** Relative path under the destination root, with `.png` suffix. */
+  destinationPath: string;
+}
+
+export interface SyncSkipOp {
+  pipeline: string;
+  capture: string;
+  locale: Locale;
+  theme: Theme;
+  destination: DestinationTarget;
+  destinationPath: string;
+  reason: 'source-missing';
+}
+
+export interface SyncPruneOp {
+  destination: DestinationTarget;
+  relativePath: string;
+}
+
+export interface SyncPlan {
+  copies: SyncCopyOp[];
+  skips: SyncSkipOp[];
+  prunes: SyncPruneOp[];
+}
+
+export interface SyncDestinationSummary {
+  destination: DestinationTarget;
+  copied: number;
+  skipped: number;
+  pruned: number;
+}
+
+export interface SyncSummary {
+  copied: number;
+  skipped: number;
+  pruned: number;
+  byDestination: SyncDestinationSummary[];
+}
+
+export interface PlanSyncInput {
+  pipelines: SyncPipeline[];
+  /**
+   * Files currently present under each destination root, expressed relative to
+   * the root with `.png` suffix. Required when `prune` is true; ignored
+   * otherwise (an empty map is fine).
+   */
+  destinationFiles: Map<DestinationTarget, Set<string>>;
+  /** When true, files in destination directories not produced by routing are pruned. */
+  prune?: boolean;
+}
+
+function key(locale: Locale, theme: Theme): string {
+  return `${locale}/${theme}`;
+}
+
+function sortBy<T>(items: T[], by: (item: T) => string): T[] {
+  return [...items].sort((a, b) => {
+    const ka = by(a);
+    const kb = by(b);
+    if (ka < kb) return -1;
+    if (ka > kb) return 1;
+    return 0;
+  });
+}
+
+/**
+ * Compute the copy/prune operations needed to resync destination directories
+ * from the captures already present on disk.
+ *
+ * The function never reads or writes files: it returns a plan that the calling
+ * script can execute (or print, for `--dry-run`).
+ */
+export function planSync(input: PlanSyncInput): SyncPlan {
+  const copies: SyncCopyOp[] = [];
+  const skips: SyncSkipOp[] = [];
+  const expected: Record<DestinationTarget, Set<string>> = {
+    starlight: new Set<string>(),
+    readme: new Set<string>(),
+    'chrome-web-store': new Set<string>(),
+  };
+
+  for (const pipeline of input.pipelines) {
+    const sourceByCombo = new Map<string, Map<string, SyncSourceCapture>>();
+    for (const cap of pipeline.capturesPresent) {
+      const k = key(cap.locale, cap.theme);
+      let bucket = sourceByCombo.get(k);
+      if (!bucket) {
+        bucket = new Map<string, SyncSourceCapture>();
+        sourceByCombo.set(k, bucket);
+      }
+      bucket.set(cap.capture, cap);
+    }
+
+    for (const route of pipeline.manifest.routes) {
+      for (const dest of route.destinations) {
+        const localesForDest = dest.locales ?? pipeline.locales;
+        const themesForDest = dest.themes ?? pipeline.themes;
+        for (const locale of localesForDest) {
+          for (const theme of themesForDest) {
+            const destinationPath = resolveDestinationPath(dest.path, locale, theme);
+            const source = sourceByCombo.get(key(locale, theme))?.get(route.capture);
+            if (!source) {
+              skips.push({
+                pipeline: pipeline.id,
+                capture: route.capture,
+                locale,
+                theme,
+                destination: dest.target,
+                destinationPath,
+                reason: 'source-missing',
+              });
+              continue;
+            }
+            expected[dest.target].add(destinationPath);
+            copies.push({
+              pipeline: pipeline.id,
+              capture: route.capture,
+              locale,
+              theme,
+              sourcePath: source.sourcePath,
+              destination: dest.target,
+              destinationPath,
+            });
+          }
+        }
+      }
+    }
+
+    if (pipeline.primaryDestination) {
+      for (const cap of pipeline.capturesPresent) {
+        const filename = `${cap.locale}-${cap.theme}-${cap.capture}.png`;
+        expected[pipeline.primaryDestination].add(filename);
+      }
+    }
+  }
+
+  const prunes: SyncPruneOp[] = [];
+  if (input.prune) {
+    for (const target of ALL_DESTINATION_TARGETS) {
+      const present = input.destinationFiles.get(target) ?? new Set<string>();
+      for (const file of present) {
+        if (!expected[target].has(file)) {
+          prunes.push({ destination: target, relativePath: file });
+        }
+      }
+    }
+  }
+
+  return {
+    copies: sortBy(copies, (c) => `${c.destination}/${c.destinationPath}`),
+    skips: sortBy(skips, (s) => `${s.destination}/${s.destinationPath}`),
+    prunes: sortBy(prunes, (p) => `${p.destination}/${p.relativePath}`),
+  };
+}
+
+/** Aggregate a plan into per-destination counters for human-readable output. */
+export function summarizeSync(plan: SyncPlan): SyncSummary {
+  const counters = new Map<DestinationTarget, SyncDestinationSummary>();
+  for (const target of ALL_DESTINATION_TARGETS) {
+    counters.set(target, { destination: target, copied: 0, skipped: 0, pruned: 0 });
+  }
+  for (const copy of plan.copies) {
+    counters.get(copy.destination)!.copied += 1;
+  }
+  for (const skip of plan.skips) {
+    counters.get(skip.destination)!.skipped += 1;
+  }
+  for (const prune of plan.prunes) {
+    counters.get(prune.destination)!.pruned += 1;
+  }
+  return {
+    copied: plan.copies.length,
+    skipped: plan.skips.length,
+    pruned: plan.prunes.length,
+    byDestination: ALL_DESTINATION_TARGETS.map((t) => counters.get(t)!),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "screenshots": "pnpm build && xvfb-maybe playwright test --config=e2e-screenshots/playwright.screenshots.config.ts",
     "doc:scenarios": "pnpm build && xvfb-maybe playwright test --config=e2e-doc-scenarios/playwright.doc.config.ts",
     "doc:scenarios:audit": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/doc-scenarios-audit.mjs",
+    "doc:scenarios:sync": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/doc-scenarios-sync.mjs",
     "docs:dev": "pnpm --dir docs dev",
     "docs:build": "pnpm --dir docs build",
     "docs:preview": "pnpm --dir docs preview",

--- a/scripts/doc-scenarios-sync.mjs
+++ b/scripts/doc-scenarios-sync.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/**
+ * On-demand routing sync (US-DS011, sub-issue of #257).
+ *
+ * Resyncs every destination root (`doc/readme/`, `doc/chrome-web-store/`, and
+ * the Starlight assets directory) from the captures already cached under
+ * `e2e-doc-scenarios/output/` and `docs/src/assets/screenshots/`, without
+ * re-running Playwright. Reuses `e2e-shared/sharp-save.ts` semantics: every
+ * file is re-encoded through `sharp` to strip ancillary PNG chunks and stay
+ * byte-stable across runs.
+ *
+ * Flags:
+ *   --prune     Delete destination files that are no longer produced by the
+ *               routing manifests. Asks for confirmation unless --yes is set.
+ *   --yes       Skip the interactive prompt for --prune.
+ *   --dry-run   Print the operations that would run, do not touch any file.
+ *   --help      Show usage.
+ *
+ * Exits non-zero when at least one declared destination has no source on disk
+ * (so the user knows a `pnpm doc:scenarios` run is still required upstream).
+ *
+ * Run via:
+ *   pnpm doc:scenarios:sync
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { fileURLToPath, pathToFileURL } from 'url';
+import sharp from 'sharp';
+
+import { DESTINATION_ROOTS } from '../e2e-shared/routing/destinations.ts';
+import { ALL_DESTINATION_TARGETS } from '../e2e-shared/routing/audit.ts';
+import { planSync, summarizeSync } from '../e2e-shared/routing/sync.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+const SCREENSHOTS_OUTPUT_DIR = path.join(PROJECT_ROOT, 'docs/src/assets/screenshots');
+const SCENARIOS_OUTPUT_ROOT = path.join(PROJECT_ROOT, 'e2e-doc-scenarios/output');
+const SCENARIOS_DIR = path.join(PROJECT_ROOT, 'e2e-doc-scenarios/scenarios');
+const SCREENSHOTS_ROUTING = path.join(PROJECT_ROOT, 'e2e-screenshots/routing.ts');
+
+const ALL_LOCALES = ['en', 'fr', 'es'];
+const ALL_THEMES = ['light', 'dark'];
+
+function parseArgs(argv) {
+  const args = { prune: false, yes: false, dryRun: false, help: false };
+  for (const arg of argv) {
+    if (arg === '--prune') args.prune = true;
+    else if (arg === '--yes' || arg === '-y') args.yes = true;
+    else if (arg === '--dry-run' || arg === '-n') args.dryRun = true;
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else {
+      console.error(`Unknown argument: ${arg}`);
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function printUsage() {
+  process.stdout.write(`Usage: pnpm doc:scenarios:sync [--prune] [--yes] [--dry-run]
+
+Resync every destination root from the captures already on disk, without
+re-running Playwright.
+
+Options:
+  --prune     Delete destination files no longer produced by routing.
+  --yes, -y   Skip the interactive confirmation for --prune.
+  --dry-run   Print operations that would run, touch no file.
+  --help, -h  Show this help message.
+`);
+}
+
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+async function importManifest(absolutePath, exportNames) {
+  const url = pathToFileURL(absolutePath).href;
+  const mod = await import(url);
+  for (const name of exportNames) {
+    if (mod[name]) return mod[name];
+  }
+  const candidate = Object.values(mod).find(
+    (value) => value && typeof value === 'object' && Array.isArray(value.routes),
+  );
+  if (candidate) return candidate;
+  throw new Error(`No manifest export found in ${absolutePath}`);
+}
+
+function listScreenshotCaptures(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const captures = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.png')) continue;
+    const base = entry.name.slice(0, -'.png'.length);
+    const parts = base.split('-');
+    if (parts.length < 3) continue;
+    const [locale, theme, ...rest] = parts;
+    if (!ALL_LOCALES.includes(locale)) continue;
+    if (!ALL_THEMES.includes(theme)) continue;
+    captures.push({
+      locale,
+      theme,
+      capture: rest.join('-'),
+      sourcePath: path.join(dir, entry.name),
+    });
+  }
+  return captures;
+}
+
+function listScenarioCaptures(scenarioId) {
+  const captures = [];
+  if (!fs.existsSync(SCENARIOS_OUTPUT_ROOT)) return captures;
+  for (const locale of ALL_LOCALES) {
+    for (const theme of ALL_THEMES) {
+      const dir = path.join(SCENARIOS_OUTPUT_ROOT, locale, theme, scenarioId);
+      if (!fs.existsSync(dir)) continue;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.png')) continue;
+        const base = entry.name.slice(0, -'.png'.length);
+        const idx = base.indexOf('-');
+        if (idx < 0) continue;
+        const capture = base.slice(idx + 1);
+        if (!capture) continue;
+        captures.push({
+          locale,
+          theme,
+          capture,
+          sourcePath: path.join(dir, entry.name),
+        });
+      }
+    }
+  }
+  return captures;
+}
+
+function walkDestination(root) {
+  const files = new Set();
+  if (!fs.existsSync(root)) return files;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith('.png')) {
+        const rel = path.relative(root, full).split(path.sep).join('/');
+        files.add(rel);
+      }
+    }
+  }
+  return files;
+}
+
+async function loadPipelines() {
+  const pipelines = [];
+
+  const screenshotsManifest = await importManifest(SCREENSHOTS_ROUTING, [
+    'SCREENSHOTS_MANIFEST',
+  ]);
+  pipelines.push({
+    id: 'e2e-screenshots',
+    manifest: screenshotsManifest,
+    capturesPresent: listScreenshotCaptures(SCREENSHOTS_OUTPUT_DIR),
+    locales: ALL_LOCALES,
+    themes: ALL_THEMES,
+    primaryDestination: 'starlight',
+  });
+
+  if (fs.existsSync(SCENARIOS_DIR)) {
+    const scenarioFiles = fs
+      .readdirSync(SCENARIOS_DIR)
+      .filter((name) => name.endsWith('.routing.ts'))
+      .sort();
+
+    for (const file of scenarioFiles) {
+      const scenarioId = file.slice(0, -'.routing.ts'.length);
+      const manifest = await importManifest(path.join(SCENARIOS_DIR, file), []);
+      pipelines.push({
+        id: scenarioId,
+        manifest,
+        capturesPresent: listScenarioCaptures(scenarioId),
+        locales: ALL_LOCALES,
+        themes: ALL_THEMES,
+      });
+    }
+  }
+
+  return pipelines;
+}
+
+function collectDestinationFiles() {
+  const map = new Map();
+  for (const target of ALL_DESTINATION_TARGETS) {
+    map.set(target, walkDestination(DESTINATION_ROOTS[target]));
+  }
+  return map;
+}
+
+async function executeCopy(copy) {
+  const root = DESTINATION_ROOTS[copy.destination];
+  const targetPath = path.join(root, copy.destinationPath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const buffer = fs.readFileSync(copy.sourcePath);
+  // Re-encode through sharp so binary output stays stable (parity with
+  // `e2e-shared/sharp-save.ts`, which strips PNG metadata by default).
+  await sharp(buffer).png().toFile(targetPath);
+}
+
+function executePrune(prune) {
+  const root = DESTINATION_ROOTS[prune.destination];
+  const targetPath = path.join(root, prune.relativePath);
+  fs.rmSync(targetPath, { force: true });
+}
+
+async function confirmPrune(prunes) {
+  log('');
+  log(`The following ${prunes.length} file(s) would be deleted:`);
+  for (const prune of prunes) {
+    log(`  - ${prune.destination}/${prune.relativePath}`);
+  }
+  log('');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise((resolve) => {
+      rl.question('Proceed with deletion? [y/N] ', (response) => resolve(response));
+    });
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  log('• Loading manifests…');
+  const pipelines = await loadPipelines();
+  log(`  ${pipelines.length} pipeline(s) discovered.`);
+
+  log('• Scanning destination directories…');
+  const destinationFiles = collectDestinationFiles();
+
+  const plan = planSync({ pipelines, destinationFiles, prune: args.prune });
+  const summary = summarizeSync(plan);
+
+  log('');
+  log('Plan:');
+  log(`  copies:   ${summary.copied}`);
+  log(`  skipped:  ${summary.skipped} (source PNG missing)`);
+  if (args.prune) {
+    log(`  prunes:   ${summary.pruned}`);
+  }
+  for (const dest of summary.byDestination) {
+    const parts = [`copied=${dest.copied}`, `skipped=${dest.skipped}`];
+    if (args.prune) parts.push(`pruned=${dest.pruned}`);
+    log(`  - ${dest.destination.padEnd(18)} ${parts.join(' ')}`);
+  }
+
+  if (args.dryRun) {
+    log('');
+    log('Dry-run mode: no file was modified.');
+    if (plan.copies.length > 0) {
+      log('');
+      log('Copies:');
+      for (const copy of plan.copies) {
+        const rel = path.relative(PROJECT_ROOT, copy.sourcePath);
+        log(`  ${rel} -> ${copy.destination}/${copy.destinationPath}`);
+      }
+    }
+    if (plan.skips.length > 0) {
+      log('');
+      log('Skipped (source missing):');
+      for (const skip of plan.skips) {
+        log(`  ${skip.pipeline} :: ${skip.locale}/${skip.theme}/${skip.capture} -> ${skip.destination}/${skip.destinationPath}`);
+      }
+    }
+    if (args.prune && plan.prunes.length > 0) {
+      log('');
+      log('Prunes:');
+      for (const prune of plan.prunes) {
+        log(`  ${prune.destination}/${prune.relativePath}`);
+      }
+    }
+    process.exit(plan.skips.length > 0 ? 1 : 0);
+  }
+
+  if (plan.copies.length > 0) {
+    log('');
+    log('• Copying…');
+    for (const copy of plan.copies) {
+      await executeCopy(copy);
+    }
+    log(`  ${plan.copies.length} file(s) copied.`);
+  }
+
+  if (args.prune && plan.prunes.length > 0) {
+    let proceed = args.yes;
+    if (!proceed) {
+      proceed = await confirmPrune(plan.prunes);
+    }
+    if (proceed) {
+      log('• Pruning orphan destination files…');
+      for (const prune of plan.prunes) {
+        executePrune(prune);
+      }
+      log(`  ${plan.prunes.length} file(s) deleted.`);
+    } else {
+      log('  Prune cancelled.');
+    }
+  }
+
+  if (plan.skips.length > 0) {
+    log('');
+    log(`✗ ${plan.skips.length} destination(s) had no source PNG. Run "pnpm doc:scenarios" first.`);
+    for (const skip of plan.skips) {
+      log(`  - ${skip.pipeline} :: ${skip.locale}/${skip.theme}/${skip.capture}`);
+    }
+    process.exit(1);
+  }
+
+  log('');
+  log('✓ Sync complete.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(2);
+});

--- a/tests/routingSync.test.ts
+++ b/tests/routingSync.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planSync,
+  summarizeSync,
+  type PlanSyncInput,
+  type SyncPipeline,
+} from '../e2e-shared/routing/sync.js';
+import type { DestinationTarget, Manifest } from '../e2e-shared/routing/types.js';
+
+const ALL_LOCALES = ['en', 'fr', 'es'] as const;
+const ALL_THEMES = ['light', 'dark'] as const;
+
+function emptyDestinationFiles(): Map<DestinationTarget, Set<string>> {
+  return new Map<DestinationTarget, Set<string>>([
+    ['starlight', new Set()],
+    ['readme', new Set()],
+    ['chrome-web-store', new Set()],
+  ]);
+}
+
+function pipeline(overrides: Partial<SyncPipeline> & { id: string; manifest: Manifest }): SyncPipeline {
+  return {
+    capturesPresent: [],
+    locales: [...ALL_LOCALES],
+    themes: [...ALL_THEMES],
+    ...overrides,
+  };
+}
+
+describe('planSync', () => {
+  it('returns an empty plan when no pipeline declares anything', () => {
+    const input: PlanSyncInput = {
+      pipelines: [],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies).toEqual([]);
+    expect(plan.skips).toEqual([]);
+    expect(plan.prunes).toEqual([]);
+  });
+
+  it('emits one copy per (locale, theme) combo when the source PNG exists', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [
+            { target: 'readme', path: 'rules-list', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: PlanSyncInput = {
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          capturesPresent: [
+            {
+              capture: 'rules-list',
+              locale: 'en',
+              theme: 'dark',
+              sourcePath: '/abs/source/en/dark/rules-list.png',
+            },
+          ],
+        }),
+      ],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies).toHaveLength(1);
+    expect(plan.copies[0]).toMatchObject({
+      pipeline: 'demo',
+      capture: 'rules-list',
+      locale: 'en',
+      theme: 'dark',
+      sourcePath: '/abs/source/en/dark/rules-list.png',
+      destination: 'readme',
+      destinationPath: 'en-dark-rules-list.png',
+    });
+    expect(plan.skips).toEqual([]);
+  });
+
+  it('records a skip when a manifest references a capture that is not on disk', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules-list',
+          destinations: [
+            { target: 'readme', path: 'rules-list', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: PlanSyncInput = {
+      pipelines: [pipeline({ id: 'demo', manifest })],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies).toEqual([]);
+    expect(plan.skips).toHaveLength(1);
+    expect(plan.skips[0]).toMatchObject({
+      pipeline: 'demo',
+      capture: 'rules-list',
+      locale: 'en',
+      theme: 'dark',
+      destination: 'readme',
+      destinationPath: 'en-dark-rules-list.png',
+      reason: 'source-missing',
+    });
+  });
+
+  it('expands routes that omit locales/themes across the pipeline matrix', () => {
+    const manifest: Manifest = {
+      routes: [{ capture: 'popup', destinations: [{ target: 'starlight', path: 'popup' }] }],
+    };
+    const presentCombos = ALL_LOCALES.flatMap((locale) =>
+      ALL_THEMES.map((theme) => ({
+        capture: 'popup',
+        locale,
+        theme,
+        sourcePath: `/abs/${locale}/${theme}/popup.png`,
+      })),
+    );
+    const input: PlanSyncInput = {
+      pipelines: [pipeline({ id: 'demo', manifest, capturesPresent: presentCombos })],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies).toHaveLength(ALL_LOCALES.length * ALL_THEMES.length);
+    expect(plan.skips).toEqual([]);
+  });
+
+  it('substitutes {locale}/{theme} placeholders in destination paths', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules',
+          destinations: [{ target: 'starlight', path: 'features/{locale}/{theme}/rules' }],
+        },
+      ],
+    };
+    const input: PlanSyncInput = {
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          locales: ['fr'],
+          themes: ['light'],
+          capturesPresent: [
+            { capture: 'rules', locale: 'fr', theme: 'light', sourcePath: '/abs/fr/light/rules.png' },
+          ],
+        }),
+      ],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies).toHaveLength(1);
+    expect(plan.copies[0].destinationPath).toBe('features/fr/light/rules.png');
+  });
+
+  it('does not return prunes when --prune is off, even with orphan destination files', () => {
+    const manifest: Manifest = { routes: [] };
+    const input: PlanSyncInput = {
+      pipelines: [pipeline({ id: 'demo', manifest })],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set()],
+        ['readme', new Set(['legacy.png'])],
+        ['chrome-web-store', new Set()],
+      ]),
+    };
+    const plan = planSync(input);
+    expect(plan.prunes).toEqual([]);
+  });
+
+  it('flags every destination file not produced by routing as a prune candidate when --prune is on', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules',
+          destinations: [
+            { target: 'readme', path: 'rules', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: PlanSyncInput = {
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          capturesPresent: [
+            { capture: 'rules', locale: 'en', theme: 'dark', sourcePath: '/abs/en/dark/rules.png' },
+          ],
+        }),
+      ],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set()],
+        ['readme', new Set(['en-dark-rules.png', 'legacy.png'])],
+        ['chrome-web-store', new Set()],
+      ]),
+      prune: true,
+    };
+    const plan = planSync(input);
+    expect(plan.prunes).toHaveLength(1);
+    expect(plan.prunes[0]).toMatchObject({
+      destination: 'readme',
+      relativePath: 'legacy.png',
+    });
+  });
+
+  it('keeps captures landing in a primary destination out of the prune list', () => {
+    const manifest: Manifest = { routes: [] };
+    const input: PlanSyncInput = {
+      pipelines: [
+        pipeline({
+          id: 'screenshots',
+          manifest,
+          capturesPresent: [
+            { capture: 'popup', locale: 'en', theme: 'dark', sourcePath: '/abs/en-dark-popup.png' },
+          ],
+          primaryDestination: 'starlight',
+        }),
+      ],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set(['en-dark-popup.png'])],
+        ['readme', new Set()],
+        ['chrome-web-store', new Set()],
+      ]),
+      prune: true,
+    };
+    const plan = planSync(input);
+    expect(plan.prunes).toEqual([]);
+  });
+
+  it('returns operations sorted deterministically by destination/path', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'b',
+          destinations: [
+            { target: 'readme', path: 'b', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+        {
+          capture: 'a',
+          destinations: [
+            { target: 'readme', path: 'a', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const input: PlanSyncInput = {
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          capturesPresent: [
+            { capture: 'a', locale: 'en', theme: 'dark', sourcePath: '/abs/a.png' },
+            { capture: 'b', locale: 'en', theme: 'dark', sourcePath: '/abs/b.png' },
+          ],
+        }),
+      ],
+      destinationFiles: emptyDestinationFiles(),
+    };
+    const plan = planSync(input);
+    expect(plan.copies.map((c) => c.destinationPath)).toEqual([
+      'en-dark-a.png',
+      'en-dark-b.png',
+    ]);
+  });
+});
+
+describe('summarizeSync', () => {
+  it('aggregates per-destination counters for copies, skips and prunes', () => {
+    const manifest: Manifest = {
+      routes: [
+        {
+          capture: 'rules',
+          destinations: [
+            { target: 'readme', path: 'rules', locales: ['en'], themes: ['dark'] },
+            { target: 'chrome-web-store', path: 'rules', locales: ['en'], themes: ['dark'] },
+          ],
+        },
+        {
+          capture: 'missing',
+          destinations: [
+            { target: 'readme', path: 'missing', locales: ['fr'], themes: ['dark'] },
+          ],
+        },
+      ],
+    };
+    const plan = planSync({
+      pipelines: [
+        pipeline({
+          id: 'demo',
+          manifest,
+          capturesPresent: [
+            { capture: 'rules', locale: 'en', theme: 'dark', sourcePath: '/abs/rules.png' },
+          ],
+        }),
+      ],
+      destinationFiles: new Map<DestinationTarget, Set<string>>([
+        ['starlight', new Set()],
+        ['readme', new Set(['legacy.png'])],
+        ['chrome-web-store', new Set()],
+      ]),
+      prune: true,
+    });
+    const summary = summarizeSync(plan);
+    expect(summary.copied).toBe(2);
+    expect(summary.skipped).toBe(1);
+    expect(summary.pruned).toBe(1);
+    expect(summary.byDestination.map((s) => s.destination)).toEqual([
+      'starlight',
+      'readme',
+      'chrome-web-store',
+    ]);
+    const readme = summary.byDestination.find((s) => s.destination === 'readme');
+    expect(readme).toMatchObject({ copied: 1, skipped: 1, pruned: 1 });
+    const cws = summary.byDestination.find((s) => s.destination === 'chrome-web-store');
+    expect(cws).toMatchObject({ copied: 1, skipped: 0, pruned: 0 });
+  });
+});


### PR DESCRIPTION
Resyncs `doc/readme/`, `doc/chrome-web-store/` and the Starlight assets
from the captures already cached under `e2e-doc-scenarios/output/` and
`docs/src/assets/screenshots/`, without re-running Playwright. Closes #262.

- `pnpm doc:scenarios:sync` (with `--dry-run`, `--prune`, `--yes`).
- Pure planner under `e2e-shared/routing/sync.ts`, unit-tested.
- Re-encodes through `sharp` for byte-stable output (parity with sharp-save).