### PR TITLE
feat(workspaces): add ListToolbar with search, highlight and shortcuts

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -139,7 +139,9 @@
   "confirmDeleteSelectedDescription": { "message": "This will permanently delete the selected rules. This action cannot be undone." },
   "searchRules": { "message": "Search rules..." },
   "searchSessions": { "message": "Search sessions..." },
+  "searchWorkspaces": { "message": "Search workspaces..." },
   "noRulesFound": { "message": "No rules found" },
+  "noWorkspacesFound": { "message": "No workspaces found" },
   "popupNoRulesTitle": { "message": "No rules configured" },
   "popupGoToRules": { "message": "Manage rules" },
   "rulesEmptyTitle": { "message": "No domain rules yet" },
@@ -536,6 +538,7 @@
   "shortcutsGroupListHome": { "message": "Home page" },
   "shortcutsGroupListRules": { "message": "Rules list" },
   "shortcutsGroupListSessions": { "message": "Sessions list" },
+  "shortcutsGroupListWorkspaces": { "message": "Workspaces list" },
   "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
 
   "shortcutDescOrganize": { "message": "Organize all tabs" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -139,7 +139,9 @@
   "confirmDeleteSelectedDescription": { "message": "Las reglas seleccionadas se eliminarán permanentemente. Esta acción no se puede deshacer." },
   "searchRules": { "message": "Buscar reglas..." },
   "searchSessions": { "message": "Buscar sesiones..." },
+  "searchWorkspaces": { "message": "Buscar espacios..." },
   "noRulesFound": { "message": "No se encontraron reglas" },
+  "noWorkspacesFound": { "message": "No se encontraron espacios" },
   "popupNoRulesTitle": { "message": "No hay reglas configuradas" },
   "popupGoToRules": { "message": "Gestionar reglas" },
   "rulesEmptyTitle": { "message": "Aún no hay reglas de dominio" },
@@ -537,6 +539,7 @@
   "shortcutsGroupListHome": { "message": "Página de inicio" },
   "shortcutsGroupListRules": { "message": "Lista de reglas" },
   "shortcutsGroupListSessions": { "message": "Lista de sesiones" },
+  "shortcutsGroupListWorkspaces": { "message": "Lista de espacios" },
   "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
 
   "shortcutDescOrganize": { "message": "Organizar todas las pestañas" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -139,7 +139,9 @@
   "confirmDeleteSelectedDescription": { "message": "Les règles sélectionnées seront définitivement supprimées. Cette action est irréversible." },
   "searchRules": { "message": "Rechercher des règles..." },
   "searchSessions": { "message": "Rechercher des sessions..." },
+  "searchWorkspaces": { "message": "Rechercher des espaces..." },
   "noRulesFound": { "message": "Aucune règle trouvée" },
+  "noWorkspacesFound": { "message": "Aucun espace trouvé" },
   "popupNoRulesTitle": { "message": "Aucune règle paramétrée" },
   "popupGoToRules": { "message": "Gérer les règles" },
   "rulesEmptyTitle": { "message": "Aucune règle de domaine" },
@@ -537,6 +539,7 @@
   "shortcutsGroupListHome": { "message": "Page d'accueil" },
   "shortcutsGroupListRules": { "message": "Liste des règles" },
   "shortcutsGroupListSessions": { "message": "Liste des sessions" },
+  "shortcutsGroupListWorkspaces": { "message": "Liste des espaces" },
   "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
 
   "shortcutDescOrganize": { "message": "Organiser tous les onglets" },

--- a/src/components/UI/ShortcutsPanel/shortcuts.ts
+++ b/src/components/UI/ShortcutsPanel/shortcuts.ts
@@ -72,6 +72,13 @@ const groupListSessions: ShortcutGroup = {
   subgroups: [groupSessionCard],
 };
 
+const groupListWorkspaces: ShortcutGroup = {
+  titleKey: 'shortcutsGroupListWorkspaces',
+  shortcuts: [
+    { keys: ['n'], descriptionKey: 'shortcutDescListNew' },
+  ],
+};
+
 const groupListHome: ShortcutGroup = {
   titleKey: 'shortcutsGroupListHome',
   shortcuts: [
@@ -109,6 +116,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   groupListHome,
   groupListRules,
   groupListSessions,
+  groupListWorkspaces,
   groupOptions,
   groupPopup,
 ];
@@ -145,6 +153,8 @@ export function isGroupOpenByDefault(
       return pageContext === 'rules';
     case 'shortcutsGroupListSessions':
       return pageContext === 'sessions';
+    case 'shortcutsGroupListWorkspaces':
+      return pageContext === 'workspaces';
     case 'shortcutsGroupSessionCard':
       return pageContext === 'sessions' || pageContext === 'home';
     default:

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -1,7 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Box, Button, Card, Flex, IconButton, Text, Tooltip } from '@radix-ui/themes';
-import { Layers, Pencil, Plus, Trash2 } from 'lucide-react';
+import { AlertCircle, Layers, Pencil, Plus, Trash2 } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
+import { ListToolbar } from '@/components/UI/ListToolbar';
+import { EmptyState } from '@/components/UI/EmptyState';
+import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import { WorkspaceAvatar } from '@/components/UI/Workspace/WorkspaceAvatar';
 import { WorkspaceFormDialog } from '@/components/UI/Workspace/WorkspaceFormDialog';
@@ -9,6 +12,9 @@ import { WorkspaceDeleteConfirmDialog } from '@/components/UI/Workspace/Workspac
 import { DEFAULT_WORKSPACE_ID } from '@/utils/workspaceStorage';
 import { getMessage } from '@/utils/i18n';
 import { logger } from '@/utils/logger';
+import { foldAccents } from '@/utils/stringUtils';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import type { AppSettings } from '@/types/syncSettings';
 import type { WorkspaceMeta } from '@/schemas/workspace';
 
@@ -21,6 +27,7 @@ interface WorkspaceRowProps {
   isActive: boolean;
   isDefault: boolean;
   isOnly: boolean;
+  searchTerm: string;
   onSwitch: () => void;
   onEdit: () => void;
   onDelete: () => void;
@@ -32,7 +39,7 @@ function resolveDeleteTooltip(isDefault: boolean, isOnly: boolean): string {
   return getMessage('workspaceDeleteLabel');
 }
 
-function WorkspaceRow({ workspace, isActive, isDefault, isOnly, onSwitch, onEdit, onDelete }: WorkspaceRowProps) {
+function WorkspaceRow({ workspace, isActive, isDefault, isOnly, searchTerm, onSwitch, onEdit, onDelete }: WorkspaceRowProps) {
   const deleteBlocked = isDefault || isOnly;
   const deleteTooltip = resolveDeleteTooltip(isDefault, isOnly);
 
@@ -42,7 +49,9 @@ function WorkspaceRow({ workspace, isActive, isDefault, isOnly, onSwitch, onEdit
         <WorkspaceAvatar name={workspace.name} accentColor={workspace.accentColor} size="md" />
         <Flex direction="column" gap="1" style={{ flex: 1, minWidth: 0 }}>
           <Flex align="center" gap="2">
-            <Text size="3" weight="medium">{workspace.name}</Text>
+            <Text size="3" weight="medium">
+              <AccessibleHighlight text={workspace.name} searchTerm={searchTerm} />
+            </Text>
             {isActive ? (
               <Text size="1" color="gray" data-testid={`workspace-row-${workspace.id}-active`}>
                 {getMessage('workspaceActiveBadge')}
@@ -113,8 +122,22 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<WorkspaceMeta | null>(null);
   const [deleting, setDeleting] = useState<WorkspaceMeta | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
 
   const takenNames = workspaces.map((w) => w.name);
+
+  const filteredWorkspaces = useMemo(() => {
+    if (!searchTerm) return workspaces;
+    const term = foldAccents(searchTerm);
+    return workspaces.filter((ws) => foldAccents(ws.name).includes(term));
+  }, [workspaces, searchTerm]);
+
+  const handleOpenCreate = useCallback(() => setCreateOpen(true), []);
+
+  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
+    { combo: 'n', action: handleOpenCreate },
+  ], [handleOpenCreate]);
+  useKeyboardShortcuts(pageShortcuts);
 
   const handleCreate = useCallback(
     async ({ name, accentColor }: { name: string; accentColor: WorkspaceMeta['accentColor'] }) => {
@@ -157,34 +180,50 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
       syncSettings={syncSettings}
     >
       {() => (
-        <Flex direction="column" gap="3">
-          <Flex justify="end">
-            <Button
-              data-testid="workspace-create-button"
-              variant="solid"
-              onClick={() => setCreateOpen(true)}
-            >
-              <Plus size={16} />
-              {getMessage('workspaceCreateLabel')}
-            </Button>
-          </Flex>
+        <Box data-testid="page-workspaces">
+          {workspaces.length > 0 && (
+            <ListToolbar
+              testId="page-workspaces-toolbar"
+              searchTestId="page-workspaces-search"
+              searchPlaceholder={getMessage('searchWorkspaces')}
+              searchValue={searchTerm}
+              onSearchChange={setSearchTerm}
+              action={
+                <Button
+                  data-testid="workspace-create-button"
+                  variant="solid"
+                  onClick={handleOpenCreate}
+                >
+                  <Plus size={16} />
+                  {getMessage('workspaceCreateLabel')}
+                </Button>
+              }
+            />
+          )}
 
-          <Box data-testid="workspace-list">
-            <Flex direction="column" gap="2">
-              {workspaces.map((ws) => (
-                <WorkspaceRow
-                  key={ws.id}
-                  workspace={ws}
-                  isActive={ws.id === activeId}
-                  isDefault={ws.id === DEFAULT_WORKSPACE_ID}
-                  isOnly={workspaces.length === 1}
-                  onSwitch={() => void switchTo(ws.id)}
-                  onEdit={() => setEditing(ws)}
-                  onDelete={() => setDeleting(ws)}
-                />
-              ))}
-            </Flex>
-          </Box>
+          {filteredWorkspaces.length === 0 && searchTerm && (
+            <EmptyState compact icon={AlertCircle} message={getMessage('noWorkspacesFound')} />
+          )}
+
+          {filteredWorkspaces.length > 0 && (
+            <Box data-testid="workspace-list">
+              <Flex direction="column" gap="2">
+                {filteredWorkspaces.map((ws) => (
+                  <WorkspaceRow
+                    key={ws.id}
+                    workspace={ws}
+                    isActive={ws.id === activeId}
+                    isDefault={ws.id === DEFAULT_WORKSPACE_ID}
+                    isOnly={workspaces.length === 1}
+                    searchTerm={searchTerm}
+                    onSwitch={() => void switchTo(ws.id)}
+                    onEdit={() => setEditing(ws)}
+                    onDelete={() => setDeleting(ws)}
+                  />
+                ))}
+              </Flex>
+            </Box>
+          )}
 
           <WorkspaceFormDialog
             open={createOpen}
@@ -205,7 +244,7 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
             workspace={deleting}
             onConfirm={handleDeleteConfirm}
           />
-        </Flex>
+        </Box>
       )}
     </PageLayout>
   );

--- a/tests/e2e/workspaces-search.spec.ts
+++ b/tests/e2e/workspaces-search.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E tests for the search and highlight features on the Workspaces page,
+ * plus the page-level keyboard shortcuts wired to the new ListToolbar:
+ * `/` focuses the search field, `Esc` clears it, `n` opens the create dialog.
+ */
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+
+async function goToWorkspaces(page: Page, extensionId: string) {
+  await page.goto(`chrome-extension://${extensionId}/options.html#workspaces`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.getByTestId('workspace-create-button').waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+async function createWorkspace(page: Page, name: string) {
+  await page.getByTestId('workspace-create-button').click();
+  await expect(page.getByTestId('workspace-form-dialog')).toBeVisible();
+  await page.getByTestId('workspace-form-name').fill(name);
+  await page.getByTestId('workspace-form-btn-submit').click();
+  await expect(page.getByTestId('workspace-form-dialog')).toBeHidden();
+  await expect(page.locator('[data-testid^="workspace-row-"]', { hasText: name })).toBeVisible();
+}
+
+test.describe('Workspaces search filter', () => {
+  test('typing filters the list and matches by name', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+    await createWorkspace(optionsPage, 'Personal');
+    await createWorkspace(optionsPage, 'Work');
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('Work');
+
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Work' })).toBeVisible();
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Personal' })).toHaveCount(0);
+  });
+
+  test('search is case and accent insensitive', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+    await createWorkspace(optionsPage, 'Café');
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('cafe');
+
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Café' })).toBeVisible();
+  });
+
+  test('clearing search restores all workspaces', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+    await createWorkspace(optionsPage, 'Alpha');
+    await createWorkspace(optionsPage, 'Beta');
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('Alpha');
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Beta' })).toHaveCount(0);
+
+    await search.fill('');
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Alpha' })).toBeVisible();
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Beta' })).toBeVisible();
+  });
+
+  test('shows no-results empty state and keeps the create button visible', async ({
+    optionsPage,
+    extensionId,
+  }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('zzz-no-such-workspace-xyz');
+
+    await expect(optionsPage.getByText(/no workspaces found/i)).toBeVisible();
+    await expect(optionsPage.getByTestId('workspace-create-button')).toBeVisible();
+    await expect(optionsPage.locator('[data-testid^="workspace-row-"]')).toHaveCount(0);
+  });
+});
+
+test.describe('Workspaces search highlight', () => {
+  test('matching part of the workspace name is wrapped in a <mark>', async ({
+    optionsPage,
+    extensionId,
+  }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+    await createWorkspace(optionsPage, 'Personal Hub');
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('Personal');
+
+    await expect(optionsPage.locator('mark').filter({ hasText: 'Personal' }).first()).toBeVisible();
+  });
+
+  test('no highlight when the search field is empty', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+    await createWorkspace(optionsPage, 'Sandbox');
+
+    await expect(optionsPage.locator('mark')).toHaveCount(0);
+  });
+});
+
+test.describe('Workspaces keyboard shortcuts', () => {
+  test('"/" focuses the search field', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+
+    await optionsPage.locator('body').click();
+    await optionsPage.keyboard.press('/');
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await expect(search).toBeFocused();
+  });
+
+  test('"Esc" clears the search input', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+
+    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    await search.fill('something');
+    await expect(search).toHaveValue('something');
+
+    await search.press('Escape');
+    await expect(search).toHaveValue('');
+  });
+
+  test('"n" opens the create workspace dialog', async ({ optionsPage, extensionId }) => {
+    await goToWorkspaces(optionsPage, extensionId);
+
+    await optionsPage.locator('body').click();
+    await optionsPage.keyboard.press('n');
+
+    await expect(optionsPage.getByTestId('workspace-form-dialog')).toBeVisible();
+  });
+});

--- a/tests/e2e/workspaces-search.spec.ts
+++ b/tests/e2e/workspaces-search.spec.ts
@@ -27,7 +27,7 @@ test.describe('Workspaces search filter', () => {
     await createWorkspace(optionsPage, 'Personal');
     await createWorkspace(optionsPage, 'Work');
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('Work');
 
     await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Work' })).toBeVisible();
@@ -38,7 +38,7 @@ test.describe('Workspaces search filter', () => {
     await goToWorkspaces(optionsPage, extensionId);
     await createWorkspace(optionsPage, 'Café');
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('cafe');
 
     await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Café' })).toBeVisible();
@@ -49,7 +49,7 @@ test.describe('Workspaces search filter', () => {
     await createWorkspace(optionsPage, 'Alpha');
     await createWorkspace(optionsPage, 'Beta');
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('Alpha');
     await expect(optionsPage.locator('[data-testid^="workspace-row-"]', { hasText: 'Beta' })).toHaveCount(0);
 
@@ -64,7 +64,7 @@ test.describe('Workspaces search filter', () => {
   }) => {
     await goToWorkspaces(optionsPage, extensionId);
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('zzz-no-such-workspace-xyz');
 
     await expect(optionsPage.getByText(/no workspaces found/i)).toBeVisible();
@@ -81,7 +81,7 @@ test.describe('Workspaces search highlight', () => {
     await goToWorkspaces(optionsPage, extensionId);
     await createWorkspace(optionsPage, 'Personal Hub');
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('Personal');
 
     await expect(optionsPage.locator('mark').filter({ hasText: 'Personal' }).first()).toBeVisible();
@@ -102,14 +102,14 @@ test.describe('Workspaces keyboard shortcuts', () => {
     await optionsPage.locator('body').click();
     await optionsPage.keyboard.press('/');
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await expect(search).toBeFocused();
   });
 
   test('"Esc" clears the search input', async ({ optionsPage, extensionId }) => {
     await goToWorkspaces(optionsPage, extensionId);
 
-    const search = optionsPage.getByTestId('page-workspaces-search').locator('input');
+    const search = optionsPage.getByTestId('page-workspaces-search');
     await search.fill('something');
     await expect(search).toHaveValue('something');
 


### PR DESCRIPTION
Replaces the right-aligned create button on the Workspaces page with the
shared ListToolbar (already used on Rules and Sessions). Adds a name-only
filter (case + accent insensitive), AccessibleHighlight on row names,
and the standard list shortcuts: `/` focus, `Esc` clear, `n` open create
dialog. Cheatsheet gets a new "Workspaces list" group; EN/FR/ES locales
gain searchWorkspaces, noWorkspacesFound and shortcutsGroupListWorkspaces
keys. Adds tests/e2e/workspaces-search.spec.ts covering filter, accent
insensitivity, highlight, empty state and the three shortcuts.