### PR TITLE
fix(import): match rules and sessions by id with label/name fallback

### DIFF
--- a/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportSessionsWizard.tsx
@@ -89,9 +89,7 @@ export function ImportSessionsWizard({ open, onOpenChange }: ImportSessionsWizar
 
     for (const conflict of classification.conflictingItems) {
       if (conflictMode === 'overwrite') {
-        const idx = updatedSessions.findIndex(
-          s => s.name.toLowerCase() === conflict.existing.name.toLowerCase()
-        );
+        const idx = updatedSessions.findIndex(s => s.id === conflict.existing.id);
         if (idx !== -1) {
           updatedSessions[idx] = { ...conflict.imported, id: conflict.existing.id };
           overwritten++;

--- a/src/components/UI/ImportExportWizards/ImportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizard.tsx
@@ -84,9 +84,7 @@ export function ImportWizard({
 
     for (const conflict of classification.conflictingItems) {
       if (conflictMode === 'overwrite') {
-        const idx = updatedRules.findIndex(
-          r => r.label.toLowerCase() === conflict.existing.label.toLowerCase()
-        );
+        const idx = updatedRules.findIndex(r => r.id === conflict.existing.id);
         if (idx !== -1) {
           updatedRules[idx] = { ...conflict.imported, id: conflict.existing.id };
           overwritten++;

--- a/src/components/UI/ImportExportWizards/SessionImportRows.tsx
+++ b/src/components/UI/ImportExportWizards/SessionImportRows.tsx
@@ -76,6 +76,7 @@ interface SessionDiffViewProps {
 
 export function SessionDiffView({ diff }: SessionDiffViewProps) {
   const hasContent =
+    diff.name !== undefined ||
     diff.isPinned !== undefined ||
     diff.categoryId !== undefined ||
     diff.groupsAdded.length > 0 ||
@@ -88,6 +89,14 @@ export function SessionDiffView({ diff }: SessionDiffViewProps) {
 
   return (
     <Flex direction="column" gap="3">
+      {diff.name !== undefined && (
+        <DiffPropertyValues
+          label="name"
+          current={diff.name.current}
+          imported={diff.name.imported}
+        />
+      )}
+
       {diff.isPinned !== undefined && (
         <DiffPropertyValues
           label="isPinned"

--- a/src/utils/importClassification.ts
+++ b/src/utils/importClassification.ts
@@ -73,7 +73,6 @@ export function getRuleDifferences(
 ): PropertyDiff[] {
   const diffs: PropertyDiff[] = [];
   for (const prop of COMPARABLE_PROPERTIES) {
-    if (prop === 'label') continue; // Label is the matching key, skip it
     if (!arePropertyValuesEqual(ruleA[prop], ruleB[prop])) {
       diffs.push({
         property: prop,
@@ -85,26 +84,44 @@ export function getRuleDifferences(
   return diffs;
 }
 
-/** Classify imported rules into new, conflicting, and identical groups */
+/**
+ * Classify imported rules into new, conflicting, and identical groups.
+ * Match by `id` first to catch renames; fall back to label match (case
+ * insensitive) so re-imports of the same content with a different id still
+ * dedupe.
+ */
 export function classifyImportedRules(
   importedRules: DomainRuleSetting[],
   existingRules: DomainRuleSetting[]
 ): RuleClassification {
+  const existingById = new Map<string, DomainRuleSetting>();
   const existingByLabel = new Map<string, DomainRuleSetting>();
   for (const rule of existingRules) {
+    existingById.set(rule.id, rule);
     existingByLabel.set(rule.label.toLowerCase(), rule);
   }
 
+  const matchedExistingIds = new Set<string>();
   const newRules: DomainRuleSetting[] = [];
   const conflictingRules: ConflictingRule[] = [];
   const identicalRules: DomainRuleSetting[] = [];
 
   for (const imported of importedRules) {
-    const existing = existingByLabel.get(imported.label.toLowerCase());
+    let existing = existingById.get(imported.id);
+    if (!existing) {
+      const labelMatch = existingByLabel.get(imported.label.toLowerCase());
+      if (labelMatch && !matchedExistingIds.has(labelMatch.id)) {
+        existing = labelMatch;
+      }
+    }
 
     if (!existing) {
       newRules.push(imported);
-    } else if (areDomainRulesEqual(existing, imported)) {
+      continue;
+    }
+
+    matchedExistingIds.add(existing.id);
+    if (areDomainRulesEqual(existing, imported)) {
       identicalRules.push(imported);
     } else {
       conflictingRules.push({

--- a/src/utils/sessionClassification.ts
+++ b/src/utils/sessionClassification.ts
@@ -8,6 +8,7 @@ export interface GroupDiff {
 }
 
 export interface SessionDiff {
+  name?: { current: string; imported: string };
   isPinned?: { current: boolean; imported: boolean };
   categoryId?: { current: string | null | undefined; imported: string | null | undefined };
   note?: { current: string | undefined; imported: string | undefined };
@@ -59,9 +60,10 @@ function areGroupArraysEqual(a: SavedTabGroup[], b: SavedTabGroup[]): boolean {
   return true;
 }
 
-/** Compare two sessions ignoring id, name, createdAt, updatedAt */
+/** Compare two sessions ignoring id, createdAt, updatedAt */
 export function areSessionsEqual(a: Session, b: Session): boolean {
   return (
+    a.name === b.name &&
     a.isPinned === b.isPinned &&
     (a.categoryId ?? null) === (b.categoryId ?? null) &&
     (a.note ?? '') === (b.note ?? '') &&
@@ -161,6 +163,10 @@ export function getSessionDiff(existing: Session, imported: Session): SessionDif
     ungroupedTabsRemoved: ungrouped.removed,
   };
 
+  if (existing.name !== imported.name) {
+    diff.name = { current: existing.name, imported: imported.name };
+  }
+
   if (existing.isPinned !== imported.isPinned) {
     diff.isPinned = { current: existing.isPinned, imported: imported.isPinned };
   }
@@ -179,25 +185,44 @@ export function getSessionDiff(existing: Session, imported: Session): SessionDif
   return diff;
 }
 
-/** Classify imported sessions into new, conflicting, and identical groups */
+/**
+ * Classify imported sessions into new, conflicting, and identical groups.
+ * Match by `id` first to catch renames; fall back to name match (case
+ * insensitive) so re-imports of the same content with a different id still
+ * dedupe.
+ */
 export function classifyImportedSessions(
   importedSessions: Session[],
   existingSessions: Session[]
 ): SessionClassification {
+  const existingById = new Map<string, Session>();
   const existingByName = new Map<string, Session>();
   for (const session of existingSessions) {
+    existingById.set(session.id, session);
     existingByName.set(session.name.toLowerCase(), session);
   }
 
+  const matchedExistingIds = new Set<string>();
   const newSessions: Session[] = [];
   const conflictingSessions: ConflictingSession[] = [];
   const identicalSessions: Session[] = [];
 
   for (const imported of importedSessions) {
-    const existing = existingByName.get(imported.name.toLowerCase());
+    let existing = existingById.get(imported.id);
+    if (!existing) {
+      const nameMatch = existingByName.get(imported.name.toLowerCase());
+      if (nameMatch && !matchedExistingIds.has(nameMatch.id)) {
+        existing = nameMatch;
+      }
+    }
+
     if (!existing) {
       newSessions.push(imported);
-    } else if (areSessionsEqual(existing, imported)) {
+      continue;
+    }
+
+    matchedExistingIds.add(existing.id);
+    if (areSessionsEqual(existing, imported)) {
       identicalSessions.push(imported);
     } else {
       conflictingSessions.push({

--- a/tests/sessionClassification.test.ts
+++ b/tests/sessionClassification.test.ts
@@ -38,10 +38,16 @@ function session(overrides: Partial<Session> = {}): Session {
 }
 
 describe('areSessionsEqual', () => {
-  it('ignores id, name, createdAt, updatedAt', async () => {
-    const a = session({ id: 'a', name: 'Alpha', createdAt: '2020', updatedAt: '2021' });
-    const b = session({ id: 'b', name: 'Beta', createdAt: '2030', updatedAt: '2031' });
+  it('ignores id, createdAt, updatedAt', async () => {
+    const a = session({ id: 'a', createdAt: '2020', updatedAt: '2021' });
+    const b = session({ id: 'b', createdAt: '2030', updatedAt: '2031' });
     expect(areSessionsEqual(a, b)).toBe(true);
+  });
+
+  it('returns false when name differs (rename surfaced)', () => {
+    const a = session({ name: 'Alpha' });
+    const b = session({ name: 'Beta' });
+    expect(areSessionsEqual(a, b)).toBe(false);
   });
 
   it('returns false when isPinned differs', () => {
@@ -145,6 +151,20 @@ describe('getSessionDiff', () => {
     expect(diff.ungroupedTabsRemoved).toHaveLength(0);
     expect(diff.isPinned).toBeUndefined();
     expect(diff.categoryId).toBeUndefined();
+  });
+
+  it('populates name diff when names differ (rename)', () => {
+    const existing = session({ name: 'Old name' });
+    const imported = session({ name: 'New name' });
+    const diff = getSessionDiff(existing, imported);
+    expect(diff.name).toEqual({ current: 'Old name', imported: 'New name' });
+  });
+
+  it('does not flag a name diff when names match', () => {
+    const existing = session({ name: 'Same' });
+    const imported = session({ name: 'Same' });
+    const diff = getSessionDiff(existing, imported);
+    expect(diff.name).toBeUndefined();
   });
 
   it('populates isPinned diff', () => {
@@ -303,17 +323,73 @@ describe('classifyImportedSessions', () => {
     expect(result.identicalSessions).toHaveLength(0);
   });
 
-  it('flags sessions as identical when structure matches (ignoring name casing)', () => {
+  it('flags sessions as conflicting when name casing differs (rename via fallback)', () => {
     const existing = [
-      session({ name: 'Work', groups: [group('G1', ['https://x.com'])] }),
+      session({ id: 'a', name: 'Work', groups: [group('G1', ['https://x.com'])] }),
     ];
     const imported = [
-      session({ name: 'WORK', groups: [group('G1', ['https://x.com'])] }),
+      session({ id: 'b', name: 'WORK', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const result = classifyImportedSessions(imported, existing);
+    // No id match, fallback to case-insensitive name → conflicting because
+    // names differ in casing (surfaced as a name diff).
+    expect(result.conflictingSessions).toHaveLength(1);
+    expect(result.conflictingSessions[0].diff.name).toEqual({ current: 'Work', imported: 'WORK' });
+    expect(result.identicalSessions).toHaveLength(0);
+    expect(result.newSessions).toHaveLength(0);
+  });
+
+  it('flags sessions as identical when same id, same name, same content', () => {
+    const existing = [
+      session({ id: 'a', name: 'Work', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const imported = [
+      session({ id: 'a', name: 'Work', groups: [group('G1', ['https://x.com'])] }),
     ];
     const result = classifyImportedSessions(imported, existing);
     expect(result.identicalSessions).toHaveLength(1);
     expect(result.conflictingSessions).toHaveLength(0);
     expect(result.newSessions).toHaveLength(0);
+  });
+
+  it('matches by id (catches rename) even when name has changed', () => {
+    const existing = [
+      session({ id: 'stable-id', name: 'Old name', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const imported = [
+      session({ id: 'stable-id', name: 'New name', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const result = classifyImportedSessions(imported, existing);
+    expect(result.conflictingSessions).toHaveLength(1);
+    expect(result.conflictingSessions[0].existing).toBe(existing[0]);
+    expect(result.conflictingSessions[0].diff.name).toEqual({ current: 'Old name', imported: 'New name' });
+    expect(result.newSessions).toHaveLength(0);
+  });
+
+  it('uses name fallback when id does not match', () => {
+    const existing = [
+      session({ id: 'aaa', name: 'Work', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const imported = [
+      session({ id: 'bbb', name: 'Work', groups: [group('G1', ['https://y.com'])] }),
+    ];
+    const result = classifyImportedSessions(imported, existing);
+    expect(result.conflictingSessions).toHaveLength(1);
+    expect(result.conflictingSessions[0].existing).toBe(existing[0]);
+    expect(result.newSessions).toHaveLength(0);
+  });
+
+  it('does not re-match an existing session already paired by id', () => {
+    const existing = [
+      session({ id: 'A', name: 'Work', groups: [group('G1', ['https://x.com'])] }),
+    ];
+    const importedById = session({ id: 'A', name: 'Work', groups: [group('G1', ['https://changed.com'])] });
+    const importedByName = session({ id: 'B', name: 'Work' });
+    const result = classifyImportedSessions([importedById, importedByName], existing);
+    expect(result.conflictingSessions).toHaveLength(1);
+    expect(result.conflictingSessions[0].imported).toBe(importedById);
+    expect(result.newSessions).toHaveLength(1);
+    expect(result.newSessions[0]).toBe(importedByName);
   });
 
   it('flags sessions as conflicting when name matches but content differs', () => {
@@ -332,13 +408,13 @@ describe('classifyImportedSessions', () => {
 
   it('splits a mixed import into new, identical, and conflicting buckets', () => {
     const existing = [
-      session({ name: 'Work', groups: [group('G1', ['https://a.com'])] }),
-      session({ name: 'Home', ungroupedTabs: [tab('https://h.com')] }),
+      session({ id: 'work-id', name: 'Work', groups: [group('G1', ['https://a.com'])] }),
+      session({ id: 'home-id', name: 'Home', ungroupedTabs: [tab('https://h.com')] }),
     ];
     const imported = [
-      session({ name: 'Work', groups: [group('G1', ['https://a.com'])] }), // identical
-      session({ name: 'Home', ungroupedTabs: [tab('https://h2.com')] }), // conflicting
-      session({ name: 'Research' }), // new
+      session({ id: 'work-id', name: 'Work', groups: [group('G1', ['https://a.com'])] }), // identical
+      session({ id: 'home-id', name: 'Home', ungroupedTabs: [tab('https://h2.com')] }), // conflicting
+      session({ id: 'research-id', name: 'Research' }), // new
     ];
     const result = classifyImportedSessions(imported, existing);
     expect(result.identicalSessions.map(s => s.name)).toEqual(['Work']);

--- a/tests/utils/importClassification.test.ts
+++ b/tests/utils/importClassification.test.ts
@@ -112,11 +112,13 @@ describe('importClassification', () => {
       expect(props).toContain('deduplicationMatchMode');
     });
 
-    it('exclut label des différences (clé de correspondance)', () => {
+    it('inclut label dans les différences (rename surfacé)', () => {
       const current = makeRule({ label: 'A' });
       const imported = makeRule({ label: 'B' });
       const diffs = getRuleDifferences(current, imported);
-      expect(diffs.find(d => d.property === 'label')).toBeUndefined();
+      const labelDiff = diffs.find(d => d.property === 'label');
+      expect(labelDiff).toBeDefined();
+      expect(labelDiff).toMatchObject({ currentValue: 'A', importedValue: 'B' });
     });
 
     it('détecte une différence sur enabled', () => {
@@ -156,15 +158,58 @@ describe('importClassification', () => {
     });
 
     it('est insensible à la casse pour la correspondance des labels (lookup)', () => {
-      const existing = makeRule({ label: 'My Rule' });
-      const imported = makeRule({ label: 'MY RULE' }); // même label, casse différente
+      const existing = makeRule({ id: 'a', label: 'My Rule' });
+      const imported = makeRule({ id: 'b', label: 'MY RULE' }); // même label, casse différente, id différent
       const result = classifyImportedRules([imported], [existing]);
-      // Retrouvée dans la map (insensible à la casse) → pas nouvelle
+      // ID différent → fallback label (insensible à la casse) → match
       expect(result.newRules).toHaveLength(0);
-      // Mais areDomainRulesEqual compare label en === → considérée comme conflit
-      // (avec 0 différences visibles car label est ignoré dans getRuleDifferences)
+      // areDomainRulesEqual compare label en === → considérée comme conflit
+      // (label apparait dans les différences pour montrer le changement de casse)
       expect(result.conflictingRules).toHaveLength(1);
-      expect(result.conflictingRules[0].differences).toHaveLength(0);
+      expect(result.conflictingRules[0].differences).toHaveLength(1);
+      expect(result.conflictingRules[0].differences[0].property).toBe('label');
+    });
+
+    it('matche par id en priorité (catch rename)', () => {
+      const existing = makeRule({ id: 'stable-id', label: 'Old Label' });
+      const imported = makeRule({ id: 'stable-id', label: 'New Label' });
+      const result = classifyImportedRules([imported], [existing]);
+      expect(result.conflictingRules).toHaveLength(1);
+      expect(result.conflictingRules[0].existing).toBe(existing);
+      expect(result.conflictingRules[0].differences.map(d => d.property)).toContain('label');
+      expect(result.newRules).toHaveLength(0);
+      expect(result.identicalRules).toHaveLength(0);
+    });
+
+    it('classe une règle identique par id (même contenu, même label)', () => {
+      const rule = makeRule({ id: 'stable-id', label: 'Foo' });
+      const result = classifyImportedRules([rule], [{ ...rule }]);
+      expect(result.identicalRules).toHaveLength(1);
+      expect(result.conflictingRules).toHaveLength(0);
+      expect(result.newRules).toHaveLength(0);
+    });
+
+    it('utilise le fallback label quand l\'id ne match pas', () => {
+      const existing = makeRule({ id: 'aaa', label: 'Foo', domainFilter: 'foo.com' });
+      const imported = makeRule({ id: 'bbb', label: 'Foo', domainFilter: 'bar.com' });
+      const result = classifyImportedRules([imported], [existing]);
+      expect(result.conflictingRules).toHaveLength(1);
+      expect(result.conflictingRules[0].existing).toBe(existing);
+      expect(result.newRules).toHaveLength(0);
+    });
+
+    it('ne re-matche pas une règle existante déjà appariée par id', () => {
+      // Existing has rule "Foo" with id A. Two imports both have label "Foo":
+      // one with id A (matches by id), the other with id B (would fall back
+      // to label, but A is already taken, so it becomes new).
+      const existing = makeRule({ id: 'A', label: 'Foo' });
+      const importedById = makeRule({ id: 'A', label: 'Foo', domainFilter: 'changed.com' });
+      const importedByLabel = makeRule({ id: 'B', label: 'Foo' });
+      const result = classifyImportedRules([importedById, importedByLabel], [existing]);
+      expect(result.conflictingRules).toHaveLength(1);
+      expect(result.conflictingRules[0].imported).toBe(importedById);
+      expect(result.newRules).toHaveLength(1);
+      expect(result.newRules[0]).toBe(importedByLabel);
     });
 
     it('gère un mélange de classifications', () => {


### PR DESCRIPTION
Renaming a rule or a session no longer hides it from the import wizard:
the renamed item used to show up as new (creating a duplicate) because
matching was done on label/name only. Match by stable id first, fall
back to case-insensitive label/name so re-imports of the same content
with a different id still dedupe. Surface the rename in the diff
popover (label for rules, name for sessions). The overwrite step in
the wizard now resolves the target by id too.