### PR TITLE
feat(shortcuts): migrate page bindings to useShortcuts and add widget scopes (#274 Lot 2/4)

### DIFF
--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -123,6 +123,8 @@ export function DomainRuleCard({
     <Card
       ref={isSummary ? null : ref}
       data-testid={`rule-card-${rule.id}`}
+      data-rule-id={isSummary ? undefined : rule.id}
+      data-shortcut-scope={isSummary ? undefined : 'widget:rule-card'}
       variant="surface"
       size="2"
       role="listitem"

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -524,6 +524,8 @@ export function SessionCard({
       ref={isSummary ? null : ref}
       data-testid={`session-card-${session.id}`}
       data-session-card="true"
+      data-session-id={isSummary ? undefined : session.id}
+      data-shortcut-scope={isSummary ? undefined : 'widget:session-card'}
       role={isSummary ? 'listitem' : undefined}
       tabIndex={isSummary ? undefined : 0}
       onKeyDown={isSummary ? undefined : onCardKeyDown}

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -12,6 +12,7 @@ import { getRuleCategory } from '@/utils/categoriesStore';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import { useListNavigation } from '@/hooks/useListNavigation';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import type { Session } from '@/types/session';
 import styles from './PopupProfilesList.module.css';
 
@@ -111,23 +112,44 @@ export function PopupProfilesList() {
 
   const { handleNavigationKey } = useListNavigation(listRef, '[data-popup-pinned-card]');
 
-  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, session: Session, index: number) => {
+  // Card-level keydown is now navigation-only; the r/Shift+r/Alt+r/Alt+Shift+r
+  // bindings are dispatched at document level via the widget-scope shortcuts
+  // registered below.
+  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number) => {
     if (e.target !== e.currentTarget) return;
-    if (handleNavigationKey(e, index)) return;
-    if (e.key.toLowerCase() === 'r' && !e.ctrlKey && !e.metaKey) {
-      e.preventDefault();
-      e.stopPropagation();
-      if (e.altKey && e.shiftKey) {
-        handleRestore(session, 'new');
-      } else if (e.altKey) {
-        handleRestore(session, 'replace');
-      } else if (e.shiftKey) {
-        handleRestore(session, 'current');
-      } else {
-        void openCustomizeRestore(session);
-      }
-    }
-  }, [handleNavigationKey, handleRestore]);
+    handleNavigationKey(e, index);
+  }, [handleNavigationKey]);
+
+  const getFocusedSession = useCallback((): Session | null => {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return null;
+    if (!active.matches('[data-shortcut-scope="widget:session-card"]')) return null;
+    const id = active.getAttribute('data-session-id');
+    if (!id) return null;
+    return pinnedSessions.find((s) => s.id === id) ?? null;
+  }, [pinnedSessions]);
+
+  useShortcuts(
+    {
+      'sessionCard.restore.custom': () => {
+        const focused = getFocusedSession();
+        if (focused) void openCustomizeRestore(focused);
+      },
+      'sessionCard.restore.current': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRestore(focused, 'current');
+      },
+      'sessionCard.restore.replace': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRestore(focused, 'replace');
+      },
+      'sessionCard.restore.new': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRestore(focused, 'new');
+      },
+    },
+    { scope: 'widget:session-card' },
+  );
 
   const handleToggleEmptyCollapsed = useCallback((nextOpen: boolean) => {
     const nextCollapsed = !nextOpen;
@@ -219,12 +241,14 @@ export function PopupProfilesList() {
             key={session.id}
             data-testid={`popup-profile-item-${session.id}`}
             data-popup-pinned-card=""
+            data-session-id={session.id}
+            data-shortcut-scope="widget:session-card"
             size="1"
             tabIndex={0}
             role="listitem"
             aria-label={session.name}
             className={styles.pinnedCard}
-            onKeyDown={(e) => handleCardKeyDown(e, session, index)}
+            onKeyDown={(e) => handleCardKeyDown(e, index)}
           >
             <Flex align="center" gap="3" style={{ minWidth: 0 }}>
               <Flex align="center" style={{ flexShrink: 0 }}>

--- a/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsDrawer.tsx
@@ -23,7 +23,7 @@ export function ShortcutsDrawer({ open, onOpenChange }: ShortcutsDrawerProps) {
   }, []);
 
   // Toggle close on `?` while the drawer is open. Attached at the document
-  // level (capture phase) because the popup-level useKeyboardShortcuts has
+  // level (capture phase) because the popup-level useShortcuts dispatch has
   // `allowWhenDialogOpen: false` and Radix Themes' Dialog.Content can swallow
   // some bubbling keydowns from focused descendants.
   useEffect(() => {

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -1,15 +1,26 @@
 /**
  * Façade hook that lets callers wire keyboard actions by registry ID instead
- * of duplicating combo strings inline. At this stage it is a thin wrapper
- * around `useKeyboardShortcuts`; Lots 2 and 3 will extend it with widget
- * scopes and key sequences.
+ * of duplicating combo strings inline. Resolves each binding against
+ * `SHORTCUTS_REGISTRY` and translates the entry's `scope` into a low-level
+ * `ShortcutDefinition`:
+ *
+ * - `global` and `page:*` scopes attach as plain document-level shortcuts.
+ *   Entries flagged `excludeIfInsideWidget` are suppressed when focus is
+ *   anywhere inside a `[data-shortcut-scope="widget:..."]` element.
+ * - `widget:*` scopes only fire when the event target itself carries the
+ *   matching `data-shortcut-scope` attribute (descendants do not steal the
+ *   combo, so a drag handle's Space still starts the drag).
  */
 
 import { useMemo } from 'react';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { SHORTCUTS_REGISTRY } from '@/shortcuts/registry';
 import type { ShortcutScope } from '@/shortcuts/types';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
+import {
+  WIDGET_SCOPE_SELECTOR,
+  widgetScopeSelector,
+  type ShortcutDefinition,
+} from '@/utils/keyboardShortcuts';
 
 export type ShortcutAction = (event: KeyboardEvent) => void;
 
@@ -30,13 +41,20 @@ export function useShortcuts(
       const entry = SHORTCUTS_REGISTRY[id];
       if (!entry) continue;
       if (entry.scope !== scope) continue;
+      const isWidget = entry.scope.startsWith('widget:');
       for (const combo of entry.defaultBindings) {
-        defs.push({
+        const def: ShortcutDefinition = {
           combo,
           action,
           allowInTypingTarget: entry.allowInTypingTarget,
           allowWhenDialogOpen: entry.allowWhenDialogOpen,
-        });
+        };
+        if (isWidget) {
+          def.requireTargetMatches = widgetScopeSelector(entry.scope);
+        } else if (entry.excludeIfInsideWidget) {
+          def.excludeIfTargetWithin = WIDGET_SCOPE_SELECTOR;
+        }
+        defs.push(def);
       }
     }
     return defs;

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -13,9 +13,8 @@ import { getMessage } from '@/utils/i18n';
 import { foldAccents } from '@/utils/stringUtils';
 import { generateUUID } from '@/utils/utils';
 import { DomainRuleCard } from '@/components/Core/DomainRule/DomainRuleCard';
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import { useListNavigation } from '@/hooks/useListNavigation';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import {
   moveToFirst,
   moveToLast,
@@ -232,47 +231,72 @@ export function DomainRulesPage({
 
   const { handleNavigationKey } = useListNavigation(listRef, '[role="listitem"]');
 
+  // The card keydown handler now only forwards arrow/Home/End to
+  // useListNavigation. The Enter binding is kept here because Enter to
+  // open the editor is a card-local interaction that is not in the registry
+  // (the registry exposes `e` for editing, surfaced via widget shortcuts
+  // below). All other key actions (e, t, Space, Delete) are dispatched at
+  // document level via `useShortcuts({...}, { scope: 'widget:rule-card' })`.
   const handleCardKeyDown = useCallback((e: React.KeyboardEvent, rule: DomainRuleSetting, index: number) => {
-    // Only act when the card element itself has focus (not a child input/button).
     if (e.target !== e.currentTarget) return;
-
     if (handleNavigationKey(e as React.KeyboardEvent<HTMLElement>, index)) return;
-
-    switch (e.key) {
-      case ' ':
-        e.preventDefault();
-        handleRowSelect(rule.id, !selectedIds.has(rule.id));
-        return;
-      case 'Enter':
-        e.preventDefault();
-        handleEditRule(rule);
-        return;
-      case 'Delete':
-        e.preventDefault();
-        setDeleteTarget({ type: 'single', ruleId: rule.id, focusIndex: index });
-        return;
-    }
-
-    if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
-    const lower = e.key.toLowerCase();
-    if (lower === 'e') {
+    if (e.key === 'Enter' && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
       e.preventDefault();
       handleEditRule(rule);
-    } else if (lower === 't') {
-      e.preventDefault();
-      handleToggleEnabled(rule.id, !rule.enabled);
     }
-  }, [handleNavigationKey, handleRowSelect, handleEditRule, handleToggleEnabled, selectedIds]);
+  }, [handleNavigationKey, handleEditRule]);
 
   const handleAddRule = useCallback(() => {
     setEditingRule(undefined);
     setIsModalOpen(true);
   }, []);
 
-  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
-    { combo: 'n', action: handleAddRule },
-  ], [handleAddRule]);
-  useKeyboardShortcuts(pageShortcuts);
+  const getFocusedRule = useCallback((): { rule: DomainRuleSetting; index: number } | null => {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return null;
+    if (!active.matches('[data-shortcut-scope="widget:rule-card"]')) return null;
+    const id = active.getAttribute('data-rule-id');
+    if (!id) return null;
+    const cards = listRef.current?.querySelectorAll<HTMLElement>('[role="listitem"]');
+    let index = -1;
+    if (cards) {
+      cards.forEach((card, i) => {
+        if (card === active) index = i;
+      });
+    }
+    const rule = syncSettings.domainRules.find((r) => r.id === id);
+    return rule ? { rule, index } : null;
+  }, [syncSettings.domainRules]);
+
+  useShortcuts({ 'list.rules.new': handleAddRule }, { scope: 'page:rules' });
+
+  useShortcuts(
+    {
+      'ruleCard.edit': () => {
+        const focused = getFocusedRule();
+        if (focused) handleEditRule(focused.rule);
+      },
+      'ruleCard.toggleEnabled': () => {
+        const focused = getFocusedRule();
+        if (focused) handleToggleEnabled(focused.rule.id, !focused.rule.enabled);
+      },
+      'ruleCard.toggleSelection': () => {
+        const focused = getFocusedRule();
+        if (focused) handleRowSelect(focused.rule.id, !selectedIds.has(focused.rule.id));
+      },
+      'ruleCard.delete': () => {
+        const focused = getFocusedRule();
+        if (focused) {
+          setDeleteTarget({
+            type: 'single',
+            ruleId: focused.rule.id,
+            focusIndex: focused.index >= 0 ? focused.index : undefined,
+          });
+        }
+      },
+    },
+    { scope: 'widget:rule-card' },
+  );
 
   const handleSubmitRule = (rule: DomainRule) => {
     if (editingRule) {

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -17,12 +17,11 @@ import { foldAccents } from '@/utils/stringUtils';
 import { matchSessionSearch, splitByPinned } from '@/utils/sessionUtils';
 import { moveSessionToFirstInGroup, moveSessionToLastInGroup } from '@/utils/sessionOrderUtils';
 import { useSessions } from '@/hooks/useSessions';
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import { useListNavigation } from '@/hooks/useListNavigation';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { updateSession } from '@/utils/sessionStorage';
 import { showSuccessNotification } from '@/utils/notifications';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
@@ -73,16 +72,19 @@ interface SessionSectionProps {
   updateOrder: (sessions: Session[]) => Promise<void>;
   /** Rename a session (forwarded straight to SessionCard). */
   renameSession: (id: string, newName: string) => Promise<void>;
-  /** Reload sessions after a mutation (used for pin/unpin). */
-  reload: () => Promise<void>;
   /** Open the RestoreWizard (owned by the parent). */
   onOpenRestoreWizard: (session: Session) => void;
   /** Open the SessionEditDialog (owned by the parent). */
   onOpenEditDialog: (session: Session) => void;
   /** Open the delete ConfirmDialog (owned by the parent). */
   onOpenDeleteDialog: (session: Session) => void;
-  /** Emit a transient feedback message (single callout shared between both sections). */
-  onRestoreFeedback: (message: string | null) => void;
+  /** Quick-restore handlers shared with the page-level widget shortcuts. */
+  onRestoreCurrentWindow: (session: Session) => void;
+  onRestoreNewWindow: (session: Session) => void;
+  onReplaceCurrentWindow: (session: Session) => void;
+  /** Pin/unpin handlers shared with the page-level widget shortcuts. */
+  onPin: (session: Session) => void;
+  onUnpin: (session: Session) => void;
 }
 
 function SessionSection({
@@ -97,11 +99,14 @@ function SessionSection({
   searchMatches,
   updateOrder,
   renameSession,
-  reload,
   onOpenRestoreWizard,
   onOpenEditDialog,
   onOpenDeleteDialog,
-  onRestoreFeedback,
+  onRestoreCurrentWindow,
+  onRestoreNewWindow,
+  onReplaceCurrentWindow,
+  onPin,
+  onUnpin,
 }: SessionSectionProps) {
   const [dragItems, setDragItems] = useState<Session[] | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -127,102 +132,19 @@ function SessionSection({
     setDragItems(null);
   }, [dragItems, sessions, allSessions, isPinned, updateOrder]);
 
-  // Quick restore: full session content, no conflict resolution wizard.
-  const handleQuickRestore = useCallback(async (session: Session, target: RestoreTarget) => {
-    try {
-      let protectedTabId: number | undefined;
-      if (target === 'replace') {
-        const currentTab = await browser.tabs.getCurrent();
-        protectedTabId = currentTab?.id;
-      }
-      const result = await restoreSessionTabs(session, target, protectedTabId);
-      onRestoreFeedback(getMessage('restoreResultTabsCreated', [String(result.tabsCreated)]));
-      if (target === 'replace') {
-        void showSuccessNotification(
-          getMessage('sessionSwitchedNotificationTitle'),
-          getMessage('sessionSwitchedNotificationMessage', [session.name]),
-        );
-      }
-    } catch {
-      onRestoreFeedback(getMessage('restoreError'));
-    }
-    setTimeout(() => onRestoreFeedback(null), 4000);
-  }, [onRestoreFeedback]);
-
-  const handleRestoreCurrentWindow = useCallback(
-    (session: Session) => handleQuickRestore(session, 'current'),
-    [handleQuickRestore],
-  );
-
-  const handleRestoreNewWindow = useCallback(
-    (session: Session) => handleQuickRestore(session, 'new'),
-    [handleQuickRestore],
-  );
-
-  const handleReplaceCurrentWindow = useCallback(
-    (session: Session) => handleQuickRestore(session, 'replace'),
-    [handleQuickRestore],
-  );
-
-  const handlePin = useCallback(async (session: Session) => {
-    await updateSession(session.id, { isPinned: true });
-    await reload();
-  }, [reload]);
-
-  const handleUnpin = useCallback(async (session: Session) => {
-    await updateSession(session.id, { isPinned: false });
-    await reload();
-  }, [reload]);
-
-  const handleRestoreCombo = useCallback((session: Session, shiftKey: boolean, altKey: boolean) => {
-    if (altKey && shiftKey) {
-      void handleRestoreNewWindow(session);
-    } else if (altKey) {
-      void handleReplaceCurrentWindow(session);
-    } else if (shiftKey) {
-      void handleRestoreCurrentWindow(session);
-    } else {
-      onOpenRestoreWizard(session);
-    }
-  }, [handleRestoreCurrentWindow, handleRestoreNewWindow, handleReplaceCurrentWindow, onOpenRestoreWizard]);
-
   const { handleNavigationKey } = useListNavigation(listRef, '[data-session-card]');
 
-  const handleCardKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, index: number, session: Session) => {
-    // Only act when the card element itself has focus (not a child input/button).
-    if (e.target !== e.currentTarget) return;
-    if (handleNavigationKey(e, index)) return;
-    if (e.key === 'Delete' || e.key === 'Backspace') {
-      e.preventDefault();
-      onOpenDeleteDialog(session);
-      return;
-    }
-    const lower = e.key.toLowerCase();
-    if (e.ctrlKey || e.metaKey) return;
-    if (lower === 'r') {
-      e.preventDefault();
-      handleRestoreCombo(session, e.shiftKey, e.altKey);
-      return;
-    }
-    if (e.altKey || e.shiftKey) return;
-    if (lower === 'e') {
-      e.preventDefault();
-      onOpenEditDialog(session);
-      return;
-    }
-    if (lower === 'p') {
-      e.preventDefault();
-      const togglePin = session.isPinned ? handleUnpin : handlePin;
-      void togglePin(session);
-    }
-  }, [
-    handleNavigationKey,
-    handleRestoreCombo,
-    onOpenEditDialog,
-    onOpenDeleteDialog,
-    handlePin,
-    handleUnpin,
-  ]);
+  // Card-level keydown is now navigation-only; per-card actions
+  // (r/Shift+r/Alt+r/Alt+Shift+r/e/Delete/p) are dispatched at document level
+  // through `useShortcuts({...}, { scope: 'widget:session-card' })` in
+  // SessionsPage.
+  const handleCardKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>, index: number) => {
+      if (e.target !== e.currentTarget) return;
+      handleNavigationKey(e, index);
+    },
+    [handleNavigationKey],
+  );
 
   const handleMoveToFirst = useCallback((session: Session) => {
     void updateOrder(moveSessionToFirstInGroup(allSessions, session.id));
@@ -260,14 +182,14 @@ function SessionSection({
                   session={session}
                   existingSessions={allSessions}
                   onRestore={onOpenRestoreWizard}
-                  onRestoreCurrentWindow={handleRestoreCurrentWindow}
-                  onRestoreNewWindow={handleRestoreNewWindow}
-                  onReplaceCurrentWindow={handleReplaceCurrentWindow}
+                  onRestoreCurrentWindow={onRestoreCurrentWindow}
+                  onRestoreNewWindow={onRestoreNewWindow}
+                  onReplaceCurrentWindow={onReplaceCurrentWindow}
                   onRename={renameSession}
                   onEdit={onOpenEditDialog}
                   onDelete={onOpenDeleteDialog}
-                  onPin={handlePin}
-                  onUnpin={handleUnpin}
+                  onPin={onPin}
+                  onUnpin={onUnpin}
                   forcePreviewOpen={searchMatch?.matchesTabs === true || searchMatch?.matchesNote === true}
                   searchMatchingGroupIds={searchMatch?.matchingGroupIds}
                   searchQuery={searchQuery || undefined}
@@ -275,7 +197,7 @@ function SessionSection({
                   isDragDisabled={!!searchQuery}
                   onMoveToFirst={() => handleMoveToFirst(session)}
                   onMoveLast={() => handleMoveLast(session)}
-                  onCardKeyDown={(e) => handleCardKeyDown(e, index, session)}
+                  onCardKeyDown={(e) => handleCardKeyDown(e, index)}
                 />
               );
             })}
@@ -319,10 +241,101 @@ export function SessionsPage({
   const [searchQuery, setSearchQuery] = useState('');
 
   const handleOpenSnapshotWizard = useCallback(() => setSnapshotOpen(true), []);
-  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
-    { combo: 'n', action: handleOpenSnapshotWizard },
-  ], [handleOpenSnapshotWizard]);
-  useKeyboardShortcuts(pageShortcuts);
+
+  // Quick-restore (no conflict-resolution wizard) handlers shared by the
+  // SessionCard split button, the dropdown menu, and the widget-scope
+  // shortcuts registered below.
+  const handleQuickRestore = useCallback(async (session: Session, target: RestoreTarget) => {
+    try {
+      let protectedTabId: number | undefined;
+      if (target === 'replace') {
+        const currentTab = await browser.tabs.getCurrent();
+        protectedTabId = currentTab?.id;
+      }
+      const result = await restoreSessionTabs(session, target, protectedTabId);
+      setQuickRestoreMessage(getMessage('restoreResultTabsCreated', [String(result.tabsCreated)]));
+      if (target === 'replace') {
+        void showSuccessNotification(
+          getMessage('sessionSwitchedNotificationTitle'),
+          getMessage('sessionSwitchedNotificationMessage', [session.name]),
+        );
+      }
+    } catch {
+      setQuickRestoreMessage(getMessage('restoreError'));
+    }
+    setTimeout(() => setQuickRestoreMessage(null), 4000);
+  }, []);
+
+  const handleRestoreCurrentWindow = useCallback(
+    (session: Session) => { void handleQuickRestore(session, 'current'); },
+    [handleQuickRestore],
+  );
+  const handleRestoreNewWindow = useCallback(
+    (session: Session) => { void handleQuickRestore(session, 'new'); },
+    [handleQuickRestore],
+  );
+  const handleReplaceCurrentWindow = useCallback(
+    (session: Session) => { void handleQuickRestore(session, 'replace'); },
+    [handleQuickRestore],
+  );
+
+  const handlePin = useCallback(async (session: Session) => {
+    await updateSession(session.id, { isPinned: true });
+    await reload();
+  }, [reload]);
+  const handleUnpin = useCallback(async (session: Session) => {
+    await updateSession(session.id, { isPinned: false });
+    await reload();
+  }, [reload]);
+
+  // Resolves the session whose card currently has focus. Returns null when
+  // focus is on a non-card element so widget shortcuts no-op silently.
+  const getFocusedSession = useCallback((): Session | null => {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return null;
+    if (!active.matches('[data-shortcut-scope="widget:session-card"]')) return null;
+    const id = active.getAttribute('data-session-id');
+    if (!id) return null;
+    return sessions.find((s) => s.id === id) ?? null;
+  }, [sessions]);
+
+  useShortcuts({ 'list.sessions.new': handleOpenSnapshotWizard }, { scope: 'page:sessions' });
+
+  useShortcuts(
+    {
+      'sessionCard.restore.custom': () => {
+        const focused = getFocusedSession();
+        if (focused) setRestoreSession(focused);
+      },
+      'sessionCard.restore.current': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRestoreCurrentWindow(focused);
+      },
+      'sessionCard.restore.replace': () => {
+        const focused = getFocusedSession();
+        if (focused) handleReplaceCurrentWindow(focused);
+      },
+      'sessionCard.restore.new': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRestoreNewWindow(focused);
+      },
+      'sessionCard.edit': () => {
+        const focused = getFocusedSession();
+        if (focused) setEditTarget(focused);
+      },
+      'sessionCard.delete': () => {
+        const focused = getFocusedSession();
+        if (focused) setDeleteTarget(focused);
+      },
+      'sessionCard.pin': () => {
+        const focused = getFocusedSession();
+        if (!focused) return;
+        const togglePin = focused.isPinned ? handleUnpin : handlePin;
+        togglePin(focused).catch(() => {});
+      },
+    },
+    { scope: 'widget:session-card' },
+  );
 
   // Deep-link: open the RestoreWizard when a sessionId has been provided via
   // URL hash (e.g. from the popup's customize restore action).
@@ -476,11 +489,14 @@ export function SessionsPage({
                 searchMatches={sessionSearchMatches}
                 updateOrder={updateOrder}
                 renameSession={renameSession}
-                reload={reload}
                 onOpenRestoreWizard={setRestoreSession}
                 onOpenEditDialog={setEditTarget}
                 onOpenDeleteDialog={setDeleteTarget}
-                onRestoreFeedback={setQuickRestoreMessage}
+                onRestoreCurrentWindow={handleRestoreCurrentWindow}
+                onRestoreNewWindow={handleRestoreNewWindow}
+                onReplaceCurrentWindow={handleReplaceCurrentWindow}
+                onPin={handlePin}
+                onUnpin={handleUnpin}
               />
 
               <Separator size="4" />
@@ -497,11 +513,14 @@ export function SessionsPage({
                 searchMatches={sessionSearchMatches}
                 updateOrder={updateOrder}
                 renameSession={renameSession}
-                reload={reload}
                 onOpenRestoreWizard={setRestoreSession}
                 onOpenEditDialog={setEditTarget}
                 onOpenDeleteDialog={setDeleteTarget}
-                onRestoreFeedback={setQuickRestoreMessage}
+                onRestoreCurrentWindow={handleRestoreCurrentWindow}
+                onRestoreNewWindow={handleRestoreNewWindow}
+                onReplaceCurrentWindow={handleReplaceCurrentWindow}
+                onPin={handlePin}
+                onUnpin={handleUnpin}
               />
             </Flex>
           )}

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -13,8 +13,7 @@ import { DEFAULT_WORKSPACE_ID } from '@/utils/workspaceStorage';
 import { getMessage } from '@/utils/i18n';
 import { logger } from '@/utils/logger';
 import { foldAccents } from '@/utils/stringUtils';
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import type { AppSettings } from '@/types/syncSettings';
 import type { WorkspaceMeta } from '@/schemas/workspace';
 
@@ -134,10 +133,7 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
 
   const handleOpenCreate = useCallback(() => setCreateOpen(true), []);
 
-  const pageShortcuts = useMemo<ShortcutDefinition[]>(() => [
-    { combo: 'n', action: handleOpenCreate },
-  ], [handleOpenCreate]);
-  useKeyboardShortcuts(pageShortcuts);
+  useShortcuts({ 'list.workspaces.new': handleOpenCreate }, { scope: 'page:workspaces' });
 
   const handleCreate = useCallback(
     async ({ name, accentColor }: { name: string; accentColor: WorkspaceMeta['accentColor'] }) => {

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -14,9 +14,8 @@ import { useSettings } from '@/hooks/useSettings.js';
 import { useStatistics } from '@/hooks/useStatistics.js';
 import { useDeepLinking } from '@/hooks/useDeepLinking.js';
 import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinking.js';
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts.js';
+import { useShortcuts, type ShortcutAction } from '@/hooks/useShortcuts.js';
 import { getMessage } from '@/utils/i18n';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
 import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 
 import { Sidebar } from '@/components/UI/Sidebar/Sidebar';
@@ -159,21 +158,20 @@ export function OptionsContent() {
         }
     }, [shortcutsAsideOpen]);
 
-    const shortcuts = useMemo<ShortcutDefinition[]>(() => {
+    const shortcutBindings = useMemo<Record<string, ShortcutAction>>(() => {
         const flatItems = sidebarSections.flatMap((section) => section.items);
-        const tabShortcuts: ShortcutDefinition[] = flatItems.map((item, index) => ({
-            combo: `Alt+${index + 1}`,
-            action: () => handleTabChange(item.id),
-        }));
-        return [
-            ...tabShortcuts,
-            { combo: '/', action: focusActiveSearch },
-            { combo: '?', action: () => setShortcutsAsideOpen((open) => !open) },
-            { combo: 'Escape', action: handleEscape, allowInTypingTarget: false },
-        ];
+        const bindings: Record<string, ShortcutAction> = {
+            'options.search.focus': focusActiveSearch,
+            'options.help': () => setShortcutsAsideOpen((open) => !open),
+            'options.search.clear': handleEscape,
+        };
+        flatItems.slice(0, 5).forEach((item, index) => {
+            bindings[`options.tab.${index + 1}`] = () => handleTabChange(item.id);
+        });
+        return bindings;
     }, [sidebarSections, handleTabChange, focusActiveSearch, handleEscape]);
 
-    useKeyboardShortcuts(shortcuts);
+    useShortcuts(shortcutBindings, { scope: 'global' });
 
     const openShortcuts = useCallback(() => setShortcutsAsideOpen(true), []);
 

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Box, Flex, Separator, Theme } from '@radix-ui/themes';
@@ -13,8 +13,7 @@ import { PopupWorkspaceSwitcher } from '@/components/UI/Workspace/PopupWorkspace
 import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
 import { openOptionsWithHash } from '@/utils/openOptions';
 import { useSettings } from '@/hooks/useSettings';
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
-import type { ShortcutDefinition } from '@/utils/keyboardShortcuts';
+import { useShortcuts } from '@/hooks/useShortcuts';
 import {
   ActiveWorkspaceProvider,
   useActiveWorkspaceContext,
@@ -61,15 +60,16 @@ export function PopupContent() {
     window.close();
   }, []);
 
-  const shortcuts = useMemo<ShortcutDefinition[]>(() => [
-    { combo: 's', action: handlePopupSave, excludeIfTargetWithin: '[data-popup-pinned-card]' },
-    { combo: 'r', action: handlePopupRestore, excludeIfTargetWithin: '[data-popup-pinned-card]' },
-    { combo: 'o', action: handlePopupOrganize, excludeIfTargetWithin: '[data-popup-pinned-card]' },
-    { combo: 'p', action: openOptionsPage, excludeIfTargetWithin: '[data-popup-pinned-card]' },
-    { combo: '?', action: () => setShortcutsOpen((open) => !open), allowWhenDialogOpen: false },
-  ], [handlePopupSave, handlePopupRestore, handlePopupOrganize, openOptionsPage]);
-
-  useKeyboardShortcuts(shortcuts);
+  useShortcuts(
+    {
+      'popup.save': handlePopupSave,
+      'popup.restore': handlePopupRestore,
+      'popup.organize': handlePopupOrganize,
+      'popup.options': openOptionsPage,
+      'popup.help': () => setShortcutsOpen((open) => !open),
+    },
+    { scope: 'page:popup' },
+  );
 
   const hasRules = isLoaded && (settings?.domainRules?.length ?? 0) > 0;
 

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -37,13 +37,17 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     commandName: '_execute_action',
   },
 
-  // Popup
+  // Popup. The four action-binding shortcuts (s/r/o/p) yield to a focused
+  // pinned card so the card's own widget bindings (sessionCard.restore.*)
+  // stay authoritative; `?` is intentionally never widget-suppressed so the
+  // help drawer can be summoned from anywhere in the popup.
   'popup.save': {
     id: 'popup.save',
     defaultBindings: ['s'],
     descriptionKey: 'shortcutDescPopupSave',
     group: 'popup',
     scope: 'page:popup',
+    excludeIfInsideWidget: true,
   },
   'popup.restore': {
     id: 'popup.restore',
@@ -51,6 +55,7 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     descriptionKey: 'shortcutDescPopupRestore',
     group: 'popup',
     scope: 'page:popup',
+    excludeIfInsideWidget: true,
   },
   'popup.organize': {
     id: 'popup.organize',
@@ -58,6 +63,7 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     descriptionKey: 'shortcutDescPopupOrganize',
     group: 'popup',
     scope: 'page:popup',
+    excludeIfInsideWidget: true,
   },
   'popup.options': {
     id: 'popup.options',
@@ -65,6 +71,7 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     descriptionKey: 'shortcutDescPopupOptions',
     group: 'popup',
     scope: 'page:popup',
+    excludeIfInsideWidget: true,
   },
   'popup.help': {
     id: 'popup.help',
@@ -147,33 +154,37 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     group: 'list-rules',
     scope: 'page:rules',
   },
-  'list.rules.edit': {
-    id: 'list.rules.edit',
+  // Per-card actions: only fire when a rule card itself has focus. They keep
+  // the same display group (`list-rules`) so the help panel still shows them
+  // under "Rules list", but their scope is widget so the page-level handler
+  // doesn't fight with focused-card shortcuts.
+  'ruleCard.edit': {
+    id: 'ruleCard.edit',
     defaultBindings: ['e'],
     descriptionKey: 'shortcutDescListEdit',
     group: 'list-rules',
-    scope: 'page:rules',
+    scope: 'widget:rule-card',
   },
-  'list.rules.toggleSelection': {
-    id: 'list.rules.toggleSelection',
+  'ruleCard.toggleSelection': {
+    id: 'ruleCard.toggleSelection',
     defaultBindings: ['Space'],
     descriptionKey: 'shortcutDescListToggleSelection',
     group: 'list-rules',
-    scope: 'page:rules',
+    scope: 'widget:rule-card',
   },
-  'list.rules.toggleEnabled': {
-    id: 'list.rules.toggleEnabled',
+  'ruleCard.toggleEnabled': {
+    id: 'ruleCard.toggleEnabled',
     defaultBindings: ['t'],
     descriptionKey: 'shortcutDescListToggleEnabled',
     group: 'list-rules',
-    scope: 'page:rules',
+    scope: 'widget:rule-card',
   },
-  'list.rules.delete': {
-    id: 'list.rules.delete',
+  'ruleCard.delete': {
+    id: 'ruleCard.delete',
     defaultBindings: ['Delete'],
     descriptionKey: 'shortcutDescListDelete',
     group: 'list-rules',
-    scope: 'page:rules',
+    scope: 'widget:rule-card',
   },
   'list.rules.reorderKeyboard': {
     id: 'list.rules.reorderKeyboard',
@@ -198,26 +209,29 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     group: 'list-sessions',
     scope: 'page:sessions',
   },
-  'list.sessions.edit': {
-    id: 'list.sessions.edit',
+  // Per-card actions on the Sessions page (Edit/Delete/Pin). Group stays
+  // `list-sessions` so the help panel keeps them under "Sessions list" while
+  // the scope ties them to the focused session card.
+  'sessionCard.edit': {
+    id: 'sessionCard.edit',
     defaultBindings: ['e'],
     descriptionKey: 'shortcutDescListEdit',
     group: 'list-sessions',
-    scope: 'page:sessions',
+    scope: 'widget:session-card',
   },
-  'list.sessions.delete': {
-    id: 'list.sessions.delete',
+  'sessionCard.delete': {
+    id: 'sessionCard.delete',
     defaultBindings: ['Delete'],
     descriptionKey: 'shortcutDescListDelete',
     group: 'list-sessions',
-    scope: 'page:sessions',
+    scope: 'widget:session-card',
   },
-  'list.sessions.pin': {
-    id: 'list.sessions.pin',
+  'sessionCard.pin': {
+    id: 'sessionCard.pin',
     defaultBindings: ['p'],
     descriptionKey: 'shortcutDescListPin',
     group: 'list-sessions',
-    scope: 'page:sessions',
+    scope: 'widget:session-card',
   },
   'list.sessions.reorderKeyboard': {
     id: 'list.sessions.reorderKeyboard',

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -47,6 +47,15 @@ export interface ShortcutEntry {
   allowWhenDialogOpen?: boolean;
 
   /**
+   * When true (only meaningful for `global` and `page:*` scopes), the
+   * shortcut is suppressed if the event target is inside any element flagged
+   * with `data-shortcut-scope="widget:..."`. Lets a focused widget claim
+   * conflicting key combos (e.g. `r` belongs to the focused session card,
+   * not the popup-level restore action).
+   */
+  excludeIfInsideWidget?: boolean;
+
+  /**
    * Manifest `commands` entry name. When set, the panel reads the live combo
    * from `browser.commands.getAll()` instead of `defaultBindings` so it
    * reflects any per-user customization done via the browser UI.

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -100,6 +100,13 @@ export interface ShortcutDefinition {
    * the card's per-session R/Shift+R/Alt+R bindings stay authoritative).
    */
   excludeIfTargetWithin?: string;
+  /**
+   * CSS selector. When set, the shortcut only fires if the event target
+   * itself matches this selector (not its descendants). Used by widget-scope
+   * bindings so that pressing the combo on an inner control (drag handle,
+   * button) does not steal it from the inner control's own handler.
+   */
+  requireTargetMatches?: string;
 }
 
 export function shouldFire(event: KeyboardEvent, def: ShortcutDefinition): boolean {
@@ -109,5 +116,26 @@ export function shouldFire(event: KeyboardEvent, def: ShortcutDefinition): boole
   if (def.excludeIfTargetWithin && event.target instanceof Element) {
     if (event.target.closest(def.excludeIfTargetWithin)) return false;
   }
+  if (def.requireTargetMatches) {
+    if (!(event.target instanceof Element)) return false;
+    if (!event.target.matches(def.requireTargetMatches)) return false;
+  }
   return true;
+}
+
+/**
+ * CSS selector matching any element that opts into a `widget:*` shortcut
+ * scope. Page-level entries flagged `excludeIfInsideWidget` use this to
+ * yield to the focused widget without enumerating every widget kind.
+ */
+export const WIDGET_SCOPE_SELECTOR = '[data-shortcut-scope^="widget:"]';
+
+/**
+ * Returns the CSS selector that matches the element opting into a given
+ * widget scope (e.g. `[data-shortcut-scope="widget:session-card"]`). Used
+ * by `useShortcuts` to derive `requireTargetMatches` from a registry
+ * entry's `scope`.
+ */
+export function widgetScopeSelector(scope: string): string {
+  return `[data-shortcut-scope="${scope}"]`;
 }

--- a/tests/hooks/useShortcuts.test.tsx
+++ b/tests/hooks/useShortcuts.test.tsx
@@ -93,3 +93,126 @@ describe('useShortcuts (façade)', () => {
     expect(action).toHaveBeenCalledTimes(1);
   });
 });
+
+function dispatchOn(
+  target: Element,
+  combo: { key: string; alt?: boolean; shift?: boolean; ctrl?: boolean; meta?: boolean },
+): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: combo.key,
+      altKey: combo.alt ?? false,
+      shiftKey: combo.shift ?? false,
+      ctrlKey: combo.ctrl ?? false,
+      metaKey: combo.meta ?? false,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+describe('useShortcuts (widget scope)', () => {
+  it('does not fire a widget binding when focus is outside the matching scope', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'sessionCard.restore.custom': action },
+        { scope: 'widget:session-card' },
+      ),
+    );
+
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('fires a widget binding only when the scoped element itself has focus', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'sessionCard.restore.custom': action },
+        { scope: 'widget:session-card' },
+      ),
+    );
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:session-card');
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+    card.focus();
+
+    dispatchOn(card, { key: 'r' });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire a widget binding when focus is on a descendant of the scoped element', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'ruleCard.toggleSelection': action },
+        { scope: 'widget:rule-card' },
+      ),
+    );
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:rule-card');
+    card.tabIndex = 0;
+    const handle = document.createElement('button');
+    card.appendChild(handle);
+    document.body.appendChild(card);
+    handle.focus();
+
+    // Space pressed on an inner control (e.g. drag handle) must not steal
+    // the widget binding so the inner control's own handler can run.
+    dispatchOn(handle, { key: ' ' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('lets a focused widget claim a combo away from a page-level binding flagged excludeIfInsideWidget', () => {
+    const pageAction = vi.fn();
+    const widgetAction = vi.fn();
+
+    renderHook(() => {
+      useShortcuts({ 'popup.restore': pageAction }, { scope: 'page:popup' });
+      useShortcuts(
+        { 'sessionCard.restore.custom': widgetAction },
+        { scope: 'widget:session-card' },
+      );
+    });
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:session-card');
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+    card.focus();
+
+    dispatchOn(card, { key: 'r' });
+    expect(pageAction).not.toHaveBeenCalled();
+    expect(widgetAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fires the page-level binding when focus is outside any widget scope', () => {
+    const pageAction = vi.fn();
+    renderHook(() =>
+      useShortcuts({ 'popup.restore': pageAction }, { scope: 'page:popup' }),
+    );
+
+    dispatch({ key: 'r' });
+    expect(pageAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not block page-level shortcuts that omit excludeIfInsideWidget when focus is in a widget', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts({ 'popup.help': action }, { scope: 'page:popup' }),
+    );
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:session-card');
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+    card.focus();
+
+    dispatchOn(card, { key: '?' });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/shortcuts/registry.test.ts
+++ b/tests/shortcuts/registry.test.ts
@@ -79,7 +79,10 @@ describe('registry helpers', () => {
     expect(popupEntries.length).toBe(5);
 
     const cardEntries = getShortcutsByScope('widget:session-card');
-    expect(cardEntries.length).toBe(4);
+    expect(cardEntries.length).toBe(7);
+
+    const ruleCardEntries = getShortcutsByScope('widget:rule-card');
+    expect(ruleCardEntries.length).toBe(4);
   });
 
   it('getShortcutsByGroup returns only entries of the requested group', () => {


### PR DESCRIPTION
Replace every remaining useKeyboardShortcuts call in popup, options,
DomainRulesPage, SessionsPage, WorkspacesPage and PopupProfilesList with
useShortcuts({...}, { scope }) reading from the central registry.

Per-card actions on rules and sessions move from card-level inline
keydown handlers to widget-scope shortcuts dispatched at document level:
ruleCard.edit/toggleEnabled/toggleSelection/delete and
sessionCard.edit/delete/pin (the restore.* set was already in the
registry). DomainRuleCard and SessionCard expose data-shortcut-scope
plus data-rule-id / data-session-id so the dispatcher can resolve the
focused entity.

Conflict resolution between page and widget scopes is now intrinsic:
widget bindings only fire when the scoped element itself has focus
(target.matches, not closest, so a drag handle's Space still starts the
drag). Popup actions s/r/o/p carry excludeIfInsideWidget so the focused
pinned card keeps ownership of the combo; popup.help (?) is exempt and
remains globally invocable.

ShortcutDefinition gains an optional requireTargetMatches selector and
useShortcuts derives both that and the existing excludeIfTargetWithin
from the registry entry. The low-level useKeyboardShortcuts contract is
unchanged for existing callers.

https://claude.ai/code/session_01MYsvedNSr4ce8FnuiBR8az