### PR TITLE
feat(shortcuts): add key sequences (`i r`, `e s`...) on Import/Export page (#275 Lot 3/4)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -543,6 +543,15 @@
   "shortcutsGroupListSessions": { "message": "Sessions list" },
   "shortcutsGroupListWorkspaces": { "message": "Workspaces list" },
   "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
+  "shortcutsGroupImportExport": { "message": "Import / Export" },
+
+  "shortcutSequenceSeparator": { "message": "then" },
+  "shortcutSequenceActiveAnnouncement": {
+    "message": "Prefix $PREFIX$ active, waiting for next key",
+    "placeholders": {
+      "prefix": { "content": "$1" }
+    }
+  },
 
   "shortcutDescOrganize": { "message": "Organize all tabs" },
   "shortcutDescSaveSession": { "message": "Save current window as a session" },
@@ -570,6 +579,12 @@
   "shortcutDescHomeFirstLast": { "message": "Move focus to first or last item" },
   "shortcutDescHomeNextSection": { "message": "Move focus to the next section" },
   "shortcutDescHomeActivate": { "message": "Activate the focused item" },
+  "shortcutDescImportRules": { "message": "Import rules" },
+  "shortcutDescImportSessions": { "message": "Import sessions" },
+  "shortcutDescImportWorkspaces": { "message": "Import workspaces" },
+  "shortcutDescExportRules": { "message": "Export rules" },
+  "shortcutDescExportSessions": { "message": "Export sessions" },
+  "shortcutDescExportWorkspaces": { "message": "Export workspaces" },
 
   "homeTab": { "message": "Home" },
   "homePageDescription": { "message": "Your SmartTab Organizer dashboard: pinned sessions, shortcuts, and activity." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -544,6 +544,15 @@
   "shortcutsGroupListSessions": { "message": "Lista de sesiones" },
   "shortcutsGroupListWorkspaces": { "message": "Lista de espacios" },
   "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
+  "shortcutsGroupImportExport": { "message": "Importar / Exportar" },
+
+  "shortcutSequenceSeparator": { "message": "después" },
+  "shortcutSequenceActiveAnnouncement": {
+    "message": "Prefijo $PREFIX$ activo, esperando la siguiente tecla",
+    "placeholders": {
+      "prefix": { "content": "$1" }
+    }
+  },
 
   "shortcutDescOrganize": { "message": "Organizar todas las pestañas" },
   "shortcutDescSaveSession": { "message": "Guardar la ventana como sesión" },
@@ -571,6 +580,12 @@
   "shortcutDescHomeFirstLast": { "message": "Mover el foco al primer o último elemento" },
   "shortcutDescHomeNextSection": { "message": "Mover el foco a la sección siguiente" },
   "shortcutDescHomeActivate": { "message": "Activar el elemento con foco" },
+  "shortcutDescImportRules": { "message": "Importar reglas" },
+  "shortcutDescImportSessions": { "message": "Importar sesiones" },
+  "shortcutDescImportWorkspaces": { "message": "Importar espacios de trabajo" },
+  "shortcutDescExportRules": { "message": "Exportar reglas" },
+  "shortcutDescExportSessions": { "message": "Exportar sesiones" },
+  "shortcutDescExportWorkspaces": { "message": "Exportar espacios de trabajo" },
 
   "homeTab": { "message": "Inicio" },
   "homePageDescription": { "message": "Tu panel de SmartTab Organizer: sesiones ancladas, accesos rápidos y actividad." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -544,6 +544,15 @@
   "shortcutsGroupListSessions": { "message": "Liste des sessions" },
   "shortcutsGroupListWorkspaces": { "message": "Liste des espaces" },
   "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
+  "shortcutsGroupImportExport": { "message": "Import / Export" },
+
+  "shortcutSequenceSeparator": { "message": "puis" },
+  "shortcutSequenceActiveAnnouncement": {
+    "message": "Préfixe $PREFIX$ actif, en attente de la touche suivante",
+    "placeholders": {
+      "prefix": { "content": "$1" }
+    }
+  },
 
   "shortcutDescOrganize": { "message": "Organiser tous les onglets" },
   "shortcutDescSaveSession": { "message": "Enregistrer la fenêtre comme session" },
@@ -571,6 +580,12 @@
   "shortcutDescHomeFirstLast": { "message": "Aller au premier ou au dernier élément" },
   "shortcutDescHomeNextSection": { "message": "Aller à la section suivante" },
   "shortcutDescHomeActivate": { "message": "Activer l'élément focus" },
+  "shortcutDescImportRules": { "message": "Importer les règles" },
+  "shortcutDescImportSessions": { "message": "Importer les sessions" },
+  "shortcutDescImportWorkspaces": { "message": "Importer les espaces de travail" },
+  "shortcutDescExportRules": { "message": "Exporter les règles" },
+  "shortcutDescExportSessions": { "message": "Exporter les sessions" },
+  "shortcutDescExportWorkspaces": { "message": "Exporter les espaces de travail" },
 
   "homeTab": { "message": "Accueil" },
   "homePageDescription": { "message": "Votre tableau de bord SmartTab Organizer : sessions épinglées, raccourcis et activité." },

--- a/src/components/UI/SequenceIndicator/SequenceIndicator.module.css
+++ b/src/components/UI/SequenceIndicator/SequenceIndicator.module.css
@@ -1,0 +1,45 @@
+.root {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 1000;
+  background: var(--gray-a3);
+  border: 1px solid var(--gray-a5);
+  border-radius: var(--radius-3);
+  padding: 8px 12px;
+  box-shadow: var(--shadow-3);
+  backdrop-filter: blur(6px);
+  animation: sequence-indicator-fade-in 120ms ease-out;
+  pointer-events: none;
+}
+
+.separator {
+  font-style: italic;
+}
+
+.ellipsis {
+  margin-left: 2px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes sequence-indicator-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/UI/SequenceIndicator/SequenceIndicator.stories.tsx
+++ b/src/components/UI/SequenceIndicator/SequenceIndicator.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SequenceIndicator } from './SequenceIndicator';
+
+const meta = {
+  title: 'Components/UI/SequenceIndicator/SequenceIndicator',
+  component: SequenceIndicator,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SequenceIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SequenceIndicatorEmpty: Story = {
+  args: {
+    activePrefix: null,
+  },
+};
+
+export const SequenceIndicatorImportPrefix: Story = {
+  args: {
+    activePrefix: ['i'],
+  },
+};
+
+export const SequenceIndicatorExportPrefix: Story = {
+  args: {
+    activePrefix: ['e'],
+  },
+};
+
+export const SequenceIndicatorMultiKey: Story = {
+  args: {
+    activePrefix: ['i', 'r'],
+  },
+};

--- a/src/components/UI/SequenceIndicator/SequenceIndicator.tsx
+++ b/src/components/UI/SequenceIndicator/SequenceIndicator.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Flex, Kbd, Text } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+import { tokenizeComboForDisplay, formatSequenceForA11y } from '@/utils/shortcutDisplay';
+import styles from './SequenceIndicator.module.css';
+
+interface SequenceIndicatorProps {
+  /** Active sequence prefix (canonical combos), or null when no prefix is active. */
+  activePrefix: string[] | null;
+}
+
+export function SequenceIndicator({ activePrefix }: SequenceIndicatorProps) {
+  if (!activePrefix || activePrefix.length === 0) return null;
+
+  const separator = getMessage('shortcutSequenceSeparator');
+  const a11yLabel = formatSequenceForA11y(activePrefix, separator);
+  const announcement = getMessage('shortcutSequenceActiveAnnouncement', a11yLabel);
+
+  return (
+    <div
+      className={styles.root}
+      data-testid="sequence-indicator"
+      role="status"
+      aria-live="polite"
+    >
+      <span className={styles.srOnly}>{announcement}</span>
+      <Flex gap="2" align="center" aria-hidden="true">
+        {activePrefix.map((combo, i) => (
+          <React.Fragment key={`${combo}-${i}`}>
+            {i > 0 && (
+              <Text size="1" color="gray" className={styles.separator}>
+                {separator}
+              </Text>
+            )}
+            <Flex gap="1" align="center">
+              {tokenizeComboForDisplay(combo).map((token, j) => (
+                <Kbd key={`${token.display}-${j}`} size="2">{token.display}</Kbd>
+              ))}
+            </Flex>
+          </React.Fragment>
+        ))}
+        <Text size="2" color="gray" className={styles.ellipsis}>…</Text>
+      </Flex>
+    </div>
+  );
+}

--- a/src/components/UI/SequenceIndicator/index.ts
+++ b/src/components/UI/SequenceIndicator/index.ts
@@ -1,0 +1,1 @@
+export { SequenceIndicator } from './SequenceIndicator';

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.module.css
@@ -33,6 +33,12 @@
   user-select: none;
 }
 
+.sequenceSeparator {
+  font-style: italic;
+  user-select: none;
+  margin: 0 2px;
+}
+
 .groupTitle {
   margin-bottom: 4px;
 }

--- a/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
+++ b/src/components/UI/ShortcutsPanel/ShortcutsContent.tsx
@@ -14,8 +14,11 @@ import {
   type Surface,
 } from '@/shortcuts/groups';
 import { getShortcutsByGroup } from '@/shortcuts/registry';
-import type { ShortcutEntry } from '@/shortcuts/types';
-import { tokenizeComboForDisplay } from '@/utils/shortcutDisplay';
+import type { Binding, ShortcutEntry } from '@/shortcuts/types';
+import {
+  formatSequenceForA11y,
+  tokenizeComboForDisplay,
+} from '@/utils/shortcutDisplay';
 import styles from './ShortcutsContent.module.css';
 
 interface ShortcutsContentProps {
@@ -34,7 +37,7 @@ interface ShortcutsContentProps {
 }
 
 interface ResolvedKeys {
-  keys: string[];
+  keys: Binding[];
   unbound: boolean;
 }
 
@@ -230,6 +233,10 @@ function CollapsibleGroup({
   );
 }
 
+function bindingKey(binding: Binding): string {
+  return typeof binding === 'string' ? binding : binding.join('|');
+}
+
 function ShortcutRow({
   entry,
   liveCommands,
@@ -249,10 +256,10 @@ function ShortcutRow({
             {getMessage('shortcutNotSet')}
           </span>
         ) : (
-          keys.map((combo, index) => (
-            <React.Fragment key={combo}>
+          keys.map((binding, index) => (
+            <React.Fragment key={bindingKey(binding)}>
               {index > 0 && <span className={styles.altSeparator} aria-hidden="true">/</span>}
-              <KeyCombo combo={combo} />
+              <KeyCombo binding={binding} />
             </React.Fragment>
           ))
         )}
@@ -261,7 +268,7 @@ function ShortcutRow({
   );
 }
 
-function KeyCombo({ combo }: { combo: string }) {
+function SimpleCombo({ combo }: { combo: string }) {
   const tokens = tokenizeComboForDisplay(combo);
   return (
     <Flex gap="1" align="center">
@@ -269,6 +276,27 @@ function KeyCombo({ combo }: { combo: string }) {
         <React.Fragment key={`${token.display}-${i}`}>
           {i > 0 && <span className={styles.plus} aria-hidden="true">+</span>}
           <Kbd size="1" aria-label={token.accessibleLabel}>{token.display}</Kbd>
+        </React.Fragment>
+      ))}
+    </Flex>
+  );
+}
+
+function KeyCombo({ binding }: { binding: Binding }) {
+  if (typeof binding === 'string') {
+    return <SimpleCombo combo={binding} />;
+  }
+  const separator = getMessage('shortcutSequenceSeparator');
+  return (
+    <Flex gap="1" align="center" aria-label={formatSequenceForA11y(binding, separator)}>
+      {binding.map((combo, i) => (
+        <React.Fragment key={`${combo}-${i}`}>
+          {i > 0 && (
+            <Text size="1" color="gray" className={styles.sequenceSeparator} aria-hidden="true">
+              {separator}
+            </Text>
+          )}
+          <SimpleCombo combo={combo} />
         </React.Fragment>
       ))}
     </Flex>

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -1,25 +1,34 @@
 /**
- * Façade hook that lets callers wire keyboard actions by registry ID instead
- * of duplicating combo strings inline. Resolves each binding against
- * `SHORTCUTS_REGISTRY` and translates the entry's `scope` into a low-level
- * `ShortcutDefinition`:
+ * Façade hook that lets callers wire keyboard actions by registry ID. Resolves
+ * each binding against `SHORTCUTS_REGISTRY` and dispatches keydown events
+ * directly. Supports both simple combos (`'Mod+K'`) and ordered key sequences
+ * (`['i', 'r']`) declared on a registry entry's `defaultBindings`.
  *
- * - `global` and `page:*` scopes attach as plain document-level shortcuts.
- *   Entries flagged `excludeIfInsideWidget` are suppressed when focus is
- *   anywhere inside a `[data-shortcut-scope="widget:..."]` element.
+ * Scope filtering mirrors Lot 2 semantics:
  * - `widget:*` scopes only fire when the event target itself carries the
  *   matching `data-shortcut-scope` attribute (descendants do not steal the
- *   combo, so a drag handle's Space still starts the drag).
+ *   combo).
+ * - `global` and `page:*` scopes attach as document-level shortcuts; entries
+ *   flagged `excludeIfInsideWidget` are suppressed when focus is inside any
+ *   `[data-shortcut-scope^="widget:"]` element.
+ *
+ * Sequences accumulate in a buffer cleared on Escape, on focus into a typing
+ * target, on dialog open, or after `sequenceTimeout` ms of inactivity. The
+ * `onSequenceState` callback fires whenever the active prefix changes so the
+ * UI can render a `SequenceIndicator`.
  */
 
-import { useMemo } from 'react';
-import { useKeyboardShortcuts } from './useKeyboardShortcuts';
+import { useEffect, useRef } from 'react';
 import { SHORTCUTS_REGISTRY } from '@/shortcuts/registry';
-import type { ShortcutScope } from '@/shortcuts/types';
+import type { Binding, ShortcutEntry, ShortcutScope } from '@/shortcuts/types';
 import {
   WIDGET_SCOPE_SELECTOR,
+  isDialogOpen,
+  isSequencePrefix,
+  isTypingTarget,
+  matchesBinding,
+  serializeKeyEvent,
   widgetScopeSelector,
-  type ShortcutDefinition,
 } from '@/utils/keyboardShortcuts';
 
 export type ShortcutAction = (event: KeyboardEvent) => void;
@@ -27,38 +36,168 @@ export type ShortcutAction = (event: KeyboardEvent) => void;
 export interface UseShortcutsOptions {
   scope?: ShortcutScope;
   enabled?: boolean;
+  /** Sequence timeout in ms. Default 1500. */
+  sequenceTimeout?: number;
+  /**
+   * Notified when the sequence buffer changes. Receives the active prefix
+   * (array of canonical combos) or `null` when the buffer is empty. Also
+   * fired on hook unmount so the indicator clears when the page changes.
+   */
+  onSequenceState?: (state: { activePrefix: string[] | null }) => void;
+}
+
+const DEFAULT_SEQUENCE_TIMEOUT_MS = 1500;
+
+function entryScopeFilter(entry: ShortcutEntry, event: KeyboardEvent): boolean {
+  if (entry.scope.startsWith('widget:')) {
+    if (!(event.target instanceof Element)) return false;
+    if (!event.target.matches(widgetScopeSelector(entry.scope))) return false;
+    return true;
+  }
+  if (entry.excludeIfInsideWidget && event.target instanceof Element) {
+    if (event.target.closest(WIDGET_SCOPE_SELECTOR)) return false;
+  }
+  return true;
+}
+
+function passesContextualFilters(entry: ShortcutEntry, event: KeyboardEvent): boolean {
+  if (!entry.allowInTypingTarget && isTypingTarget(event.target)) return false;
+  if (!entry.allowWhenDialogOpen && isDialogOpen()) return false;
+  return entryScopeFilter(entry, event);
 }
 
 export function useShortcuts(
   bindings: Record<string, ShortcutAction>,
   options: UseShortcutsOptions = {},
 ): void {
-  const { scope = 'global', enabled = true } = options;
+  const {
+    scope = 'global',
+    enabled = true,
+    sequenceTimeout = DEFAULT_SEQUENCE_TIMEOUT_MS,
+    onSequenceState,
+  } = options;
 
-  const definitions = useMemo<ShortcutDefinition[]>(() => {
-    const defs: ShortcutDefinition[] = [];
-    for (const [id, action] of Object.entries(bindings)) {
-      const entry = SHORTCUTS_REGISTRY[id];
-      if (!entry) continue;
-      if (entry.scope !== scope) continue;
-      const isWidget = entry.scope.startsWith('widget:');
-      for (const combo of entry.defaultBindings) {
-        const def: ShortcutDefinition = {
-          combo,
-          action,
-          allowInTypingTarget: entry.allowInTypingTarget,
-          allowWhenDialogOpen: entry.allowWhenDialogOpen,
-        };
-        if (isWidget) {
-          def.requireTargetMatches = widgetScopeSelector(entry.scope);
-        } else if (entry.excludeIfInsideWidget) {
-          def.excludeIfTargetWithin = WIDGET_SCOPE_SELECTOR;
-        }
-        defs.push(def);
+  const bindingsRef = useRef(bindings);
+  bindingsRef.current = bindings;
+  const onSequenceStateRef = useRef(onSequenceState);
+  onSequenceStateRef.current = onSequenceState;
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    let buffer: string[] = [];
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimer = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
       }
-    }
-    return defs;
-  }, [bindings, scope]);
+    };
 
-  useKeyboardShortcuts(definitions, { enabled });
+    const reset = () => {
+      const wasActive = buffer.length > 0;
+      buffer = [];
+      clearTimer();
+      if (wasActive) onSequenceStateRef.current?.({ activePrefix: null });
+    };
+
+    const collectScopedEntries = (): { id: string; entry: ShortcutEntry; action: ShortcutAction }[] => {
+      const out: { id: string; entry: ShortcutEntry; action: ShortcutAction }[] = [];
+      for (const [id, action] of Object.entries(bindingsRef.current)) {
+        const entry = SHORTCUTS_REGISTRY[id];
+        if (!entry) continue;
+        if (entry.scope !== scope) continue;
+        out.push({ id, entry, action });
+      }
+      return out;
+    };
+
+    const tryFullMatch = (
+      scoped: { entry: ShortcutEntry; action: ShortcutAction }[],
+      candidateBuffer: string[],
+      event: KeyboardEvent,
+    ): boolean => {
+      for (const { entry, action } of scoped) {
+        for (const binding of entry.defaultBindings) {
+          if (!matchesBinding(candidateBuffer, binding as Binding, event)) continue;
+          if (!passesContextualFilters(entry, event)) {
+            reset();
+            return true;
+          }
+          event.preventDefault();
+          try {
+            action(event);
+          } finally {
+            reset();
+          }
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const tryPartialMatch = (
+      scoped: { entry: ShortcutEntry }[],
+      candidateBuffer: string[],
+      event: KeyboardEvent,
+    ): boolean => {
+      for (const { entry } of scoped) {
+        for (const binding of entry.defaultBindings) {
+          if (!isSequencePrefix(candidateBuffer, binding as Binding, event)) continue;
+          if (isTypingTarget(event.target) || isDialogOpen()) {
+            reset();
+            return true;
+          }
+          buffer = candidateBuffer;
+          clearTimer();
+          timer = setTimeout(reset, sequenceTimeout);
+          onSequenceStateRef.current?.({ activePrefix: [...buffer] });
+          event.preventDefault();
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const tryDispatch = (candidateBuffer: string[], event: KeyboardEvent): boolean => {
+      const scoped = collectScopedEntries();
+      if (tryFullMatch(scoped, candidateBuffer, event)) return true;
+      return tryPartialMatch(scoped, candidateBuffer, event);
+    };
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && buffer.length > 0) {
+        reset();
+      }
+
+      const keyCombo = serializeKeyEvent(event);
+      if (keyCombo === null) return;
+
+      const candidateBuffer = [...buffer, keyCombo];
+      if (tryDispatch(candidateBuffer, event)) return;
+
+      if (buffer.length > 0) {
+        reset();
+        tryDispatch([keyCombo], event);
+      }
+    };
+
+    const focusHandler = (event: FocusEvent) => {
+      if (buffer.length === 0) return;
+      if (isTypingTarget(event.target)) reset();
+    };
+
+    document.addEventListener('keydown', handler);
+    document.addEventListener('focusin', focusHandler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+      document.removeEventListener('focusin', focusHandler);
+      clearTimer();
+      if (buffer.length > 0) {
+        buffer = [];
+        onSequenceStateRef.current?.({ activePrefix: null });
+      }
+    };
+  }, [enabled, scope, sequenceTimeout]);
 }

--- a/src/pages/ImportExportPage.tsx
+++ b/src/pages/ImportExportPage.tsx
@@ -11,6 +11,7 @@ import { ImportExportActionCard } from '@/components/UI/ImportExportWizards/Impo
 import { ExportWorkspaceDialog } from '@/components/UI/Workspace/ExportWorkspaceDialog';
 import { ImportWorkspaceDialog } from '@/components/UI/Workspace/ImportWorkspaceDialog';
 import { useSessions } from '@/hooks/useSessions';
+import { useShortcuts, type ShortcutAction } from '@/hooks/useShortcuts';
 import type { ImportExportAction, ImportExportFrom } from '@/hooks/useDeepLinking';
 import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 import type { AppSettings, DomainRuleSetting } from '@/types/syncSettings';
@@ -30,6 +31,8 @@ interface ImportExportPageProps {
   importRulesInitialMode?: SourceMode | null;
   /** Called when the rules import wizard closes so the parent can clear `importRulesInitialMode`. */
   onImportRulesClosed?: () => void;
+  /** Forwarded sequence-buffer state so a parent can render the global indicator. */
+  onSequencePrefixChange?: (prefix: string[] | null) => void;
 }
 
 export function ImportExportPage({
@@ -41,6 +44,7 @@ export function ImportExportPage({
   onNavigate,
   importRulesInitialMode,
   onImportRulesClosed,
+  onSequencePrefixChange,
 }: ImportExportPageProps) {
   const [exportOpen, setExportOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
@@ -95,6 +99,26 @@ export function ImportExportPage({
     },
     [triggeredByDeepLink, pendingFrom, onNavigate],
   );
+
+  const shortcutBindings: Record<string, ShortcutAction> = {
+    'importexport.import.rules': () => setImportOpen(true),
+    'importexport.import.sessions': () => setImportSessionsOpen(true),
+    'importexport.import.workspaces': () => setImportWorkspaceOpen(true),
+    'importexport.export.rules': () => {
+      if (syncSettings.domainRules.length === 0) return;
+      setExportOpen(true);
+    },
+    'importexport.export.sessions': () => {
+      if (sessions.length === 0) return;
+      setExportSessionsOpen(true);
+    },
+    'importexport.export.workspaces': () => setExportWorkspaceOpen(true),
+  };
+
+  useShortcuts(shortcutBindings, {
+    scope: 'page:importexport',
+    onSequenceState: ({ activePrefix }) => onSequencePrefixChange?.(activePrefix),
+  });
 
   return (
     <PageLayout

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -23,6 +23,7 @@ import type { SidebarSection } from '@/components/UI/Sidebar/Sidebar';
 import { OptionsHeader, OptionsHeaderCollapsed } from '@/components/UI/OptionsLayout/OptionsHeader';
 import { WorkspaceFooter, WorkspaceFooterCollapsed } from '@/components/UI/Workspace/WorkspaceFooter';
 import { ShortcutsAside, type PageContext } from '@/components/UI/ShortcutsPanel';
+import { SequenceIndicator } from '@/components/UI/SequenceIndicator';
 import { DomainRulesPage } from './DomainRulesPage';
 import { HomePage } from './HomePage';
 import { StatisticsPage } from './StatisticsPage';
@@ -57,6 +58,7 @@ export function OptionsContent() {
     const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
     const [shortcutsAsideOpen, setShortcutsAsideOpen] = useState(false);
     const [importInitialMode, setImportInitialMode] = useState<SourceMode | null>(null);
+    const [sequencePrefix, setSequencePrefix] = useState<string[] | null>(null);
 
     const updateRules = useCallback((newRules: DomainRuleSettings) => {
         updateSettings({ domainRules: newRules });
@@ -233,6 +235,7 @@ export function OptionsContent() {
                                 onNavigate={handleTabChange}
                                 importRulesInitialMode={importInitialMode}
                                 onImportRulesClosed={handleImportRulesClosed}
+                                onSequencePrefixChange={setSequencePrefix}
                             />
                         )}
                         {currentTab === 'sessions' && (
@@ -276,6 +279,7 @@ export function OptionsContent() {
                 confirmLabel={getMessage('confirmAction')}
                 color="orange"
             />
+            <SequenceIndicator activePrefix={sequencePrefix} />
         </div>
         </ShortcutsControlProvider>
     );

--- a/src/shortcuts/groups.ts
+++ b/src/shortcuts/groups.ts
@@ -59,6 +59,11 @@ export const GROUP_DESCRIPTORS: Record<ShortcutGroupId, ShortcutGroupDescriptor>
     titleKey: 'shortcutsGroupSessionCard',
     topLevel: false,
   },
+  importexport: {
+    id: 'importexport',
+    titleKey: 'shortcutsGroupImportExport',
+    topLevel: true,
+  },
 };
 
 /**
@@ -72,6 +77,7 @@ export const TOP_LEVEL_GROUP_ORDER: ShortcutGroupId[] = [
   'list-rules',
   'list-sessions',
   'list-workspaces',
+  'importexport',
   'options',
   'popup',
 ];
@@ -89,6 +95,7 @@ export const VISIBLE_GROUPS_BY_SURFACE: Record<Surface, ShortcutGroupId[]> = {
     'list-rules',
     'list-sessions',
     'list-workspaces',
+    'importexport',
     'options',
     'popup',
   ],
@@ -153,6 +160,8 @@ export function isGroupOpenByDefault(
       return pageContext === 'sessions';
     case 'list-workspaces':
       return pageContext === 'workspaces';
+    case 'importexport':
+      return pageContext === 'importexport';
     case 'session-card':
       return pageContext === 'sessions' || pageContext === 'home';
     default:

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -309,6 +309,53 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     group: 'session-card',
     scope: 'widget:session-card',
   },
+
+  // Page: Import/Export. Mnemonic two-key sequences (i/e prefix + target
+  // initial). The `i` and `e` letters are reserved as sequence prefixes in
+  // this scope: no simple combo may use them so the sequence timeout never
+  // delays a single keypress (enforced by registry invariant test).
+  'importexport.import.rules': {
+    id: 'importexport.import.rules',
+    defaultBindings: [['i', 'r']],
+    descriptionKey: 'shortcutDescImportRules',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
+  'importexport.import.sessions': {
+    id: 'importexport.import.sessions',
+    defaultBindings: [['i', 's']],
+    descriptionKey: 'shortcutDescImportSessions',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
+  'importexport.import.workspaces': {
+    id: 'importexport.import.workspaces',
+    defaultBindings: [['i', 'w']],
+    descriptionKey: 'shortcutDescImportWorkspaces',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
+  'importexport.export.rules': {
+    id: 'importexport.export.rules',
+    defaultBindings: [['e', 'r']],
+    descriptionKey: 'shortcutDescExportRules',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
+  'importexport.export.sessions': {
+    id: 'importexport.export.sessions',
+    defaultBindings: [['e', 's']],
+    descriptionKey: 'shortcutDescExportSessions',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
+  'importexport.export.workspaces': {
+    id: 'importexport.export.workspaces',
+    defaultBindings: [['e', 'w']],
+    descriptionKey: 'shortcutDescExportWorkspaces',
+    group: 'importexport',
+    scope: 'page:importexport',
+  },
 };
 
 export function getShortcutsByScope(scope: ShortcutScope): ShortcutEntry[] {

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -19,17 +19,25 @@ export type ShortcutGroupId =
   | 'list-sessions'
   | 'list-workspaces'
   | 'list-home'
-  | 'session-card';
+  | 'session-card'
+  | 'importexport';
+
+/**
+ * A single combo (e.g. `'Mod+K'`) OR an ordered sequence of combos (e.g.
+ * `['i', 'r']`). Sequences match as a chord: each step must be pressed within
+ * the timeout window of the previous one.
+ */
+export type Binding = string | string[];
 
 export interface ShortcutEntry {
   /** Stable ID. Doubles as customization key and test selector. */
   id: string;
 
   /**
-   * Default combos. Multiple entries are equivalent alternative bindings.
-   * Kept as plain strings for now; Lot 3 will widen to support key sequences.
+   * Default bindings. Multiple entries are equivalent alternatives. Each
+   * entry is either a single combo string or an ordered sequence of combos.
    */
-  defaultBindings: string[];
+  defaultBindings: Binding[];
 
   /** i18n key for the description shown in the help panel. */
   descriptionKey: string;

--- a/src/utils/keyboardShortcuts.ts
+++ b/src/utils/keyboardShortcuts.ts
@@ -17,6 +17,7 @@
  */
 
 import { IS_MAC } from './platform';
+import type { Binding } from '@/shortcuts/types';
 
 export interface ParsedCombo {
   key: string;
@@ -138,4 +139,76 @@ export const WIDGET_SCOPE_SELECTOR = '[data-shortcut-scope^="widget:"]';
  */
 export function widgetScopeSelector(scope: string): string {
   return `[data-shortcut-scope="${scope}"]`;
+}
+
+const LONE_MODIFIER_KEYS = new Set([
+  'Shift', 'Control', 'Alt', 'Meta', 'OS', 'ContextMenu',
+]);
+
+/**
+ * Serializes a `KeyboardEvent` into a canonical combo string compatible with
+ * `parseCombo`. Used to feed the sequence buffer in `useShortcuts`. Returns
+ * `null` for lone modifier keypresses so the buffer ignores them.
+ */
+export function serializeKeyEvent(event: KeyboardEvent): string | null {
+  if (LONE_MODIFIER_KEYS.has(event.key)) return null;
+  const key = event.key.toLowerCase();
+  const parts: string[] = [];
+  if (event.metaKey) parts.push('Meta');
+  if (event.ctrlKey) parts.push('Ctrl');
+  if (event.altKey) parts.push('Alt');
+  if (event.shiftKey && !SHIFT_INSENSITIVE_KEYS.has(key)) parts.push('Shift');
+  parts.push(key);
+  return parts.join('+');
+}
+
+function comboEquivalent(a: string, b: string): boolean {
+  const pa = parseCombo(a);
+  const pb = parseCombo(b);
+  return pa.key === pb.key
+    && pa.shift === pb.shift
+    && pa.alt === pb.alt
+    && pa.ctrl === pb.ctrl
+    && pa.meta === pb.meta;
+}
+
+/**
+ * Returns true when the buffer (already including the latest keypress) fully
+ * matches `binding`. Simple combos require a length-1 buffer matching the
+ * combo. Sequences require equal length: the last step is matched against
+ * the live event for layout-aware fallbacks (`event.code`), prior steps
+ * compared canonically.
+ */
+export function matchesBinding(
+  buffer: string[],
+  binding: Binding,
+  lastEvent: KeyboardEvent,
+): boolean {
+  if (typeof binding === 'string') {
+    return buffer.length === 1 && matchesShortcut(lastEvent, binding);
+  }
+  if (buffer.length !== binding.length) return false;
+  for (let i = 0; i < binding.length - 1; i++) {
+    if (!comboEquivalent(buffer[i], binding[i])) return false;
+  }
+  return matchesShortcut(lastEvent, binding[binding.length - 1]);
+}
+
+/**
+ * Returns true when the buffer is a strict prefix of `binding`. Returns
+ * false for simple combos (no prefix possible) and for full matches (use
+ * `matchesBinding` for those).
+ */
+export function isSequencePrefix(
+  buffer: string[],
+  binding: Binding,
+  lastEvent: KeyboardEvent,
+): boolean {
+  if (typeof binding === 'string') return false;
+  if (buffer.length >= binding.length) return false;
+  if (buffer.length === 0) return false;
+  for (let i = 0; i < buffer.length - 1; i++) {
+    if (!comboEquivalent(buffer[i], binding[i])) return false;
+  }
+  return matchesShortcut(lastEvent, binding[buffer.length - 1]);
 }

--- a/src/utils/shortcutDisplay.ts
+++ b/src/utils/shortcutDisplay.ts
@@ -85,3 +85,12 @@ export function formatComboForA11y(combo: string): string {
   const separator = IS_MAC ? ' ' : ' + ';
   return tokens.map((t) => t.accessibleLabel).join(separator);
 }
+
+/**
+ * Plain-text formatting for sequence bindings (e.g. `['i', 'r']`). Each step
+ * is rendered via `formatComboForA11y`, joined by the localised separator
+ * passed in (typically `getMessage('shortcutSequenceSeparator')`).
+ */
+export function formatSequenceForA11y(sequence: string[], separator: string): string {
+  return sequence.map((combo) => formatComboForA11y(combo)).join(` ${separator} `);
+}

--- a/tests/components/SequenceIndicator.test.tsx
+++ b/tests/components/SequenceIndicator.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { SequenceIndicator } from '../../src/components/UI/SequenceIndicator/SequenceIndicator';
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <Theme>{children}</Theme>
+);
+
+describe('SequenceIndicator', () => {
+  it('renders nothing when activePrefix is null', () => {
+    const { container } = render(
+      <TestWrapper>
+        <SequenceIndicator activePrefix={null} />
+      </TestWrapper>,
+    );
+    expect(container.querySelector('[data-testid="sequence-indicator"]')).toBeNull();
+  });
+
+  it('renders nothing when activePrefix is an empty array', () => {
+    const { container } = render(
+      <TestWrapper>
+        <SequenceIndicator activePrefix={[]} />
+      </TestWrapper>,
+    );
+    expect(container.querySelector('[data-testid="sequence-indicator"]')).toBeNull();
+  });
+
+  it('renders the prefix as a status region with aria-live="polite"', () => {
+    render(
+      <TestWrapper>
+        <SequenceIndicator activePrefix={['i']} />
+      </TestWrapper>,
+    );
+    const indicator = screen.getByTestId('sequence-indicator');
+    expect(indicator).toHaveAttribute('role', 'status');
+    expect(indicator).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows each combo from the active prefix', () => {
+    render(
+      <TestWrapper>
+        <SequenceIndicator activePrefix={['i', 'r']} />
+      </TestWrapper>,
+    );
+    const indicator = screen.getByTestId('sequence-indicator');
+    expect(indicator.textContent).toContain('I');
+    expect(indicator.textContent).toContain('R');
+  });
+});

--- a/tests/e2e/import-export-shortcuts.spec.ts
+++ b/tests/e2e/import-export-shortcuts.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * E2E tests for the Import/Export sequence shortcuts (issue #275).
+ * Validates that two-key sequences (`i r`, `i s`, `e r`, `e s`, etc.) opened
+ * from the Import/Export options page each open the matching wizard, and
+ * that escape / timeout / focus changes cancel the sequence cleanly.
+ */
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+async function goToImportExportSection(page: Page, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => {
+      const body = document.body.textContent ?? '';
+      return !body.includes('Chargement') && body.length > 50;
+    },
+    null,
+    { timeout: 10_000 },
+  );
+  await page.getByTestId('sidebar-nav-item-importexport').click();
+  await page.getByTestId('page-import-export-card-import-rules').waitFor({ state: 'visible' });
+}
+
+async function focusBody(page: Page): Promise<void> {
+  await page.locator('body').click({ position: { x: 5, y: 5 } });
+}
+
+test.describe('[issue-275] Import/Export sequence shortcuts', () => {
+  test('i then r opens the rules import wizard', async ({ extensionContext, extensionId }) => {
+    const page = await extensionContext.newPage();
+    await goToImportExportSection(page, extensionId);
+    await focusBody(page);
+
+    await page.keyboard.press('i');
+    await page.keyboard.press('r');
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    await page.close();
+  });
+
+  test('i then s opens the sessions import wizard', async ({ extensionContext, extensionId }) => {
+    const page = await extensionContext.newPage();
+    await goToImportExportSection(page, extensionId);
+    await focusBody(page);
+
+    await page.keyboard.press('i');
+    await page.keyboard.press('s');
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    await page.close();
+  });
+
+  test('i then w opens the workspace import dialog', async ({ extensionContext, extensionId }) => {
+    const page = await extensionContext.newPage();
+    await goToImportExportSection(page, extensionId);
+    await focusBody(page);
+
+    await page.keyboard.press('i');
+    await page.keyboard.press('w');
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    await page.close();
+  });
+
+  test('typing only i and waiting past the timeout does not open any wizard', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToImportExportSection(page, extensionId);
+    await focusBody(page);
+
+    await page.keyboard.press('i');
+    const indicator = page.getByTestId('sequence-indicator');
+    await expect(indicator).toBeVisible({ timeout: 2000 });
+    // Sequence times out after 1500ms; the indicator disappears.
+    await expect(indicator).toBeHidden({ timeout: 3000 });
+    // r alone is not a binding in this scope, so no dialog opens.
+    await page.keyboard.press('r');
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await page.close();
+  });
+
+  test('Escape mid-sequence cancels the buffer', async ({ extensionContext, extensionId }) => {
+    const page = await extensionContext.newPage();
+    await goToImportExportSection(page, extensionId);
+    await focusBody(page);
+
+    await page.keyboard.press('i');
+    const indicator = page.getByTestId('sequence-indicator');
+    await expect(indicator).toBeVisible({ timeout: 2000 });
+    await page.keyboard.press('Escape');
+    await expect(indicator).toBeHidden({ timeout: 1000 });
+    // r alone is not a binding in this scope, so no dialog opens.
+    await page.keyboard.press('r');
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await page.close();
+  });
+});

--- a/tests/hooks/useShortcuts.test.tsx
+++ b/tests/hooks/useShortcuts.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
 import { useShortcuts } from '../../src/hooks/useShortcuts';
 
 function dispatch(combo: {
@@ -214,5 +214,140 @@ describe('useShortcuts (widget scope)', () => {
 
     dispatchOn(card, { key: '?' });
     expect(action).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useShortcuts (sequences)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires the action when a sequence is typed within the timeout window', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport' },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    expect(action).not.toHaveBeenCalled();
+    dispatch({ key: 'r' });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when the second key arrives after the timeout', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport', sequenceTimeout: 1500 },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    act(() => {
+      vi.advanceTimersByTime(1600);
+    });
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('clears the buffer when an unrelated key is pressed mid-sequence', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport' },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    dispatch({ key: 'x' });
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('clears the buffer when Escape is pressed', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport' },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    dispatch({ key: 'Escape' });
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('clears the buffer on focusin into a typing target', () => {
+    const action = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport' },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    dispatch({ key: 'r' });
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('reports buffer state via onSequenceState (active then null)', () => {
+    const action = vi.fn();
+    const onSequenceState = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport', onSequenceState },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    expect(onSequenceState).toHaveBeenLastCalledWith({ activePrefix: ['i'] });
+
+    dispatch({ key: 'r' });
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(onSequenceState).toHaveBeenLastCalledWith({ activePrefix: null });
+  });
+
+  it('clears the indicator when the timeout expires', () => {
+    const action = vi.fn();
+    const onSequenceState = vi.fn();
+    renderHook(() =>
+      useShortcuts(
+        { 'importexport.import.rules': action },
+        { scope: 'page:importexport', sequenceTimeout: 500, onSequenceState },
+      ),
+    );
+
+    dispatch({ key: 'i' });
+    expect(onSequenceState).toHaveBeenLastCalledWith({ activePrefix: ['i'] });
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(onSequenceState).toHaveBeenLastCalledWith({ activePrefix: null });
+  });
+
+  it('does not affect simple combos pressed before any sequence prefix', () => {
+    const simpleAction = vi.fn();
+    renderHook(() =>
+      useShortcuts({ 'popup.save': simpleAction }, { scope: 'page:popup' }),
+    );
+
+    dispatch({ key: 's' });
+    expect(simpleAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/shortcuts/groups.test.ts
+++ b/tests/shortcuts/groups.test.ts
@@ -27,7 +27,7 @@ describe('getDisplayTree("popup")', () => {
 });
 
 describe('getDisplayTree("options")', () => {
-  it('returns the 7 top-level groups in the historical order', () => {
+  it('returns the 8 top-level groups in the historical order', () => {
     const tree = getDisplayTree('options');
     expect(tree.map((n) => n.descriptor.id)).toEqual([
       'global',
@@ -35,6 +35,7 @@ describe('getDisplayTree("options")', () => {
       'list-rules',
       'list-sessions',
       'list-workspaces',
+      'importexport',
       'options',
       'popup',
     ]);
@@ -47,7 +48,7 @@ describe('getDisplayTree("options")', () => {
     );
     expect(subIdsByGroup['list-home']).toEqual(['session-card']);
     expect(subIdsByGroup['list-sessions']).toEqual(['session-card']);
-    for (const id of ['global', 'list-rules', 'list-workspaces', 'options', 'popup'] as const) {
+    for (const id of ['global', 'list-rules', 'list-workspaces', 'importexport', 'options', 'popup'] as const) {
       expect(subIdsByGroup[id]).toEqual([]);
     }
   });
@@ -87,6 +88,12 @@ describe('isGroupOpenByDefault', () => {
   it('opens list-workspaces only on the workspaces page', () => {
     for (const ctx of ALL_CONTEXTS) {
       expect(isGroupOpenByDefault('list-workspaces', ctx)).toBe(ctx === 'workspaces');
+    }
+  });
+
+  it('opens importexport only on the importexport page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('importexport', ctx)).toBe(ctx === 'importexport');
     }
   });
 

--- a/tests/shortcuts/registry.test.ts
+++ b/tests/shortcuts/registry.test.ts
@@ -30,10 +30,13 @@ describe('SHORTCUTS_REGISTRY', () => {
 
   it('parses every defaultBinding without error', () => {
     for (const entry of Object.values(SHORTCUTS_REGISTRY)) {
-      for (const combo of entry.defaultBindings) {
-        expect(() => parseCombo(combo)).not.toThrow();
-        const parsed = parseCombo(combo);
-        expect(parsed.key.length).toBeGreaterThan(0);
+      for (const binding of entry.defaultBindings) {
+        const combos = typeof binding === 'string' ? [binding] : binding;
+        for (const combo of combos) {
+          expect(() => parseCombo(combo)).not.toThrow();
+          const parsed = parseCombo(combo);
+          expect(parsed.key.length).toBeGreaterThan(0);
+        }
       }
     }
   });
@@ -56,6 +59,26 @@ describe('SHORTCUTS_REGISTRY', () => {
     expect(getShortcutsByGroup('list-workspaces')).toHaveLength(1);
     expect(getShortcutsByGroup('list-home')).toHaveLength(4);
     expect(getShortcutsByGroup('session-card')).toHaveLength(4);
+    expect(getShortcutsByGroup('importexport')).toHaveLength(6);
+  });
+
+  it('reserves i and e as sequence prefixes in page:importexport scope', () => {
+    const ieScope = getShortcutsByScope('page:importexport');
+    expect(ieScope.length).toBeGreaterThan(0);
+
+    const offending: { id: string; combo: string; key: string }[] = [];
+    for (const entry of ieScope) {
+      for (const binding of entry.defaultBindings) {
+        const combos = typeof binding === 'string' ? [binding] : [];
+        for (const combo of combos) {
+          const parsed = parseCombo(combo);
+          if (parsed.key === 'i' || parsed.key === 'e') {
+            offending.push({ id: entry.id, combo, key: parsed.key });
+          }
+        }
+      }
+    }
+    expect(offending).toEqual([]);
   });
 
   it('attaches commandName only on global manifest entries', () => {

--- a/tests/utils/keyboardShortcuts.test.ts
+++ b/tests/utils/keyboardShortcuts.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  serializeKeyEvent,
+  matchesBinding,
+  isSequencePrefix,
+} from '../../src/utils/keyboardShortcuts';
+
+function makeEvent(init: {
+  key: string;
+  alt?: boolean;
+  shift?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  code?: string;
+}): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key: init.key,
+    altKey: init.alt ?? false,
+    shiftKey: init.shift ?? false,
+    ctrlKey: init.ctrl ?? false,
+    metaKey: init.meta ?? false,
+    code: init.code,
+  });
+}
+
+describe('serializeKeyEvent', () => {
+  it('returns the lowercase key for a plain letter', () => {
+    expect(serializeKeyEvent(makeEvent({ key: 'r' }))).toBe('r');
+    expect(serializeKeyEvent(makeEvent({ key: 'R' }))).toBe('r');
+  });
+
+  it('prepends modifiers in canonical order Meta+Ctrl+Alt+Shift', () => {
+    expect(
+      serializeKeyEvent(
+        makeEvent({ key: 'k', meta: true, ctrl: true, alt: true, shift: true }),
+      ),
+    ).toBe('Meta+Ctrl+Alt+Shift+k');
+  });
+
+  it('returns null for lone modifier keys', () => {
+    for (const key of ['Shift', 'Control', 'Alt', 'Meta', 'OS', 'ContextMenu']) {
+      expect(serializeKeyEvent(makeEvent({ key }))).toBeNull();
+    }
+  });
+
+  it('omits Shift for shift-insensitive keys (? and /)', () => {
+    expect(serializeKeyEvent(makeEvent({ key: '?', shift: true }))).toBe('?');
+    expect(serializeKeyEvent(makeEvent({ key: '/', shift: true }))).toBe('/');
+  });
+
+  it('keeps Shift for ordinary keys', () => {
+    expect(serializeKeyEvent(makeEvent({ key: 'r', shift: true }))).toBe('Shift+r');
+  });
+});
+
+describe('matchesBinding', () => {
+  it('matches a simple combo when the buffer is length 1', () => {
+    const event = makeEvent({ key: 'r' });
+    expect(matchesBinding(['r'], 'r', event)).toBe(true);
+  });
+
+  it('rejects a simple combo when the buffer is longer than 1', () => {
+    const event = makeEvent({ key: 'r' });
+    expect(matchesBinding(['i', 'r'], 'r', event)).toBe(false);
+  });
+
+  it('matches a sequence when the buffer mirrors it exactly', () => {
+    const event = makeEvent({ key: 'r' });
+    expect(matchesBinding(['i', 'r'], ['i', 'r'], event)).toBe(true);
+  });
+
+  it('rejects a sequence when only partially typed', () => {
+    const event = makeEvent({ key: 'i' });
+    expect(matchesBinding(['i'], ['i', 'r'], event)).toBe(false);
+  });
+
+  it('rejects a sequence when the last step does not match the live event', () => {
+    const event = makeEvent({ key: 'x' });
+    expect(matchesBinding(['i', 'x'], ['i', 'r'], event)).toBe(false);
+  });
+});
+
+describe('isSequencePrefix', () => {
+  it('returns false for simple combo bindings', () => {
+    const event = makeEvent({ key: 'r' });
+    expect(isSequencePrefix(['r'], 'r', event)).toBe(false);
+  });
+
+  it('returns true when the buffer is a strict prefix of the sequence', () => {
+    const event = makeEvent({ key: 'i' });
+    expect(isSequencePrefix(['i'], ['i', 'r'], event)).toBe(true);
+  });
+
+  it('returns false when the buffer fully matches the sequence', () => {
+    const event = makeEvent({ key: 'r' });
+    expect(isSequencePrefix(['i', 'r'], ['i', 'r'], event)).toBe(false);
+  });
+
+  it('returns false when the buffer step diverges from the sequence', () => {
+    const event = makeEvent({ key: 'x' });
+    expect(isSequencePrefix(['x'], ['i', 'r'], event)).toBe(false);
+  });
+
+  it('returns false for an empty buffer', () => {
+    const event = makeEvent({ key: 'i' });
+    expect(isSequencePrefix([], ['i', 'r'], event)).toBe(false);
+  });
+});

--- a/tests/utils/shortcutDisplay.test.ts
+++ b/tests/utils/shortcutDisplay.test.ts
@@ -75,3 +75,24 @@ describe('formatComboForA11y', () => {
     vi.doUnmock('../../src/utils/platform');
   });
 });
+
+describe('formatSequenceForA11y', () => {
+  it('joins each combo with the localized separator', async () => {
+    const { formatSequenceForA11y } = await loadDisplay(false);
+    expect(formatSequenceForA11y(['i', 'r'], 'then')).toBe('I then R');
+    expect(formatSequenceForA11y(['e', 's'], 'then')).toBe('E then S');
+    vi.doUnmock('../../src/utils/platform');
+  });
+
+  it('honors the separator on Mac builds too', async () => {
+    const { formatSequenceForA11y } = await loadDisplay(true);
+    expect(formatSequenceForA11y(['i', 'r'], 'puis')).toBe('I puis R');
+    vi.doUnmock('../../src/utils/platform');
+  });
+
+  it('returns a single combo unchanged when sequence has length 1', async () => {
+    const { formatSequenceForA11y } = await loadDisplay(false);
+    expect(formatSequenceForA11y(['i'], 'then')).toBe('I');
+    vi.doUnmock('../../src/utils/platform');
+  });
+});


### PR DESCRIPTION
Widens `Binding` to `string | string[]` so registry entries can declare ordered
chord shortcuts. `useShortcuts` now buffers keypresses with a configurable
timeout, resets on Escape, focusin into a typing target, dialog open or
unmount, and reports buffer state via `onSequenceState` so a `SequenceIndicator`
can announce the active prefix (visual + aria-live="polite") for accessibility
and voice dictation.

Six sequences wired on the Import/Export page (`i r`, `i s`, `i w`, `e r`,
`e s`, `e w`); the `i` and `e` letters become reserved sequence prefixes in
that scope (enforced by registry invariant test). Help panel renders sequences
with a localized "puis" / "then" / "después" separator.

https://claude.ai/code/session_014ysy4zWoPL12pijbHUnjSj