### PR TITLE
docs: rewrite multilingual READMEs as concise vitrine

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -4,167 +4,93 @@
 
 # SmartTab Organizer
 
-![Licencia](https://img.shields.io/badge/License-GPL_v3-blue.svg)
+> **Doma tus pestañas. Sin nube, sin IA, sin tracking.**
 
-**SmartTab Organizer** es una extensión multinavegador que agrupa automáticamente las pestañas relacionadas, evita duplicados y guarda tus espacios de trabajo como sesiones con nombre.
+Una extensión para Chrome y Firefox que agrupa tus pestañas por dominio, elimina los duplicados y captura tus espacios de trabajo como sesiones que puedes restaurar con un clic.
 
 <p align="center">
-  <img src="assets/store.png" alt="SmartTab Organizer">
+  <img src="assets/store.png" alt="SmartTab Organizer" width="720">
 </p>
 
-## 🛒 Chrome Web Store ##
-
-
-[![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
-
-## 🦊 Firefox Add-ons ##
-
-
-[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
-
-## Características
-
-### ⚙️ Gestión de Reglas
-
-Las reglas de dominio se crean mediante un asistente guiado de 4 pasos: identidad → modo de nombrado → opciones → resumen.
-
-Tres modos de nombrado de grupo:
-- **Preajuste** — elige un patrón regex integrado o personalizado (IDs de tickets Jira, nombres de repos de GitHub…)
-- **Preguntar** — solicita un nombre cuando se abre la pestaña
-- **Manual** — nombre de grupo fijo
-
 <p align="center">
-  <img src="doc/readme/es-dark-rules-create-summary.png" alt="Asistente de creación de regla — paso resumen">
+  <a href="https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah">
+    <img src="https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=Chrome%20Web%20Store&logo=googlechrome&color=4285F4" alt="Disponible en Chrome Web Store">
+  </a>
+  <a href="https://addons.mozilla.org/firefox/addon/smarttab-organizer/">
+    <img src="https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=Firefox%20Add-ons&logo=firefox&color=FF7139" alt="Disponible en Firefox Add-ons">
+  </a>
+  <img src="https://img.shields.io/badge/Licencia-GPL_v3-blue.svg?style=for-the-badge" alt="Licencia : GPL v3">
 </p>
 
-### 🗂️ Agrupación Automática
+## ¿Por qué?
 
-Clic central o clic derecho → «Abrir en una pestaña nueva» en un sitio configurado, y la pestaña aterriza al instante en el grupo correcto.
+- Tus pestañas se acumulan más rápido de lo que las cierras. SmartTab las pone en su sitio, automáticamente.
+- Las otras herramientas envían tus datos a la nube o meten IA por todas partes. Aquí, todo se queda en tu navegador, cero telemetría.
+- El espacio de trabajo que has montado merece volver mañana. Guárdalo, ponle nombre, restáuralo.
 
-- Nombre del grupo extraído del título de la página, la URL o un preajuste regex
-- Preajustes integrados para Jira, GitLab, GitHub, Trello y más
+## Lo que hace
+
+### 🗂️ Agrupación automática por dominio
+
+Abres un ticket de Jira, una PR de GitHub, una página de docs : la nueva pestaña aterriza al instante en el grupo correcto. El nombre del grupo viene del título de la página, de la URL, o de un preajuste regex (Jira, GitHub, GitLab, Trello, y muchos más).
 
 <p align="center">
-  <img src="assets/readme/gifs/regroup.gif" alt="Vídeo de agrupación automática">
+  <img src="assets/readme/gifs/regroup.gif" alt="Demo de agrupación automática" width="640">
 </p>
 
 ### 🔁 Deduplicación
 
-Abrir una página que ya está abierta reactiva y recarga la pestaña existente en lugar de crear una nueva.
-La sensibilidad de coincidencia es configurable por regla: URL exacta, nombre de host + ruta, nombre de host o «includes».
+¿Abres una página que ya estaba abierta ? El duplicado desaparece. El modo de comparación se ajusta por regla (URL exacta, "contiene", o "ignora estos parámetros"), y tú eliges cuál de las dos pestañas sobrevive.
 
 <p align="center">
-  <img src="assets/readme/gifs/dedup.gif" alt="Vídeo de deduplicación">
+  <img src="assets/readme/gifs/dedup.gif" alt="Demo de deduplicación" width="640">
 </p>
 
+### 📷 Sesiones que de verdad usarás
 
-### 📷 Sesiones
-
-Guarda un snapshot con nombre de tus pestañas y grupos abiertos, y restáuralos cuando los necesites.
-
-- **Sesiones ancladas** — convierte cualquier snapshot en acceso rápido desde el popup, con un icono personalizado
-- **Asistente de restauración** — elige qué pestañas recuperar, la ventana de destino y resuelve conflictos de grupos antes de aplicar
-- **Búsqueda profunda** — encuentra pestañas y grupos por nombre en todas tus sesiones guardadas
-- **Editor de sesión** — reorganiza, renombra y elimina pestañas y grupos sin necesidad de restaurar
-- **Notas de sesión** — anota tus sesiones con texto libre
-- **Drag-and-drop** — reordena tus sesiones arrastrando
+Captura tus pestañas y grupos abiertos, ponles nombre, fija las que más usas. Restaura en la ventana actual, en una nueva, o reemplaza lo que tienes. Cada sesión es editable, buscable hasta el nivel de pestaña, y puede llevar tus propias notas.
 
 <p align="center">
-  <img src="doc/readme/es-dark-sessions-list.png" alt="Lista de sesiones">
+  <img src="assets/readme/es-dark-sessions-list.png" alt="Lista de sesiones" width="720">
 </p>
 
-<p align="center">
-  <img src="doc/readme/es-dark-sessions-search-deep.png" alt="Búsqueda profunda en sesiones">
-</p>
+## Y además
 
+- **Espacios de trabajo** : reglas, sesiones y estadísticas separadas por contexto (trabajo, personal, side project)
+- **20+ packs de reglas** listos para importar para herramientas populares (GitHub, GitLab, Jira, AWS, asistentes de IA, Discord...)
+- **Importar / exportar** con resolución de conflictos para reglas y sesiones
+- **Estadísticas locales** : ve cuántas agrupaciones y deduplicaciones te ahorran tiempo
+- **Atajos de teclado** con panel de ayuda integrado
+- **Tema claro / oscuro / sistema**
+- **Accesibilidad primero** : auditado con axe-core, navegación por teclado, compatible con lectores de pantalla
+- **3 idiomas** : inglés, francés, español
 
-Un **asistente de importación/exportación para Reglas y Sesiones** clasifica los elementos entrantes como nuevos, en conflicto o idénticos, y resuelve los conflictos paso a paso.
+## 📖 Documentación
 
-<p align="center">
-  <img src="doc/readme/es-dark-rules-import-text-conflicts.png" alt="Asistente de importación con resolución de conflictos">
-</p>
-
-### ⚡ Popup de Acceso Rápido
-
-- Activa/desactiva globalmente la agrupación y la deduplicación
-- Toma un snapshot o accede a Sesiones con un clic
-- Sesiones ancladas listadas con acciones de restauración rápida
-
-<p align="center">
-
-<img src="doc/readme/es-dark-popup-content.png" alt="Contenido del popup">
-</p>
-
-### ♿ Accesibilidad e i18n
-
-Navegación completa por teclado y soporte para lectores de pantalla mediante primitivas Radix UI. Disponible en Inglés, Francés y Español.
-
-## 💻 Instalación
+La guía completa está en [`docs/`](docs/src/content/docs/es/) (Astro Starlight, 3 idiomas, más de 30 páginas con capturas). Lee el MDX directamente en GitHub, o lanza la doc en local :
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
-npm install -g pnpm  # si es necesario
-pnpm install
-pnpm build
+pnpm docs:dev
 ```
 
-- **Chrome:** `chrome://extensions/` → Cargar descomprimida → `.output/chrome-mv3`
+## 🛠️ Para contribuir
 
-Para desarrollo con recarga automática: `pnpm dev` (Chrome) o `pnpm dev:firefox`.
-
-## 🛠️ Stack Tecnológico
-
-| Capa | Tecnología |
-|---|---|
-| Framework de extensión | [WXT](https://wxt.dev/) |
-| Interfaz | [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
-| Biblioteca de componentes | [Radix UI Themes](https://www.radix-ui.com/themes) + iconos [Lucide](https://lucide.dev/) |
-| Formularios & validación | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
-| Árbol de pestañas | [react-accessible-treeview](https://github.com/dgreene1/react-accessible-treeview) |
-| Paleta de comandos | [cmdk](https://cmdk.paco.me/) |
-| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
-| Temas | [next-themes](https://github.com/pacocoursey/next-themes) |
-| Tests unitarios | [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) |
-| Tests E2E | [Playwright](https://playwright.dev/) |
-| Auditorías de accesibilidad | [axe-core](https://github.com/dequelabs/axe-core) (Storybook + Playwright) |
-| Calidad del código | [ESLint](https://eslint.org/) + [SonarJS](https://github.com/SonarSource/SonarJS) + [jscpd](https://github.com/kucherenko/jscpd) (duplicación) |
-| Informes de tests | [CTRF](https://ctrf.io/) (formato unificado de informe de tests) |
-| Explorador de componentes | [Storybook](https://storybook.js.org/) |
-| Sitio de documentación | [Astro Starlight](https://starlight.astro.build/) |
-| Gestor de paquetes | [pnpm](https://pnpm.io/) |
-
-## 🤝 Contribuir
-
-¡Las contribuciones son bienvenidas! Aquí tienes cómo empezar:
-
-**Requisitos previos:** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+**Requisitos :** Node.js, [pnpm](https://pnpm.io/)
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
 pnpm install
-pnpm dev          # Chrome con recarga automática
-pnpm dev:firefox  # Firefox con recarga automática
-```
-
-**Tests**
-
-```bash
-pnpm test         # Tests unitarios (Vitest)
-pnpm test:e2e     # Tests end-to-end (Playwright)
+pnpm dev          # Chrome con auto-recarga
+pnpm dev:firefox  # Firefox con auto-recarga
+pnpm test         # Tests unitarios Vitest
+pnpm test:e2e     # Tests E2E Playwright
 pnpm storybook    # Explorador de componentes (puerto 6006)
+pnpm build        # Build de producción
 ```
 
-**Convenciones de código**
+El stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) y las convenciones de código están documentadas en [`CLAUDE.md`](CLAUDE.md) y el [anexo stack técnico](docs/src/content/docs/annexes/stack-technique.mdx).
 
-- Usar `logger.debug()` de `src/utils/logger.ts` — nunca `console.log()`
-- Sin tipos `any` — usar tipos precisos o `unknown` con narrowing
-- Todo texto de UI mediante `getMessage()` de `src/utils/i18n.ts` — sin cadenas hardcodeadas
-- Accesibilidad mediante primitivas Radix UI; los iconos Lucide requieren `aria-hidden="true"`
-
-Por favor, abre un issue antes de enviar un pull request grande.
+Por favor, abre una issue antes de enviar una pull request grande.
 
 ## 📜 Licencia
 
-GNU General Public License v3.0
+GNU General Public License v3.0.

--- a/README-fr.md
+++ b/README-fr.md
@@ -4,168 +4,93 @@
 
 # SmartTab Organizer
 
-![Licence](https://img.shields.io/badge/License-GPL_v3-blue.svg)
+> **Dompte tes onglets. Sans cloud, sans IA, sans tracking.**
 
-**SmartTab Organizer** est une extension multi-navigateur qui regroupe automatiquement les onglets liés, évite les doublons et sauvegarde vos espaces de travail sous forme de sessions nommées.
+Une extension Chrome et Firefox qui regroupe tes onglets par domaine, supprime les doublons, et capture tes espaces de travail sous forme de sessions à restaurer en un clic.
 
 <p align="center">
-  <img src="assets/store.png" alt="SmartTab Organizer">
+  <img src="assets/store.png" alt="SmartTab Organizer" width="720">
 </p>
 
-## 🛒 Chrome Web Store ##
-
-
-[![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
-
-## 🦊 Firefox Add-ons ##
-
-
-[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
-
-## Fonctionnalités
-
-### ⚙️ Gestion des Règles
-
-Les règles de domaine sont créées via un assistant guidé en 4 étapes : identité → mode de nommage → options → récapitulatif.
-
-Trois modes de nommage de groupe :
-- **Préréglage** — choisissez un motif regex intégré ou personnalisé (numéros de tickets Jira, noms de dépôts GitHub…)
-- **Demander** — prompt pour saisir un nom à l'ouverture de l'onglet
-- **Manuel** — nom de groupe fixe
-
 <p align="center">
-  <img src="doc/readme/fr-dark-rules-create-summary.png" alt="Assistant de création de règle — étape récapitulatif">
+  <a href="https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah">
+    <img src="https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=Chrome%20Web%20Store&logo=googlechrome&color=4285F4" alt="Disponible sur le Chrome Web Store">
+  </a>
+  <a href="https://addons.mozilla.org/firefox/addon/smarttab-organizer/">
+    <img src="https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=Firefox%20Add-ons&logo=firefox&color=FF7139" alt="Disponible sur Firefox Add-ons">
+  </a>
+  <img src="https://img.shields.io/badge/Licence-GPL_v3-blue.svg?style=for-the-badge" alt="Licence : GPL v3">
 </p>
 
-### 🗂️ Regroupement Automatique
+## Pourquoi ?
 
-Clic molette ou clic droit → « Ouvrir dans un nouvel onglet » sur un site configuré, et l'onglet rejoint instantanément le bon groupe.
+- Tes onglets s'accumulent plus vite que tu ne les fermes. SmartTab les met à leur place, automatiquement.
+- Les autres outils envoient tes données ailleurs ou collent de l'IA partout. Ici, tout reste dans ton navigateur, zéro télémétrie.
+- L'espace de travail que tu as monté mérite de revenir demain. Sauvegarde-le, nomme-le, restaure-le.
 
-- Nom du groupe extrait du titre de la page, de l'URL ou d'un préréglage regex
-- Préréglages intégrés pour Jira, GitLab, GitHub, Trello et plus encore
+## Ce que ça fait
+
+### 🗂️ Regroupement automatique par domaine
+
+Tu ouvres un ticket Jira, une PR GitHub, une page de docs : le nouvel onglet atterrit dans le bon groupe instantanément. Le nom du groupe vient du titre de la page, de l'URL, ou d'un préréglage regex (Jira, GitHub, GitLab, Trello, et bien d'autres).
 
 <p align="center">
-  <img src="assets/readme/gifs/regroup.gif" alt="Vidéo de regroupement automatique">
+  <img src="assets/readme/gifs/regroup.gif" alt="Démo du regroupement automatique" width="640">
 </p>
 
 ### 🔁 Déduplication
 
-Ouvrir une page déjà ouverte ferme le doublon et ne conserve qu'un seul onglet.
-La sensibilité de correspondance est configurable par règle : URL exacte, URL sans paramètres ignorés, ou « includes ».
-Vous choisissez lequel des deux onglets survit : le groupé puis le nouveau (par défaut), le groupé puis l'existant, toujours l'existant, ou toujours le nouveau.
+Tu ouvres une page déjà ouverte ? Le doublon disparaît. Le mode de comparaison se règle par règle (URL exacte, "contient", ou "ignore ces paramètres"), et tu choisis lequel des deux onglets survit.
 
 <p align="center">
-  <img src="assets/readme/gifs/dedup.gif" alt="Vidéo de déduplication">
+  <img src="assets/readme/gifs/dedup.gif" alt="Démo de la déduplication" width="640">
 </p>
 
+### 📷 Des sessions vraiment utilisables
 
-### 📷 Sessions
-
-Sauvegardez un snapshot nommé de vos onglets et groupes ouverts, et restaurez-les quand vous en avez besoin.
-
-- **Sessions épinglées** — promouvez un snapshot dans le popup pour un accès en un clic, avec une icône personnalisée
-- **Assistant de restauration** — choisissez les onglets à récupérer, la fenêtre cible, et résolvez les conflits de groupes avant d'appliquer
-- **Recherche profonde** — retrouvez onglets et groupes par nom dans toutes vos sessions sauvegardées
-- **Éditeur de session** — réorganisez, renommez et supprimez onglets et groupes sans avoir à restaurer
-- **Notes de session** — annotez vos sessions avec du texte libre
-- **Drag-and-drop** — réordonnez vos sessions par glisser-déposer
+Capture tes onglets et tes groupes ouverts, nomme-les, épingle ceux dans lesquels tu vis. Restaure dans la fenêtre courante, dans une nouvelle, ou remplace ce que tu as. Chaque session est éditable, cherchable jusqu'au niveau des onglets, et peut porter tes propres notes.
 
 <p align="center">
-  <img src="doc/readme/fr-dark-sessions-list.png" alt="Liste des sessions">
+  <img src="assets/readme/fr-dark-sessions-list.png" alt="Liste des sessions" width="720">
 </p>
 
-<p align="center">
-  <img src="doc/readme/fr-dark-sessions-search-deep.png" alt="Recherche profonde dans les sessions">
-</p>
+## Et aussi
 
+- **Espaces de travail** : règles, sessions et stats séparés par contexte (pro, perso, projet annexe)
+- **20+ packs de règles** prêts à importer pour les outils courants (GitHub, GitLab, Jira, AWS, assistants IA, Discord...)
+- **Import / export** avec résolution de conflits pour les règles comme pour les sessions
+- **Statistiques locales** : vois combien de regroupements et de déduplications te font gagner du temps
+- **Raccourcis clavier** avec panneau d'aide intégré
+- **Thème clair / sombre / système**
+- **Accessibilité d'abord** : audité par axe-core, navigation clavier, compatible lecteurs d'écran
+- **3 langues** : français, anglais, espagnol
 
-Un **assistant d'import/export pour les Règles et les Sessions** classe les éléments entrants en nouveaux, en conflit ou identiques, et résout les conflits pas à pas.
+## 📖 Documentation
 
-<p align="center">
-  <img src="doc/readme/fr-dark-rules-import-text-conflicts.png" alt="Assistant d'import avec résolution de conflits">
-</p>
-
-### ⚡ Popup d'Accès Rapide
-
-- Activez/désactivez globalement le regroupement et la déduplication
-- Prenez un snapshot ou accédez aux Sessions en un clic
-- Sessions épinglées listées avec des actions de restauration rapide
-
-<p align="center">
-
-<img src="doc/readme/fr-dark-popup-content.png" alt="Contenu du popup">
-</p>
-
-### ♿ Accessibilité & i18n
-
-Navigation complète au clavier et support des lecteurs d'écran via les primitives Radix UI. Disponible en Anglais, Français et Espagnol.
-
-## 💻 Installation
+Le guide complet est dans [`docs/`](docs/src/content/docs/) (Astro Starlight, 3 langues, plus de 30 pages avec captures). Lis le MDX directement sur GitHub, ou lance la doc en local :
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
-npm install -g pnpm  # si nécessaire
-pnpm install
-pnpm build
+pnpm docs:dev
 ```
 
-- **Chrome :** `chrome://extensions/` → Charger l'extension non empaquetée → `.output/chrome-mv3`
+## 🛠️ Pour les contributeurs
 
-Pour le développement avec rechargement automatique : `pnpm dev` (Chrome) ou `pnpm dev:firefox`.
-
-## 🛠️ Stack Technique
-
-| Couche | Technologie |
-|---|---|
-| Framework d'extension | [WXT](https://wxt.dev/) |
-| Interface | [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
-| Bibliothèque de composants | [Radix UI Themes](https://www.radix-ui.com/themes) + icônes [Lucide](https://lucide.dev/) |
-| Formulaires & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
-| Arbre d'onglets | [react-accessible-treeview](https://github.com/dgreene1/react-accessible-treeview) |
-| Palette de commandes | [cmdk](https://cmdk.paco.me/) |
-| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
-| Thèmes | [next-themes](https://github.com/pacocoursey/next-themes) |
-| Tests unitaires | [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) |
-| Tests E2E | [Playwright](https://playwright.dev/) |
-| Audits accessibilité | [axe-core](https://github.com/dequelabs/axe-core) (Storybook + Playwright) |
-| Qualité du code | [ESLint](https://eslint.org/) + [SonarJS](https://github.com/SonarSource/SonarJS) + [jscpd](https://github.com/kucherenko/jscpd) (duplication) |
-| Rapports de tests | [CTRF](https://ctrf.io/) (format unifié de rapport de tests) |
-| Explorateur de composants | [Storybook](https://storybook.js.org/) |
-| Site de documentation | [Astro Starlight](https://starlight.astro.build/) |
-| Gestionnaire de paquets | [pnpm](https://pnpm.io/) |
-
-## 🤝 Contribuer
-
-Les contributions sont les bienvenues ! Voici comment démarrer :
-
-**Prérequis :** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+**Prérequis :** Node.js, [pnpm](https://pnpm.io/)
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
 pnpm install
-pnpm dev          # Chrome avec rechargement automatique
-pnpm dev:firefox  # Firefox avec rechargement automatique
-```
-
-**Tests**
-
-```bash
-pnpm test         # Tests unitaires (Vitest)
-pnpm test:e2e     # Tests end-to-end (Playwright)
+pnpm dev          # Chrome avec rechargement auto
+pnpm dev:firefox  # Firefox avec rechargement auto
+pnpm test         # Tests unitaires Vitest
+pnpm test:e2e     # Tests E2E Playwright
 pnpm storybook    # Explorateur de composants (port 6006)
+pnpm build        # Build production
 ```
 
-**Conventions de code**
-
-- Utiliser `logger.debug()` de `src/utils/logger.ts` — jamais `console.log()`
-- Pas de type `any` — utiliser des types précis ou `unknown` avec narrowing
-- Tout texte UI via `getMessage()` de `src/utils/i18n.ts` — pas de chaînes en dur
-- Accessibilité via les primitives Radix UI ; les icônes Lucide nécessitent `aria-hidden="true"`
+La stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) et les conventions de code sont documentées dans [`CLAUDE.md`](CLAUDE.md) et l'[annexe stack technique](docs/src/content/docs/annexes/stack-technique.mdx).
 
 Merci d'ouvrir une issue avant de soumettre une pull request importante.
 
 ## 📜 Licence
 
-GNU General Public License v3.0
+GNU General Public License v3.0.

--- a/README.md
+++ b/README.md
@@ -4,168 +4,93 @@
 
 # SmartTab Organizer
 
-![License](https://img.shields.io/badge/License-GPL_v3-blue.svg)
+> **Tame your tabs. No cloud, no AI, no tracking.**
 
-**SmartTab Organizer** is a cross-browser extension that automatically groups related tabs, prevents duplicates, and saves your workspaces as named sessions.
+A Chrome and Firefox extension that groups your tabs by domain, kills duplicates, and snapshots your workspaces as sessions you can restore in one click.
 
 <p align="center">
-  <img src="assets/store.png" alt="SmartTab Organizer">
+  <img src="assets/store.png" alt="SmartTab Organizer" width="720">
 </p>
 
-## 🛒 Chrome Web Store ##
-
-
-[![](https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=version)](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah)
-
-## 🦊 Firefox Add-ons ##
-
-
-[![](https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=version)](https://addons.mozilla.org/firefox/addon/smarttab-organizer/)
-
-## Features
-
-### ⚙️ Rule Management
-
-Domain rules are created through a guided 4-step wizard: identity → group naming mode → options → summary.
-
-Three group naming modes:
-- **Preset** — pick a built-in or custom regex pattern (Jira ticket IDs, GitHub repo names…)
-- **Ask** — prompt for a name when the tab opens
-- **Manual** — fixed group name
-
 <p align="center">
-  <img src="doc/readme/en-dark-rules-create-summary.png" alt="Rule creation wizard — summary step">
+  <a href="https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah">
+    <img src="https://img.shields.io/chrome-web-store/v/ijnpdkkcbmfikocmboibffjgbohhlmah?style=for-the-badge&label=Chrome%20Web%20Store&logo=googlechrome&color=4285F4" alt="Get it on Chrome Web Store">
+  </a>
+  <a href="https://addons.mozilla.org/firefox/addon/smarttab-organizer/">
+    <img src="https://img.shields.io/amo/v/smarttab-organizer?style=for-the-badge&label=Firefox%20Add-ons&logo=firefox&color=FF7139" alt="Get it on Firefox Add-ons">
+  </a>
+  <img src="https://img.shields.io/badge/License-GPL_v3-blue.svg?style=for-the-badge" alt="License: GPL v3">
 </p>
 
-### 🗂️ Automatic Grouping
+## Why?
 
-Middle-click or right-click → "Open in new tab" on a configured site and the tab lands in the right group instantly.
+- Your tabs pile up faster than you can close them. SmartTab puts them in their place, automatically.
+- Other tools either ship your data to a cloud or shove AI in your face. This one runs entirely in your browser, with zero telemetry.
+- The workspace you built deserves to come back tomorrow. Save it, name it, restore it.
 
-- Group names extracted from the page title, URL, or a regex preset
-- Built-in presets for Jira, GitLab, GitHub, Trello and more
+## What it does
+
+### 🗂️ Auto-grouping by domain
+
+Open a Jira ticket, a GitHub PR, a docs page: the new tab lands in the right group instantly. Group names come from the page title, the URL, or a regex preset (Jira, GitHub, GitLab, Trello, and many more).
 
 <p align="center">
-  <img src="assets/readme/gifs/regroup.gif" alt="Automatic Regroupment video">
+  <img src="assets/readme/gifs/regroup.gif" alt="Auto-grouping in action" width="640">
 </p>
 
 ### 🔁 Deduplication
 
-Opening a page that's already open closes the duplicate and keeps a single tab active.
-Matching sensitivity is configurable per rule: exact URL, URL without ignored params, or "includes".
-You pick which of the two tabs survives: grouped tab first then the new one (default), grouped tab first then the existing one, always the existing one, or always the new one.
+Open a page that's already open? The duplicate vanishes. Matching is configurable per rule (exact URL, "includes", or "ignore these query params"), and you choose which of the two tabs survives.
 
 <p align="center">
-  <img src="assets/readme/gifs/dedup.gif" alt="Deduplication video">
+  <img src="assets/readme/gifs/dedup.gif" alt="Deduplication in action" width="640">
 </p>
 
+### 📷 Sessions you actually want to use
 
-### 📷 Sessions
-
-Save a named snapshot of your open tabs and groups, restore them whenever you need.
-
-- **Pinned sessions** — promote any snapshot to your popup for one-click access, with a custom icon
-- **Restore wizard** — pick which tabs to bring back, choose the target window, resolve group conflicts before applying
-- **Deep search** — find tabs and groups by name across all your saved sessions
-- **Session editor** — reorganize, rename and delete tabs and groups without restoring first
-- **Session notes** — annotate any session with free-form text
-- **Drag-and-drop** — reorder your sessions list by dragging
+Snapshot your open tabs and groups, name them, pin the ones you live in. Restore into the current window, a new one, or replace what you have. Every session is editable, searchable across tabs and groups, and can carry your own notes.
 
 <p align="center">
-  <img src="doc/readme/en-dark-sessions-list.png" alt="Sessions list">
+  <img src="assets/readme/en-dark-sessions-list.png" alt="Sessions list" width="720">
 </p>
 
-<p align="center">
-  <img src="doc/readme/en-dark-sessions-search-deep.png" alt="Deep search in sessions">
-</p>
+## And there's more
 
+- **Workspaces** : keep separate rules, sessions and stats per context (work, personal, side project)
+- **20+ rule packs** for popular tools (GitHub, GitLab, Jira, AWS, AI assistants, Discord...) ready to import
+- **Import / export** with conflict resolution for both rules and sessions
+- **Local statistics** : see how much grouping and dedup actually saves you
+- **Keyboard shortcuts** with a built-in help panel
+- **Light / dark / system theme**
+- **Accessibility-first** : axe-core audited, keyboard-first, screen reader friendly
+- **3 languages** : English, French, Spanish
 
-An **Import/Export wizard for Rules and Sessions** classifies incoming as new, conflicting or identical, and resolves conflicts step by step.
+## 📖 Documentation
 
-<p align="center">
-  <img src="doc/readme/en-dark-rules-import-text-conflicts.png" alt="Import wizard with conflict resolution">
-</p>
-
-### ⚡ Quick Access Popup
-
-- Toggle grouping and deduplication globally
-- Take a snapshot or jump to Sessions in one click
-- Pinned sessions listed with quick-restore actions
-
-<p align="center">
-
-<img src="doc/readme/en-dark-popup-content.png" alt="Popup content">
-</p>
-
-### ♿ Accessibility & i18n
-
-Full keyboard navigation and screen-reader support via Radix UI primitives. Available in English, French and Spanish.
-
-## 💻 Installation
+The full guide lives in [`docs/`](docs/src/content/docs/en/) (Astro Starlight, 3 languages, 30+ pages with screenshots). Browse the MDX on GitHub, or run it locally:
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
-npm install -g pnpm  # if needed
-pnpm install
-pnpm build
+pnpm docs:dev
 ```
 
-- **Chrome:** `chrome://extensions/` → Load unpacked → `.output/chrome-mv3`
+## 🛠️ For contributors
 
-For development with auto-reload: `pnpm dev` (Chrome) or `pnpm dev:firefox`.
-
-## 🛠️ Tech Stack
-
-| Layer | Technology |
-|---|---|
-| Extension framework | [WXT](https://wxt.dev/) |
-| UI | [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) |
-| Component library | [Radix UI Themes](https://www.radix-ui.com/themes) + [Lucide](https://lucide.dev/) icons |
-| Forms & validation | [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) |
-| Tab tree | [react-accessible-treeview](https://github.com/dgreene1/react-accessible-treeview) |
-| Command palette | [cmdk](https://cmdk.paco.me/) |
-| Drag-and-drop | [@dnd-kit](https://dndkit.com/) |
-| Theming | [next-themes](https://github.com/pacocoursey/next-themes) |
-| Unit tests | [Vitest](https://vitest.dev/) + [Testing Library](https://testing-library.com/) |
-| E2E tests | [Playwright](https://playwright.dev/) |
-| Accessibility audits | [axe-core](https://github.com/dequelabs/axe-core) (Storybook + Playwright) |
-| Code quality | [ESLint](https://eslint.org/) + [SonarJS](https://github.com/SonarSource/SonarJS) + [jscpd](https://github.com/kucherenko/jscpd) (code duplication) |
-| Test reports | [CTRF](https://ctrf.io/) (unified test report format) |
-| Component explorer | [Storybook](https://storybook.js.org/) |
-| Documentation site | [Astro Starlight](https://starlight.astro.build/) |
-| Package manager | [pnpm](https://pnpm.io/) |
-
-## 🤝 Contributing
-
-Contributions are welcome! Here's how to get started:
-
-**Prerequisites:** Node.js, [pnpm](https://pnpm.io/) (`npm install -g pnpm`)
+**Prerequisites :** Node.js, [pnpm](https://pnpm.io/)
 
 ```bash
-git clone https://github.com/EspritVorace/smart-tab-organizer.git
-cd smart-tab-organizer
 pnpm install
 pnpm dev          # Chrome with auto-reload
 pnpm dev:firefox  # Firefox with auto-reload
-```
-
-**Tests**
-
-```bash
-pnpm test         # Unit tests (Vitest)
-pnpm test:e2e     # End-to-end tests (Playwright)
+pnpm test         # Vitest unit tests
+pnpm test:e2e     # Playwright E2E
 pnpm storybook    # Component explorer (port 6006)
+pnpm build        # Production build
 ```
 
-**Code conventions**
-
-- Use `logger.debug()` from `src/utils/logger.ts` — never `console.log()`
-- No `any` types — use precise types or narrow `unknown`
-- All UI text via `getMessage()` from `src/utils/i18n.ts` — no hardcoded strings
-- Accessibility via Radix UI primitives; Lucide icons need `aria-hidden="true"`
+The stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) and code conventions are documented in [`CLAUDE.md`](CLAUDE.md) and the [stack technique annex](docs/src/content/docs/annexes/stack-technique.mdx).
 
 Please open an issue before submitting a large pull request.
 
 ## 📜 License
 
-GNU General Public License v3.0
+GNU General Public License v3.0.


### PR DESCRIPTION
The READMEs had drifted from the product (171 lines covering only the
v1.0 perimeter, no mention of workspaces, sessions notes, multi-mode
restore, dedup keep-strategies, statistics, rule packs, a11y audits).
They also duplicated content now exhaustively covered by the Starlight
docs (174 screenshots, 3 languages, 30+ pages).

Reset all three READMEs (EN, FR, ES) to a 96-line vitrine: tagline,
hero, store CTAs, 3 hero features with GIFs/screenshot, compact
"and more" list, link to docs, contributor section, license. Same
structure across the 3 files for easy parallel maintenance.