### PR TITLE
refactor(sessions): extract sharedSectionProps to eliminate duplicated SessionSection props

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -2,7 +2,6 @@ import { Flex } from '@radix-ui/themes';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
-import { DialogShell } from '@/components/UI/DialogShell';
 import { type GroupNameSourceValue, type UrlExtractionModeValue } from '@/schemas/enums';
 import { createRegexValidator } from '@/schemas/common';
 import type { PresetCategory } from '@/utils/presetUtils';
@@ -10,7 +9,7 @@ import { getPresetById } from '@/utils/presetUtils';
 import { logger } from '@/utils/logger';
 import { DomainRuleConfigForm } from './DomainRuleConfigForm';
 import type { ConfigMode } from './ConfigModeSelector';
-import { EditModalFooter } from './EditModalFooter';
+import { EditModalShell } from './EditModalShell';
 
 const regexValidator = createRegexValidator(true);
 const QUERY_PARAM_NAME_PATTERN = /^[A-Za-z0-9_\-.]+$/;
@@ -146,19 +145,14 @@ export function ConfigEditModal({
     onClose();
   };
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) onClose();
-  };
-
   return (
-    <DialogShell
-      open={isOpen}
-      onOpenChange={handleOpenChange}
+    <EditModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      disabled={hasError}
       title={getMessage('editConfigTitle')}
-      description={getMessage('editConfigTitle')}
-      hideDescription
       maxWidth={820}
-      showHeaderSeparator={false}
       contentStyle={{
         display: 'flex',
         flexDirection: 'column',
@@ -196,8 +190,6 @@ export function ConfigEditModal({
           urlQueryParamNameError={queryParamNameError}
         />
       </Flex>
-
-      <EditModalFooter onClose={onClose} onApply={handleApply} disabled={hasError} />
-    </DialogShell>
+    </EditModalShell>
   );
 }

--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@radix-ui/themes';
+import { Flex } from '@radix-ui/themes';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
@@ -10,6 +10,7 @@ import { getPresetById } from '@/utils/presetUtils';
 import { logger } from '@/utils/logger';
 import { DomainRuleConfigForm } from './DomainRuleConfigForm';
 import type { ConfigMode } from './ConfigModeSelector';
+import { EditModalFooter } from './EditModalFooter';
 
 const regexValidator = createRegexValidator(true);
 const QUERY_PARAM_NAME_PATTERN = /^[A-Za-z0-9_\-.]+$/;
@@ -196,14 +197,7 @@ export function ConfigEditModal({
         />
       </Flex>
 
-      <Flex gap="3" justify="end" mt="4" style={{ flexShrink: 0 }}>
-        <Button variant="soft" color="gray" onClick={onClose}>
-          {getMessage('cancel')}
-        </Button>
-        <Button onClick={handleApply} disabled={hasError}>
-          {getMessage('apply')}
-        </Button>
-      </Flex>
+      <EditModalFooter onClose={onClose} onApply={handleApply} disabled={hasError} />
     </DialogShell>
   );
 }

--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu } from '@radix-ui/themes';
 import { Pencil, Trash2, MoreHorizontal, GripVertical, AlertTriangle } from 'lucide-react';
 import { useSortable } from '@dnd-kit/react/sortable';
-
-function getStatusStyle(status: 'default' | 'conflict' | 'identical'): React.CSSProperties {
-  if (status === 'conflict') return { background: 'var(--orange-a2)' };
-  if (status === 'identical') return { opacity: 0.6 };
-  return {};
-}
-
+import { getStatusStyle, type CardStatus } from '@/utils/statusStyle';
 import { RuleDetailPopover } from './RuleDetailPopover';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { getMessage } from '@/utils/i18n';
@@ -29,7 +23,7 @@ export interface DomainRuleCardProps {
    * 'conflict': orange background plus AlertTriangle icon.
    * 'identical': reduced opacity.
    */
-  status?: 'default' | 'conflict' | 'identical';
+  status?: CardStatus;
   /** Leading slot in summary mode (e.g. selection Checkbox for import/export). */
   leading?: React.ReactNode;
   /** Trailing slot in summary mode (e.g. status Badge, DiffPopover). */

--- a/src/components/Core/DomainRule/EditModalFooter.tsx
+++ b/src/components/Core/DomainRule/EditModalFooter.tsx
@@ -1,0 +1,22 @@
+import { Button, Flex } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+
+interface EditModalFooterProps {
+  onClose: () => void;
+  onApply: () => void;
+  disabled: boolean;
+  applyTestId?: string;
+}
+
+export function EditModalFooter({ onClose, onApply, disabled, applyTestId }: EditModalFooterProps) {
+  return (
+    <Flex gap="3" justify="end" mt="4" style={{ flexShrink: 0 }}>
+      <Button variant="soft" color="gray" onClick={onClose}>
+        {getMessage('cancel')}
+      </Button>
+      <Button data-testid={applyTestId} onClick={onApply} disabled={disabled}>
+        {getMessage('apply')}
+      </Button>
+    </Flex>
+  );
+}

--- a/src/components/Core/DomainRule/EditModalShell.tsx
+++ b/src/components/Core/DomainRule/EditModalShell.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import type React from 'react';
+import { DialogShell } from '@/components/UI/DialogShell';
+import { EditModalFooter } from './EditModalFooter';
+
+interface EditModalShellProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: () => void;
+  disabled: boolean;
+  title: string;
+  maxWidth?: number | string;
+  applyTestId?: string;
+  'data-testid'?: string;
+  children: ReactNode;
+  contentStyle?: React.CSSProperties;
+}
+
+export function EditModalShell({
+  isOpen,
+  onClose,
+  onApply,
+  disabled,
+  title,
+  maxWidth,
+  applyTestId,
+  'data-testid': dataTestId,
+  children,
+  contentStyle,
+}: EditModalShellProps) {
+  const handleOpenChange = (open: boolean) => {
+    if (!open) onClose();
+  };
+
+  return (
+    <DialogShell
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      title={title}
+      description={title}
+      hideDescription
+      maxWidth={maxWidth}
+      showHeaderSeparator={false}
+      data-testid={dataTestId}
+      contentStyle={contentStyle}
+    >
+      {children}
+
+      <EditModalFooter onClose={onClose} onApply={onApply} disabled={disabled} applyTestId={applyTestId} />
+    </DialogShell>
+  );
+}

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -2,8 +2,7 @@ import { Flex, TextField } from '@radix-ui/themes';
 import { useState, useEffect, useMemo } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
-import { DialogShell } from '@/components/UI/DialogShell';
-import { EditModalFooter } from './EditModalFooter';
+import { EditModalShell } from './EditModalShell';
 import { FormField } from '@/components/Form/FormFields';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
@@ -92,19 +91,15 @@ export function IdentityEditModal({
     onClose();
   };
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) onClose();
-  };
-
   return (
-    <DialogShell
-      open={isOpen}
-      onOpenChange={handleOpenChange}
+    <EditModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      disabled={hasError}
       title={getMessage('editIdentityTitle')}
-      description={getMessage('editIdentityTitle')}
-      hideDescription
       maxWidth={680}
-      showHeaderSeparator={false}
+      applyTestId="modal-edit-identity-btn-apply"
       data-testid="modal-edit-identity"
     >
       <Flex direction="column" gap="4" mt="4">
@@ -147,13 +142,6 @@ export function IdentityEditModal({
           )}
         </FormField>
       </Flex>
-
-      <EditModalFooter
-        onClose={onClose}
-        onApply={handleApply}
-        disabled={hasError}
-        applyTestId="modal-edit-identity-btn-apply"
-      />
-    </DialogShell>
+    </EditModalShell>
   );
 }

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex, TextField } from '@radix-ui/themes';
+import { Flex, TextField } from '@radix-ui/themes';
 import { useState, useEffect, useMemo } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { DialogShell } from '@/components/UI/DialogShell';
+import { EditModalFooter } from './EditModalFooter';
 import { FormField } from '@/components/Form/FormFields';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
@@ -147,18 +148,12 @@ export function IdentityEditModal({
         </FormField>
       </Flex>
 
-      <Flex gap="3" justify="end" mt="4" style={{ flexShrink: 0 }}>
-        <Button variant="soft" color="gray" onClick={onClose}>
-          {getMessage('cancel')}
-        </Button>
-        <Button
-          data-testid="modal-edit-identity-btn-apply"
-          onClick={handleApply}
-          disabled={hasError}
-        >
-          {getMessage('apply')}
-        </Button>
-      </Flex>
+      <EditModalFooter
+        onClose={onClose}
+        onApply={handleApply}
+        disabled={hasError}
+        applyTestId="modal-edit-identity-btn-apply"
+      />
     </DialogShell>
   );
 }

--- a/src/components/Core/DomainRule/OptionsEditModal.tsx
+++ b/src/components/Core/DomainRule/OptionsEditModal.tsx
@@ -2,8 +2,7 @@ import { Flex } from '@radix-ui/themes';
 import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
-import { DialogShell } from '@/components/UI/DialogShell';
-import { EditModalFooter } from './EditModalFooter';
+import { EditModalShell } from './EditModalShell';
 import { WizardStep3Options } from './WizardStep3Options';
 import type { DeduplicationMatchModeValue } from '@/schemas/enums';
 import type { DomainRule } from '@/schemas/domainRule';
@@ -61,19 +60,15 @@ export function OptionsEditModal({ isOpen, onClose, onApply, initial }: OptionsE
     onClose();
   };
 
-  const handleOpenChange = (open: boolean) => {
-    if (!open) onClose();
-  };
-
   return (
-    <DialogShell
-      open={isOpen}
-      onOpenChange={handleOpenChange}
+    <EditModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      disabled={ignoredParamsInvalid}
       title={getMessage('editOptionsTitle')}
-      description={getMessage('editOptionsTitle')}
-      hideDescription
       maxWidth={680}
-      showHeaderSeparator={false}
+      applyTestId="modal-edit-options-btn-apply"
       data-testid="modal-edit-options"
     >
       <Flex direction="column" gap="4" mt="4">
@@ -83,13 +78,6 @@ export function OptionsEditModal({ isOpen, onClose, onApply, initial }: OptionsE
           errors={errors}
         />
       </Flex>
-
-      <EditModalFooter
-        onClose={onClose}
-        onApply={handleApply}
-        disabled={ignoredParamsInvalid}
-        applyTestId="modal-edit-options-btn-apply"
-      />
-    </DialogShell>
+    </EditModalShell>
   );
 }

--- a/src/components/Core/DomainRule/OptionsEditModal.tsx
+++ b/src/components/Core/DomainRule/OptionsEditModal.tsx
@@ -1,8 +1,9 @@
-import { Button, Flex } from '@radix-ui/themes';
+import { Flex } from '@radix-ui/themes';
 import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { DialogShell } from '@/components/UI/DialogShell';
+import { EditModalFooter } from './EditModalFooter';
 import { WizardStep3Options } from './WizardStep3Options';
 import type { DeduplicationMatchModeValue } from '@/schemas/enums';
 import type { DomainRule } from '@/schemas/domainRule';
@@ -83,18 +84,12 @@ export function OptionsEditModal({ isOpen, onClose, onApply, initial }: OptionsE
         />
       </Flex>
 
-      <Flex gap="3" justify="end" mt="4" style={{ flexShrink: 0 }}>
-        <Button variant="soft" color="gray" onClick={onClose}>
-          {getMessage('cancel')}
-        </Button>
-        <Button
-          data-testid="modal-edit-options-btn-apply"
-          onClick={handleApply}
-          disabled={ignoredParamsInvalid}
-        >
-          {getMessage('apply')}
-        </Button>
-      </Flex>
+      <EditModalFooter
+        onClose={onClose}
+        onApply={handleApply}
+        disabled={ignoredParamsInvalid}
+        applyTestId="modal-edit-options-btn-apply"
+      />
     </DialogShell>
   );
 }

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -257,13 +257,15 @@ export function RuleWizardModal({
     }
   }, [setValue, trigger]);
 
-  const captureSnapshot = useCallback((): ModeStateSnapshot => ({
+  const readModeState = useCallback((): ModeStateSnapshot => ({
     groupNameSource: getValues('groupNameSource') as GroupNameSourceValue,
     titleParsingRegEx: getValues('titleParsingRegEx') ?? '',
     urlParsingRegEx: getValues('urlParsingRegEx') ?? '',
     urlExtractionMode: (getValues('urlExtractionMode') ?? 'regex') as UrlExtractionModeValue,
     urlQueryParamName: getValues('urlQueryParamName') ?? '',
   }), [getValues]);
+
+  const captureSnapshot = readModeState;
 
   const applySnapshot = useCallback((snapshot: ModeStateSnapshot) => {
     setValue('groupNameSource', snapshot.groupNameSource);
@@ -432,11 +434,7 @@ export function RuleWizardModal({
   const currentConfigValues: ConfigEditValues = {
     configMode,
     presetId: getValues('presetId') ?? null,
-    groupNameSource: groupNameSource as GroupNameSourceValue,
-    titleParsingRegEx: getValues('titleParsingRegEx') ?? '',
-    urlParsingRegEx: getValues('urlParsingRegEx') ?? '',
-    urlExtractionMode: (getValues('urlExtractionMode') ?? 'regex') as UrlExtractionModeValue,
-    urlQueryParamName: getValues('urlQueryParamName') ?? '',
+    ...readModeState(),
   };
 
   const currentIdentityValues: IdentityEditValues = {

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -17,11 +17,12 @@ import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/Accessi
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
 import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
 import { getDragHandleStyle } from '@/utils/dragHandleStyle';
+import { getStatusStyle } from '@/utils/statusStyle';
 import { SessionPreviewTree } from './SessionPreviewTree';
 import { SessionRestoreButton } from './SessionRestoreButton/SessionRestoreButton';
 import type { Session } from '@/types/session';
 
-interface SessionCardProps {
+interface SessionCardProps extends SessionRestoreCallbacks {
   session: Session;
   /**
    * 'full' (default): full card with drag, pin, restore, menu.
@@ -39,10 +40,6 @@ interface SessionCardProps {
   /** Trailing slot in summary mode (e.g. status Badge, DiffPopover). */
   trailing?: React.ReactNode;
   existingSessions?: Session[];
-  onRestore?: (session: Session) => void;
-  onRestoreCurrentWindow?: (session: Session) => void;
-  onRestoreNewWindow?: (session: Session) => void;
-  onReplaceCurrentWindow?: (session: Session) => void;
   onRename?: (id: string, newName: string) => Promise<void>;
   onEdit?: (session: Session) => void;
   onDelete?: (session: Session) => void;
@@ -75,12 +72,11 @@ interface SessionCardProps {
 /** Visual state of a SessionCard in summary mode. */
 export type SessionCardStatus = 'default' | 'conflict' | 'identical';
 
-/* Helpers */
-
-function getStatusStyle(status: SessionCardStatus): React.CSSProperties {
-  if (status === 'conflict') return { background: 'var(--orange-a2)' };
-  if (status === 'identical') return { opacity: 0.6 };
-  return {};
+interface SessionRestoreCallbacks {
+  onRestore?: (session: Session) => void;
+  onRestoreCurrentWindow?: (session: Session) => void;
+  onRestoreNewWindow?: (session: Session) => void;
+  onReplaceCurrentWindow?: (session: Session) => void;
 }
 
 /* SessionMoreMenu */
@@ -285,7 +281,7 @@ function SessionCardSummaryHeader({
 
 /* SessionCardFullHeader */
 
-interface SessionCardFullHeaderProps {
+interface SessionCardFullHeaderProps extends SessionRestoreCallbacks {
   session: Session;
   handleRef: (element: HTMLElement | null) => void;
   isDragDisabled: boolean;
@@ -304,10 +300,6 @@ interface SessionCardFullHeaderProps {
   hoverCardContent: React.ReactNode;
   onPin?: (session: Session) => void;
   onUnpin?: (session: Session) => void;
-  onRestore?: (session: Session) => void;
-  onRestoreCurrentWindow?: (session: Session) => void;
-  onRestoreNewWindow?: (session: Session) => void;
-  onReplaceCurrentWindow?: (session: Session) => void;
   onEdit?: (session: Session) => void;
   onDelete?: (session: Session) => void;
   onMoveToFirst?: () => void;

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ExternalLink, Pin } from 'lucide-react';
 import { SessionRestoreButton } from '@/components/Core/Session/SessionRestoreButton/SessionRestoreButton';
 import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
+import { getFocusedSessionFromDOM } from '@/utils/sessionUtils';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { showSuccessNotification } from '@/utils/notifications';
 import { getRuleCategory } from '@/utils/categoriesStore';
@@ -119,14 +120,10 @@ export function PopupProfilesList() {
     handleNavigationKey(e, index);
   }, [handleNavigationKey]);
 
-  const getFocusedSession = useCallback((): Session | null => {
-    const active = document.activeElement;
-    if (!(active instanceof HTMLElement)) return null;
-    if (!active.matches('[data-shortcut-scope="widget:session-card"]')) return null;
-    const id = active.getAttribute('data-session-id');
-    if (!id) return null;
-    return pinnedSessions.find((s) => s.id === id) ?? null;
-  }, [pinnedSessions]);
+  const getFocusedSession = useCallback(
+    () => getFocusedSessionFromDOM(pinnedSessions),
+    [pinnedSessions],
+  );
 
   useShortcuts(
     {

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -26,6 +26,19 @@ const STEP_DESCRIPTION_KEYS = [
   'restoreStepConflictDescription',
 ] as const;
 
+function RadioOption({ testId, value, label }: { testId: string; value: string; label: string }) {
+  return (
+    <Text size="2" asChild>
+      <label>
+        <Flex align="center" gap="2">
+          <RadioGroup.Item data-testid={testId} value={value} />
+          {label}
+        </Flex>
+      </label>
+    </Text>
+  );
+}
+
 interface RestoreWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -238,30 +251,9 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
                 onValueChange={v => setTarget(v as RestoreTarget)}
               >
                 <Flex direction="column" gap="2">
-                  <Text size="2" asChild>
-                    <label>
-                      <Flex align="center" gap="2">
-                        <RadioGroup.Item data-testid="wizard-restore-radio-current-window" value="current" />
-                        {getMessage('restoreTargetCurrent')}
-                      </Flex>
-                    </label>
-                  </Text>
-                  <Text size="2" asChild>
-                    <label>
-                      <Flex align="center" gap="2">
-                        <RadioGroup.Item data-testid="wizard-restore-radio-new-window" value="new" />
-                        {getMessage('restoreTargetNew')}
-                      </Flex>
-                    </label>
-                  </Text>
-                  <Text size="2" asChild>
-                    <label>
-                      <Flex align="center" gap="2">
-                        <RadioGroup.Item data-testid="wizard-restore-radio-replace-window" value="replace" />
-                        {getMessage('restoreTargetReplace')}
-                      </Flex>
-                    </label>
-                  </Text>
+                  <RadioOption testId="wizard-restore-radio-current-window" value="current" label={getMessage('restoreTargetCurrent')} />
+                  <RadioOption testId="wizard-restore-radio-new-window" value="new" label={getMessage('restoreTargetNew')} />
+                  <RadioOption testId="wizard-restore-radio-replace-window" value="replace" label={getMessage('restoreTargetReplace')} />
                 </Flex>
               </RadioGroup.Root>
             </Flex>

--- a/src/components/UI/Workspace/WorkspaceFooter.tsx
+++ b/src/components/UI/Workspace/WorkspaceFooter.tsx
@@ -11,13 +11,18 @@ interface WorkspaceFooterProps {
   onManage?: () => void;
 }
 
+function useWorkspaceName() {
+  const { active, accentColor } = useActiveWorkspaceContext();
+  const name = active?.name ?? getMessage('workspaceDefaultName');
+  return { name, accentColor };
+}
+
 /**
  * Sidebar footer that surfaces the active workspace and exposes the workspace
  * switcher. Replaces the static EspritVorace/GitHub footer.
  */
 export function WorkspaceFooter({ onManage }: WorkspaceFooterProps) {
-  const { active, accentColor } = useActiveWorkspaceContext();
-  const name = active?.name ?? getMessage('workspaceDefaultName');
+  const { name, accentColor } = useWorkspaceName();
 
   const trigger = (
     <Flex
@@ -70,8 +75,7 @@ export function WorkspaceFooter({ onManage }: WorkspaceFooterProps) {
 
 /** Collapsed sidebar footer: avatar only acting as the dropdown trigger. */
 export function WorkspaceFooterCollapsed({ onManage }: WorkspaceFooterProps) {
-  const { active, accentColor } = useActiveWorkspaceContext();
-  const name = active?.name ?? getMessage('workspaceDefaultName');
+  const { name, accentColor } = useWorkspaceName();
 
   const trigger = (
     <Flex

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -14,7 +14,7 @@ import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { ListToolbar } from '@/components/UI/ListToolbar';
 import { getMessage } from '@/utils/i18n';
 import { foldAccents } from '@/utils/stringUtils';
-import { matchSessionSearch, splitByPinned } from '@/utils/sessionUtils';
+import { matchSessionSearch, splitByPinned, getFocusedSessionFromDOM } from '@/utils/sessionUtils';
 import { moveSessionToFirstInGroup, moveSessionToLastInGroup } from '@/utils/sessionOrderUtils';
 import { useSessions } from '@/hooks/useSessions';
 import { useShortcuts } from '@/hooks/useShortcuts';
@@ -288,16 +288,10 @@ export function SessionsPage({
     await reload();
   }, [reload]);
 
-  // Resolves the session whose card currently has focus. Returns null when
-  // focus is on a non-card element so widget shortcuts no-op silently.
-  const getFocusedSession = useCallback((): Session | null => {
-    const active = document.activeElement;
-    if (!(active instanceof HTMLElement)) return null;
-    if (!active.matches('[data-shortcut-scope="widget:session-card"]')) return null;
-    const id = active.getAttribute('data-session-id');
-    if (!id) return null;
-    return sessions.find((s) => s.id === id) ?? null;
-  }, [sessions]);
+  const getFocusedSession = useCallback(
+    () => getFocusedSessionFromDOM(sessions),
+    [sessions],
+  );
 
   useShortcuts({ 'list.sessions.new': handleOpenSnapshotWizard }, { scope: 'page:sessions' });
 

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -401,6 +401,37 @@ export function SessionsPage({
     setDeleteTarget(null);
   }, [deleteTarget, removeSession]);
 
+  const sharedSectionProps: Pick<
+    SessionSectionProps,
+    | 'allSessions'
+    | 'searchQuery'
+    | 'searchMatches'
+    | 'updateOrder'
+    | 'renameSession'
+    | 'onOpenRestoreWizard'
+    | 'onOpenEditDialog'
+    | 'onOpenDeleteDialog'
+    | 'onRestoreCurrentWindow'
+    | 'onRestoreNewWindow'
+    | 'onReplaceCurrentWindow'
+    | 'onPin'
+    | 'onUnpin'
+  > = {
+    allSessions: sortedSessions,
+    searchQuery,
+    searchMatches: sessionSearchMatches,
+    updateOrder,
+    renameSession,
+    onOpenRestoreWizard: setRestoreSession,
+    onOpenEditDialog: setEditTarget,
+    onOpenDeleteDialog: setDeleteTarget,
+    onRestoreCurrentWindow: handleRestoreCurrentWindow,
+    onRestoreNewWindow: handleRestoreNewWindow,
+    onReplaceCurrentWindow: handleReplaceCurrentWindow,
+    onPin: handlePin,
+    onUnpin: handleUnpin,
+  };
+
   return (
     <PageLayout
       titleKey="sessionsTab"
@@ -484,19 +515,7 @@ export function SessionsPage({
                 emptyDescriptionKey="pinnedSessionsEmptyDescription"
                 isPinned={true}
                 sessions={pinnedSessions}
-                allSessions={sortedSessions}
-                searchQuery={searchQuery}
-                searchMatches={sessionSearchMatches}
-                updateOrder={updateOrder}
-                renameSession={renameSession}
-                onOpenRestoreWizard={setRestoreSession}
-                onOpenEditDialog={setEditTarget}
-                onOpenDeleteDialog={setDeleteTarget}
-                onRestoreCurrentWindow={handleRestoreCurrentWindow}
-                onRestoreNewWindow={handleRestoreNewWindow}
-                onReplaceCurrentWindow={handleReplaceCurrentWindow}
-                onPin={handlePin}
-                onUnpin={handleUnpin}
+                {...sharedSectionProps}
               />
 
               <Separator size="4" />
@@ -508,19 +527,7 @@ export function SessionsPage({
                 emptyDescriptionKey="unpinnedSessionsEmptyDescription"
                 isPinned={false}
                 sessions={unpinnedSessions}
-                allSessions={sortedSessions}
-                searchQuery={searchQuery}
-                searchMatches={sessionSearchMatches}
-                updateOrder={updateOrder}
-                renameSession={renameSession}
-                onOpenRestoreWizard={setRestoreSession}
-                onOpenEditDialog={setEditTarget}
-                onOpenDeleteDialog={setDeleteTarget}
-                onRestoreCurrentWindow={handleRestoreCurrentWindow}
-                onRestoreNewWindow={handleRestoreNewWindow}
-                onReplaceCurrentWindow={handleReplaceCurrentWindow}
-                onPin={handlePin}
-                onUnpin={handleUnpin}
+                {...sharedSectionProps}
               />
             </Flex>
           )}

--- a/src/utils/sessionUtils.ts
+++ b/src/utils/sessionUtils.ts
@@ -5,6 +5,20 @@ import { foldAccents } from './stringUtils';
 import { getMessage } from './i18n';
 
 /**
+ * Returns the session whose card currently has DOM focus, looked up from the
+ * provided session list. Returns null when the focused element is not a session
+ * card (so callers can no-op silently).
+ */
+export function getFocusedSessionFromDOM(sessions: readonly Session[]): Session | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  if (!active.matches('[data-shortcut-scope="widget:session-card"]')) return null;
+  const id = active.getAttribute('data-session-id');
+  if (!id) return null;
+  return sessions.find((s) => s.id === id) ?? null;
+}
+
+/**
  * Result of matching a session against a search term.
  * Used to determine which sessions to show and how to render them.
  */

--- a/src/utils/statusStyle.ts
+++ b/src/utils/statusStyle.ts
@@ -1,0 +1,9 @@
+import type React from 'react';
+
+export type CardStatus = 'default' | 'conflict' | 'identical';
+
+export function getStatusStyle(status: CardStatus): React.CSSProperties {
+  if (status === 'conflict') return { background: 'var(--orange-a2)' };
+  if (status === 'identical') return { opacity: 0.6 };
+  return {};
+}


### PR DESCRIPTION
Both <SessionSection> usages in SessionsPage shared 13 identical props
(allSessions, searchQuery, searchMatches, updateOrder, renameSession, and 8
on* handlers). These are now collected into a typed Pick<SessionSectionProps>
constant and spread into each usage.

Painpoint: clone 10 (SessionsPage.tsx:486-505 ~ 510-529, score 30, pages weight 1.5).

https://claude.ai/code/session_01K9gxAFRTJTrT3g11khR5LM