### PR TITLE
fix(pack-gallery): keep search input visible while scrolling import wizard

### DIFF
--- a/src/components/Core/Pack/PackGallery/PackGallery.module.css
+++ b/src/components/Core/Pack/PackGallery/PackGallery.module.css
@@ -3,6 +3,4 @@
   top: 0;
   z-index: 1;
   background: var(--color-panel-solid);
-  padding-block: var(--space-2);
-  margin-block: calc(-1 * var(--space-2));
 }

--- a/src/components/Core/Pack/PackGallery/PackGallery.module.css
+++ b/src/components/Core/Pack/PackGallery/PackGallery.module.css
@@ -1,0 +1,8 @@
+.searchSticky {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-panel-solid);
+  padding-block: var(--space-2);
+  margin-block: calc(-1 * var(--space-2));
+}

--- a/src/components/Core/Pack/PackGallery/PackGallery.module.css
+++ b/src/components/Core/Pack/PackGallery/PackGallery.module.css
@@ -1,6 +1,9 @@
 .searchSticky {
   position: sticky;
-  top: 0;
+  /* Compense la padding-top de WizardModal.Body (var(--space-4)) :
+     sans cela, la zone du padding reste défilante et laisse voir le
+     contenu qui passe avant d'être clipé par overflow-y: auto. */
+  top: calc(-1 * var(--space-4));
   z-index: 1;
   background: var(--color-panel-solid);
 }

--- a/src/components/Core/Pack/PackGallery/PackGallery.tsx
+++ b/src/components/Core/Pack/PackGallery/PackGallery.tsx
@@ -12,6 +12,7 @@ import type { PackCategory, PackFile } from '@/schemas/pack';
 import { PackCard } from './PackCard/PackCard';
 import { PackCategoryHeader } from './PackCategoryHeader/PackCategoryHeader';
 import type { PackSelectionState } from './usePackSelections';
+import styles from './PackGallery.module.css';
 
 interface PackGalleryProps {
   packs: PackFile[];
@@ -96,17 +97,19 @@ export function PackGallery({
 
   return (
     <Flex direction="column" gap="3" data-testid="pack-gallery">
-      <TextField.Root
-        size="2"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder={getMessage('packGallerySearchPlaceholder')}
-        aria-label={getMessage('packGallerySearchPlaceholder')}
-      >
-        <TextField.Slot>
-          <Search size={14} />
-        </TextField.Slot>
-      </TextField.Root>
+      <Box className={styles.searchSticky}>
+        <TextField.Root
+          size="2"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={getMessage('packGallerySearchPlaceholder')}
+          aria-label={getMessage('packGallerySearchPlaceholder')}
+        >
+          <TextField.Slot>
+            <Search size={14} />
+          </TextField.Slot>
+        </TextField.Root>
+      </Box>
 
       {filteredPacks.length === 0 && (
         <Flex


### PR DESCRIPTION
Wrap the search field in a sticky container so it stays pinned at the
top of the scrollable wizard body once the content above scrolls out,
while the pack list continues to scroll behind it.

https://claude.ai/code/session_01Rsw9TbecMcQiuXxpxnZmVi