### PR TITLE
Fix hydration race conditions in popup and workspaces

### DIFF
--- a/.claude/agents/e2e-flaky-detector.md
+++ b/.claude/agents/e2e-flaky-detector.md
@@ -33,9 +33,20 @@ You specialize in Playwright tests for browser extensions built with WXT (Web Ex
 ### 5. Cross-test state dependencies (MEDIUM)
 - Tests assuming an initial state without explicitly forcing it
 - Confirm each test initializes its own state via the `seed.ts` helpers
+- **Cross-spec leakage**: the `extensionContext` fixture is worker-scoped, so `chrome.storage.local` persists across spec files within a worker. Spec files that mutate global state (workspaces, `activeWorkspaceId`, sessions, domain rules) via the UI and never reset it leak that state into the next spec. Suspect any UI flow with side effects: creating a workspace, for example, silently auto-switches `activeWorkspaceId` to the new id.
 
 ### 6. Storage quota (LOW)
 - Looped writes to `chrome.storage.sync` without a retry: the project has a retry mechanism, verify it is used
+
+### 7. Last-page browser exit (LOW)
+- Chromium persistent contexts launched with `--user-data-dir` and `--load-extension` terminate the browser process when their last page closes. A test that aggressively closes every stale page AND its own page at the end leaves zero pages. The next test's `extensionContext.newPage()` then fails with "Target page, context or browser has been closed", which can masquerade as a service-worker eviction.
+- Fix: keep at least one page alive (do not close the last one).
+
+## When local repro passes but CI still flakes
+
+The MCP GitHub tools surface check-run metadata (id, name, conclusion, html_url) but **not** the raw workflow log content. There is no `get_workflow_logs` endpoint exposed, and the local environment has no `gh` CLI access. The CTRF sticky comment on the PR only tells you "test X retried once" without the failing assertion.
+
+If local repro is clean across 10+ runs and you only have CTRF retry counts, the actual failure mode is unknowable from code alone, and speculation routinely costs 4-5 blind fixes per session. In that case, ask the user for the signed job-logs URL from the failed CI run. It appears under the failed job in the GitHub Actions UI as a `productionresultssa*.blob.core.windows.net/.../job-logs.txt?...&sig=...` link. Fetch it with WebFetch and look for the Playwright "Error: ... failed", "Locator:", and "Call log:" block. That pinpoints which assertion is timing out, which is often the only fact that separates a real fix from another speculative one.
 
 ## Expected output
 For each issue detected:

--- a/tests/e2e/popup.spec.ts
+++ b/tests/e2e/popup.spec.ts
@@ -106,7 +106,12 @@ test.describe('[US-PO01] Toolbar', () => {
     // Must NOT have native disabled so it stays in the tab order
     await expect(saveBtn).not.toHaveAttribute('disabled');
 
-    await page.close();
+    // Intentionally do NOT close `page` here. This test already closes every
+    // stale page so hasCapturableTabs() returns false; closing the popup too
+    // would leave the persistent Chromium context with zero pages, which
+    // terminates the browser process. The next test's `clearSessions`
+    // beforeEach then can't reach the service worker and the suite goes
+    // flaky. The worker-scoped extensionContext closes everything at teardown.
   });
 
   test('Restore button has aria-disabled when no sessions exist [US-A11Y001]', async ({

--- a/tests/e2e/workspaces.spec.ts
+++ b/tests/e2e/workspaces.spec.ts
@@ -19,6 +19,33 @@ async function goToWorkspaces(page: import('@playwright/test').Page, extensionId
   await page.getByTestId('workspace-create-button').waitFor({ state: 'visible', timeout: 10_000 });
 }
 
+// Other spec files in the same worker (notably workspaces-search.spec.ts) call
+// the create-workspace UI, which adds workspaces to storage and auto-switches
+// `activeWorkspaceId` to the new one. Storage is shared by extensionContext
+// across spec files, so leftover state leaks here and breaks both the
+// "default is active" assertion and the "create Personal" flow (the form
+// rejects names that already exist). Reset to a post-migration baseline
+// before each test: only the default workspace, and it is active.
+test.beforeEach(async ({ extensionContext }) => {
+  const sw = extensionContext.serviceWorkers()[0];
+  if (!sw) return;
+  await sw
+    .evaluate(async () => {
+      const { workspaces } = await chrome.storage.local.get('workspaces');
+      const defaultOnly = Array.isArray(workspaces)
+        ? workspaces.filter((w) => (w as { id: string }).id === 'default')
+        : null;
+      const update: Record<string, unknown> = { activeWorkspaceId: 'default' };
+      if (defaultOnly && defaultOnly.length > 0) {
+        update.workspaces = defaultOnly;
+      }
+      await chrome.storage.local.set(update);
+    })
+    .catch(() => {
+      // SW may be evicted; the test will surface the real failure if any.
+    });
+});
+
 test.describe('Workspaces — baseline', () => {
   test('default workspace is migrated and active', async ({ optionsPage, extensionId }) => {
     await goToWorkspaces(optionsPage, extensionId);


### PR DESCRIPTION
## Summary
Fixes race conditions where UI components could render with stale or incomplete data during async initialization. Introduces a `data-ready` attribute pattern to signal when async stores have finished hydrating, and updates E2E tests to wait for this signal before asserting on initial state.

## Key Changes

- **PopupToolbar**: Extracted state initialization into a new `useToolbarState` hook that tracks hydration status via `isHydrated`. Consolidates multiple async operations (loading sessions, checking capturable tabs, querying active tab group) and waits for all to settle before marking as hydrated. Exposes `data-ready` attribute on the toolbar root element.

- **ActiveWorkspaceContext**: Reordered initialization to register storage watchers *before* the async read, preventing loss of storage changes that arrive mid-flight (e.g., background migration writing the default workspace). Uses functional setState to avoid clobbering watcher updates with stale data. Ensures `isLoaded` is set even on error.

- **WorkspacesPage**: Added `data-ready` attribute that reflects both context hydration (`isLoaded`) and data availability (`workspaces.length > 0`).

- **E2E helpers**: Added `waitForReady()` utility in `tests/e2e/helpers/ready.ts` to wait for elements with `data-ready="true"` before asserting, preventing flaky tests that sample DOM mid-hydration.

- **E2E tests**: Updated popup and workspaces specs to call `waitForReady()` before asserting on initial button states and workspace list visibility. Added timeout parameters to assertions for consistency.

## Implementation Details

The `useToolbarState` hook uses `Promise.allSettled()` to wait for all async initialization tasks in parallel, then sets `isHydrated` only after all have settled (successfully or not). This ensures the UI doesn't render incomplete state while async operations are in flight.

The `ActiveWorkspaceContext` fix prevents a subtle bug where a storage watcher could fire with new data, but then be overwritten by the result of the async `getValue()` call that was already in flight. By registering watchers first and using functional setState, the latest value always wins.

https://claude.ai/code/session_01974JYq4YVjV9smGxiVm1mq