### PR TITLE
refactor(packs): prioritize mainstream categories in Gallery order

### DIFF
--- a/src/data/packs/_categories.json
+++ b/src/data/packs/_categories.json
@@ -1,31 +1,13 @@
 {
   "categories": [
     {
-      "id": "development",
+      "id": "search",
       "label": {
-        "en": "Development",
-        "fr": "Développement",
-        "es": "Desarrollo"
+        "en": "Search",
+        "fr": "Recherche",
+        "es": "Búsqueda"
       },
-      "icon": "💻"
-    },
-    {
-      "id": "cloud",
-      "label": {
-        "en": "Cloud & DevOps",
-        "fr": "Cloud & DevOps",
-        "es": "Cloud y DevOps"
-      },
-      "icon": "☁️"
-    },
-    {
-      "id": "productivity",
-      "label": {
-        "en": "Productivity",
-        "fr": "Productivité",
-        "es": "Productividad"
-      },
-      "icon": "📋"
+      "icon": "🔍"
     },
     {
       "id": "communication",
@@ -35,24 +17,6 @@
         "es": "Comunicación"
       },
       "icon": "💬"
-    },
-    {
-      "id": "ai",
-      "label": {
-        "en": "AI assistants",
-        "fr": "Assistants IA",
-        "es": "Asistentes de IA"
-      },
-      "icon": "🤖"
-    },
-    {
-      "id": "search",
-      "label": {
-        "en": "Search",
-        "fr": "Recherche",
-        "es": "Búsqueda"
-      },
-      "icon": "🔍"
     },
     {
       "id": "media",
@@ -82,6 +46,33 @@
       "icon": "🛍️"
     },
     {
+      "id": "news",
+      "label": {
+        "en": "News",
+        "fr": "Actualités",
+        "es": "Actualidad"
+      },
+      "icon": "📰"
+    },
+    {
+      "id": "productivity",
+      "label": {
+        "en": "Productivity",
+        "fr": "Productivité",
+        "es": "Productividad"
+      },
+      "icon": "📋"
+    },
+    {
+      "id": "ai",
+      "label": {
+        "en": "AI assistants",
+        "fr": "Assistants IA",
+        "es": "Asistentes de IA"
+      },
+      "icon": "🤖"
+    },
+    {
       "id": "travel",
       "label": {
         "en": "Travel",
@@ -100,15 +91,6 @@
       "icon": "💰"
     },
     {
-      "id": "news",
-      "label": {
-        "en": "News",
-        "fr": "Actualités",
-        "es": "Actualidad"
-      },
-      "icon": "📰"
-    },
-    {
       "id": "education",
       "label": {
         "en": "Learning",
@@ -116,6 +98,24 @@
         "es": "Aprendizaje"
       },
       "icon": "🎓"
+    },
+    {
+      "id": "development",
+      "label": {
+        "en": "Development",
+        "fr": "Développement",
+        "es": "Desarrollo"
+      },
+      "icon": "💻"
+    },
+    {
+      "id": "cloud",
+      "label": {
+        "en": "Cloud & DevOps",
+        "fr": "Cloud & DevOps",
+        "es": "Cloud y DevOps"
+      },
+      "icon": "☁️"
     }
   ]
 }

--- a/src/data/packs/pk-comm-messaging.json
+++ b/src/data/packs/pk-comm-messaging.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-comm-messaging",
+    "name": {
+      "en": "Messaging clients",
+      "fr": "Clients de messagerie",
+      "es": "Clientes de mensajería"
+    },
+    "description": {
+      "en": "Group Messenger, Mattermost and Google Chat tabs by conversation, team or room.",
+      "fr": "Regroupe les onglets Messenger, Mattermost et Google Chat par conversation, équipe ou salon.",
+      "es": "Agrupa las pestañas de Messenger, Mattermost y Google Chat por conversación, equipo o sala."
+    },
+    "categoryId": "communication"
+  },
+  "domainRules": [
+    {
+      "id": "pk-comm-messenger-thread",
+      "enabled": true,
+      "domainFilter": "*.messenger.com",
+      "label": "Messenger: Thread",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "messenger\\.com/t/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "communication",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-comm-mattermost-team",
+      "enabled": true,
+      "domainFilter": "*.mattermost.com",
+      "label": "Mattermost: Team",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "mattermost\\.com/([^/?#]+)/channels",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "communication",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-comm-google-chat-room",
+      "enabled": true,
+      "domainFilter": "chat.google.com",
+      "label": "Google Chat: Room",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "chat\\.google\\.com/room/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "communication",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-comm-google-chat-dm",
+      "enabled": true,
+      "domainFilter": "chat.google.com",
+      "label": "Google Chat: Direct message",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "chat\\.google\\.com/dm/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "communication",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-edu-corporate.json
+++ b/src/data/packs/pk-edu-corporate.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-edu-corporate",
+    "name": {
+      "en": "Corporate learning",
+      "fr": "Formation professionnelle",
+      "es": "Formación profesional"
+    },
+    "description": {
+      "en": "Group LinkedIn Learning, Pluralsight and DataCamp tabs by course or skill path.",
+      "fr": "Regroupe les onglets LinkedIn Learning, Pluralsight et DataCamp par cours ou parcours.",
+      "es": "Agrupa las pestañas de LinkedIn Learning, Pluralsight y DataCamp por curso o ruta."
+    },
+    "categoryId": "education"
+  },
+  "domainRules": [
+    {
+      "id": "pk-edu-linkedin-learning",
+      "enabled": true,
+      "domainFilter": "*.linkedin.com",
+      "label": "LinkedIn Learning: Course",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "linkedin\\.com/learning/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-pluralsight-paths",
+      "enabled": true,
+      "domainFilter": "*.pluralsight.com",
+      "label": "Pluralsight: Skill path",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "pluralsight\\.com/paths/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-pluralsight-course",
+      "enabled": true,
+      "domainFilter": "*.pluralsight.com",
+      "label": "Pluralsight: Course",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "pluralsight\\.com/courses/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-datacamp-course",
+      "enabled": true,
+      "domainFilter": "*.datacamp.com",
+      "label": "DataCamp: Course",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "datacamp\\.com/courses/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-edu-creative.json
+++ b/src/data/packs/pk-edu-creative.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-edu-creative",
+    "name": {
+      "en": "Creative & open learning",
+      "fr": "Apprentissage créatif & libre",
+      "es": "Aprendizaje creativo y abierto"
+    },
+    "description": {
+      "en": "Group Skillshare, MasterClass, Khan Academy and OpenClassrooms tabs by class or topic.",
+      "fr": "Regroupe les onglets Skillshare, MasterClass, Khan Academy et OpenClassrooms par cours ou matière.",
+      "es": "Agrupa las pestañas de Skillshare, MasterClass, Khan Academy y OpenClassrooms por clase o materia."
+    },
+    "categoryId": "education"
+  },
+  "domainRules": [
+    {
+      "id": "pk-edu-skillshare-class",
+      "enabled": true,
+      "domainFilter": "*.skillshare.com",
+      "label": "Skillshare: Class",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "skillshare\\.com/(?:[a-z]{2}/)?classes/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-masterclass-class",
+      "enabled": true,
+      "domainFilter": "*.masterclass.com",
+      "label": "MasterClass: Class",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "masterclass\\.com/classes/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-khanacademy-topic",
+      "enabled": true,
+      "domainFilter": "*.khanacademy.org",
+      "label": "Khan Academy: Topic",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "khanacademy\\.org/(?:math|science|computing|humanities|economics-finance-domain|test-prep|ela)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-edu-openclassrooms-course",
+      "enabled": true,
+      "domainFilter": "*.openclassrooms.com",
+      "label": "OpenClassrooms: Course",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "openclassrooms\\.com/(?:[a-z]{2}/)?courses/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "education",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-finance-payments.json
+++ b/src/data/packs/pk-finance-payments.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-finance-payments",
+    "name": {
+      "en": "Payments dashboards",
+      "fr": "Tableaux de bord paiements",
+      "es": "Paneles de pagos"
+    },
+    "description": {
+      "en": "Group Stripe Dashboard, PayPal and Wise tabs by section.",
+      "fr": "Regroupe les onglets Stripe Dashboard, PayPal et Wise par section.",
+      "es": "Agrupa las pestañas de Stripe Dashboard, PayPal y Wise por sección."
+    },
+    "categoryId": "finance"
+  },
+  "domainRules": [
+    {
+      "id": "pk-finance-stripe-dashboard",
+      "enabled": true,
+      "domainFilter": "dashboard.stripe.com",
+      "label": "Stripe Dashboard: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "dashboard\\.stripe\\.com/(?:test/)?([a-z][a-z0-9_-]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-paypal-section",
+      "enabled": true,
+      "domainFilter": "*.paypal.com",
+      "label": "PayPal: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "paypal\\.com/myaccount/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-wise-section",
+      "enabled": true,
+      "domainFilter": "wise.com",
+      "label": "Wise: Section",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "wise\\.com/(?:[a-z]{2}/)?(?:user|account|business)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "green",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-finance-stocks.json
+++ b/src/data/packs/pk-finance-stocks.json
@@ -1,0 +1,67 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-finance-stocks",
+    "name": {
+      "en": "Stocks & quotes",
+      "fr": "Actions & cotations",
+      "es": "Acciones y cotizaciones"
+    },
+    "description": {
+      "en": "Group Yahoo Finance, Google Finance and MarketWatch tabs by ticker symbol.",
+      "fr": "Regroupe les onglets Yahoo Finance, Google Finance et MarketWatch par symbole boursier.",
+      "es": "Agrupa las pestañas de Yahoo Finance, Google Finance y MarketWatch por símbolo bursátil."
+    },
+    "categoryId": "finance"
+  },
+  "domainRules": [
+    {
+      "id": "pk-finance-yahoo-quote",
+      "enabled": true,
+      "domainFilter": "finance.yahoo.com",
+      "label": "Yahoo Finance: Quote",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "finance\\.yahoo\\.com/quote/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-google-quote",
+      "enabled": true,
+      "domainFilter": "www.google.com",
+      "label": "Google Finance: Quote",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "google\\.com/finance/quote/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "blue",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-finance-marketwatch-quote",
+      "enabled": true,
+      "domainFilter": "*.marketwatch.com",
+      "label": "MarketWatch: Quote",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "marketwatch\\.com/investing/(?:stock|fund|index|cryptocurrency)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "yellow",
+      "categoryId": "finance",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-media-music.json
+++ b/src/data/packs/pk-media-music.json
@@ -1,0 +1,99 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-media-music",
+    "name": {
+      "en": "Music streaming",
+      "fr": "Streaming musical",
+      "es": "Streaming musical"
+    },
+    "description": {
+      "en": "Group Apple Music, Deezer and SoundCloud tabs by artist, album or user.",
+      "fr": "Regroupe les onglets Apple Music, Deezer et SoundCloud par artiste, album ou utilisateur.",
+      "es": "Agrupa las pestañas de Apple Music, Deezer y SoundCloud por artista, álbum o usuario."
+    },
+    "categoryId": "media"
+  },
+  "domainRules": [
+    {
+      "id": "pk-media-applemusic-artist",
+      "enabled": true,
+      "domainFilter": "music.apple.com",
+      "label": "Apple Music: Artist",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "music\\.apple\\.com/[a-z]{2}/artist/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-applemusic-album",
+      "enabled": true,
+      "domainFilter": "music.apple.com",
+      "label": "Apple Music: Album",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "music\\.apple\\.com/[a-z]{2}/album/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-deezer-artist",
+      "enabled": true,
+      "domainFilter": "*.deezer.com",
+      "label": "Deezer: Artist",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "deezer\\.com/(?:[a-z]{2}/)?artist/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-deezer-album",
+      "enabled": true,
+      "domainFilter": "*.deezer.com",
+      "label": "Deezer: Album",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "deezer\\.com/(?:[a-z]{2}/)?album/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-soundcloud-user",
+      "enabled": true,
+      "domainFilter": "*.soundcloud.com",
+      "label": "SoundCloud: User",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "soundcloud\\.com/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "orange",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-media-twitch.json
+++ b/src/data/packs/pk-media-twitch.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-media-twitch",
+    "name": {
+      "en": "Twitch",
+      "fr": "Twitch",
+      "es": "Twitch"
+    },
+    "description": {
+      "en": "Group Twitch tabs by category and channel.",
+      "fr": "Regroupe les onglets Twitch par catégorie et chaîne.",
+      "es": "Agrupa las pestañas de Twitch por categoría y canal."
+    },
+    "categoryId": "media"
+  },
+  "domainRules": [
+    {
+      "id": "pk-media-twitch-category",
+      "enabled": true,
+      "domainFilter": "*.twitch.tv",
+      "label": "Twitch: Category",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "twitch\\.tv/directory/(?:category|game)/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-media-twitch-channel",
+      "enabled": true,
+      "domainFilter": "*.twitch.tv",
+      "label": "Twitch: Channel",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "twitch\\.tv/(?!directory|videos|search|subscriptions|moderator|drops|prime|jobs|popout|settings|wallet|inventory|p)([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "media",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-social-fediverse.json
+++ b/src/data/packs/pk-social-fediverse.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-social-fediverse",
+    "name": {
+      "en": "Fediverse & Bluesky",
+      "fr": "Fédiverse & Bluesky",
+      "es": "Fediverso y Bluesky"
+    },
+    "description": {
+      "en": "Group Mastodon, Bluesky and Threads tabs by profile.",
+      "fr": "Regroupe les onglets Mastodon, Bluesky et Threads par profil.",
+      "es": "Agrupa las pestañas de Mastodon, Bluesky y Threads por perfil."
+    },
+    "categoryId": "social"
+  },
+  "domainRules": [
+    {
+      "id": "pk-social-mastodon-social-profile",
+      "enabled": true,
+      "domainFilter": "mastodon.social",
+      "label": "Mastodon (mastodon.social): Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "mastodon\\.social/(@[^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-mastodon-online-profile",
+      "enabled": true,
+      "domainFilter": "mastodon.online",
+      "label": "Mastodon (mastodon.online): Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "mastodon\\.online/(@[^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "purple",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-bluesky-profile",
+      "enabled": true,
+      "domainFilter": "bsky.app",
+      "label": "Bluesky: Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "bsky\\.app/profile/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-threads-profile",
+      "enabled": true,
+      "domainFilter": "*.threads.net",
+      "label": "Threads: Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "threads\\.net/(@[^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}

--- a/src/data/packs/pk-social-photo-video.json
+++ b/src/data/packs/pk-social-photo-video.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "pack": {
+    "id": "pk-social-photo-video",
+    "name": {
+      "en": "Photo & video social",
+      "fr": "Réseaux photo & vidéo",
+      "es": "Redes de foto y vídeo"
+    },
+    "description": {
+      "en": "Group Instagram, TikTok and Pinterest tabs by profile or hashtag.",
+      "fr": "Regroupe les onglets Instagram, TikTok et Pinterest par profil ou hashtag.",
+      "es": "Agrupa las pestañas de Instagram, TikTok y Pinterest por perfil o hashtag."
+    },
+    "categoryId": "social"
+  },
+  "domainRules": [
+    {
+      "id": "pk-social-instagram-profile",
+      "enabled": true,
+      "domainFilter": "*.instagram.com",
+      "label": "Instagram: Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "instagram\\.com/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "pink",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-tiktok-tag",
+      "enabled": true,
+      "domainFilter": "*.tiktok.com",
+      "label": "TikTok: Hashtag",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "tiktok\\.com/tag/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "cyan",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-tiktok-profile",
+      "enabled": true,
+      "domainFilter": "*.tiktok.com",
+      "label": "TikTok: Profile",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "tiktok\\.com/@([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "grey",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    },
+    {
+      "id": "pk-social-pinterest-profile",
+      "enabled": true,
+      "domainFilter": "*.pinterest.com",
+      "label": "Pinterest: Profile or topic",
+      "titleParsingRegEx": "",
+      "urlParsingRegEx": "pinterest\\.[a-z.]+/([^/?#]+)",
+      "groupNameSource": "url",
+      "deduplicationMatchMode": "exact",
+      "color": "red",
+      "categoryId": "social",
+      "deduplicationEnabled": true,
+      "ignoredQueryParams": [],
+      "presetId": null,
+      "urlExtractionMode": "regex"
+    }
+  ]
+}


### PR DESCRIPTION
Reorder _categories.json so the Pack Gallery surfaces the categories
that resonate with the broadest audience first (Search, Communication,
Media, Social, Commerce...) and pushes the developer-focused entries
(Development, Cloud & DevOps) to the end of the list.

https://claude.ai/code/session_01Pgw9Gg1EFJifuxdkMSVwPd