### PR TITLE
docs(fr): document packs, workspaces and pinned profiles

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig({
             { slug: 'concepts/sources-nom-groupe' },
             { slug: 'concepts/modes-nommage' },
             { slug: 'concepts/sessions-epinglees' },
+            { slug: 'concepts/packs' },
+            { slug: 'concepts/workspaces' },
           ],
         },
         {
@@ -38,6 +40,7 @@ export default defineConfig({
           items: [
             { slug: 'demarrage/installation' },
             { slug: 'demarrage/tour-interface' },
+            { slug: 'demarrage/page-accueil' },
           ],
         },
         {
@@ -52,6 +55,7 @@ export default defineConfig({
                 { slug: 'fonctionnalites/regles/vue-ensemble' },
                 { slug: 'fonctionnalites/regles/creer-une-regle' },
                 { slug: 'fonctionnalites/regles/modifier-supprimer' },
+                { slug: 'fonctionnalites/regles/packs' },
                 { slug: 'fonctionnalites/regles/presets-regex' },
               ],
             },
@@ -66,12 +70,24 @@ export default defineConfig({
               ],
             },
             {
+              label: 'Espaces de travail',
+              translations: { en: 'Workspaces', es: 'Espacios de trabajo' },
+              items: [
+                { slug: 'fonctionnalites/workspaces/vue-ensemble' },
+                { slug: 'fonctionnalites/workspaces/gerer-workspaces' },
+                { slug: 'fonctionnalites/workspaces/changer-workspace-actif' },
+                { slug: 'fonctionnalites/workspaces/profils-popup' },
+              ],
+            },
+            {
               label: 'Import / Export',
               items: [
                 { slug: 'fonctionnalites/import-export/exporter-regles' },
                 { slug: 'fonctionnalites/import-export/importer-regles' },
                 { slug: 'fonctionnalites/import-export/exporter-sessions' },
                 { slug: 'fonctionnalites/import-export/importer-sessions' },
+                { slug: 'fonctionnalites/import-export/exporter-workspace' },
+                { slug: 'fonctionnalites/import-export/importer-workspace' },
               ],
             },
             { slug: 'fonctionnalites/statistiques' },
@@ -88,6 +104,7 @@ export default defineConfig({
           label: 'Annexes',
           translations: { en: 'Reference', es: 'Referencia' },
           items: [
+            { slug: 'annexes/packs-integres' },
             { slug: 'annexes/presets-regex' },
             { slug: 'annexes/raccourcis-clavier' },
             { slug: 'annexes/stack-technique' },

--- a/docs/src/content/docs/annexes/packs-integres.mdx
+++ b/docs/src/content/docs/annexes/packs-integres.mdx
@@ -1,0 +1,138 @@
+---
+title: Liste des packs intégrés
+description: Catalogue complet des 49 packs prêts à l'emploi embarqués dans SmartTab Organizer, organisés par catégorie.
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- 49 packs intégrés répartis en 13 catégories.
+- Un pack est un bundle de règles importable d'un coup, à ne pas confondre avec les [presets regex](/annexes/presets-regex) du wizard de création de règle.
+- Les packs marqués **configurables** vous demandent de choisir un paramètre avant l'import (par exemple le service AWS principal).
+</Aside>
+
+Pour comprendre ce qu'est un pack et comment l'importer, voir la page [Qu'est-ce qu'un pack ?](/concepts/packs) et le guide [Importer des packs de règles](/fonctionnalites/regles/packs).
+
+## Catalogue par catégorie
+
+### 💻 Développement
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Enregistrements ServiceNow inter-outils | Regroupe les onglets ServiceNow, GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par l'identifiant de record ServiceNow (INC, CHG, REQ, RITM, PRB) référencé dans leur titre. | `*.service-now.com, github.com, gitlab.com` | 7 | Non |
+| GitHub | Regroupe les onglets GitHub par dépôt, issue, pull request et discussion. | `github.com` | 4 | Non |
+| GitLab | Regroupe les onglets GitLab par projet, issue et merge request. | `gitlab.com` | 3 | Non |
+| Références ticket inter-outils | Regroupe les onglets GitHub, GitLab, Gitea, Bitbucket, Trello et Asana par la clé de ticket (PROJ-123). Fonctionne avec Jira, Linear, Shortcut, YouTrack, Plane et ClickUp. | `github.com, gitlab.com, *.gitea.io` | 6 | Non |
+| Registres de paquets | Regroupe les pages de paquets sur npm, PyPI et Docker Hub par nom de paquet. | `*.npmjs.com, pypi.org, hub.docker.com` | 3 | Non |
+| Stack Overflow & Stack Exchange | Regroupe les onglets Q/R sur Stack Overflow, Server Fault, Super User et les sites Stack Exchange. | `stackoverflow.com` | 2 | Non |
+
+### ☁️ Cloud et DevOps
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Console AWS | Regroupe les onglets de la console AWS selon le service que vous utilisez le plus. | `*.console.aws.amazon.com` | 8 | Oui |
+| Console Google Cloud | Regroupe les onglets de la console Google Cloud par projet ou par famille de produit. | `console.cloud.google.com` | 2 | Oui |
+| Plateformes de déploiement | Regroupe les tableaux de bord Cloudflare, Vercel, Netlify et Render par site ou projet. | `dash.cloudflare.com, vercel.com, app.netlify.com` | 4 | Non |
+| Portail Azure | Regroupe les onglets du portail Azure par abonnement ou par fournisseur de service Microsoft. | `portal.azure.com` | 2 | Oui |
+
+### 📋 Productivité
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Google Workspace | Regroupe les onglets Google Docs, Sheets et Slides par titre de document. | `docs.google.com` | 3 | Non |
+| Jira | Regroupe les onglets Jira par clé de ticket (PROJ-123) sur tous les espaces Atlassian Cloud. | `*.atlassian.net` | 1 | Non |
+| Linear | Regroupe les onglets Linear par identifiant d'issue (TEAM-123). | `linear.app` | 1 | Non |
+| Notion | Regroupe les onglets Notion par titre de page. | `*.notion.so` | 1 | Non |
+| Trello, Asana & ClickUp | Regroupe les tableaux de projet sur Trello, Asana et ClickUp. | `trello.com, app.asana.com, app.clickup.com` | 3 | Non |
+
+### 💬 Communication
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Clients de messagerie | Regroupe les onglets Messenger, Mattermost et Google Chat par conversation, équipe ou salon. | `*.messenger.com, *.mattermost.com, chat.google.com` | 4 | Non |
+| Discord | Regroupe les onglets Discord par identifiant de serveur. | `discord.com` | 1 | Non |
+| Slack | Regroupe les onglets Slack par espace de travail. | `*.slack.com` | 1 | Non |
+| Visioconférences | Regroupe les onglets de réunion par identifiant sur Zoom, Google Meet et Microsoft Teams. | `*.zoom.us, meet.google.com, teams.microsoft.com` | 3 | Non |
+
+### 🤖 Assistants IA
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Assistants IA | Regroupe les conversations ChatGPT, Claude et Gemini par outil. | `chatgpt.com, claude.ai, gemini.google.com` | 3 | Non |
+| Hugging Face | Regroupe les onglets Hugging Face par slug de modèle ou de dataset. | `huggingface.co` | 2 | Non |
+| Moteurs de recherche IA | Regroupe les onglets de recherche IA par requête sur Perplexity, Phind et You.com. | `*.perplexity.ai, *.phind.com, you.com` | 3 | Non |
+
+### 🗣️ Réseaux sociaux
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Fédiverse & Bluesky | Regroupe les onglets Mastodon, Bluesky et Threads par profil. | `mastodon.social, mastodon.online, bsky.app` | 4 | Non |
+| LinkedIn | Regroupe les onglets LinkedIn par profil, entreprise et requête d'offre d'emploi. | `*.linkedin.com` | 3 | Non |
+| Reddit | Regroupe les onglets Reddit par subreddit et par requête de recherche. | `*.reddit.com` | 2 | Non |
+| Réseaux photo & vidéo | Regroupe les onglets Instagram, TikTok et Pinterest par profil ou hashtag. | `*.instagram.com, *.tiktok.com, *.pinterest.com` | 4 | Non |
+| X (Twitter) | Regroupe les onglets X / Twitter par identifiant. | `*.x.com, *.twitter.com` | 2 | Non |
+
+### 🎬 Médias et Streaming
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Plateformes SVOD | Regroupe les onglets Netflix, Disney+ et Prime Video par titre. | `*.netflix.com, *.disneyplus.com, *.primevideo.com` | 3 | Non |
+| Spotify | Regroupe les onglets Spotify par artiste, album et playlist. | `open.spotify.com` | 3 | Non |
+| Streaming musical | Regroupe les onglets Apple Music, Deezer et SoundCloud par artiste, album ou utilisateur. | `music.apple.com, *.deezer.com, *.soundcloud.com` | 5 | Non |
+| Twitch | Regroupe les onglets Twitch par catégorie et chaîne. | `*.twitch.tv` | 2 | Non |
+| YouTube | Regroupe les onglets YouTube par chaîne et par requête de recherche. | `*.youtube.com` | 2 | Non |
+
+### 🔍 Recherche
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Moteurs de recherche | Regroupe les onglets de résultats par requête sur Google, Bing, DuckDuckGo, Brave et Kagi. | `*.google.com, bing.com, duckduckgo.com` | 5 | Non |
+| Wikipédia | Regroupe les onglets Wikipédia par titre d'article toutes langues confondues. | `*.wikipedia.org` | 1 | Non |
+
+### 📰 Actualités
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Presse française | Regroupe les onglets Le Monde, Le Figaro et Libération par rubrique. | `*.lemonde.fr, *.lefigaro.fr, *.liberation.fr` | 3 | Non |
+| Presse internationale | Regroupe les onglets The Guardian, NYT et BBC News par rubrique. | `*.theguardian.com, *.nytimes.com, *.bbc.com` | 3 | Non |
+
+### 🛍️ Commerce
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Amazon | Regroupe les onglets Amazon par code produit ASIN et par requête (FR, COM, ES, DE). | `*.amazon.*` | 2 | Non |
+| Places de marché | Regroupe les onglets eBay, AliExpress, Etsy et Vinted par identifiant d'article ou requête. | `*.ebay.*, *.aliexpress.com, *.etsy.com` | 5 | Non |
+| Places de marché françaises | Regroupe les onglets Leboncoin, Backmarket et Cdiscount par annonce ou requête. | `*.leboncoin.fr, *.backmarket.*, *.cdiscount.com` | 4 | Non |
+
+### ✈️ Voyage
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Billets de train (FR/EU) | Regroupe les onglets SNCF Connect et Trainline par itinéraire ou destination. | `*.sncf-connect.com, *.trainline.*` | 2 | Non |
+| Hôtels & locations | Regroupe les onglets Booking, Airbnb et Hotels.com par destination ou annonce. | `*.booking.com, *.airbnb.*, *.hotels.com` | 3 | Non |
+| Vols | Regroupe les onglets Skyscanner, Google Flights et Kayak par itinéraire. | `*.skyscanner.*, *.google.*, *.kayak.*` | 3 | Non |
+
+### 💰 Finance
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Actions & cotations | Regroupe les onglets Yahoo Finance, Google Finance et MarketWatch par symbole boursier. | `finance.yahoo.com, www.google.com, *.marketwatch.com` | 3 | Non |
+| Marchés & tickers | Regroupe les onglets Yahoo Finance, TradingView et Investing.com par symbole ticker. | `finance.yahoo.com, *.tradingview.com, *.investing.com` | 3 | Non |
+| Plateformes crypto | Regroupe les onglets Coinbase et Binance par actif crypto ou paire de trading. | `*.coinbase.com, *.binance.com` | 2 | Non |
+| Tableaux de bord paiements | Regroupe les onglets Stripe Dashboard, PayPal et Wise par section. | `dashboard.stripe.com, *.paypal.com, wise.com` | 3 | Non |
+
+### 🎓 Apprentissage
+
+| Pack | Description | Domaines principaux | Règles | Configurable |
+|---|---|---|---:|:---:|
+| Apprentissage créatif & libre | Regroupe les onglets Skillshare, MasterClass, Khan Academy et OpenClassrooms par cours ou matière. | `*.skillshare.com, *.masterclass.com, *.khanacademy.org` | 4 | Non |
+| Cours en ligne & docs | Regroupe les onglets Coursera, Udemy, edX et MDN Web Docs par cours ou section. | `*.coursera.org, *.udemy.com, *.edx.org` | 4 | Non |
+| Formation professionnelle | Regroupe les onglets LinkedIn Learning, Pluralsight et DataCamp par cours ou parcours. | `*.linkedin.com, *.pluralsight.com, *.datacamp.com` | 4 | Non |
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="La notion de pack, les paramètres configurables, et la différence avec les presets." />
+  <LinkCard title="Importer des packs de règles" href="/fonctionnalites/regles/packs" description="Galerie de packs, navigation par catégorie, sélection multiple et import." />
+  <LinkCard title="Liste des presets regex" href="/annexes/presets-regex" description="L'autre annexe catalogue : les patterns regex du wizard de règle." />
+</CardGrid>

--- a/docs/src/content/docs/annexes/presets-regex.mdx
+++ b/docs/src/content/docs/annexes/presets-regex.mdx
@@ -1,6 +1,166 @@
 ---
 title: Liste des presets regex
-description: Tableau de référence de tous les patterns regex intégrés dans SmartTab Organizer, avec pour chacun le nom, la description et un exemple de correspondance.
+description: Tableau de référence des 65 patterns regex intégrés dans SmartTab Organizer, avec pour chacun le nom, la description et un exemple de correspondance.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- 65 patterns regex prêts à l'emploi, répartis en 11 catégories.
+- Un preset est un **modèle de regex isolé**, sélectionnable depuis le dropdown du wizard de création de règle. À distinguer des [packs intégrés](/annexes/packs-integres) qui sont des bundles complets de règles importables.
+- Sélectionner un preset configure automatiquement les regex de titre et d'URL ainsi qu'un mode de nommage adapté.
+</Aside>
+
+Cette annexe liste l'intégralité des presets fournis avec l'extension. Pour comprendre comment ils s'utilisent dans l'assistant de règle, voir la page [Presets regex](/fonctionnalites/regles/presets-regex).
+
+## Catalogue par catégorie
+
+### 🛠️ Patterns Génériques
+
+Modèles de regex réutilisables pour créer vos propres règles.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| ID Numérique | Extrait un identifiant numérique | Titre: 'Ticket ID 12345' → Groupe: '12345' |
+| ID Alphanumérique | Extrait un code alphanumérique | Titre: '[PROJ-123] Fix bug' → Groupe: 'PROJ-123' |
+| Contenu entre Parenthèses | Extrait le texte entre parenthèses | Titre: 'Article (Catégorie)' → Groupe: 'Catégorie' |
+| Contenu entre Crochets | Extrait le texte entre crochets | Titre: 'Document [Version 2.0]' → Groupe: 'Version 2.0' |
+| Date (YYYY-MM-DD) | Extrait une date au format ISO | URL: '/reports/2024-03-15' → Groupe: '2024-03-15' |
+| Mot après Mot-clé | Extrait le mot après un mot-clé | Titre: 'Projet: WebApp' → Groupe: 'WebApp' |
+| Premier Mot | Extrait le premier mot du titre | Titre: 'Marketing Dashboard' → Groupe: 'Marketing' |
+| Numéro de Version | Extrait un numéro de version | Titre: 'API v2.1.3' → Groupe: '2.1.3' |
+| UUID/GUID | Extrait un identifiant UUID | URL: '/object/550e8400-e29b-41d4-a716-446655440000' → Groupe: '550e8400-...' |
+| Mention Utilisateur | Extrait un nom d'utilisateur après @ | URL: '/@username/posts' → Groupe: 'username' |
+| Google Search | Groupe les recherches Google par requête (paramètre q) | `https://www.google.com/search?q=tab+organizer` |
+| Bing Search | Groupe les recherches Bing par requête (paramètre q) | `https://www.bing.com/search?q=tab+organizer` |
+| DuckDuckGo | Groupe les recherches DuckDuckGo par requête (paramètre q) | `https://duckduckgo.com/?q=tab+organizer` |
+| YouTube Search | Groupe les recherches YouTube par requête (paramètre search_query) | `https://www.youtube.com/results?search_query=tab+organizer` |
+| Amazon Search | Groupe les recherches Amazon par requête (paramètre k) | `https://www.amazon.com/s?k=tab+organizer` |
+| eBay Search | Groupe les recherches eBay par requête (paramètre _nkw) | `https://www.ebay.com/sch/i.html?_nkw=tab+organizer` |
+| Stack Overflow Search | Groupe les recherches Stack Overflow par requête (paramètre q) | `https://stackoverflow.com/search?q=tab+organizer` |
+| Reddit Search | Groupe les recherches Reddit par requête (paramètre q) | `https://www.reddit.com/search/?q=tab+organizer` |
+| GitHub Search | Groupe les recherches GitHub par requête (paramètre q) | `https://github.com/search?q=tab+organizer` |
+| npm Search | Groupe les recherches npm par requête (paramètre q) | `https://www.npmjs.com/search?q=tab+organizer` |
+| MDN Search | Groupe les recherches MDN par requête (paramètre q) | `https://developer.mozilla.org/en-US/search?q=tab+organizer` |
+| Wikipedia Search | Groupe les recherches Wikipedia par requête (paramètre search) | `https://en.wikipedia.org/wiki/Special:Search?search=tab+organizer` |
+
+### Développement et Code
+
+Sites de développement, repositories, documentation technique.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| GitHub - Repository | Regroupe par repository | URL: '/microsoft/vscode' → Groupe: 'microsoft/vscode' |
+| GitHub - Issues | Regroupe par numéro d'issue | Titre: 'Fix memory leak · Issue #1234 · microsoft/vscode' → Groupe: '1234' |
+| Stack Overflow - Questions | Regroupe par ID de question | URL: '/questions/12345' → Groupe: '12345' |
+| GitLab - Projets | Regroupe par projet GitLab | URL: '/gitlab-org/gitlab' → Groupe: 'gitlab-org/gitlab' |
+| Figma - Fichiers | Regroupe par nom de fichier | Titre: 'Design System, Figma' → Groupe: 'Design System' |
+| NPM - Packages | Regroupe par nom de package | URL: '/package/react' → Groupe: 'react' |
+
+### Productivité et Tickets
+
+Outils de gestion de projets, tickets, tâches.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Jira - Tickets | Regroupe par ID de ticket Jira | Titre: 'PROJ-123: Fix the login bug \| Jira' → Groupe: 'PROJ-123' |
+| Jira - Ticket dans le titre (cross-domaine) | Extrait un ID de ticket Jira (PROJ-123) dans le titre, quel que soit le domaine. Utile pour les PR GitHub/GitLab, commits et reviews qui référencent un ticket Jira. | Titre: 'Fix login bug (PROJ-123)' → Groupe: 'PROJ-123' |
+| GitHub - Issue dans le titre (cross-domaine) | Extrait une référence d'issue GitHub (#123) dans le titre, quel que soit le domaine. | Titre: 'Fix bug (#123)' → Groupe: '123' |
+| ServiceNow - Record dans le titre (cross-domaine) | Extrait un identifiant ServiceNow (INC, CHG, REQ, RITM, PRB) dans le titre, quel que soit le domaine. | Titre: 'Fix login outage INC0012345' → Groupe: 'INC0012345' |
+| Trello - Boards | Regroupe par nom de board | Titre: 'Project Board \| Trello' → Groupe: 'Project Board' |
+| Notion - Pages | Regroupe par titre de page | Titre: 'Project Planning \| Notion' → Groupe: 'Project Planning' |
+| Asana - Tâches | Regroupe par projet Asana | URL: '/0/123456/789012' → Groupe: '123456' |
+| Salesforce - Organisations | Regroupe par organisation | URL: 'https://mycompany.salesforce.com' → Groupe: 'mycompany' |
+| Miro - Boards | Regroupe par nom de board | Titre: 'Sprint Planning \| Miro' → Groupe: 'Sprint Planning' |
+
+### E-commerce
+
+Sites marchands et comparateurs.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Amazon - Produits | Regroupe par ASIN produit | URL: '/dp/B08N5WRWNW' → Groupe: 'B08N5WRWNW' |
+| eBay - Articles | Regroupe par ID d'article | URL: '/itm/123456789' → Groupe: '123456789' |
+| Shopify - Administration | Regroupe par boutique | URL: 'https://mystore.myshopify.com' → Groupe: 'mystore' |
+
+### Voyage et Réservations
+
+Booking, transport, hébergement.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Airbnb - Logements | Regroupe par destination (demande si non trouvée) | Titre: 'Apartment, Paris, Airbnb' → Groupe: 'Paris' |
+| Booking.com - Hôtels | Regroupe par ville (demande si non trouvée) | Titre: 'Hilton London Bankside, London, Booking.com' → Groupe: 'London' |
+| Expedia - Voyages | Regroupe par destination | URL: '?destination=Paris' → Groupe: 'Paris' |
+| Skyscanner - Vols | Regroupe par destination | Titre: 'Flights from Paris to London, Skyscanner' → Groupe: 'London' |
+
+### Recherche et Documentation
+
+Moteurs de recherche et documentation.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Google - Recherches | Regroupe par termes de recherche | Titre: 'javascript tutorial, Google Search' → Groupe: 'javascript tutorial' |
+| Wikipedia - Articles | Regroupe par article | Titre: 'JavaScript, Wikipedia' → Groupe: 'JavaScript' |
+| MDN - Documentation | Regroupe par technologie | URL: '/docs/Web/JavaScript' → Groupe: 'JavaScript' |
+| Medium - Articles | Regroupe par auteur | URL: '/@author_name/article' → Groupe: 'author_name' |
+
+### Réseaux sociaux
+
+Plateformes sociales et communication.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| LinkedIn - Profils | Regroupe par profil | URL: '/in/john-doe-123' → Groupe: 'john-doe-123' |
+| Twitter/X - Profils | Regroupe par utilisateur | URL: '/elonmusk' → Groupe: 'elonmusk' |
+| Reddit - Subreddits | Regroupe par subreddit | URL: '/r/programming' → Groupe: 'programming' |
+| Slack - Workspaces | Regroupe par workspace | URL: 'https://myteam.slack.com' → Groupe: 'myteam' |
+| Zoom - Réunions | Regroupe par ID de meeting | Titre: 'Zoom Meeting ID: 123456789' → Groupe: '123456789' |
+
+### Streaming et Médias
+
+Vidéos, musique, actualités.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| YouTube - Vidéos | Regroupe par ID de vidéo | URL: '/watch?v=dQw4w9WgXcQ' → Groupe: 'dQw4w9WgXcQ' |
+| YouTube - Chaînes | Regroupe par chaîne | Titre: 'TechChannel, YouTube' → Groupe: 'TechChannel' |
+| Netflix - Contenus | Regroupe par ID de contenu | URL: '/title/80018499' → Groupe: '80018499' |
+| Spotify - Musiques | Regroupe par ID de piste | URL: '/track/4iV5W9uYEdYUVa79Axb7Rh' → Groupe: '4iV5W9uYEdYUVa79Axb7Rh' |
+| Twitch - Chaînes | Regroupe par chaîne | URL: '/ninja' → Groupe: 'ninja' |
+
+### Cloud et Infrastructure
+
+Services cloud et infrastructure.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| AWS - Console | Regroupe par service AWS | URL: '/ec2/home' → Groupe: 'ec2' |
+| Azure - Portal | Regroupe par resource group | URL: '/resourceGroups/mygroup' → Groupe: 'mygroup' |
+| Vercel - Dashboard | Regroupe par projet | Titre: 'myproject, Vercel' → Groupe: 'myproject' |
+
+### Finance et Banking
+
+Banques, trading, crypto.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Coinbase - Cryptomonnaies | Regroupe par crypto | URL: '/price/bitcoin' → Groupe: 'bitcoin' |
+| TradingView - Graphiques | Regroupe par symbole | URL: '?symbol=NASDAQ:AAPL' → Groupe: 'NASDAQ:AAPL' |
+
+### Education et Apprentissage
+
+Cours en ligne, formations.
+
+| Preset | Description | Exemple |
+|---|---|---|
+| Udemy - Cours | Regroupe par cours | Titre: 'JavaScript Guide \| Udemy' → Groupe: 'JavaScript Guide' |
+| Coursera - Cours | Regroupe par cours | Titre: 'Machine Learning \| Coursera' → Groupe: 'Machine Learning' |
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Presets regex (guide)" href="/fonctionnalites/regles/presets-regex" description="Comment utiliser le dropdown de presets dans l'assistant de création de règle." />
+  <LinkCard title="Liste des packs intégrés" href="/annexes/packs-integres" description="L'autre annexe catalogue : les 49 bundles importables." />
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="Pack et preset, deux notions distinctes mais complémentaires." />
+</CardGrid>

--- a/docs/src/content/docs/concepts/groupement.mdx
+++ b/docs/src/content/docs/concepts/groupement.mdx
@@ -56,9 +56,9 @@ La couleur du groupe est héritée de la catégorie associée à la règle. Si a
 
 Le nom affiché sur le groupe Chrome dépend du **mode de nommage** configuré dans la règle. Trois choix sont proposés lors de la création d'une règle.
 
-### Preset
+### Intelligent (depuis un pack ou un preset)
 
-L'extension extrait automatiquement un nom depuis le titre ou l'URL de l'onglet parent, en s'appuyant sur les expressions régulières du preset sélectionné. C'est le choix recommandé pour les sites courants.
+L'extension extrait automatiquement un nom depuis le titre ou l'URL de l'onglet parent, en s'appuyant sur les regex héritées du [pack importé](/concepts/packs) ou du preset choisi manuellement dans l'assistant de règle. C'est le choix recommandé pour les sites courants.
 
 ### Demander
 
@@ -88,6 +88,7 @@ Chaque règle possède un toggle individuel dans la liste des règles. Désactiv
 
 <CardGrid>
   <LinkCard title="Sources de nom de groupe" href="/concepts/sources-nom-groupe" description="Le principe d'extraction et les 6 modes de nommage disponibles." />
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="Importer plusieurs règles d'un coup pour un site ou un usage donné." />
   <LinkCard title="Modes de déduplication" href="/concepts/deduplication" description="Éviter les doublons en complément du groupement." />
   <LinkCard title="Créer une règle" href="/fonctionnalites/regles/creer-une-regle" description="Guide pas-à-pas de l'assistant de création." />
 </CardGrid>

--- a/docs/src/content/docs/concepts/modes-nommage.mdx
+++ b/docs/src/content/docs/concepts/modes-nommage.mdx
@@ -6,7 +6,7 @@ description: Catalogue des six modes de nommage de groupe, leurs chaînes de rep
 import { Aside, Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <Aside type="tip" title="En bref">
-- Six modes couvrent les situations possibles : saisie manuelle, extraction depuis le titre ou l'URL, mode intelligent basé sur un preset, avec différents replis si l'extraction échoue.
+- Six modes couvrent les situations possibles : saisie manuelle, extraction depuis le titre ou l'URL, mode intelligent basé sur les regex d'un pack ou d'un preset, avec différents replis si l'extraction échoue.
 - Certains modes laissent l'onglet non groupé en cas d'échec ; d'autres utilisent le label de la règle ou une invite comme filet de sécurité.
 </Aside>
 
@@ -50,11 +50,11 @@ Symétrique du mode Titre : extraction depuis l'URL en premier, puis repli sur l
 
 ## Intelligent
 
-L'extension utilise les regex du preset sélectionné pour tenter l'extraction depuis le titre puis depuis l'URL. Si les deux échouent, l'onglet n'est pas groupé.
+L'extension utilise les regex héritées du pack importé (ou du preset sélectionné manuellement) pour tenter l'extraction depuis le titre puis depuis l'URL. Si les deux échouent, l'onglet n'est pas groupé.
 
 <Steps>
-1. Extraction depuis le **titre** avec la regex du preset.
-2. À défaut, extraction depuis l'**URL** avec la regex du preset.
+1. Extraction depuis le **titre** avec la regex du pack ou du preset.
+2. À défaut, extraction depuis l'**URL** avec la regex du pack ou du preset.
 3. À défaut, l'onglet n'est **pas groupé**.
 </Steps>
 
@@ -63,8 +63,8 @@ L'extension utilise les regex du preset sélectionné pour tenter l'extraction d
 Même stratégie d'extraction que le mode Intelligent. En cas d'échec, le **label de la règle** est utilisé comme nom de repli.
 
 <Steps>
-1. Extraction depuis le **titre** avec la regex du preset.
-2. À défaut, extraction depuis l'**URL** avec la regex du preset.
+1. Extraction depuis le **titre** avec la regex du pack ou du preset.
+2. À défaut, extraction depuis l'**URL** avec la regex du pack ou du preset.
 3. À défaut, utilisation du **label de la règle** comme nom de groupe.
 </Steps>
 
@@ -77,8 +77,8 @@ Ce mode garantit qu'un groupe est toujours créé, même quand la regex ne corre
 Même stratégie d'extraction que le mode Intelligent. En cas d'échec, une invite de saisie est présentée, comme en mode Demander.
 
 <Steps>
-1. Extraction depuis le **titre** avec la regex du preset.
-2. À défaut, extraction depuis l'**URL** avec la regex du preset.
+1. Extraction depuis le **titre** avec la regex du pack ou du preset.
+2. À défaut, extraction depuis l'**URL** avec la regex du pack ou du preset.
 3. À défaut, **invite utilisateur**. Les onglets sont dégroupés si vous annulez.
 </Steps>
 
@@ -90,6 +90,7 @@ Ce mode combine l'extraction automatique et la saisie manuelle comme filet de s�
 
 <CardGrid>
   <LinkCard title="Sources de nom de groupe" href="/concepts/sources-nom-groupe" description="Principe d'extraction et choix du mode dans l'assistant de règle." />
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="L'autre source de regex prêtes à l'emploi pour le mode Intelligent." />
   <LinkCard title="Presets regex" href="/fonctionnalites/regles/presets-regex" description="Utiliser les patterns intégrés pour configurer le mode et les regex." />
   <LinkCard title="Comment fonctionne le groupement" href="/concepts/groupement" description="Conditions de déclenchement et comportement général." />
 </CardGrid>

--- a/docs/src/content/docs/concepts/packs.mdx
+++ b/docs/src/content/docs/concepts/packs.mdx
@@ -1,0 +1,79 @@
+---
+title: Qu'est-ce qu'un pack ?
+description: Collection trilingue de règles prêtes à l'emploi, organisée par catégorie et importable en un clic dans SmartTab Organizer.
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Un **pack** est un ensemble de règles de domaine prêtes à l'emploi, regroupées autour d'un site ou d'un usage.
+- SmartTab Organizer embarque 49 packs intégrés répartis en 13 catégories thématiques.
+- Certains packs sont **configurables** : vous choisissez un paramètre avant l'import (par exemple le service AWS principal).
+</Aside>
+
+Un pack est un raccourci pour configurer plusieurs règles d'un coup. Plutôt que de créer manuellement une règle par section d'un site, vous importez le pack correspondant et toutes les règles s'ajoutent à votre liste avec des regex, des couleurs et des catégories déjà ajustées.
+
+## Pack et preset, deux notions distinctes
+
+SmartTab Organizer manipule deux notions proches mais différentes.
+
+| Notion | À quoi ça sert | Où la rencontrer |
+|---|---|---|
+| **Pack** | Bundle complet de règles à importer (URL, regex, couleur, catégorie). Modifie votre liste de règles. | Galerie de packs, page Règles, bouton "Importer un pack". |
+| **Preset** | Modèle regex isolé sélectionnable depuis le dropdown de l'assistant de règle. N'ajoute rien tout seul. | Wizard de création de règle, champ "Preset". |
+
+Métaphore : un pack est à une règle ce qu'une suite logicielle est à une application. Un preset est un patron de regex qu'on greffe sur une règle existante.
+
+## Anatomie d'un pack
+
+Un pack repose sur un manifeste (validé par le schéma Zod `packFileSchema` dans `src/schemas/pack.ts`) qui contient :
+
+- `id` : identifiant stable (par exemple `pk-dev-github`).
+- `name` : nom localisé en français, anglais et espagnol.
+- `description` : phrase courte qui explique l'usage du pack.
+- `categoryId` : rattachement à l'une des 13 catégories listées plus bas.
+- `configurable` (optionnel) : un ou plusieurs paramètres à choisir avant l'import.
+- `domainRules` : la liste des règles que le pack ajoutera à votre configuration.
+
+Chaque règle issue d'un pack est une règle de domaine ordinaire après l'import : vous pouvez la renommer, la modifier ou la supprimer sans contrainte.
+
+## Les 13 catégories
+
+Les packs sont rangés dans des catégories visibles dans la galerie d'import. Chaque catégorie possède une icône et un libellé localisé.
+
+| Icône | Catégorie | Exemples de packs |
+|---|---|---|
+| 🔍 | Recherche | Moteurs de recherche, Wikipédia |
+| 💬 | Communication | Slack, Discord, Visioconférences |
+| 🎬 | Médias et Streaming | YouTube, Spotify, plateformes SVOD |
+| 🗣️ | Réseaux sociaux | LinkedIn, X (Twitter), Reddit |
+| 🛍️ | Commerce | Amazon, places de marché |
+| 📰 | Actualités | Presse française et internationale |
+| 📋 | Productivité | Jira, Linear, Notion, Google Workspace |
+| 🤖 | Assistants IA | Assistants IA, Hugging Face, recherche IA |
+| ✈️ | Voyage | Vols, hôtels, billets de train |
+| 💰 | Finance | Marchés, paiements, crypto, actions |
+| 🎓 | Apprentissage | MOOC, formation professionnelle, créatif |
+| 💻 | Développement | GitHub, GitLab, Stack Overflow |
+| ☁️ | Cloud et DevOps | AWS, Azure, GCP, déploiement |
+
+La liste exhaustive des packs catégorie par catégorie figure dans [l'annexe "Packs intégrés"](/annexes/packs-integres).
+
+## Packs configurables
+
+Certains packs proposent un paramètre à choisir avant l'import. C'est le cas des packs cloud, qui se spécialisent autour d'un service donné.
+
+Exemple : le pack **Console AWS** propose un paramètre `Service AWS` avec 8 valeurs (EC2, S3, Lambda, RDS, CloudWatch, IAM, DynamoDB, ECS). Le service sélectionné devient la règle mise en avant lors de l'import. Les autres règles du pack restent disponibles dans la liste, mais le pack lui-même est marqué comme spécialisé sur le service choisi.
+
+<Aside type="note">
+Les paramètres configurables sont déclarés dans le manifeste (`pack.configurable.params`). Chaque paramètre liste ses options avec une valeur par défaut. Vous pouvez réimporter un pack plusieurs fois avec des paramètres différents : les règles déjà présentes seront détectées comme conflits par le wizard d'import.
+</Aside>
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Importer des packs de règles" href="/fonctionnalites/regles/packs" description="Guide pas-à-pas de la galerie de packs : navigation, recherche, configuration, import." />
+  <LinkCard title="Liste des packs intégrés" href="/annexes/packs-integres" description="Catalogue complet des 49 packs intégrés, par catégorie." />
+  <LinkCard title="Sources de nom de groupe" href="/concepts/sources-nom-groupe" description="Le rôle des regex dans le nommage des groupes créés par les règles d'un pack." />
+  <LinkCard title="Presets regex" href="/fonctionnalites/regles/presets-regex" description="L'autre brique de configuration : les patterns regex isolés du wizard de règle." />
+</CardGrid>

--- a/docs/src/content/docs/concepts/sessions-epinglees.mdx
+++ b/docs/src/content/docs/concepts/sessions-epinglees.mdx
@@ -31,10 +31,20 @@ Les sessions ordinaires conviennent mieux aux captures ponctuelles : sauvegarder
 
 Chaque session épinglée peut être associée à une catégorie. Ce sont les mêmes catégories que celles utilisées pour les règles de domaine : elles apportent une couleur et un emoji qui s'affichent dans la popup à côté du nom de la session. Cela permet de distinguer visuellement vos sessions épinglées d'un coup d'oeil quand vous en avez plusieurs.
 
+## Profils dans la popup et la page d'accueil
+
+Quand une session est épinglée dans le workspace actif, elle est projetée comme **profil** à deux endroits :
+
+- la popup, dans le composant `PopupProfilesList`, pour permettre la restauration en un clic depuis la barre d'outils du navigateur ;
+- la page d'accueil de l'extension, dans la section `PinnedSessionsSection`, sous forme de tuiles navigables au clavier.
+
+Les profils sont **cloisonnés par workspace** : si vous changez de workspace actif, la popup et la page d'accueil n'afficheront que les sessions épinglées du nouveau contexte.
+
 ## Voir aussi
 
 <CardGrid>
   <LinkCard title="Épingler une session" href="/fonctionnalites/sessions/sessions-epinglees" description="Comment épingler, désépingler et associer une catégorie." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="L'accès rapide aux sessions épinglées du workspace actif." />
   <LinkCard title="Vue d'ensemble des sessions" href="/fonctionnalites/sessions/vue-ensemble" description="La liste des sessions et ses fonctionnalités." />
   <LinkCard title="Popup" href="/fonctionnalites/popup" description="Accéder aux sessions épinglées depuis la popup." />
 </CardGrid>

--- a/docs/src/content/docs/concepts/sources-nom-groupe.mdx
+++ b/docs/src/content/docs/concepts/sources-nom-groupe.mdx
@@ -7,7 +7,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <Aside type="tip" title="En bref">
 - Chaque règle configure un **mode de nommage** qui décide comment le nom du groupe est calculé.
-- Trois familles de modes : **Preset** (recommandé), **Demander**, **Manuel**.
+- Trois familles de modes : **Intelligent** (recommandé, basé sur un pack ou un preset), **Demander**, **Manuel**.
 - Les modes extractifs utilisent une expression régulière sur le titre ou l'URL de l'onglet parent.
 </Aside>
 
@@ -31,9 +31,9 @@ Une regex syntaxiquement invalide est ignorée sans faire planter l'extension. L
 
 Lors de la création ou de l'édition d'une règle, trois segments sont proposés.
 
-### Preset
+### Intelligent (depuis un pack ou un preset)
 
-Délègue entièrement le choix du mode au preset sélectionné. Chaque preset embarque un mode de nommage recommandé adapté au site visé (Titre, URL, Intelligent, Intelligent + Label ou Intelligent + Demander) et configure aussi les regex automatiquement. C'est l'approche recommandée pour les sites courants.
+Délègue entièrement le choix du mode aux regex héritées : soit celles fournies par le [pack importé](/concepts/packs), soit celles du preset sélectionné dans le dropdown de l'assistant. Chaque source embarque un mode de nommage recommandé adapté au site visé (Titre, URL, Intelligent, Intelligent + Label ou Intelligent + Demander) et configure aussi les regex automatiquement. C'est l'approche recommandée pour les sites courants.
 
 ### Demander
 
@@ -50,9 +50,9 @@ Vous laisse choisir explicitement le mode parmi les six options disponibles, et 
 | Demander | Invite utilisateur | Dégroupage si annulation | |
 | Titre | Extraction titre | Extraction URL | Pas de groupage |
 | URL | Extraction URL | Extraction titre | Pas de groupage |
-| Intelligent | Extraction titre (preset) | Extraction URL (preset) | Pas de groupage |
-| Intelligent + Label | Extraction titre (preset) | Extraction URL (preset) | Label de la règle |
-| Intelligent + Demander | Extraction titre (preset) | Extraction URL (preset) | Invite utilisateur, dégroupage si annulation |
+| Intelligent | Extraction titre (pack ou preset) | Extraction URL (pack ou preset) | Pas de groupage |
+| Intelligent + Label | Extraction titre (pack ou preset) | Extraction URL (pack ou preset) | Label de la règle |
+| Intelligent + Demander | Extraction titre (pack ou preset) | Extraction URL (pack ou preset) | Invite utilisateur, dégroupage si annulation |
 
 <CardGrid>
   <LinkCard title="Détail des modes de nommage" href="/concepts/modes-nommage" description="Catalogue complet des six modes, avec les cas limites et les comportements de repli." />
@@ -62,6 +62,7 @@ Vous laisse choisir explicitement le mode parmi les six options disponibles, et 
 
 <CardGrid>
   <LinkCard title="Comment fonctionne le groupement" href="/concepts/groupement" description="Conditions de déclenchement et comportement général." />
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="L'autre source de regex toute prête, sous forme de bundle importable." />
   <LinkCard title="Presets regex" href="/fonctionnalites/regles/presets-regex" description="Utiliser les patterns intégrés pour configurer automatiquement le mode et les regex." />
   <LinkCard title="Liste des presets" href="/annexes/presets-regex" description="Tableau de référence des presets disponibles." />
 </CardGrid>

--- a/docs/src/content/docs/concepts/workspaces.mdx
+++ b/docs/src/content/docs/concepts/workspaces.mdx
@@ -1,0 +1,62 @@
+---
+title: Qu'est-ce qu'un espace de travail ?
+description: Cloisonner règles, sessions et statistiques par contexte professionnel ou personnel grâce aux workspaces de SmartTab Organizer.
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Un **workspace** est un conteneur isolé qui regroupe ses propres règles, sessions et statistiques.
+- Une couleur d'accent par workspace permet de reconnaître d'un coup d'oeil le contexte actif.
+- Le workspace **Par défaut** existe toujours et ne peut pas être supprimé.
+</Aside>
+
+Un espace de travail (ou workspace) permet de séparer deux contextes d'usage sans que leurs configurations se mélangent. Travail et vie personnelle, projet A et projet B, environnement client et environnement R&D : chaque contexte garde ses règles de domaine, ses sessions épinglées et ses compteurs.
+
+## Ce que cloisonne un workspace
+
+Quand vous basculez d'un workspace à l'autre, l'interface ne montre plus que les données rattachées au workspace actif.
+
+| Donnée | Cloisonnée par workspace ? |
+|---|---|
+| Règles de domaine | Oui |
+| Sessions et profils épinglés | Oui |
+| Statistiques (groupes créés, doublons fermés) | Oui |
+| Paramètres globaux (notifications, langue, thème) | Non, partagés |
+| Presets et packs intégrés | Non, partagés |
+
+Le workspace actif est mémorisé dans `browser.storage.local` et exposé à toute l'interface via le contexte React `ActiveWorkspaceContext` (`src/contexts/ActiveWorkspaceContext.tsx`).
+
+## Workspace par défaut
+
+Un workspace appelé **Par défaut** existe dès la première installation. Il porte l'identifiant `DEFAULT_WORKSPACE_ID` et héberge toutes les règles et sessions présentes avant que vous n'introduisiez d'autres workspaces.
+
+<Aside type="caution">
+Le workspace **Par défaut** ne peut pas être supprimé. C'est le seul à bénéficier de ce statut, pour garantir qu'il existe toujours un espace de repli même si vous supprimez tous les autres.
+</Aside>
+
+## Couleur d'accent
+
+À la création d'un workspace, vous choisissez une couleur d'accent. Cette couleur sert d'indicateur visuel dans le sélecteur de workspace, le footer des options et la popup. Vingt couleurs Radix sont proposées :
+
+`tomato`, `red`, `ruby`, `crimson`, `pink`, `plum`, `purple`, `violet`, `iris`, `indigo`, `blue`, `cyan`, `teal`, `jade`, `green`, `grass`, `orange`, `amber`, `yellow`, `lime`.
+
+Les neutres (gray, mauve, slate, sage, olive, sand) et les couleurs métalliques (bronze, gold, brown) sont volontairement exclues car elles rendent mal en accent d'interface.
+
+## Limites de saisie
+
+Le schéma Zod `workspaceMetaSchema` (`src/schemas/workspace.ts`) impose deux limites strictes :
+
+- Nom : entre 1 et 40 caractères.
+- Identifiant interne : entre 1 et 64 caractères (généré automatiquement à la création).
+
+Les dates `createdAt` et `updatedAt` sont gérées par l'extension, vous n'avez pas à les fournir.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Vue d'ensemble des workspaces" href="/fonctionnalites/workspaces/vue-ensemble" description="La page de gestion des espaces de travail : lister, rechercher, basculer." />
+  <LinkCard title="Créer, renommer, supprimer un workspace" href="/fonctionnalites/workspaces/gerer-workspaces" description="Les actions CRUD et leurs contraintes." />
+  <LinkCard title="Changer de workspace actif" href="/fonctionnalites/workspaces/changer-workspace-actif" description="Basculer depuis les Options ou depuis la popup, et son effet sur les données affichées." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="Les sessions épinglées projetées dans la popup et la page d'accueil." />
+</CardGrid>

--- a/docs/src/content/docs/demarrage/page-accueil.mdx
+++ b/docs/src/content/docs/demarrage/page-accueil.mdx
@@ -1,0 +1,59 @@
+---
+title: La page d'accueil
+description: "Le hub central des Options : onboarding, profils épinglés, actions rapides, mini-statistiques et astuces."
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- La page d'accueil est le **premier écran** affiché à l'ouverture des Options.
+- Tant qu'aucune règle n'est créée, un **Hero d'onboarding** propose de créer une règle ou d'importer un pack.
+- Une fois l'extension utilisée, la page agrège **profils épinglés**, **actions rapides**, **mini-statistiques** et **astuces**.
+</Aside>
+
+## Les sections de la page
+
+La page d'accueil est composée de plusieurs sections, affichées de haut en bas dans cet ordre quand elles sont pertinentes.
+
+### Hero d'onboarding
+
+Quand aucune règle n'est encore définie dans le workspace actif, le Hero d'onboarding occupe la partie haute. Deux actions principales y sont proposées :
+
+- **Créer ma première règle** : ouvre directement l'assistant de création de règle.
+- **Importer un pack** : ouvre la galerie de packs dans le wizard d'import (mode `pack`).
+
+Dès qu'au moins une règle existe, le Hero d'onboarding disparait au profit des autres sections.
+
+### Profils épinglés
+
+Cette section regroupe jusqu'à **6 sessions épinglées** du workspace actif, triées par date de mise à jour décroissante. Chaque profil s'affiche sous forme de tuile cliquable.
+
+La navigation au clavier est possible (flèches pour se déplacer entre tuiles). Quatre raccourcis pilotent la restauration du profil ayant le focus :
+
+- `R` : ouvre le wizard et laisse choisir le mode.
+- `Shift+R` : restaure dans la fenêtre actuelle.
+- `Alt+R` : remplace les onglets de la fenêtre actuelle.
+- `Alt+Shift+R` : ouvre une nouvelle fenêtre.
+
+Le détail des cibles est documenté dans [Profils dans la popup](/fonctionnalites/workspaces/profils-popup).
+
+### Actions rapides
+
+Une grille d'actions usuelles : organiser tous les onglets, capturer un instantané, créer une règle, ouvrir Import/Export, voir les statistiques, accéder aux Espaces de travail, ouvrir le panneau des raccourcis clavier.
+
+### Mini-statistiques
+
+Trois compteurs synthétiques : groupes créés, doublons fermés, sessions enregistrées. Chaque compteur est cliquable et amène vers la page complète correspondante. La section n'apparait que si au moins un compteur est non nul.
+
+### Astuces
+
+Un carrousel léger d'astuces tournantes (mode Intelligent, raccourcis, sessions épinglées, packs, etc.). Sa visibilité peut être désactivée depuis la page Paramètres.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Tour de l'interface" href="/demarrage/tour-interface" description="Vue d'ensemble des écrans des Options et de la popup." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="Sessions épinglées et leurs raccourcis de restauration." />
+  <LinkCard title="Importer des packs de règles" href="/fonctionnalites/regles/packs" description="L'action proposée par le Hero d'onboarding." />
+  <LinkCard title="Vue d'ensemble des sessions" href="/fonctionnalites/sessions/vue-ensemble" description="Toutes les sessions, y compris les non épinglées." />
+</CardGrid>

--- a/docs/src/content/docs/demarrage/tour-interface.mdx
+++ b/docs/src/content/docs/demarrage/tour-interface.mdx
@@ -24,12 +24,16 @@ Depuis cet écran vous accédez aux toggles de groupement et de déduplication, 
 
 ## La page Options
 
-La page Options regroupe quatre sections principales :
+La page Options regroupe les sections principales suivantes :
 
+- **Accueil** : page d'entrée qui agrège profils épinglés, actions rapides et mini-statistiques (voir [La page d'accueil](/demarrage/page-accueil)).
 - **Règles de domaine** : créer, modifier et organiser les règles qui pilotent le groupement et la déduplication.
 - **Sessions** : capturer un instantané des onglets ouverts, l'éditer, ou en restaurer un précédent.
+- **Espaces de travail** : cloisonner règles, sessions et statistiques par contexte (voir [Qu'est-ce qu'un espace de travail ?](/concepts/workspaces)).
 - **Statistiques** : suivre l'activité de groupement et de déduplication dans le temps.
 - **Import / Export** : sauvegarder ou restaurer votre configuration et vos sessions au format JSON.
+
+Le footer de la page Options héberge un **sélecteur de workspace** (`WorkspaceSwitcherDropdown`) qui permet de basculer d'espace de travail à tout moment. Le même sélecteur est disponible dans la popup.
 
 <Aside type="note">
 La capture ci-dessus est extraite du parcours narratif `00-main-journey` du pipeline `e2e-doc-scenarios/`. Elle est régénérée à chaque exécution de `pnpm doc:scenarios` pour rester synchronisée avec l'UI.

--- a/docs/src/content/docs/fonctionnalites/import-export/exporter-workspace.mdx
+++ b/docs/src/content/docs/fonctionnalites/import-export/exporter-workspace.mdx
@@ -1,0 +1,54 @@
+---
+title: Exporter un workspace
+description: Sauvegarder le contenu complet d'un espace de travail dans un fichier JSON pour archivage ou transfert.
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- L'export embarque les **règles de domaine**, les **sessions**, les **catégories** et les **paramètres** du workspace actif dans un seul fichier JSON.
+- Les statistiques (compteurs) sont **désactivées par défaut**. Un champ optionnel **Note** permet d'ajouter un commentaire embarqué dans l'archive.
+- Le fichier produit suit le format `smarttab_organizer_workspace_{slug}.json`.
+</Aside>
+
+L'export d'un workspace produit une archive autonome contenant l'intégralité de la configuration de cet espace de travail. C'est l'outil à utiliser pour faire une sauvegarde manuelle, transférer un workspace vers un autre profil Chrome, ou partager une configuration de travail avec un collègue.
+
+## Ouvrir le dialog
+
+<Steps>
+1. Depuis la page Espaces de travail ou les Options, ouvrez l'action **Exporter le workspace actif**.
+2. Le dialog se charge avec un récapitulatif du nombre de règles et de sessions qui seront embarqués.
+</Steps>
+
+L'export concerne toujours le **workspace actif**. Pour exporter un autre workspace, basculez dessus au préalable (voir [Changer de workspace actif](/fonctionnalites/workspaces/changer-workspace-actif)).
+
+## Options proposées
+
+| Option | Valeur par défaut | Effet |
+|---|---|---|
+| **Note** | Vide | Texte libre embarqué dans l'archive, lisible à l'import. |
+| **Inclure les statistiques** | Désactivé | Embarque les compteurs (groupes créés, doublons fermés). |
+
+<Aside type="note">
+La case **Inclure les statistiques** est volontairement décochée par défaut. Les compteurs ne sont pas indispensables pour transférer une configuration et exportent des données qui peuvent être considérées comme personnelles.
+</Aside>
+
+## Contenu de l'archive
+
+L'archive JSON contient les sections suivantes :
+
+- `workspace` : nom et couleur d'accent du workspace.
+- `settings` : toggles globaux (groupement, déduplication, notifications) et stratégie de déduplication.
+- `domainRules` : la liste complète des règles, dans l'ordre choisi par l'utilisateur.
+- `categories` : les catégories définies dans le workspace.
+- `sessions` : toutes les sessions enregistrées, épinglées ou non.
+- `statistics` : présent uniquement si la case correspondante a été cochée.
+- `note` : présent uniquement si vous avez saisi du texte dans le champ Note.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Importer un workspace" href="/fonctionnalites/import-export/importer-workspace" description="Restaurer une archive précédemment exportée." />
+  <LinkCard title="Exporter des règles" href="/fonctionnalites/import-export/exporter-regles" description="Export ciblé sur les seules règles de domaine." />
+  <LinkCard title="Exporter des sessions" href="/fonctionnalites/import-export/exporter-sessions" description="Export ciblé sur les seules sessions." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/import-export/importer-workspace.mdx
+++ b/docs/src/content/docs/fonctionnalites/import-export/importer-workspace.mdx
@@ -1,0 +1,47 @@
+---
+title: Importer un workspace
+description: Restaurer une archive de workspace dans SmartTab Organizer en créant un nouvel espace ou en fusionnant avec un workspace existant.
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Deux modes d'import : créer un **nouveau workspace** ou **fusionner** dans le workspace actif.
+- L'archive est validée par le schéma Zod `importWorkspaceDataSchema` avant toute modification.
+- Une note embarquée et un compteur de règles/sessions sont affichés avant la confirmation.
+</Aside>
+
+## Ouvrir le dialog
+
+<Steps>
+1. Depuis la page Espaces de travail ou les Options, ouvrez l'action **Importer un workspace**.
+2. Sélectionnez la source : un fichier JSON local (drag and drop ou parcours) ou du texte JSON collé.
+3. Le dialog valide la structure et affiche un récapitulatif (nombre de règles, nombre de sessions, présence de statistiques).
+</Steps>
+
+Si la validation échoue, un message d'erreur précise la cause (champ manquant, type invalide). Aucune donnée n'est modifiée tant que vous n'avez pas confirmé.
+
+## Choisir le mode d'import
+
+| Mode | Comportement |
+|---|---|
+| **Nouveau workspace** | Crée un workspace neuf avec le nom et la couleur fournis par l'archive. Vous pouvez surcharger le nom dans le champ **Nom** avant validation. |
+| **Fusionner dans le workspace actif** | Ajoute les règles, catégories et sessions de l'archive au workspace actif. Les conflits éventuels (ID déjà présent) sont gérés au cas par cas. |
+
+<Aside type="caution">
+Le mode **Fusionner** modifie le workspace actif. Si vous voulez préserver le contenu actuel, utilisez plutôt **Nouveau workspace** et basculez ensuite manuellement.
+</Aside>
+
+## Options additionnelles
+
+- **Inclure les statistiques** : importe les compteurs de l'archive (uniquement disponible si l'archive en contient).
+- **Note** : si l'archive embarque une note, elle est affichée dans un encart avant la confirmation.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Exporter un workspace" href="/fonctionnalites/import-export/exporter-workspace" description="Produire une archive JSON à réimporter." />
+  <LinkCard title="Importer des règles" href="/fonctionnalites/import-export/importer-regles" description="Import ciblé sur les seules règles de domaine, avec wizard de conflits." />
+  <LinkCard title="Importer des sessions" href="/fonctionnalites/import-export/importer-sessions" description="Import ciblé sur les seules sessions." />
+  <LinkCard title="Qu'est-ce qu'un espace de travail ?" href="/concepts/workspaces" description="Ce qu'un workspace cloisonne et ce qui reste partagé." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/popup.mdx
+++ b/docs/src/content/docs/fonctionnalites/popup.mdx
@@ -21,4 +21,7 @@ La popup affiche :
 
 - Les **statistiques** de groupement et de déduplication (nombre d'onglets traités)
 - Les **boutons d'accès rapide** vers les règles, les sessions et les paramètres
-- La liste des **profils épinglés** actifs
+- Le **sélecteur de workspace** (`PopupWorkspaceSwitcher`) qui permet de basculer d'espace de travail sans ouvrir les Options
+- La liste des **profils épinglés** du workspace actif (sessions promues via épinglage), avec leurs raccourcis de restauration
+
+Pour le détail du sélecteur de workspace, voir [Changer de workspace actif](/fonctionnalites/workspaces/changer-workspace-actif). Pour la liste des profils et leurs raccourcis, voir [Profils dans la popup](/fonctionnalites/workspaces/profils-popup).

--- a/docs/src/content/docs/fonctionnalites/regles/packs.mdx
+++ b/docs/src/content/docs/fonctionnalites/regles/packs.mdx
@@ -1,0 +1,68 @@
+---
+title: Importer des packs de règles
+description: Découvrir et importer en quelques clics des dizaines de règles prêtes à l'emploi depuis la galerie de packs.
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- La galerie de packs propose 49 collections de règles prêtes à l'emploi, classées par catégorie.
+- Vous pouvez parcourir la galerie par catégorie ou rechercher par mot-clé (le nom, la description et le libellé de catégorie sont indexés).
+- Les packs marqués configurables vous demandent de choisir un paramètre avant l'import.
+</Aside>
+
+Plutôt que de créer manuellement chaque règle pour un site donné, ouvrez la galerie de packs et importez celui qui correspond à votre usage. Toutes ses règles seront ajoutées à votre liste de règles de domaine, dans le workspace actif.
+
+## Ouvrir la galerie
+
+<Steps>
+1. Depuis la page Règles, ouvrez l'assistant d'import.
+2. Sélectionnez l'onglet **Packs intégrés**.
+3. La galerie liste tous les packs disponibles, regroupés par catégorie.
+</Steps>
+
+La galerie est également accessible depuis le **Hero d'onboarding** de la page d'accueil, via le bouton **Importer un pack** qui s'affiche tant qu'aucune règle n'a été créée dans le workspace actif.
+
+## Parcourir et rechercher
+
+La galerie propose deux modes de navigation, exclusifs l'un de l'autre :
+
+- **Par catégorie** : la barre latérale gauche affiche les 13 catégories avec leur icône et le nombre de packs disponibles. Cliquer sur une catégorie filtre la liste.
+- **Par recherche** : la zone de recherche au-dessus de la galerie filtre les packs dont le nom, la description ou le libellé de catégorie contient le terme saisi. La recherche est insensible aux accents (le mot `videoconference` trouve aussi le pack **Visioconférences**).
+
+Quand une recherche est active, la sélection par catégorie est ignorée pour ne pas masquer de résultats.
+
+## Configurer un pack avant import
+
+Certains packs (typiquement les packs cloud) sont **configurables** : ils proposent un paramètre à choisir avant l'import.
+
+Exemple avec le pack **Console AWS** :
+
+<Steps>
+1. La carte du pack affiche un sélecteur **Service AWS** avec 8 valeurs possibles (EC2, S3, Lambda, RDS, CloudWatch, IAM, DynamoDB, ECS).
+2. Choisissez le service que vous utilisez le plus, par exemple `Lambda (Functions)`.
+3. À l'import, le pack ajoute toutes ses règles, et celle correspondant au service choisi est marquée comme règle principale.
+</Steps>
+
+<Aside type="note">
+Si vous changez d'avis plus tard, vous pouvez réimporter le pack avec un autre paramètre. Le wizard d'import détectera les règles déjà présentes comme conflits et vous proposera de les remplacer ou de les laisser telles quelles.
+</Aside>
+
+## Sélection multiple
+
+Vous pouvez préparer plusieurs imports en cochant successivement plusieurs packs. La galerie maintient un compteur en bas de page indiquant le nombre de packs sélectionnés et le nombre total de règles qui seront ajoutées si vous validez maintenant.
+
+## Conflits à l'import
+
+Si un pack contient une règle dont l'identifiant existe déjà dans le workspace actif (par exemple suite à un import précédent), le wizard d'import affiche cette règle comme **conflit** et vous propose de la conserver ou de l'écraser. Les règles strictement identiques sont marquées comme **identiques** et ignorées automatiquement.
+
+Pour le détail du wizard de conflits, voir [Importer des règles de domaine](/fonctionnalites/import-export/importer-regles).
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Qu'est-ce qu'un pack ?" href="/concepts/packs" description="La notion de pack, anatomie du manifeste et catégories." />
+  <LinkCard title="Liste des packs intégrés" href="/annexes/packs-integres" description="Catalogue complet des 49 packs disponibles, par catégorie." />
+  <LinkCard title="Presets regex" href="/fonctionnalites/regles/presets-regex" description="L'autre source de regex prête à l'emploi, dans le wizard de création de règle." />
+  <LinkCard title="Vue d'ensemble des règles" href="/fonctionnalites/regles/vue-ensemble" description="La page de gestion des règles de domaine." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/regles/presets-regex.mdx
+++ b/docs/src/content/docs/fonctionnalites/regles/presets-regex.mdx
@@ -1,6 +1,54 @@
 ---
 title: Presets regex
-description: Utiliser le catalogue de patterns regex intégrés pour configurer rapidement le mode de correspondance d'une règle.
+description: Sélectionner un preset depuis l'assistant de création de règle pour configurer automatiquement le mode de nommage et les expressions régulières.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Un preset est un modèle de regex isolé, sélectionnable depuis le **dropdown Preset** du wizard de création de règle.
+- 65 presets sont intégrés, répartis en 11 catégories (Génériques, Développement, Productivité, etc.).
+- Sélectionner un preset configure automatiquement le mode de nommage, la regex de titre et la regex d'URL adaptés au site visé.
+</Aside>
+
+Les presets sont l'option recommandée pour les sites courants. Plutôt que de saisir vous-même les expressions régulières, choisissez le preset adapté et l'assistant remplit le reste.
+
+## À ne pas confondre avec un pack
+
+Un preset configure **une seule règle**, celle que vous êtes en train de créer dans l'assistant. Si vous cherchez à importer plusieurs règles d'un coup, regardez plutôt du côté des [packs](/fonctionnalites/regles/packs), qui sont des bundles complets prêts à l'emploi.
+
+| Notion | Action | Où la rencontrer |
+|---|---|---|
+| **Preset** | Pré-remplit la règle en cours d'édition. | Dropdown de l'assistant de règle. |
+| **Pack** | Ajoute plusieurs règles d'un coup. | Galerie de packs, page Règles, page d'accueil. |
+
+## Utiliser un preset
+
+<Steps>
+1. Ouvrez la page Règles puis cliquez sur **Nouvelle règle**.
+2. Saisissez le domaine concerné (ou laissez le champ vide pour un pattern transverse).
+3. Dans le champ **Preset**, sélectionnez le preset adapté à votre site. Les presets sont groupés par catégorie pour faciliter la recherche.
+4. Le mode de nommage, la regex de titre et la regex d'URL sont remplis automatiquement.
+5. Validez. La règle est créée avec une configuration cohérente.
+</Steps>
+
+## Modifier les regex après sélection
+
+Sélectionner un preset n'est pas définitif. Une fois la règle créée, vous pouvez ajuster ses regex à tout moment depuis l'éditeur de règle. La référence au preset est conservée à titre indicatif mais ne contraint plus le contenu.
+
+<Aside type="caution">
+Si vous modifiez les regex d'une règle issue d'un preset puis ré-ouvrez le dropdown pour choisir un autre preset, les valeurs modifiées seront écrasées par celles du nouveau preset.
+</Aside>
+
+## Presets transverses (cross-domaine)
+
+Quelques presets ont une portée volontairement large pour fonctionner quel que soit le domaine : par exemple **Jira - Ticket dans le titre (cross-domaine)** extrait une clé `PROJ-123` depuis n'importe quel onglet dont le titre mentionne cette référence. Utiles pour suivre un même ticket à travers GitHub, GitLab, Trello, Slack, etc.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Liste des presets regex" href="/annexes/presets-regex" description="Catalogue complet des 65 presets, par catégorie." />
+  <LinkCard title="Importer des packs de règles" href="/fonctionnalites/regles/packs" description="Ajouter plusieurs règles d'un coup depuis la galerie de packs." />
+  <LinkCard title="Sources de nom de groupe" href="/concepts/sources-nom-groupe" description="Comment le preset détermine le mode de nommage de la règle." />
+  <LinkCard title="Détail des modes de nommage" href="/concepts/modes-nommage" description="Les six stratégies de nommage et leurs chaînes de repli." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/sessions/sessions-epinglees.mdx
+++ b/docs/src/content/docs/fonctionnalites/sessions/sessions-epinglees.mdx
@@ -1,6 +1,45 @@
 ---
-title: Sessions épinglées
-description: Épingler une session pour la rendre permanente et l'associer à une fenêtre de navigateur dédiée.
+title: Épingler une session
+description: Marquer une session comme épinglée pour la promouvoir au rang de profil dans la popup et la page d'accueil du workspace actif.
 ---
 
-{/* TODO: contenu à rédiger */}
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- L'épinglage promeut une session au rang de **profil** : elle s'affiche dans la popup et dans la page d'accueil du workspace actif.
+- L'action est réversible à tout moment depuis la carte de session.
+- Une **catégorie** optionnelle (couleur + emoji) permet de distinguer visuellement plusieurs profils.
+</Aside>
+
+## Épingler une session
+
+<Steps>
+1. Ouvrez la page Sessions et identifiez la session cible.
+2. Sur sa carte, cliquez sur l'icône **Épingler** (ou utilisez le menu contextuel).
+3. La session passe immédiatement dans la section **Sessions épinglées** en haut de la page, et apparait dans la popup et la page d'accueil.
+</Steps>
+
+L'épinglage ne modifie ni le nom de la session, ni les onglets sauvegardés. Seul son statut change.
+
+## Désépingler une session
+
+Cliquez sur la même icône (qui change de tooltip pour indiquer **Désépingler**). La session retourne dans la section des sessions ordinaires et disparait de la popup et de la page d'accueil.
+
+## Associer une catégorie
+
+Chaque session, épinglée ou non, peut être associée à une catégorie. Pour les sessions épinglées, la catégorie apporte un emoji et une couleur d'accent qui aident à les distinguer visuellement dans la popup quand vous en avez plusieurs.
+
+La catégorie se choisit depuis le dialog d'édition de session, dans le champ **Catégorie**.
+
+## Différence avec les "profils" de la popup
+
+L'épinglage est l'action côté **page Sessions**. La **projection** dans la popup et la page d'accueil sous forme de profils est automatique, et reste cloisonnée au workspace actif. Pour le détail de cette projection (raccourcis, restauration), voir [Profils dans la popup](/fonctionnalites/workspaces/profils-popup).
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Sessions épinglées (concept)" href="/concepts/sessions-epinglees" description="Pourquoi épingler, cas d'usage et distinction avec les sessions ordinaires." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="La projection workspace-scoped et ses raccourcis de restauration." />
+  <LinkCard title="Vue d'ensemble des sessions" href="/fonctionnalites/sessions/vue-ensemble" description="Lister, rechercher et réorganiser les sessions." />
+  <LinkCard title="Éditer une session" href="/fonctionnalites/sessions/editer-session" description="Renommer, modifier la structure, associer une catégorie." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/workspaces/changer-workspace-actif.mdx
+++ b/docs/src/content/docs/fonctionnalites/workspaces/changer-workspace-actif.mdx
@@ -1,0 +1,51 @@
+---
+title: Changer de workspace actif
+description: Basculer entre les espaces de travail depuis les Options ou depuis la popup, et comprendre l'effet sur les données affichées.
+---
+
+import { Aside, CardGrid, LinkCard, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Deux entrées de bascule existent : un **sélecteur** dans le footer des Options et un autre dans la popup.
+- Le changement est immédiat. Toute l'interface se rafraichit pour n'afficher que les données du nouveau workspace actif.
+- Le workspace actif est mémorisé : à la prochaine ouverture du navigateur, vous repartez du dernier workspace utilisé.
+</Aside>
+
+Le workspace actif détermine ce que vous voyez : les règles de domaine listées, les sessions disponibles, les statistiques affichées. Basculer entre workspaces est conçu pour être instantané et réversible.
+
+## Deux entrées d'accès
+
+<Tabs>
+  <TabItem label="Depuis les Options">
+Le composant `WorkspaceSwitcherDropdown` est intégré au footer des Options. Cliquez dessus pour ouvrir la liste de vos workspaces, puis sélectionnez le workspace cible. Le dropdown affiche l'avatar et la couleur d'accent de chaque entrée pour aider à choisir.
+  </TabItem>
+  <TabItem label="Depuis la popup">
+Le composant `PopupWorkspaceSwitcher` reprend la même mécanique dans la popup de la barre d'outils du navigateur. Pratique pour basculer sans ouvrir la page Options : la liste de profils et les boutons de restauration affichés en dessous suivent immédiatement le changement.
+  </TabItem>
+</Tabs>
+
+## Effet sur les données affichées
+
+Quand vous changez de workspace actif :
+
+- la page **Règles de domaine** n'affiche plus que les règles du workspace cible ;
+- la page **Sessions** ne montre plus que les sessions enregistrées dans ce workspace ;
+- la popup et la page d'accueil n'affichent plus que les **profils** (sessions épinglées) du workspace cible ;
+- les **statistiques** (groupes créés, doublons fermés) reflètent les compteurs du workspace cible ;
+- les **paramètres globaux** (notifications, langue, thème) ne changent pas, ils sont partagés.
+
+<Aside type="note">
+Les **packs intégrés** et les **presets regex** sont également partagés entre workspaces : il n'y a pas besoin de les réimporter en changeant de contexte. Seules les règles **issues** d'un import de pack restent cloisonnées au workspace dans lequel elles ont été importées.
+</Aside>
+
+## Persistance
+
+Le workspace actif est mémorisé dans `browser.storage.local` via le contexte `ActiveWorkspaceContext`. À la prochaine ouverture de la popup, des Options ou du navigateur, vous reprenez là où vous vous étiez arrêté.
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Vue d'ensemble des workspaces" href="/fonctionnalites/workspaces/vue-ensemble" description="La page de gestion et le bouton Basculer." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="Les sessions épinglées projetées dans la popup et la page d'accueil." />
+  <LinkCard title="Qu'est-ce qu'un espace de travail ?" href="/concepts/workspaces" description="Ce qu'un workspace cloisonne et ce qui reste partagé." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/workspaces/gerer-workspaces.mdx
+++ b/docs/src/content/docs/fonctionnalites/workspaces/gerer-workspaces.mdx
@@ -1,0 +1,63 @@
+---
+title: Créer, renommer, supprimer un workspace
+description: Les trois actions CRUD sur les espaces de travail dans SmartTab Organizer, et leurs validations.
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- La création et la modification passent par le même formulaire : un champ **Nom** (max 40 caractères) et un sélecteur de **Couleur d'accent** parmi 20 valeurs.
+- Les noms doivent être uniques (insensible à la casse).
+- La suppression demande une confirmation et n'est pas autorisée pour le workspace **Par défaut** ni pour le dernier workspace restant.
+</Aside>
+
+Les trois actions sont accessibles depuis la [page Espaces de travail](/fonctionnalites/workspaces/vue-ensemble).
+
+## Créer un workspace
+
+<Steps>
+1. Sur la page Espaces de travail, cliquez sur **Nouveau workspace**.
+2. Saisissez un nom dans le champ texte (1 à 40 caractères, doit être unique).
+3. Choisissez une couleur d'accent dans le sélecteur (la valeur par défaut proposée est `jade`).
+4. L'aperçu en haut du formulaire montre l'avatar et la couleur tels qu'ils apparaitront dans la liste.
+5. Validez. Le workspace apparait dans la liste, prêt à être activé.
+</Steps>
+
+<Aside type="note">
+Créer un workspace ne le rend pas automatiquement actif. Pour basculer dessus, utilisez le bouton **Basculer** de sa carte. Voir [Changer de workspace actif](/fonctionnalites/workspaces/changer-workspace-actif).
+</Aside>
+
+## Renommer ou changer la couleur
+
+<Steps>
+1. Sur la carte du workspace, cliquez sur l'icône **Modifier** (crayon).
+2. Le même formulaire que la création s'ouvre, pré-rempli avec le nom et la couleur actuels.
+3. Modifiez ce que vous souhaitez et validez.
+</Steps>
+
+Les contraintes restent identiques (1 à 40 caractères, unicité). Si vous tentez d'utiliser un nom déjà pris par un autre workspace, le bouton de validation reste désactivé.
+
+## Supprimer un workspace
+
+<Steps>
+1. Sur la carte du workspace, cliquez sur l'icône **Supprimer** (corbeille).
+2. Une boite de dialogue de confirmation rappelle que toutes les règles, sessions et statistiques du workspace seront perdues.
+3. Confirmez pour effectuer la suppression.
+</Steps>
+
+<Aside type="caution">
+Deux situations empêchent la suppression :
+
+- Le workspace **Par défaut** ne peut pas être supprimé. Son icône **Supprimer** est désactivée avec un tooltip explicatif.
+- Le dernier workspace restant ne peut pas non plus être supprimé. Il faut garantir qu'au moins un espace de travail existe à tout moment.
+
+Si vous supprimez le workspace actuellement actif, l'extension bascule automatiquement sur le workspace **Par défaut**.
+</Aside>
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Vue d'ensemble des workspaces" href="/fonctionnalites/workspaces/vue-ensemble" description="La page qui liste les workspaces et héberge ces trois actions." />
+  <LinkCard title="Changer de workspace actif" href="/fonctionnalites/workspaces/changer-workspace-actif" description="Après avoir créé un workspace, basculer dessus depuis les Options ou la popup." />
+  <LinkCard title="Exporter un workspace" href="/fonctionnalites/import-export/exporter-workspace" description="Sauvegarder un workspace complet sous forme d'archive JSON." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/workspaces/profils-popup.mdx
+++ b/docs/src/content/docs/fonctionnalites/workspaces/profils-popup.mdx
@@ -1,0 +1,51 @@
+---
+title: Profils dans la popup
+description: Les sessions épinglées du workspace actif, projetées comme profils dans la popup et la page d'accueil pour un accès rapide.
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- Un **profil** est une session épinglée du workspace actif, projetée dans la popup et sur la page d'accueil.
+- Quatre raccourcis clavier permettent de restaurer un profil dans des modes différents (fenêtre actuelle, nouvelle fenêtre, etc.).
+- Les profils suivent le workspace actif : changer de workspace remplace immédiatement la liste affichée.
+</Aside>
+
+## Définition
+
+Une session devient **profil** dès lors qu'elle est marquée comme épinglée (`isPinned: true`) dans le workspace actif. La projection se fait à deux endroits :
+
+- la **popup** de la barre d'outils, dans le composant `PopupProfilesList` ;
+- la **page d'accueil** de l'extension, dans la section `PinnedSessionsSection` (tuiles cliquables, navigation flèches).
+
+Les sessions non épinglées restent visibles dans la page Sessions mais ne sont pas projetées comme profils.
+
+## Cloisonnement par workspace
+
+La liste de profils est **scopée au workspace actif**. Si vous basculez vers un autre workspace, la popup et la page d'accueil affichent immédiatement les profils de ce nouvel espace. Une même session ne peut être épinglée que dans le workspace où elle a été créée.
+
+## Raccourcis de restauration
+
+Quand un profil a le focus (clic ou navigation au clavier sur la page d'accueil), quatre raccourcis pilotent sa restauration :
+
+| Raccourci | Cible | Comportement |
+|---|---|---|
+| `R` | Personnalisée | Ouvre le wizard de restauration et vous laisse choisir le mode. |
+| `Shift+R` | Fenêtre actuelle | Ajoute les onglets à la fenêtre actuellement au premier plan. |
+| `Alt+R` | Remplacer | Ferme les onglets actuels et restaure ceux du profil dans la même fenêtre. |
+| `Alt+Shift+R` | Nouvelle fenêtre | Ouvre une nouvelle fenêtre dédiée et y restaure les onglets. |
+
+Les mêmes cibles sont disponibles dans la popup via le menu contextuel des profils.
+
+<Aside type="note">
+Le wizard de restauration détecte les conflits (URLs déjà ouvertes, groupes homonymes) et propose des stratégies de résolution (fusionner, ignorer, créer un nouveau groupe). Voir [Restaurer une session](/fonctionnalites/sessions/restaurer-session).
+</Aside>
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Sessions épinglées" href="/concepts/sessions-epinglees" description="La notion d'épinglage de session et ses cas d'usage." />
+  <LinkCard title="Restaurer une session" href="/fonctionnalites/sessions/restaurer-session" description="Le wizard de restauration et la gestion des conflits." />
+  <LinkCard title="Changer de workspace actif" href="/fonctionnalites/workspaces/changer-workspace-actif" description="Basculer entre workspaces depuis les Options ou la popup." />
+  <LinkCard title="Popup" href="/fonctionnalites/popup" description="L'interface complète de la popup." />
+</CardGrid>

--- a/docs/src/content/docs/fonctionnalites/workspaces/vue-ensemble.mdx
+++ b/docs/src/content/docs/fonctionnalites/workspaces/vue-ensemble.mdx
@@ -1,0 +1,60 @@
+---
+title: Vue d'ensemble des espaces de travail
+description: "La page de gestion des workspaces dans SmartTab Organizer : lister, rechercher, basculer entre les espaces de travail."
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="En bref">
+- La page **Espaces de travail** liste tous les workspaces et permet de basculer entre eux.
+- Chaque ligne affiche l'avatar, le nom, la couleur d'accent et deux badges optionnels : **Actif** et **Par défaut**.
+- Une recherche par nom est disponible quand vous avez plusieurs workspaces.
+</Aside>
+
+La page **Espaces de travail** centralise la gestion des workspaces : créer un nouvel espace, basculer vers un autre, renommer ou supprimer. Elle s'ouvre depuis le menu principal des Options.
+
+## Ce que la page affiche
+
+Chaque workspace apparait sous forme de carte avec :
+
+- un **avatar** dérivé du nom et coloré par l'accent du workspace ;
+- son **nom**, surligné si une recherche est active (accent-folding) ;
+- la mention de sa **couleur d'accent** ;
+- un **badge "Actif"** si c'est le workspace en cours d'utilisation ;
+- un **badge "Par défaut"** s'il s'agit du workspace `DEFAULT_WORKSPACE_ID`.
+
+Les actions disponibles à droite de la carte sont : **Basculer** (sauf pour le workspace actif), **Modifier** et **Supprimer**.
+
+## Basculer vers un autre workspace
+
+<Steps>
+1. Identifiez le workspace cible dans la liste (la barre de recherche aide quand vous en avez beaucoup).
+2. Cliquez sur le bouton **Basculer** de sa carte.
+3. L'interface se rafraichit pour afficher les règles, sessions et statistiques du nouveau workspace actif.
+</Steps>
+
+Pour les détails du switch (effet sur les données, possibilité de basculer depuis la popup), voir [Changer de workspace actif](/fonctionnalites/workspaces/changer-workspace-actif).
+
+## Contraintes de suppression
+
+<Aside type="caution">
+Deux cas empêchent la suppression :
+
+- le workspace **Par défaut** ne peut jamais être supprimé ;
+- le **dernier workspace** restant ne peut pas être supprimé non plus, pour garantir qu'il y en a toujours au moins un.
+
+Dans ces deux cas, le bouton **Supprimer** est désactivé et un tooltip explique la raison.
+</Aside>
+
+## Recherche
+
+Une barre de recherche apparait en haut de la liste dès que plusieurs workspaces existent. Elle filtre la liste par nom, accent-folding inclus (`recette` trouve `Recette`).
+
+## Voir aussi
+
+<CardGrid>
+  <LinkCard title="Qu'est-ce qu'un espace de travail ?" href="/concepts/workspaces" description="La notion de workspace, ce qu'il cloisonne, le workspace par défaut, les couleurs d'accent." />
+  <LinkCard title="Créer, renommer, supprimer un workspace" href="/fonctionnalites/workspaces/gerer-workspaces" description="Les trois actions CRUD et leurs validations." />
+  <LinkCard title="Changer de workspace actif" href="/fonctionnalites/workspaces/changer-workspace-actif" description="Basculer depuis les Options ou depuis la popup." />
+  <LinkCard title="Profils dans la popup" href="/fonctionnalites/workspaces/profils-popup" description="Accès rapide aux sessions épinglées du workspace actif." />
+</CardGrid>


### PR DESCRIPTION
The French Starlight docs lagged behind the codebase on two fronts:
references to "presets" conflated the wizard-only regex models with the
new pack bundles, and the workspaces feature (CRUD, switcher,
import/export, popup projection) was undocumented. This commit covers
both: new concept pages for packs and workspaces, full annex catalogues
for the 49 packs and 65 presets, four feature pages for workspaces, two
for workspace import/export, a HomePage walkthrough, and vocabulary
clarifications across the existing concept pages so "preset" and "pack"
read as the distinct ideas they are in the code. EN/ES locales fall
back to the FR content as planned; their translations will follow.