### PR TITLE
chore(hooks): relax ESLint PostToolUse hook with --fix, drop --max-warnings=0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // \"\"' | { read -r f; [ -z \"$f\" ] && exit 0; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;; *) exit 0 ;; esac; output=$(pnpm exec eslint --max-warnings=0 --no-warn-ignored \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then echo \"ESLint signale des erreurs/warnings sur $f. Corrigez avant de continuer:\" >&2; echo \"$output\" >&2; exit 2; fi; }",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // \"\"' | { read -r f; [ -z \"$f\" ] && exit 0; case \"$f\" in *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;; *) exit 0 ;; esac; output=$(pnpm exec eslint --fix --no-warn-ignored \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then echo \"ESLint signale des erreurs sur $f. Corrigez avant de continuer:\" >&2; echo \"$output\" >&2; exit 2; fi; }",
             "timeout": 60,
             "statusMessage": "ESLint check..."
           }


### PR DESCRIPTION
Le hook auto-corrige désormais les violations fixables (notamment
local/prefer-alias-imports) et ne bloque plus sur de simples warnings.
Les vraies erreurs ESLint bloquent toujours. Le filet final reste le
job CI lint qui exécute pnpm lint:ctrf sur src/ et tests/.

https://claude.ai/code/session_01LCkjQaAWAwJUHSnXNCcrz3