### PR TITLE
test(e2e-shared): scaffold pages/actions/matchers + pilot ImportWizardPage

### DIFF
--- a/e2e-shared/actions/index.ts
+++ b/e2e-shared/actions/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Composed flows (domain actions) shared between `tests/e2e/` and
+ * `e2e-doc-scenarios/`. Consumes Page Objects from `../pages/`.
+ *
+ * Intentionally empty in lot 1: only the structure is in place. Concrete
+ * helpers (e.g. `importRulesViaText`) land at lot 3 once the migration of
+ * `import-export.spec.ts` starts.
+ */
+export {};

--- a/e2e-shared/matchers/index.ts
+++ b/e2e-shared/matchers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Custom Playwright matchers shared between `tests/e2e/` and
+ * `e2e-doc-scenarios/`.
+ *
+ * Intentionally empty in lot 1: only the structure is in place. Concrete
+ * matchers (e.g. `toShowToast`, `toMatchClassification`) land in a later
+ * lot if/when the migration surfaces repeated assertion patterns worth
+ * extracting.
+ */
+export {};

--- a/e2e-shared/pages/DialogPage.ts
+++ b/e2e-shared/pages/DialogPage.ts
@@ -1,0 +1,46 @@
+/**
+ * Abstract base for Page Objects that wrap a Radix `role="dialog"` element.
+ *
+ * Subclasses provide locators, atomic actions and assertions specific to
+ * their dialog. They may override `dialog()` when more than one dialog can
+ * be visible at the same time (use `.first()`, `.nth(n)`, or a more
+ * specific scope).
+ *
+ * Page Objects in this folder stay close to the DOM: one method per
+ * locator, one method per atomic action, one method per atomic
+ * expectation. Composed flows (e.g. "import rules via text") live in
+ * `e2e-shared/actions/` and consume Page Objects.
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export abstract class DialogPage {
+  constructor(protected readonly page: Page) {}
+
+  /**
+   * Root locator for the dialog. Defaults to the first `role="dialog"` on
+   * the page; override in subclasses when several dialogs can co-exist
+   * (e.g. nested wizards, confirmation overlays, ...).
+   */
+  dialog(): Locator {
+    return this.page.getByRole('dialog');
+  }
+
+  /** Wait for the dialog to become visible. */
+  async expectVisible(options?: { timeout?: number }): Promise<void> {
+    await expect(this.dialog()).toBeVisible(options);
+  }
+
+  /** Wait for the dialog to be hidden or detached. */
+  async expectHidden(options?: { timeout?: number }): Promise<void> {
+    await expect(this.dialog()).toBeHidden(options);
+  }
+
+  /**
+   * Shortcut for `dialog().getByRole('button', { name }).click()`.
+   * Accepts both an exact string and a RegExp (case-insensitive matchers
+   * are recommended to stay robust across i18n).
+   */
+  async clickButton(name: RegExp | string): Promise<void> {
+    await this.dialog().getByRole('button', { name }).click();
+  }
+}

--- a/e2e-shared/pages/ImportWizardPage.ts
+++ b/e2e-shared/pages/ImportWizardPage.ts
@@ -1,0 +1,173 @@
+/**
+ * Page Object for the rules / sessions Import wizard.
+ *
+ * Wraps the Radix dialog opened from the Import/Export options page. The
+ * goal of this class is to expose **atomic** building blocks:
+ *
+ * - locators (`textArea`, `nextButton`, ...),
+ * - atomic actions (`selectTextMode`, `pasteJson`, `clickNext`, ...),
+ * - atomic assertions (`expectInvalidJsonError`,
+ *   `expectClassification`).
+ *
+ * Composed flows (e.g. `importRulesViaText(...)`) belong in
+ * `e2e-shared/actions/` so that they can be shared between
+ * `tests/e2e/` (functional) and `e2e-doc-scenarios/` (narrative
+ * captures) without forcing callers through the imperative spec style.
+ *
+ * The selectors target the English UI used by the default Playwright
+ * Chromium launch (`--lang=en-US`). When the wizard is exercised under a
+ * different locale, override the regexes by subclassing and replacing the
+ * locator getters.
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export interface ImportClassificationCounts {
+  new?: number;
+  conflicting?: number;
+  identical?: number;
+}
+
+export class ImportWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Textarea for raw JSON input (visible in Text mode). */
+  textArea(): Locator {
+    return this.dialog().locator('textarea').first();
+  }
+
+  /** "Drag and drop" zone (visible in File mode). */
+  fileDropZone(): Locator {
+    return this.dialog().getByText(/drag/i);
+  }
+
+  /** "Browse" button inside the file drop zone. */
+  browseButton(): Locator {
+    return this.dialog().getByRole('button', { name: /browse/i });
+  }
+
+  /** "Next" button in the source-step footer. */
+  nextButton(): Locator {
+    return this.dialog().getByRole('button', { name: /next/i });
+  }
+
+  /** "Confirm import" button in the classification-step footer. */
+  confirmButton(): Locator {
+    return this.dialog().getByRole('button', { name: /confirm import/i });
+  }
+
+  /**
+   * Gray info callout shown on step 1 when the imported payload carries a
+   * user-supplied note (rendered by `ImportedNoteCallout`).
+   */
+  noteCallout(): Locator {
+    return this.dialog()
+      .locator('.rt-CalloutRoot')
+      .filter({ hasText: /export note/i })
+      .first();
+  }
+
+  /**
+   * Red error callout shown on step 0 when JSON parsing fails (rendered by
+   * `ImportErrorCallout`). The "Invalid JSON format" text is stable enough
+   * to anchor on; finer-grained banners (Zod errors) appear in the same
+   * callout.
+   */
+  errorBanner(): Locator {
+    return this.dialog()
+      .locator('.rt-CalloutRoot')
+      .filter({ hasText: /invalid json format/i })
+      .first();
+  }
+
+  /**
+   * Collection of per-row selection checkboxes rendered on the
+   * classification step. Each row is `role="checkbox"`; callers can
+   * filter further by accessible name.
+   */
+  selectionList(): Locator {
+    return this.dialog().getByRole('checkbox');
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /** Switch the source segmented control to "File" mode. */
+  async selectFileMode(): Promise<void> {
+    await this.dialog()
+      .getByRole('radio', { name: /file/i })
+      .locator('..')
+      .click();
+  }
+
+  /** Switch the source segmented control to "Text" mode. */
+  async selectTextMode(): Promise<void> {
+    await this.dialog()
+      .getByRole('radio', { name: /text/i })
+      .locator('..')
+      .click();
+    await this.textArea().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Ensure Text mode is active and fill the textarea with `json`.
+   * Idempotent: if Text mode is already active, only the textarea is
+   * filled.
+   */
+  async pasteJson(json: string): Promise<void> {
+    if (!(await this.textArea().isVisible())) {
+      await this.selectTextMode();
+    }
+    await this.textArea().fill(json);
+  }
+
+  /** Click the "Next" button (advances source-step to classification). */
+  async clickNext(): Promise<void> {
+    await this.nextButton().click();
+  }
+
+  /** Click the "Confirm import" button on the classification step. */
+  async confirmImport(): Promise<void> {
+    await this.confirmButton().click();
+  }
+
+  /** Close the wizard via the "Cancel" button. */
+  async cancel(): Promise<void> {
+    await this.clickButton(/cancel/i);
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /** Assert the "Invalid JSON format" callout is visible. */
+  async expectInvalidJsonError(): Promise<void> {
+    await expect(this.errorBanner()).toBeVisible();
+  }
+
+  /**
+   * Assert the classification step exposes the expected counts for each
+   * bucket. Every field of `counts` is optional; omitted buckets are not
+   * asserted, which lets a single call cover partial scenarios such as
+   * `expectClassification({ new: 1 })`.
+   */
+  async expectClassification(counts: ImportClassificationCounts): Promise<void> {
+    const dialog = this.dialog();
+    if (counts.new !== undefined) {
+      await expect(
+        dialog.getByText(new RegExp(`new rules.*${counts.new}`, 'i')),
+      ).toBeVisible();
+    }
+    if (counts.conflicting !== undefined) {
+      await expect(
+        dialog.getByText(new RegExp(`conflicting rules.*${counts.conflicting}`, 'i')),
+      ).toBeVisible();
+    }
+    if (counts.identical !== undefined) {
+      await expect(
+        dialog.getByText(new RegExp(`identical rules.*${counts.identical}`, 'i')),
+      ).toBeVisible();
+    }
+  }
+}

--- a/e2e-shared/pages/README.md
+++ b/e2e-shared/pages/README.md
@@ -1,0 +1,112 @@
+# `e2e-shared/pages/`
+
+Page Objects shared between the two Playwright pipelines:
+
+- `tests/e2e/` (functional suite, runs on every PR),
+- `e2e-doc-scenarios/` (narrative captures, runs in its own workflow).
+
+Each Page Object wraps a single UI surface (a dialog, a section of the
+options page, a popup view) and exposes **atomic** building blocks:
+locators, atomic actions, atomic assertions. Composition (full user
+journeys) belongs to `e2e-shared/actions/`, which consumes Page Objects.
+
+## When to create a Page Object
+
+Create a new Page Object when:
+
+- the same UI surface is exercised by more than one spec or scenario, or
+- the surface is non-trivial enough that inline `page.getByRole(...)`
+  calls would clutter the spec.
+
+A typical Page Object is **one class per dialog or per page section**.
+Splitting per step (`SourceStep`, `ClassificationStep`, ...) is fine when
+the steps each carry significant state, but the default is one class per
+visible surface.
+
+## Naming convention
+
+- File: PascalCase, suffixed with the surface kind
+  (`ImportWizardPage.ts`, `DialogPage.ts`, `PopupPage.ts`).
+- Class: same as the file (`ImportWizardPage`).
+- Methods:
+  - **Locators**: nouns, returned as `Locator`
+    (`textArea()`, `nextButton()`, `errorBanner()`).
+  - **Atomic actions**: verbs, returning `Promise<void>`
+    (`selectTextMode()`, `pasteJson(json)`, `clickNext()`,
+    `confirmImport()`, `cancel()`).
+  - **Atomic assertions**: prefixed with `expect`, returning
+    `Promise<void>` (`expectVisible()`, `expectInvalidJsonError()`,
+    `expectClassification({ new, conflicting, identical })`).
+
+Keep method bodies short. If you reach for orchestration logic
+(seeding storage, opening a wizard from a page, asserting toasts after a
+form submission), it probably belongs in `e2e-shared/actions/`.
+
+## Dialog Page Objects
+
+Subclass `DialogPage` (declared in this folder). It exposes:
+
+- `dialog()`: root locator, defaulting to `page.getByRole('dialog')`,
+- `expectVisible()` / `expectHidden()`: parameterised waits,
+- `clickButton(name: RegExp | string)`: footer button shortcut.
+
+Override `dialog()` in your subclass when **more than one dialog can be
+visible at a time** (nested confirmation, error overlay, ...) so each
+Page Object scopes its locators to its own dialog:
+
+```ts
+export class ConfirmDialogPage extends DialogPage {
+  override dialog(): Locator {
+    // Pick the topmost dialog when nested.
+    return this.page.getByRole('dialog').last();
+  }
+}
+```
+
+## Template
+
+Copy/paste this skeleton for a new dialog Page Object:
+
+```ts
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export class MyWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+  primaryButton(): Locator {
+    return this.dialog().getByRole('button', { name: /save/i });
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+  async clickPrimary(): Promise<void> {
+    await this.primaryButton().click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+  async expectPrimaryEnabled(): Promise<void> {
+    await expect(this.primaryButton()).toBeEnabled();
+  }
+}
+```
+
+Don't forget to re-export the new class from `index.ts`.
+
+## Imports
+
+Use **explicit relative imports with the `.js` extension**, in line with
+the existing `e2e-shared/extension-loader.ts`, `e2e-shared/extension-id.ts`,
+etc.:
+
+```ts
+import { ImportWizardPage } from '../../e2e-shared/pages/ImportWizardPage.js';
+// or, via the barrel:
+import { ImportWizardPage } from '../../e2e-shared/pages/index.js';
+```
+
+No path alias is configured for `e2e-shared/`; relative imports keep the
+two Playwright pipelines symmetrical and let `tsc --noEmit` resolve the
+files without extra configuration.

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Barrel for Page Objects shared between `tests/e2e/` and
+ * `e2e-doc-scenarios/`. See `README.md` for the naming convention and the
+ * template used to create a new Page Object.
+ */
+export { DialogPage } from './DialogPage.js';
+export {
+  ImportWizardPage,
+  type ImportClassificationCounts,
+} from './ImportWizardPage.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,11 @@
     },
     "skipLibCheck": true
   },
-  "include": ["src/**/*", ".wxt/wxt.d.ts"]
+  "include": [
+    "src/**/*",
+    "e2e-shared/pages/**/*",
+    "e2e-shared/actions/**/*",
+    "e2e-shared/matchers/**/*",
+    ".wxt/wxt.d.ts"
+  ]
 }


### PR DESCRIPTION
Lot 1 of the Page Objects + Domain Actions migration (#304). Sets up
the directory structure shared between tests/e2e and e2e-doc-scenarios
and lands the pilot ImportWizardPage to validate the convention before
the spec migration begins in lot 3.

- e2e-shared/pages/DialogPage.ts: abstract base for any Radix dialog
  Page Object (dialog(), expectVisible/Hidden, clickButton).
- e2e-shared/pages/ImportWizardPage.ts: pilot covering textArea,
  fileDropZone, browseButton, nextButton, confirmButton, noteCallout,
  errorBanner, selectionList + atomic actions (selectFileMode,
  selectTextMode, pasteJson, clickNext, confirmImport, cancel) and
  atomic assertions (expectInvalidJsonError, expectClassification).
- e2e-shared/actions and e2e-shared/matchers: empty barrels so the
  structure is in place for lots 3 and beyond.
- pages/README.md: convention (naming, template, when to subclass,
  import style).
- tsconfig.json: include the new e2e-shared subfolders so tsc --noEmit
  type-checks them without surfacing pre-existing issues in the rest
  of e2e-shared.

No existing spec is modified; the migration starts at lot 3.