### PR TITLE
test(e2e): add extensionPage fixture and 5 base custom matchers (#305)

### DIFF
--- a/e2e-shared/matchers/index.ts
+++ b/e2e-shared/matchers/index.ts
@@ -2,9 +2,265 @@
  * Custom Playwright matchers shared between `tests/e2e/` and
  * `e2e-doc-scenarios/`.
  *
- * Intentionally empty in lot 1: only the structure is in place. Concrete
- * matchers (e.g. `toShowToast`, `toMatchClassification`) land in a later
- * lot if/when the migration surfaces repeated assertion patterns worth
- * extracting.
+ * The matchers are split into two surfaces:
+ *
+ * - **Context-scoped matchers** (`toHaveDomainRulesCount`,
+ *   `toHaveSessionsCount`, `toHaveStatistic`) read `chrome.storage.local`
+ *   through the extension service worker. They poll until the storage
+ *   converges (no `waitForTimeout`), which keeps async storage writes
+ *   from racing the assertion.
+ *
+ * - **Page-scoped matchers** (`toHaveDialogOpen`, `toHaveToast`) wrap
+ *   `expect(locator).toBeVisible()` so test authors can write
+ *   `await expect(page).toHaveToast('success')` instead of locating the
+ *   Radix `data-testid` themselves.
+ *
+ * Matchers are registered globally via `./register.ts`; importing this
+ * file directly does NOT activate them.
  */
-export {};
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+
+// Minimal Chrome typings used inside `evaluate` callbacks. The full
+// `@types/chrome` is not a dependency of the test bundle, so we only
+// model the surface this file needs (storage.local). Declaring the
+// global as `any` here keeps the call-sites readable without leaking
+// `as any` casts.
+declare const chrome: {
+  storage: {
+    local: {
+      get(
+        defaults: Record<string, unknown>,
+      ): Promise<Record<string, unknown>>;
+    };
+  };
+};
+
+const POLL_TIMEOUT_MS = 5000;
+const POLL_INTERVAL_MS = 100;
+
+type MatcherResult = {
+  pass: boolean;
+  message: () => string;
+  name?: string;
+  expected?: unknown;
+  actual?: unknown;
+};
+
+/** Statistic field name allowed by `toHaveStatistic`. */
+export type StatisticName = 'tabGroupsCreatedCount' | 'tabsDeduplicatedCount';
+
+/**
+ * Resolve the running service worker, retrying briefly when Chrome has
+ * idle-terminated it between tests.
+ */
+async function getServiceWorker(context: BrowserContext) {
+  const deadline = Date.now() + 5000;
+  let sw = context.serviceWorkers()[0];
+  while (!sw && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+    sw = context.serviceWorkers()[0];
+  }
+  if (!sw) throw new Error('Service worker not available (idle termination?)');
+  return sw;
+}
+
+async function readDomainRulesCount(context: BrowserContext): Promise<number> {
+  const sw = await getServiceWorker(context);
+  return sw.evaluate(async () => {
+    const result = await chrome.storage.local.get({ domainRules: [] });
+    return Array.isArray(result.domainRules) ? result.domainRules.length : 0;
+  });
+}
+
+async function readSessionsCount(context: BrowserContext): Promise<number> {
+  const sw = await getServiceWorker(context);
+  return sw.evaluate(async () => {
+    const result = await chrome.storage.local.get({ sessions: [] });
+    return Array.isArray(result.sessions) ? result.sessions.length : 0;
+  });
+}
+
+async function readStatistic(
+  context: BrowserContext,
+  name: StatisticName,
+): Promise<number> {
+  const sw = await getServiceWorker(context);
+  return sw.evaluate(async (field: StatisticName) => {
+    const result = await chrome.storage.local.get({
+      statistics: { tabGroupsCreatedCount: 0, tabsDeduplicatedCount: 0 },
+    });
+    const stats = (result.statistics ?? {}) as Record<string, number>;
+    return Number(stats[field] ?? 0);
+  }, name);
+}
+
+/**
+ * Poll `read` until it returns `expected` or `timeoutMs` elapses. Returns
+ * the last observed value, regardless of whether the predicate matched.
+ */
+async function pollUntilEquals<T>(
+  read: () => Promise<T>,
+  expected: T,
+  timeoutMs: number,
+): Promise<{ pass: boolean; lastValue: T }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastValue = await read();
+  if (lastValue === expected) return { pass: true, lastValue };
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    lastValue = await read();
+    if (lastValue === expected) return { pass: true, lastValue };
+  }
+  return { pass: false, lastValue };
+}
+
+export const customMatchers = {
+  /**
+   * Assert that the extension has exactly `expected` domain rules stored
+   * in `chrome.storage.local.domainRules`. Polls until the value
+   * converges, so it is safe to call right after an import or a UI
+   * action that mutates storage asynchronously.
+   */
+  async toHaveDomainRulesCount(
+    context: BrowserContext,
+    expected: number,
+  ): Promise<MatcherResult> {
+    const { pass, lastValue } = await pollUntilEquals(
+      () => readDomainRulesCount(context),
+      expected,
+      POLL_TIMEOUT_MS,
+    );
+    return {
+      pass,
+      name: 'toHaveDomainRulesCount',
+      expected,
+      actual: lastValue,
+      message: () =>
+        pass
+          ? `Expected domainRules count NOT to be ${expected}, but it was.`
+          : `Expected domainRules count to be ${expected}, but got ${lastValue}.`,
+    };
+  },
+
+  /**
+   * Assert that `chrome.storage.local.sessions` contains exactly
+   * `expected` entries. Polling matches the async write performed by the
+   * sessions wizard / snapshot flow.
+   */
+  async toHaveSessionsCount(
+    context: BrowserContext,
+    expected: number,
+  ): Promise<MatcherResult> {
+    const { pass, lastValue } = await pollUntilEquals(
+      () => readSessionsCount(context),
+      expected,
+      POLL_TIMEOUT_MS,
+    );
+    return {
+      pass,
+      name: 'toHaveSessionsCount',
+      expected,
+      actual: lastValue,
+      message: () =>
+        pass
+          ? `Expected sessions count NOT to be ${expected}, but it was.`
+          : `Expected sessions count to be ${expected}, but got ${lastValue}.`,
+    };
+  },
+
+  /**
+   * Assert that a single statistic field
+   * (`tabGroupsCreatedCount` or `tabsDeduplicatedCount`) matches
+   * `expected`. Both fields default to 0 when missing.
+   */
+  async toHaveStatistic(
+    context: BrowserContext,
+    name: StatisticName,
+    expected: number,
+  ): Promise<MatcherResult> {
+    const { pass, lastValue } = await pollUntilEquals(
+      () => readStatistic(context, name),
+      expected,
+      POLL_TIMEOUT_MS,
+    );
+    return {
+      pass,
+      name: 'toHaveStatistic',
+      expected,
+      actual: lastValue,
+      message: () =>
+        pass
+          ? `Expected statistic "${name}" NOT to be ${expected}, but it was.`
+          : `Expected statistic "${name}" to be ${expected}, but got ${lastValue}.`,
+    };
+  },
+
+  /**
+   * Assert that a Radix dialog (`role="dialog"`) is visible on the page,
+   * optionally filtered by accessible name (case-insensitive substring
+   * match).
+   */
+  async toHaveDialogOpen(
+    page: Page,
+    name?: string | RegExp,
+  ): Promise<MatcherResult> {
+    const dialogs = name
+      ? page.getByRole('dialog', { name })
+      : page.getByRole('dialog');
+    try {
+      await expect(dialogs.first()).toBeVisible({ timeout: POLL_TIMEOUT_MS });
+      return {
+        pass: true,
+        name: 'toHaveDialogOpen',
+        expected: name ?? 'any dialog',
+        message: () =>
+          name
+            ? `Expected NO dialog matching ${String(name)} to be visible, but one was.`
+            : `Expected NO dialog to be visible, but one was.`,
+      };
+    } catch {
+      return {
+        pass: false,
+        name: 'toHaveDialogOpen',
+        expected: name ?? 'any dialog',
+        actual: 'no matching dialog visible',
+        message: () =>
+          name
+            ? `Expected a dialog matching ${String(name)} to be visible, but none was.`
+            : `Expected a dialog to be visible, but none was.`,
+      };
+    }
+  },
+
+  /**
+   * Assert that a Radix Toast of the requested variant is visible. The
+   * Toaster (`src/components/UI/Toaster/Toaster.tsx`) renders
+   * `data-testid="toast-${variant}"` so the matcher targets the same
+   * locator used in existing specs (`options-toasts.spec.ts`).
+   */
+  async toHaveToast(
+    page: Page,
+    variant: 'success' | 'error' | 'info',
+  ): Promise<MatcherResult> {
+    const toast = page.getByTestId(`toast-${variant}`).first();
+    try {
+      await expect(toast).toBeVisible({ timeout: POLL_TIMEOUT_MS });
+      return {
+        pass: true,
+        name: 'toHaveToast',
+        expected: variant,
+        message: () =>
+          `Expected NO "${variant}" toast to be visible, but one was.`,
+      };
+    } catch {
+      return {
+        pass: false,
+        name: 'toHaveToast',
+        expected: variant,
+        actual: 'not visible',
+        message: () =>
+          `Expected a "${variant}" toast to be visible, but none was.`,
+      };
+    }
+  },
+};

--- a/e2e-shared/matchers/register.ts
+++ b/e2e-shared/matchers/register.ts
@@ -1,0 +1,59 @@
+/**
+ * Registers the custom matchers from `./index.ts` on Playwright's global
+ * `expect`. Importing this module once (typically from a Playwright
+ * fixtures file) activates the matchers for every test that uses the
+ * same `expect`.
+ *
+ * Splitting registration from definition lets `./index.ts` stay
+ * side-effect-free, which is useful for unit-style imports (e.g.
+ * documentation, ad-hoc scripts) that need the matcher functions
+ * without polluting the global `expect`.
+ *
+ * Augments the global `PlaywrightTest.Matchers` interface so callers
+ * get type-safe access to the new matchers:
+ *
+ * ```ts
+ * await expect(extensionContext).toHaveDomainRulesCount(1);
+ * await expect(page).toHaveToast('success');
+ * ```
+ */
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+import { customMatchers, type StatisticName } from './index.js';
+
+expect.extend(customMatchers);
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace PlaywrightTest {
+    interface Matchers<R, T> {
+      /** Storage-backed assertion: `chrome.storage.local.domainRules.length`. */
+      toHaveDomainRulesCount(
+        this: T extends BrowserContext ? Matchers<R, T> : never,
+        expected: number,
+      ): R;
+      /** Storage-backed assertion: `chrome.storage.local.sessions.length`. */
+      toHaveSessionsCount(
+        this: T extends BrowserContext ? Matchers<R, T> : never,
+        expected: number,
+      ): R;
+      /** Storage-backed assertion: single `statistics` field equality. */
+      toHaveStatistic(
+        this: T extends BrowserContext ? Matchers<R, T> : never,
+        name: StatisticName,
+        expected: number,
+      ): R;
+      /** UI assertion: a Radix `role="dialog"` is visible. */
+      toHaveDialogOpen(
+        this: T extends Page ? Matchers<R, T> : never,
+        name?: string | RegExp,
+      ): R;
+      /** UI assertion: a Radix Toast of the given variant is visible. */
+      toHaveToast(
+        this: T extends Page ? Matchers<R, T> : never,
+        variant: 'success' | 'error' | 'info',
+      ): R;
+    }
+  }
+}
+
+export {};

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,125 @@
+# `tests/e2e/` — Playwright functional suite
+
+Functional E2E suite that loads the built Chrome MV3 extension into a
+persistent Chromium context, drives the popup / options pages, and
+asserts behavior end-to-end.
+
+Sister pipeline `e2e-doc-scenarios/` reuses the same Page Objects and
+matchers (see `e2e-shared/`).
+
+## Running
+
+```bash
+pnpm test:e2e            # build + run
+pnpm test:e2e:ui         # UI mode (debug)
+pnpm test:e2e:headed     # headed (default; extensions cannot run headless)
+```
+
+## Fixtures
+
+Defined in `fixtures.ts`. Import via:
+
+```ts
+import { test, expect } from './fixtures';
+```
+
+| Fixture            | Scope    | Purpose                                                                 |
+|--------------------|----------|-------------------------------------------------------------------------|
+| `extensionContext` | worker   | Persistent `BrowserContext` with the extension loaded.                  |
+| `extensionId`      | worker   | Chrome-assigned ID of the loaded extension.                             |
+| `extensionPage`    | **test** | Fresh `Page` per test, auto-closed (with "last page" guard, see below). |
+| `popupPage`        | test     | Pre-navigated to `popup.html`.                                          |
+| `optionsPage`      | test     | Pre-navigated to `options.html`.                                        |
+| `helpers`          | test     | Domain helpers (rules, tabs, statistics, grouping waits, ...).          |
+
+### When to use `extensionPage`
+
+Default to `extensionPage` for any single-page spec. It removes the
+boilerplate `const page = await extensionContext.newPage()` /
+`await page.close()` pair that pollutes most existing tests and is the
+root cause of the `last-page-browser-exit` flake pattern documented in
+`.claude/agents/e2e-flaky-detector.md`.
+
+```ts
+test('rule import shows an in-page toast', async ({
+  extensionId,
+  extensionPage,
+}) => {
+  await goToImportExportSection(extensionPage, extensionId);
+  // ...
+  await expect(extensionPage).toHaveToast('success');
+});
+```
+
+Keep using `extensionContext.newPage()` directly when a test needs more
+than one page at the same time (sessions, deduplication, multi-window
+flows). No forced migration: existing specs continue to work.
+
+### "Last page" guard
+
+The teardown of `extensionPage` refuses to close the page when it is
+the only one left in the context. Closing the last page closes the
+persistent context, which terminates the worker and breaks every
+subsequent test in the same worker. The guard, paired with a silent
+`isClosed()` check, makes the fixture safe even when the test itself
+closes the page.
+
+## Custom matchers
+
+Registered globally via `e2e-shared/matchers/register.ts` (side-effect
+import from `fixtures.ts`). All five matchers poll the target until it
+matches (`expect.poll`-style) so they tolerate the async writes
+performed by `chrome.storage.local` and the React commit phase. No
+`waitForTimeout` is used.
+
+### Storage-backed assertions (`BrowserContext`)
+
+```ts
+// After an import, assert that one rule made it to storage.
+await expect(extensionContext).toHaveDomainRulesCount(1);
+
+// After a snapshot, assert the sessions array gained one entry.
+await expect(extensionContext).toHaveSessionsCount(1);
+
+// Statistics fields are addressed by name.
+await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 1);
+await expect(extensionContext).toHaveStatistic('tabsDeduplicatedCount', 2);
+```
+
+### UI assertions (`Page`)
+
+```ts
+// Assert any Radix dialog is visible.
+await expect(extensionPage).toHaveDialogOpen();
+
+// Optionally filter by accessible name (string or RegExp).
+await expect(extensionPage).toHaveDialogOpen(/import rules/i);
+
+// Assert a Radix Toast of the requested variant is visible.
+await expect(extensionPage).toHaveToast('success');
+await expect(extensionPage).toHaveToast('error');
+await expect(extensionPage).toHaveToast('info');
+```
+
+The toast matcher targets the `data-testid="toast-${variant}"` rendered
+by `src/components/UI/Toaster/Toaster.tsx`.
+
+## Page Objects & actions
+
+Shared between this suite and `e2e-doc-scenarios/`:
+
+- `e2e-shared/pages/` — atomic Page Objects (locators + atomic actions +
+  atomic assertions). See `e2e-shared/pages/README.md`.
+- `e2e-shared/actions/` — composed flows (`importRulesViaText`, ...).
+  Built on top of Page Objects.
+
+## Conventions
+
+- Never `waitForTimeout(...)` to "give it time". Prefer
+  `expect(locator).toBeVisible({ timeout })`, the custom matchers
+  above, or one of the polling helpers exposed by the `helpers`
+  fixture (`waitForGrouping`, `waitForDeduplication`,
+  `waitForTabTitle`, `waitForTabGrouped`).
+- Never `console.log()` from specs; use the existing logger conventions
+  if debugging output is genuinely needed.
+- Group tests with `test.describe` only when a `beforeEach` is shared.

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -5,9 +5,15 @@ import {
 } from '../../e2e-shared/extension-loader.js';
 import { getExtensionId } from '../../e2e-shared/extension-id.js';
 
+// Side-effect import: registers custom matchers on Playwright's `expect`.
+// Must be imported once from a fixture file so every spec inherits the
+// extended matchers (`toHaveDomainRulesCount`, `toHaveToast`, ...).
+import '../../e2e-shared/matchers/register.js';
+
 export interface ExtensionFixtures {
   extensionContext: BrowserContext;
   extensionId: string;
+  extensionPage: Page;
   popupPage: Page;
   optionsPage: Page;
 }
@@ -110,6 +116,40 @@ export const test = base.extend<ExtensionFixtures & { helpers: ExtensionHelpers 
   extensionId: [async ({ extensionContext }, use) => {
     await use(getExtensionId(extensionContext));
   }, { scope: 'worker' }],
+
+  /**
+   * Page-scoped fixture providing a fresh `Page` per test, sparing the
+   * caller from the `extensionContext.newPage()` + `page.close()`
+   * plumbing that pollutes most specs (and is the root cause of the
+   * `last-page-browser-exit` pattern documented in
+   * `.claude/agents/e2e-flaky-detector.md`).
+   *
+   * After the test:
+   *   1. silently ignore an already-closed page (`isClosed()`),
+   *   2. refuse to close the page if it is the last one in the
+   *      context (closing it would terminate the persistent context
+   *      and kill the worker for the next test).
+   *
+   * Multi-page specs (sessions, deduplication, ...) keep using
+   * `extensionContext.newPage()` directly; this fixture is a
+   * convenience for the single-page majority.
+   */
+  extensionPage: async ({ extensionContext }, use) => {
+    const page = await extensionContext.newPage();
+    await use(page);
+    if (page.isClosed()) return;
+    // "Last page" guard: closing the only remaining page closes the
+    // persistent context, which Chromium-launched extensions cannot
+    // survive between tests. Keep it open instead.
+    if (extensionContext.pages().length <= 1) return;
+    try {
+      await page.close();
+    } catch {
+      // Page was closed between the isClosed() check and the close()
+      // call (race when the test triggers an extension flow that
+      // tears the page down).
+    }
+  },
 
   // Popup page fixture
   popupPage: async ({ extensionContext, extensionId }, use) => {

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -70,8 +70,14 @@ function makeRuleJson(label: string, domainFilter: string): string {
   });
 }
 
-async function submitTextImport(page: any, json: string): Promise<void> {
-  await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
+async function submitTextImport(
+  page: any,
+  json: string,
+  options: { skipOpen?: boolean } = {},
+): Promise<void> {
+  if (!options.skipOpen) {
+    await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
+  }
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 5000 });
   await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
@@ -90,38 +96,39 @@ test.describe('Options page toasts', () => {
   test('rule import shows an in-page toast and no native notification', async ({
     extensionContext,
     extensionId,
+    extensionPage,
   }) => {
-    const page = await extensionContext.newPage();
-    await goToImportExportSection(page, extensionId);
+    await goToImportExportSection(extensionPage, extensionId);
 
     const notifBefore = await getSmartTabNotificationIds(extensionContext);
 
-    await submitTextImport(page, makeRuleJson('Toast Rule', 'toast-visible.com'));
+    await extensionPage.getByTestId('page-import-export-card-import-rules')
+      .getByRole('button', { name: /^import$/i })
+      .click();
+    await expect(extensionPage).toHaveDialogOpen();
 
-    const toast = page.getByTestId('toast-success');
-    await expect(toast).toBeVisible({ timeout: 3000 });
+    await submitTextImport(extensionPage, makeRuleJson('Toast Rule', 'toast-visible.com'), {
+      skipOpen: true,
+    });
+
+    await expect(extensionPage).toHaveToast('success');
+    await expect(extensionContext).toHaveDomainRulesCount(1);
 
     const notifAfter = await getSmartTabNotificationIds(extensionContext);
     expect(notifAfter).toEqual(notifBefore);
-
-    await page.close();
   });
 
   test('closing a toast removes it from the viewport', async ({
-    extensionContext,
     extensionId,
+    extensionPage,
   }) => {
-    const page = await extensionContext.newPage();
-    await goToImportExportSection(page, extensionId);
+    await goToImportExportSection(extensionPage, extensionId);
 
-    await submitTextImport(page, makeRuleJson('Toast Close Rule', 'toast-close.com'));
+    await submitTextImport(extensionPage, makeRuleJson('Toast Close Rule', 'toast-close.com'));
 
-    const toast = page.getByTestId('toast-success');
-    await expect(toast).toBeVisible({ timeout: 3000 });
+    await expect(extensionPage).toHaveToast('success');
 
-    await page.getByTestId('toast-btn-close').first().click();
-    await expect(toast).toBeHidden({ timeout: 2000 });
-
-    await page.close();
+    await extensionPage.getByTestId('toast-btn-close').first().click();
+    await expect(extensionPage.getByTestId('toast-success')).toBeHidden({ timeout: 2000 });
   });
 });


### PR DESCRIPTION
Lot 2 of the E2E migration to Page Objects + Domain Actions.

Fixture extensionPage
- Page-scoped (per test), spares specs from extensionContext.newPage()
  + page.close() plumbing.
- Auto-closes after the test, with two guards: silent skip when the
  page is already closed, and refuse to close when it is the last
  page in the context (prevents the last-page-browser-exit flake
  pattern from .claude/agents/e2e-flaky-detector.md).

Custom matchers (e2e-shared/matchers/)
- toHaveDomainRulesCount(n) on BrowserContext: polls
  chrome.storage.local.domainRules until length matches.
- toHaveSessionsCount(n) on BrowserContext: same for sessions.
- toHaveStatistic(name, value) on BrowserContext: single statistic
  field equality.
- toHaveDialogOpen(name?) on Page: Radix role="dialog" visible,
  optionally filtered by accessible name.
- toHaveToast(variant) on Page: Radix Toast visible, targets the
  data-testid="toast-${variant}" rendered by the Toaster.

All matchers use polling (no waitForTimeout), tolerate the async
chrome.storage.local writes and the React commit phase.

Registration is split into register.ts which side-effect-imports the
matchers and augments PlaywrightTest.Matchers for type safety. The
fixture file imports register.ts once so every spec inherits the
extended expect.

Migration proof
- options-toasts.spec.ts converted to extensionPage and exercises
  three of the five matchers (toHaveDialogOpen, toHaveToast,
  toHaveDomainRulesCount).

Other specs (sessions, deduplication, ...) keep using
extensionContext.newPage() directly. No forced migration in this lot.

tests/e2e/README.md created and documents fixture usage, the
"last page" guard and the five matchers with examples.