### PR TITLE
test(e2e): migrate import-export.spec.ts to Page Objects + Domain Actions (#306)

### DIFF
--- a/e2e-shared/actions/index.ts
+++ b/e2e-shared/actions/index.ts
@@ -2,8 +2,17 @@
  * Composed flows (domain actions) shared between `tests/e2e/` and
  * `e2e-doc-scenarios/`. Consumes Page Objects from `../pages/`.
  *
- * Intentionally empty in lot 1: only the structure is in place. Concrete
- * helpers (e.g. `importRulesViaText`) land at lot 3 once the migration of
- * `import-export.spec.ts` starts.
+ * Each action narrates a single business outcome ("import rules from
+ * JSON text", "export rules to a file") and hides the wizard step
+ * plumbing so specs read as business intent rather than a sequence of
+ * clicks.
  */
-export {};
+export {
+  openRulesImportWizard,
+  openRulesExportWizard,
+  importRulesViaText,
+  importRulesViaFile,
+  exportRulesToFile,
+  exportRulesToClipboard,
+  type ExportRulesOptions,
+} from './rules-import-export.js';

--- a/e2e-shared/actions/rules-import-export.ts
+++ b/e2e-shared/actions/rules-import-export.ts
@@ -1,0 +1,171 @@
+/**
+ * Composed domain actions for the rules Import/Export wizards.
+ *
+ * Each action narrates a single business outcome ("import these rules from
+ * JSON text", "export the current rules to a file") and hides the wizard
+ * step plumbing. Composes the Page Objects from `../pages/`; never
+ * reaches into raw locators.
+ *
+ * Shared between `tests/e2e/` (functional suite, US-IE001..US-IE009) and
+ * `e2e-doc-scenarios/` (narrative captures that walk through the same
+ * flows for screenshots / docs).
+ */
+import { expect, type Page } from '@playwright/test';
+import { ImportWizardPage } from '../pages/ImportWizardPage.js';
+import { ExportWizardPage } from '../pages/ExportWizardPage.js';
+
+/**
+ * Open the rules import wizard from the Import/Export cards page.
+ * Returns the `ImportWizardPage` instance so callers can interact with
+ * the open dialog without re-instantiating it.
+ *
+ * Relevant US: US-IE001 (wizard entry point).
+ */
+export async function openRulesImportWizard(page: Page): Promise<ImportWizardPage> {
+  await page
+    .getByTestId('page-import-export-card-import-rules')
+    .getByRole('button', { name: /^import$/i })
+    .click();
+  const wizard = new ImportWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * Open the rules export wizard from the Import/Export cards page.
+ *
+ * Relevant US: US-IE008 (export entry point).
+ */
+export async function openRulesExportWizard(page: Page): Promise<ExportWizardPage> {
+  await page
+    .getByTestId('page-import-export-card-export-rules')
+    .getByRole('button', { name: /^export$/i })
+    .click();
+  const wizard = new ExportWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * End-to-end "import these rules from raw JSON text" flow.
+ *
+ * Steps: open wizard, switch to Text mode, paste JSON, advance to the
+ * classification step, confirm, wait for the dialog to close.
+ *
+ * Relevant US: US-IE001 (source selection), US-IE002 (JSON validation),
+ * US-IE007 (confirmation + close).
+ */
+export async function importRulesViaText(page: Page, json: string): Promise<void> {
+  const wizard = await openRulesImportWizard(page);
+  await wizard.pasteJson(json);
+  await wizard.clickNext();
+  await wizard.confirmImport();
+  await wizard.expectHidden();
+}
+
+/**
+ * End-to-end "import these rules from a JSON file" flow (drag-and-drop
+ * substitute: drives the hidden `<input type="file">` via Playwright's
+ * `setInputFiles`, which exercises the same handler as Browse / drop).
+ *
+ * `file` accepts a filesystem path, a `Buffer` payload (`{ name, mimeType,
+ * buffer }`) or any value Playwright's `Locator.setInputFiles` understands.
+ *
+ * Relevant US: US-IE001 (source selection / File mode), US-IE007.
+ */
+export async function importRulesViaFile(
+  page: Page,
+  file: Parameters<ReturnType<Page['locator']>['setInputFiles']>[0],
+): Promise<void> {
+  const wizard = await openRulesImportWizard(page);
+  await wizard.selectFileMode();
+  await wizard.dialog().locator('input[type="file"]').setInputFiles(file);
+  await wizard.clickNext();
+  await wizard.confirmImport();
+  await wizard.expectHidden();
+}
+
+export interface ExportRulesOptions {
+  /** Optional free-form note persisted at the top of the JSON payload. */
+  note?: string;
+}
+
+/**
+ * Stub `window.showSaveFilePicker` so the Chrome native Save As dialog
+ * does not block the export flow under Playwright. The stub returns an
+ * in-memory writer whose contents are exposed via the returned `getJson`
+ * function (useful for asserting the payload shape).
+ *
+ * Idempotent: re-installs the stub on every call so tests do not need to
+ * track installation state.
+ */
+async function stubShowSaveFilePicker(page: Page): Promise<() => Promise<string>> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __exportedJson?: string;
+      showSaveFilePicker: (opts: unknown) => Promise<{
+        createWritable: () => Promise<{
+          write: (data: string) => Promise<void>;
+          close: () => Promise<void>;
+        }>;
+      }>;
+    };
+    w.__exportedJson = '';
+    w.showSaveFilePicker = async () => ({
+      createWritable: async () => ({
+        write: async (data: string) => {
+          w.__exportedJson = data;
+        },
+        close: async () => undefined,
+      }),
+    });
+  });
+  return async () => {
+    return (await page.evaluate(
+      () => (window as unknown as { __exportedJson?: string }).__exportedJson ?? '',
+    )) as string;
+  };
+}
+
+/**
+ * End-to-end "export the selected rules to a JSON file" flow.
+ *
+ * Steps: open wizard, optionally fill the note, stub the OS save picker,
+ * click the primary Export button, wait for the dialog to close. The
+ * caller can use the returned `getJson()` to inspect the written payload.
+ *
+ * Relevant US: US-IE009 (export to file + dialog closes on success).
+ */
+export async function exportRulesToFile(
+  page: Page,
+  opts: ExportRulesOptions = {},
+): Promise<{ getJson: () => Promise<string> }> {
+  const wizard = await openRulesExportWizard(page);
+  if (opts.note !== undefined) await wizard.fillNote(opts.note);
+  const getJson = await stubShowSaveFilePicker(page);
+  await wizard.clickExportToFile();
+  await wizard.expectHidden();
+  return { getJson };
+}
+
+/**
+ * End-to-end "export the selected rules to the clipboard" flow.
+ *
+ * Steps: open wizard, optionally fill the note, open the split-button
+ * popover, click the "Clipboard" entry, wait for the dialog to close.
+ *
+ * The clipboard write itself is performed by `navigator.clipboard.writeText`,
+ * which Playwright stubs transparently when the test is granted the
+ * `clipboard-write` permission (configured in `playwright.config.ts`).
+ *
+ * Relevant US: US-IE009 (export to clipboard + dialog closes on success).
+ */
+export async function exportRulesToClipboard(
+  page: Page,
+  opts: ExportRulesOptions = {},
+): Promise<void> {
+  const wizard = await openRulesExportWizard(page);
+  if (opts.note !== undefined) await wizard.fillNote(opts.note);
+  await wizard.clickExportToClipboard();
+  await expect(wizard.dialog()).toBeHidden();
+}

--- a/e2e-shared/pages/ExportWizardPage.ts
+++ b/e2e-shared/pages/ExportWizardPage.ts
@@ -1,0 +1,168 @@
+/**
+ * Page Object for the rules / sessions Export wizard.
+ *
+ * Pendant of `ImportWizardPage`. Wraps the Radix dialog opened from the
+ * Import/Export options page (rules) and from the Sessions page
+ * (sessions). The wizard is single-step:
+ *
+ * - an optional note `TextArea`,
+ * - a "Select all / Deselect all" toolbar,
+ * - a list of selectable rows (flat for rules, grouped Pinned/Sessions
+ *   for sessions, cf. US-IE013),
+ * - a "{n} rule(s) selected" / "{n} session(s) selected" count label,
+ * - a footer split-button (`Export` + chevron menu with "JSON File" /
+ *   "Clipboard").
+ *
+ * As with the import wizard, this class exposes **atomic** building
+ * blocks. Composed flows (`exportRulesToFile`, ...) live in
+ * `e2e-shared/actions/rules-import-export.ts`.
+ *
+ * Selectors target the English UI (`--lang=en-US`). Sub-class and
+ * override the locator getters to retarget another locale.
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export class ExportWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Every selectable row checkbox (rules or sessions). */
+  selectionList(): Locator {
+    return this.dialog().getByRole('checkbox');
+  }
+
+  /** Free-form export note textarea. */
+  noteField(): Locator {
+    return this.dialog().locator('textarea').first();
+  }
+
+  /** Primary "Export" button (opens the OS file save picker on Chrome). */
+  exportFileButton(): Locator {
+    return this.dialog().getByRole('button', { name: /^export$/i });
+  }
+
+  /**
+   * Chevron / "Export options" button that opens the split-button popover
+   * (file vs clipboard).
+   */
+  exportOptionsButton(): Locator {
+    return this.dialog().getByRole('button', { name: /export.*option|chevron/i });
+  }
+
+  /**
+   * Clipboard menu item inside the split-button popover. Lives outside
+   * the dialog (Radix Popover.Content is portalled), so we anchor on the
+   * page, not on `dialog()`.
+   */
+  exportClipboardButton(): Locator {
+    return this.page.getByRole('menuitem', { name: /clipboard/i });
+  }
+
+  /** "Select all" toolbar button (exact match to avoid the "Deselect all" sibling). */
+  selectAllButton(): Locator {
+    return this.dialog().getByRole('button', { name: 'Select All', exact: true });
+  }
+
+  /** "Deselect all" toolbar button. */
+  deselectAllButton(): Locator {
+    return this.dialog().getByRole('button', { name: /deselect all/i });
+  }
+
+  /**
+   * "Pinned Sessions" sub-group header checkbox (US-IE013). Locates the
+   * group-level checkbox by its accessible label so it does not collide
+   * with the per-session row checkboxes.
+   */
+  pinnedSessionsGroup(): Locator {
+    return this.dialog().getByRole('checkbox', { name: /pinned sessions/i });
+  }
+
+  /** "Sessions" sub-group header checkbox (US-IE013). */
+  sessionsGroup(): Locator {
+    return this.dialog().getByRole('checkbox', { name: /^sessions$/i });
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /** Type a note into the optional note field. */
+  async fillNote(text: string): Promise<void> {
+    await this.noteField().fill(text);
+  }
+
+  /** Click the "Select All" toolbar button. */
+  async selectAll(): Promise<void> {
+    await this.selectAllButton().click();
+  }
+
+  /** Click the "Deselect All" toolbar button. */
+  async deselectAll(): Promise<void> {
+    await this.deselectAllButton().click();
+  }
+
+  /**
+   * Toggle a single row by its accessible label (rule label or session
+   * name). Uses the dialog-scoped checkbox lookup so headers and toolbar
+   * buttons cannot interfere.
+   */
+  async toggleRule(label: string): Promise<void> {
+    await this.dialog().getByRole('checkbox', { name: label }).click();
+  }
+
+  /** Click the primary "Export" button (file save path). */
+  async clickExportToFile(): Promise<void> {
+    await this.exportFileButton().click();
+  }
+
+  /** Open the split-button popover and click the "Clipboard" entry. */
+  async clickExportToClipboard(): Promise<void> {
+    await this.exportOptionsButton().click();
+    await this.exportClipboardButton().click();
+  }
+
+  /** Close the wizard via the "Cancel" button. */
+  async cancel(): Promise<void> {
+    await this.clickButton(/cancel/i);
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /**
+   * Assert the wizard opened with every item pre-selected, by checking
+   * the count label matches `total`. Pass the known number of items so
+   * the assertion stays explicit (the page object never queries storage).
+   */
+  async expectAllRulesSelected(total: number): Promise<void> {
+    await expect(
+      this.dialog().getByText(new RegExp(`${total} rule.*selected`, 'i')),
+    ).toBeVisible();
+  }
+
+  /** Assert a previously typed note is reflected in the note field value. */
+  async expectNoteVisible(text: string): Promise<void> {
+    await expect(this.noteField()).toHaveValue(text);
+  }
+
+  /** Assert the primary Export button is enabled (selection non-empty). */
+  async expectExportButtonEnabled(): Promise<void> {
+    await expect(this.exportFileButton()).toBeEnabled();
+  }
+
+  /** Assert the primary Export button is disabled (no selection). */
+  async expectExportButtonDisabled(): Promise<void> {
+    await expect(this.exportFileButton()).toBeDisabled();
+  }
+
+  /**
+   * Assert the "{count} rule(s) selected" label reflects `count`.
+   * Useful after `selectAll()` / `deselectAll()` / `toggleRule(...)`.
+   */
+  async expectSelectedCount(count: number): Promise<void> {
+    await expect(
+      this.dialog().getByText(new RegExp(`${count} rule.*selected`, 'i')),
+    ).toBeVisible();
+  }
+}

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -8,3 +8,4 @@ export {
   ImportWizardPage,
   type ImportClassificationCounts,
 } from './ImportWizardPage.js';
+export { ExportWizardPage } from './ExportWizardPage.js';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -146,5 +146,17 @@ export default tseslint.config(
   {
     files: ['tests/e2e/**/*.spec.ts', 'tests/e2e/helpers/**/*.ts'],
     ...playwright.configs['flat/recommended'],
+    rules: {
+      ...playwright.configs['flat/recommended'].rules,
+      // Page Objects in e2e-shared/pages expose `expect*` wrapper methods
+      // (e.g. `wizard.expectInvalidJsonError()`) that internally call
+      // Playwright's `expect`. Teach the rule about that convention so
+      // tests written in Page Object style are not flagged as
+      // assertion-less.
+      'playwright/expect-expect': ['warn', {
+        assertFunctionNames: ['expect'],
+        assertFunctionPatterns: ['^expect[A-Z]'],
+      }],
+    },
   },
 );

--- a/tests/e2e/helpers/navigation.ts
+++ b/tests/e2e/helpers/navigation.ts
@@ -62,6 +62,29 @@ export async function goToDomainRulesSection(page: Page, extensionId: string): P
   await page.getByTestId('page-rules-btn-add').waitFor({ state: 'visible', timeout: 10_000 });
 }
 
+/**
+ * Navigate to the Import / Export section of the options page and wait
+ * until both action cards are visible (rules + sessions). Uses the
+ * sidebar nav item rather than the hash so the same code path covers
+ * tests that exercise hash routing separately.
+ */
+export async function goToImportExportSection(page: Page, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => {
+      const body = document.body.textContent ?? '';
+      return !body.includes('Chargement') && body.length > 50;
+    },
+    null,
+    { timeout: 10_000 },
+  );
+  // Use the test id so the click is unambiguous (the accessible name now
+  // matches both the sidebar nav item and the home quick-action card).
+  await page.getByTestId('sidebar-nav-item-importexport').click();
+  await page.getByTestId('page-import-export-card-import-rules').waitFor({ state: 'visible' });
+}
+
 /** Navigate to the extension popup page. */
 export async function goToPopup(page: Page, extensionId: string): Promise<void> {
   await page.goto(`chrome-extension://${extensionId}/popup.html`);

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -11,171 +11,126 @@
  * - US-IE007: Import confirmation summary and success notification
  * - US-IE008: Export rule selection (select all / deselect all / individual)
  * - US-IE009: Export to file or clipboard, dialog closes on success
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 3).
+ * Page Objects live in `e2e-shared/pages/`, composed flows in
+ * `e2e-shared/actions/`.
  */
-
+import type { BrowserContext, Page } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { auditPage } from './helpers/a11y';
+import { goToImportExportSection } from './helpers/navigation';
+import { ImportWizardPage } from '../../e2e-shared/pages/index.js';
+import { openRulesImportWizard, openRulesExportWizard } from '../../e2e-shared/actions/index.js';
 
-// ─── helpers ────────────────────────────────────────────────────────────────
+// ─── Local fixtures ─────────────────────────────────────────────────────────
 
-/** Navigate to the Import/Export section of the options page and wait for it to load. */
-async function goToImportExportSection(page: any, extensionId: string): Promise<void> {
-  await page.goto(`chrome-extension://${extensionId}/options.html`);
-  await page.waitForLoadState('domcontentloaded');
-  await page.waitForFunction(
-    () => {
-      const body = document.body.textContent ?? '';
-      return !body.includes('Chargement') && body.length > 50;
-    },
-    null,
-    { timeout: 10_000 },
-  );
-
-  // Click the "Import / Export" sidebar item (use the test id since the
-  // accessible name now matches both the sidebar nav item and the home
-  // quick-action card with the same label).
-  await page.getByTestId('sidebar-nav-item-importexport').click();
-  await page.getByTestId('page-import-export-card-import-rules').waitFor({ state: 'visible' });
+interface SeedRule {
+  id: string;
+  label: string;
+  domainFilter: string;
+  enabled: boolean;
+  deduplicationEnabled: boolean;
+  deduplicationMatchMode: 'exact';
+  groupNameSource: 'title' | 'label';
+  presetId: string | null;
+  color: string;
+  titleParsingRegEx: string;
+  urlParsingRegEx: string;
+  badge: string;
+  groupingEnabled?: boolean;
 }
 
-/** A minimal valid rule JSON for import testing. */
-function makeRuleJson(label: string, domainFilter: string): string {
-  return JSON.stringify({
-    domainRules: [
-      {
-        id: `test-rule-${Date.now()}`,
-        label,
-        domainFilter,
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      },
-    ],
-  });
+/** Build a minimal rule object usable both as a seed and as an import payload row. */
+function makeRule(label: string, domainFilter: string, overrides: Partial<SeedRule> = {}): SeedRule {
+  return {
+    id: `test-rule-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    label,
+    domainFilter,
+    enabled: true,
+    deduplicationEnabled: false,
+    deduplicationMatchMode: 'exact',
+    groupNameSource: 'title',
+    presetId: null,
+    color: 'blue',
+    titleParsingRegEx: '',
+    urlParsingRegEx: '',
+    badge: '',
+    ...overrides,
+  };
 }
 
-/** Seed domain rules directly into storage. */
-async function seedDomainRules(extensionContext: any, rules: any[]): Promise<void> {
-  const sw = extensionContext.serviceWorkers()[0];
-  await sw.evaluate(async (r: any[]) => {
-    await chrome.storage.local.set({ domainRules: r });
-  }, rules);
+/** Serialize one or more rules as the JSON payload expected by the importer. */
+function makeRuleJson(...rules: SeedRule[]): string {
+  return JSON.stringify({ domainRules: rules });
+}
+
+async function setStorage(context: BrowserContext, data: Record<string, unknown>): Promise<void> {
+  const sw = context.serviceWorkers()[0];
+  await sw.evaluate(async (d: Record<string, unknown>) => {
+    await chrome.storage.local.set(d);
+  }, data);
   await new Promise(r => setTimeout(r, 200));
 }
 
-/** Clear all domain rules from storage. */
-async function clearDomainRules(extensionContext: any): Promise<void> {
-  const sw = extensionContext.serviceWorkers()[0];
-  await sw.evaluate(async () => {
-    await chrome.storage.local.set({ domainRules: [] });
-  });
-  await new Promise(r => setTimeout(r, 200));
-}
+const seedRules = (context: BrowserContext, rules: SeedRule[]) =>
+  setStorage(context, { domainRules: rules });
+const clearRules = (context: BrowserContext) => setStorage(context, { domainRules: [] });
+const clearSessions = (context: BrowserContext) => setStorage(context, { sessions: [] });
 
-/** Clear all sessions from storage. Used by deep-link tests that rely on the
- *  sessions empty state appearing. Without this a prior spec may have left
- *  sessions in chrome.storage.local. */
-async function clearSessions(extensionContext: any): Promise<void> {
-  const sw = extensionContext.serviceWorkers()[0];
-  await sw.evaluate(async () => {
-    await chrome.storage.local.set({ sessions: [] });
-  });
-  await new Promise(r => setTimeout(r, 200));
-}
-
-/** Open the Import wizard dialog from the Import/Export page. */
-async function openImportWizard(page: any): Promise<void> {
-  await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
-  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-}
-
-/** Open the Export wizard dialog from the Import/Export page. */
-async function openExportWizard(page: any): Promise<void> {
-  await page.getByTestId('page-import-export-card-export-rules').getByRole('button', { name: /^export$/i }).click();
-  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-}
-
-// ─── suite ──────────────────────────────────────────────────────────────────
+// ─── Suite ──────────────────────────────────────────────────────────────────
 
 test.describe('Import / Export', () => {
   test.beforeEach(async ({ extensionContext }) => {
-    await clearDomainRules(extensionContext);
+    await clearRules(extensionContext);
   });
 
   // ── US-IE001: JSON source selection ─────────────────────────────────────
 
   test.describe('JSON Source Selection [US-IE001]', () => {
     test('Import wizard shows File and Text mode tabs [US-IE001]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await auditPage(page, 'import-export-landing');
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      await auditPage(extensionPage, 'import-export-landing');
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      // Both mode tabs should be visible
-      await expect(dialog.getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
-      await expect(dialog.getByRole('radio', { name: 'Text' }).locator('..')).toBeVisible();
-      await auditPage(page, 'import-wizard-source-step', { include: '[role="dialog"]' });
-
-      await page.close();
+      await expect(wizard.dialog().getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
+      await expect(wizard.dialog().getByRole('radio', { name: 'Text' }).locator('..')).toBeVisible();
+      await auditPage(extensionPage, 'import-wizard-source-step', { include: '[role="dialog"]' });
     });
 
     test('File mode shows a drop zone with Browse button [US-IE001]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      // Default mode is File — should show drag-drop zone text and Browse button
-      await expect(dialog.getByText(/drag/i)).toBeVisible();
-      await expect(dialog.getByRole('button', { name: /browse/i })).toBeVisible();
-
-      await page.close();
+      await expect(wizard.fileDropZone()).toBeVisible();
+      await expect(wizard.browseButton()).toBeVisible();
     });
 
     test('switching to Text mode shows a textarea for raw JSON [US-IE001]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      // Switch to Text mode
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await expect(dialog.locator('textarea')).toBeVisible();
-
-      await page.close();
+      await wizard.selectTextMode();
+      await expect(wizard.textArea()).toBeVisible();
     });
 
     test('Next button is disabled when no JSON has been loaded [US-IE001]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      const nextBtn = dialog.getByRole('button', { name: /next/i });
-      await expect(nextBtn).toBeDisabled();
-
-      await page.close();
+      await expect(wizard.nextButton()).toBeDisabled();
     });
   });
 
@@ -183,72 +138,41 @@ test.describe('Import / Export', () => {
 
   test.describe('JSON Validation [US-IE002]', () => {
     test('shows error callout for syntactically invalid JSON [US-IE002]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      // Enter invalid JSON
-      await dialog.locator('textarea').fill('{ invalid json }');
-
-      // Should show an error indicator
-      await expect(dialog.getByText('Invalid JSON format')).toBeVisible();
-
-      await page.close();
+      await wizard.pasteJson('{ invalid json }');
+      await wizard.expectInvalidJsonError();
     });
 
     test('shows success indicator for valid JSON with rules [US-IE002]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      const validJson = makeRuleJson('Valid Rule', 'valid.com');
-      await dialog.locator('textarea').fill(validJson);
-
-      // Should show success: "1 rule(s) found"
-      await expect(dialog.getByText(/1 rule/i)).toBeVisible();
-      // Next button should now be enabled
-      await expect(dialog.getByRole('button', { name: /next/i })).toBeEnabled();
-
-      await page.close();
+      await wizard.pasteJson(makeRuleJson(makeRule('Valid Rule', 'valid.com')));
+      await expect(wizard.dialog().getByText(/1 rule/i)).toBeVisible();
+      await expect(wizard.nextButton()).toBeEnabled();
     });
 
     test('clearing the text field removes validation feedback [US-IE002]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
+      await wizard.pasteJson('{ invalid }');
+      await wizard.expectInvalidJsonError();
 
-      await dialog.locator('textarea').fill('{ invalid }');
-      await expect(dialog.getByText('Invalid JSON format')).toBeVisible();
-
-      // Clear the textarea
-      await dialog.locator('textarea').fill('');
-
-      // No error and no success indicator
-      await expect(dialog.getByText('Invalid JSON format')).toBeHidden();
-      await expect(dialog.getByText(/rule.*found/i)).toBeHidden();
-
-      await page.close();
+      await wizard.textArea().fill('');
+      await expect(wizard.errorBanner()).toBeHidden();
+      await expect(wizard.dialog().getByText(/rule.*found/i)).toBeHidden();
     });
   });
 
@@ -256,110 +180,50 @@ test.describe('Import / Export', () => {
 
   test.describe('Rule Classification [US-IE003]', () => {
     test('classifies imported rules as New when no existing rule has the same label [US-IE003]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(makeRuleJson('Brand New Rule', 'brandnew.com'));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Should show "New rules (1)"
-      await expect(dialog.getByText(/new rules.*1/i)).toBeVisible();
-
-      await page.close();
+      await wizard.pasteJson(makeRuleJson(makeRule('Brand New Rule', 'brandnew.com')));
+      await wizard.clickNext();
+      await wizard.expectClassification({ new: 1 });
     });
 
     test('classifies imported rules as Identical when the same rule already exists [US-IE003]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      // Seed an existing rule
-      const existing = {
-        id: 'rule-identical',
-        label: 'Identical Rule',
-        domainFilter: 'identical.com',
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      };
-      await seedDomainRules(extensionContext, [existing]);
+      const existing = makeRule('Identical Rule', 'identical.com', { id: 'rule-identical' });
+      await seedRules(extensionContext, [existing]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      // Import same rule (same label + same properties)
-      await dialog.locator('textarea').fill(
-        JSON.stringify({ domainRules: [existing] }),
-      );
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Should show identical rules group
-      await expect(dialog.getByText(/identical rules.*1/i)).toBeVisible();
-      // Should show "Already exists" badge
-      await expect(dialog.getByText(/already exists/i)).toBeVisible();
-
-      await page.close();
+      await wizard.pasteJson(makeRuleJson(existing));
+      await wizard.clickNext();
+      await wizard.expectClassification({ identical: 1 });
+      await expect(wizard.dialog().getByText(/already exists/i)).toBeVisible();
     });
 
     test('classifies imported rules as Conflicting when label matches but properties differ [US-IE003]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const existing = {
-        id: 'rule-conflict',
-        label: 'Conflict Rule',
-        domainFilter: 'conflict.com',
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      };
-      await seedDomainRules(extensionContext, [existing]);
+      const existing = makeRule('Conflict Rule', 'conflict.com', { id: 'rule-conflict' });
+      await seedRules(extensionContext, [existing]);
 
-      // Import same label but different domainFilter
-      const imported = { ...existing, id: 'rule-conflict-new', color: 'red' };
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Should show conflicting rules group
-      await expect(dialog.getByText(/conflicting rules.*1/i)).toBeVisible();
-
-      await page.close();
+      await wizard.pasteJson(
+        makeRuleJson({ ...existing, id: 'rule-conflict-new', color: 'red' }),
+      );
+      await wizard.clickNext();
+      await wizard.expectClassification({ conflicting: 1 });
     });
   });
 
@@ -367,148 +231,93 @@ test.describe('Import / Export', () => {
 
   test.describe('Individual Rule Selection [US-IE004]', () => {
     test('new rules are pre-selected by default [US-IE004]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
+      await wizard.pasteJson(makeRuleJson(makeRule('Pre-Selected Rule', 'preselect.com')));
+      await wizard.clickNext();
 
-      await dialog.locator('textarea').fill(makeRuleJson('Pre-Selected Rule', 'preselect.com'));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // The rule row's checkbox should be checked (role=checkbox)
-      const checkboxes = dialog.getByRole('checkbox');
-      const checkedCount = await checkboxes.evaluateAll(
-        (els: Element[]) => els.filter((el: any) => el.checked || el.getAttribute('data-state') === 'checked').length,
+      const checkedCount = await wizard.selectionList().evaluateAll(
+        (els: Element[]) =>
+          els.filter((el: any) => el.checked || el.getAttribute('data-state') === 'checked').length,
       );
       expect(checkedCount).toBeGreaterThan(0);
-
-      // Count should show at least 1 rule to import
-      await expect(dialog.getByText(/1 rule.*import/i)).toBeVisible();
-
-      await page.close();
+      await expect(wizard.dialog().getByText(/1 rule.*import/i)).toBeVisible();
     });
 
     test('Confirm Import button is disabled when all new rules are deselected [US-IE004]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
+      await wizard.pasteJson(makeRuleJson(makeRule('Deselect Rule', 'deselect.com')));
+      await wizard.clickNext();
 
-      await dialog.locator('textarea').fill(makeRuleJson('Deselect Rule', 'deselect.com'));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Deselect the rule (aria-label matches the rule label passed to makeRuleJson)
-      await dialog.getByRole('checkbox', { name: 'Deselect Rule' }).click();
-
-      // "0 rule(s) to import" and Confirm Import disabled
-      await expect(dialog.getByText(/0 rule.*import/i)).toBeVisible();
-      await expect(dialog.getByRole('button', { name: /confirm import/i })).toBeDisabled();
-
-      await page.close();
+      // Each rule row checkbox carries the rule label as its aria-label.
+      await wizard.dialog().getByRole('checkbox', { name: 'Deselect Rule' }).click();
+      await expect(wizard.dialog().getByText(/0 rule.*import/i)).toBeVisible();
+      await expect(wizard.confirmButton()).toBeDisabled();
     });
   });
 
   // ── US-IE005: Global conflict resolution ────────────────────────────────
 
   test.describe('Conflict Resolution Modes [US-IE005]', () => {
+    async function setupConflict(
+      context: BrowserContext,
+      page: Page,
+      extensionId: string,
+      existing: SeedRule,
+      importedOverrides: Partial<SeedRule>,
+    ): Promise<ImportWizardPage> {
+      await seedRules(context, [existing]);
+      await goToImportExportSection(page, extensionId);
+      const wizard = await openRulesImportWizard(page);
+      await wizard.pasteJson(makeRuleJson({ ...existing, ...importedOverrides }));
+      await wizard.clickNext();
+      return wizard;
+    }
+
     test('conflict resolution mode selector shows Overwrite / Duplicate / Ignore options [US-IE005]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const existing = {
-        id: 'rule-cr',
-        label: 'CR Rule',
-        domainFilter: 'cr.com',
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      };
-      await seedDomainRules(extensionContext, [existing]);
+      const wizard = await setupConflict(
+        extensionContext,
+        extensionPage,
+        extensionId,
+        makeRule('CR Rule', 'cr.com', { id: 'rule-cr' }),
+        { id: 'rule-cr-new', color: 'green' },
+      );
 
-      const imported = { ...existing, id: 'rule-cr-new', color: 'green' };
-
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // The conflict resolution segmented control should be visible
-      await expect(dialog.getByRole('radio', { name: 'Overwrite' })).toBeAttached();
-      await expect(dialog.getByRole('radio', { name: 'Duplicate' })).toBeAttached();
-      await expect(dialog.getByRole('radio', { name: 'Ignore' })).toBeAttached();
-
-      await page.close();
+      await expect(wizard.dialog().getByRole('radio', { name: 'Overwrite' })).toBeAttached();
+      await expect(wizard.dialog().getByRole('radio', { name: 'Duplicate' })).toBeAttached();
+      await expect(wizard.dialog().getByRole('radio', { name: 'Ignore' })).toBeAttached();
     });
 
     test('Ignore mode: conflicting rule count is excluded from import count [US-IE005]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const existing = {
-        id: 'rule-ignore',
-        label: 'Ignore Rule',
-        domainFilter: 'ignore.com',
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      };
-      await seedDomainRules(extensionContext, [existing]);
+      const wizard = await setupConflict(
+        extensionContext,
+        extensionPage,
+        extensionId,
+        makeRule('Ignore Rule', 'ignore.com', { id: 'rule-ignore' }),
+        { id: 'rule-ignore-new', color: 'red' },
+      );
 
-      const imported = { ...existing, id: 'rule-ignore-new', color: 'red' };
-
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Switch to Ignore mode (SegmentedControl item — use class selector to avoid strict-mode issues
-      // with duplicate spans and rule-card text that also contains "Ignore")
-      await dialog.locator('.rt-SegmentedControlItem').filter({ hasText: 'Ignore' }).first().click();
-
-      // Import count should be 0 (conflict ignored, no new rules)
-      await expect(dialog.getByText(/0 rule.*import/i)).toBeVisible();
-
-      await page.close();
+      // Target the SegmentedControl item directly: the rule-card text also
+      // contains "Ignore" and would otherwise trigger a strict-mode violation.
+      await wizard.dialog().locator('.rt-SegmentedControlItem').filter({ hasText: 'Ignore' }).first().click();
+      await expect(wizard.dialog().getByText(/0 rule.*import/i)).toBeVisible();
     });
   });
 
@@ -517,44 +326,20 @@ test.describe('Import / Export', () => {
   test.describe('Conflict Diff Visualization [US-IE006]', () => {
     test('conflicting rule shows a "View differences" / eye icon button [US-IE006]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const existing = {
-        id: 'rule-diff',
-        label: 'Diff Rule',
-        domainFilter: 'diff.com',
-        enabled: true,
-        deduplicationEnabled: false,
-        deduplicationMatchMode: 'exact',
-        groupNameSource: 'title',
-        presetId: null,
-        color: 'blue',
-        titleParsingRegEx: '',
-        urlParsingRegEx: '',
-        badge: '',
-      };
-      await seedDomainRules(extensionContext, [existing]);
+      const existing = makeRule('Diff Rule', 'diff.com', { id: 'rule-diff' });
+      await seedRules(extensionContext, [existing]);
 
-      const imported = { ...existing, id: 'rule-diff-new', color: 'green' };
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
+      await wizard.pasteJson(makeRuleJson({ ...existing, id: 'rule-diff-new', color: 'green' }));
+      await wizard.clickNext();
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(JSON.stringify({ domainRules: [imported] }));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // There should be a button to view differences (aria-label or title containing "diff" / "view")
-      // The Eye icon button may have an accessible label
-      const diffBtn = dialog.getByRole('button', { name: /diff|view|see/i });
-      await expect(diffBtn.first()).toBeVisible();
-
-      await page.close();
+      await expect(
+        wizard.dialog().getByRole('button', { name: /diff|view|see/i }).first(),
+      ).toBeVisible();
     });
   });
 
@@ -562,76 +347,45 @@ test.describe('Import / Export', () => {
 
   test.describe('Import Confirmation [US-IE007]', () => {
     test('selection step shows rule count and Confirm Import button [US-IE007]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(makeRuleJson('Confirm Rule', 'confirm.com'));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      // Selection step shows rule count and enabled Confirm Import button
-      await expect(dialog.getByText(/1 rule.*import/i)).toBeVisible();
-      await expect(dialog.getByRole('button', { name: /confirm import/i })).toBeEnabled();
-
-      await page.close();
+      await wizard.pasteJson(makeRuleJson(makeRule('Confirm Rule', 'confirm.com')));
+      await wizard.clickNext();
+      await expect(wizard.dialog().getByText(/1 rule.*import/i)).toBeVisible();
+      await expect(wizard.confirmButton()).toBeEnabled();
     });
 
     test('wizard dialog closes after successful import [US-IE007]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openImportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesImportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-
-      await dialog.locator('textarea').fill(makeRuleJson('Import Close Rule', 'importclose.com'));
-
-      await dialog.getByRole('button', { name: /next/i }).click();
-
-      await dialog.getByRole('button', { name: /confirm import/i }).click();
-
-      // Dialog should close after import
-      await expect(page.getByRole('dialog')).toBeHidden();
-
-      await page.close();
+      await wizard.pasteJson(makeRuleJson(makeRule('Import Close Rule', 'importclose.com')));
+      await wizard.clickNext();
+      await wizard.confirmImport();
+      await wizard.expectHidden();
     });
 
     test('wizard state resets when reopened after import [US-IE007]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
+      await goToImportExportSection(extensionPage, extensionId);
 
-      // First import
-      await openImportWizard(page);
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-      await dialog.locator('textarea').waitFor({ state: 'visible' });
-      await dialog.locator('textarea').fill(makeRuleJson('First Import', 'firstimport.com'));
-      await dialog.getByRole('button', { name: /next/i }).click();
-      await dialog.getByRole('button', { name: /confirm import/i }).click();
-      await expect(page.getByRole('dialog')).toBeHidden();
+      const first = await openRulesImportWizard(extensionPage);
+      await first.pasteJson(makeRuleJson(makeRule('First Import', 'firstimport.com')));
+      await first.clickNext();
+      await first.confirmImport();
+      await first.expectHidden();
 
-      // Reopen wizard — should start fresh at step 0 (source)
-      await openImportWizard(page);
-      const dialog2 = page.getByRole('dialog');
-      // Should be back at step 0 (file/text selector visible, not selection step)
-      await expect(dialog2.getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
-
-      await page.close();
+      const reopened = await openRulesImportWizard(extensionPage);
+      await expect(reopened.dialog().getByRole('radio', { name: 'File' }).locator('..')).toBeVisible();
     });
   });
 
@@ -640,138 +394,65 @@ test.describe('Import / Export', () => {
   test.describe('Export Rule Selection [US-IE008]', () => {
     test('all rules are pre-selected when Export wizard opens [US-IE008]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r1',
-          label: 'Rule One',
-          domainFilter: 'one.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
-        {
-          id: 'r2',
-          label: 'Rule Two',
-          domainFilter: 'two.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('Rule One', 'one.com', { id: 'r1', groupingEnabled: true, groupNameSource: 'label' }),
+        makeRule('Rule Two', 'two.com', { id: 'r2', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      // Should show "2 rule(s) selected"
-      await expect(dialog.getByText(/2 rule.*selected/i)).toBeVisible();
-
-      await page.close();
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
+      await wizard.expectAllRulesSelected(2);
     });
 
     test('Select All and Deselect All buttons work correctly [US-IE008]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r3',
-          label: 'Select All Test',
-          domainFilter: 'selectall.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('Select All Test', 'selectall.com', { id: 'r3', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
+      await wizard.deselectAll();
+      await wizard.expectSelectedCount(0);
+      await wizard.expectExportButtonDisabled();
 
-      // Deselect All
-      await dialog.getByRole('button', { name: /deselect all/i }).click();
-      await expect(dialog.getByText(/0 rule.*selected/i)).toBeVisible();
-
-      // Export button should be disabled when nothing is selected
-      await expect(dialog.getByRole('button', { name: /^export$/i })).toBeDisabled();
-
-      // Select All
-      await dialog.getByRole('button', { name: 'Select All', exact: true }).click();
-      await expect(dialog.getByText(/1 rule.*selected/i)).toBeVisible();
-      await expect(dialog.getByRole('button', { name: /^export$/i })).toBeEnabled();
-
-      await page.close();
+      await wizard.selectAll();
+      await wizard.expectSelectedCount(1);
+      await wizard.expectExportButtonEnabled();
     });
 
     test('Export button is disabled when no rules are selected [US-IE008]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r4',
-          label: 'No Select Test',
-          domainFilter: 'noselect.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('No Select Test', 'noselect.com', { id: 'r4', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
-
-      const dialog = page.getByRole('dialog');
-      await dialog.getByRole('button', { name: /deselect all/i }).click();
-
-      await expect(dialog.getByRole('button', { name: /^export$/i })).toBeDisabled();
-
-      await page.close();
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
+      await wizard.deselectAll();
+      await wizard.expectExportButtonDisabled();
     });
 
     test('Export button is disabled on the Import/Export page when there are no rules [US-IE008]', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      // No rules seeded (cleared in beforeEach)
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
+      await goToImportExportSection(extensionPage, extensionId);
 
-      // Export button should be disabled when domainRules is empty
-      const exportBtn = page.getByTestId('page-import-export-card-export-rules').getByRole('button', { name: /^export$/i });
+      const exportBtn = extensionPage
+        .getByTestId('page-import-export-card-export-rules')
+        .getByRole('button', { name: /^export$/i });
       await expect(exportBtn).toBeDisabled();
-
-      await page.close();
     });
   });
 
@@ -780,225 +461,142 @@ test.describe('Import / Export', () => {
   test.describe('Export Output [US-IE009]', () => {
     test('Export wizard shows selected rule count and Export button [US-IE009]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r5',
-          label: 'Export Ready Rule',
-          domainFilter: 'exportready.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('Export Ready Rule', 'exportready.com', { id: 'r5', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-
-      // Should show "1 rule(s) selected" and Export button enabled
-      await expect(dialog.getByText(/1 rule.*selected/i)).toBeVisible();
-      await expect(dialog.getByRole('button', { name: /^export$/i })).toBeEnabled();
-
-      await page.close();
+      await wizard.expectAllRulesSelected(1);
+      await wizard.expectExportButtonEnabled();
     });
 
     test('Export step has a split button with Export and chevron/dropdown [US-IE009]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r6',
-          label: 'Split Button Rule',
-          domainFilter: 'splitbtn.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('Split Button Rule', 'splitbtn.com', { id: 'r6', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-
-      // The SplitButton should have an Export button and a dropdown chevron button
-      await expect(dialog.getByRole('button', { name: /^export$/i })).toBeVisible();
-      // The split button dropdown trigger (chevron / "Export options")
-      await expect(
-        dialog.getByRole('button', { name: /export.*option|chevron|▾/i }),
-      ).toBeVisible();
-
-      await page.close();
+      await expect(wizard.exportFileButton()).toBeVisible();
+      await expect(wizard.exportOptionsButton()).toBeVisible();
     });
 
     test('Copy to Clipboard option is available in the export dropdown [US-IE009]', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      await seedDomainRules(extensionContext, [
-        {
-          id: 'r7',
-          label: 'Clipboard Rule',
-          domainFilter: 'clipboard.com',
-          enabled: true,
-          groupingEnabled: true,
-          deduplicationEnabled: false,
-          deduplicationMatchMode: 'exact',
-          groupNameSource: 'label',
-          color: '',
-          titleParsingRegEx: '',
-          urlParsingRegEx: '',
-          badge: '',
-        },
+      await seedRules(extensionContext, [
+        makeRule('Clipboard Rule', 'clipboard.com', { id: 'r7', groupingEnabled: true, groupNameSource: 'label' }),
       ]);
 
-      const page = await extensionContext.newPage();
-      await goToImportExportSection(page, extensionId);
-      await openExportWizard(page);
+      await goToImportExportSection(extensionPage, extensionId);
+      const wizard = await openRulesExportWizard(extensionPage);
 
-      const dialog = page.getByRole('dialog');
-
-      // Open the export options dropdown
-      await dialog.getByRole('button', { name: /export.*option|chevron/i }).click();
-
-      // Should show clipboard option
-      await expect(page.getByRole('menuitem', { name: /clipboard/i })).toBeVisible();
-
-      await page.close();
+      await wizard.exportOptionsButton().click();
+      await expect(wizard.exportClipboardButton()).toBeVisible();
     });
   });
 
   // ── Wizard triggers (context-based, no URL routing for import/export) ──────
 
   test.describe('Wizard triggers', () => {
-    test('opens the rules import wizard from the #importexport cards page and stays on that hash', async ({
-      extensionContext,
-      extensionId,
-    }) => {
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#importexport`);
+    /**
+     * Open the wizard from one entry point, then assert (a) the dialog is
+     * visible, (b) the hash didn't change, (c) Escape closes the dialog
+     * and leaves the same hash.
+     */
+    async function expectWizardOpenAndHashStable(
+      page: Page,
+      extensionId: string,
+      hash: string,
+      openWizard: () => Promise<void>,
+    ): Promise<void> {
+      await page.goto(`chrome-extension://${extensionId}/options.html${hash}`);
       await page.waitForLoadState('domcontentloaded');
 
-      const importBtn = page
-        .getByTestId('page-import-export-card-import-rules')
-        .getByRole('button');
-      await importBtn.click();
+      await openWizard();
       await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(hash);
 
       await page.keyboard.press('Escape');
       await expect(page.getByRole('dialog')).toBeHidden();
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#importexport');
-      await expect(page.getByTestId('page-import-export')).toBeVisible();
+      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(hash);
+    }
 
-      await page.close();
+    test('opens the rules import wizard from the #importexport cards page and stays on that hash', async ({
+      extensionPage,
+      extensionId,
+    }) => {
+      await expectWizardOpenAndHashStable(extensionPage, extensionId, '#importexport', async () => {
+        await extensionPage
+          .getByTestId('page-import-export-card-import-rules')
+          .getByRole('button')
+          .click();
+      });
+      await expect(extensionPage.getByTestId('page-import-export')).toBeVisible();
     });
 
     test('rules empty-state Import button opens the wizard and leaves the hash on #rules', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#rules`);
-      await page.waitForLoadState('domcontentloaded');
-
-      const emptyState = page.getByTestId('page-rules-empty');
-      await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
-      const importBtn = emptyState.getByRole('button', { name: /import/i });
-      await importBtn.click();
-
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#rules');
-
-      await page.keyboard.press('Escape');
-      await expect(page.getByRole('dialog')).toBeHidden();
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#rules');
-
-      await page.close();
+      await expectWizardOpenAndHashStable(extensionPage, extensionId, '#rules', async () => {
+        const emptyState = extensionPage.getByTestId('page-rules-empty');
+        await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
+        await emptyState.getByRole('button', { name: /import/i }).click();
+      });
     });
 
     test('sessions empty-state Import button opens the wizard and leaves the hash on #sessions', async ({
       extensionContext,
+      extensionPage,
       extensionId,
     }) => {
       await clearSessions(extensionContext);
 
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#sessions`);
-      await page.waitForLoadState('domcontentloaded');
-
-      const emptyState = page.getByTestId('page-sessions-empty');
-      await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
-      const importBtn = emptyState.getByRole('button', { name: /import/i });
-      await importBtn.click();
-
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#sessions');
-
-      await page.keyboard.press('Escape');
-      await expect(page.getByRole('dialog')).toBeHidden();
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#sessions');
-
-      await page.close();
+      await expectWizardOpenAndHashStable(extensionPage, extensionId, '#sessions', async () => {
+        const emptyState = extensionPage.getByTestId('page-sessions-empty');
+        await emptyState.waitFor({ state: 'visible', timeout: 10_000 });
+        await emptyState.getByRole('button', { name: /import/i }).click();
+      });
     });
 
     test('home onboarding "Import pack" button opens the wizard and leaves the hash on #home', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
       // No rules seeded -> hero is shown.
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#home`);
-      await page.waitForLoadState('domcontentloaded');
-
-      const heroImport = page.getByTestId('home-hero-import');
-      await heroImport.waitFor({ state: 'visible', timeout: 10_000 });
-      await heroImport.click();
-
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#home');
-
-      await page.keyboard.press('Escape');
-      await expect(page.getByRole('dialog')).toBeHidden();
-      await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('#home');
-
-      await page.close();
+      await expectWizardOpenAndHashStable(extensionPage, extensionId, '#home', async () => {
+        const heroImport = extensionPage.getByTestId('home-hero-import');
+        await heroImport.waitFor({ state: 'visible', timeout: 10_000 });
+        await heroImport.click();
+      });
     });
 
     test('refresh on #importexport does not re-open any wizard', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#importexport`);
-      await page.waitForLoadState('domcontentloaded');
-      await expect(page.getByTestId('page-import-export')).toBeVisible();
-      await expect(page.getByRole('dialog')).toBeHidden();
+      await extensionPage.goto(`chrome-extension://${extensionId}/options.html#importexport`);
+      await extensionPage.waitForLoadState('domcontentloaded');
+      await expect(extensionPage.getByTestId('page-import-export')).toBeVisible();
+      await expect(extensionPage.getByRole('dialog')).toBeHidden();
 
-      await page.reload();
-      await page.waitForLoadState('domcontentloaded');
-      await expect(page.getByTestId('page-import-export')).toBeVisible();
-      await expect(page.getByRole('dialog')).toBeHidden();
-
-      await page.close();
+      await extensionPage.reload();
+      await extensionPage.waitForLoadState('domcontentloaded');
+      await expect(extensionPage.getByTestId('page-import-export')).toBeVisible();
+      await expect(extensionPage.getByRole('dialog')).toBeHidden();
     });
   });
 
@@ -1006,21 +604,18 @@ test.describe('Import / Export', () => {
 
   test.describe('Popup -> rules deeplink', () => {
     test('navigating to #rules?action=import opens the import wizard on the rules page', async ({
-      extensionContext,
+      extensionPage,
       extensionId,
     }) => {
-      const page = await extensionContext.newPage();
-      await page.goto(`chrome-extension://${extensionId}/options.html#rules?action=import`);
-      await page.waitForLoadState('domcontentloaded');
+      await extensionPage.goto(`chrome-extension://${extensionId}/options.html#rules?action=import`);
+      await extensionPage.waitForLoadState('domcontentloaded');
 
-      await expect(page.getByTestId('page-rules')).toBeVisible({ timeout: 10_000 });
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await expect(extensionPage.getByTestId('page-rules')).toBeVisible({ timeout: 10_000 });
+      await expect(extensionPage.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
 
-      await page.keyboard.press('Escape');
-      await expect(page.getByRole('dialog')).toBeHidden();
-      await expect(page.getByTestId('page-rules')).toBeVisible();
-
-      await page.close();
+      await extensionPage.keyboard.press('Escape');
+      await expect(extensionPage.getByRole('dialog')).toBeHidden();
+      await expect(extensionPage.getByTestId('page-rules')).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
Lot 3 of the E2E migration. Add `ExportWizardPage` (companion to
`ImportWizardPage` from lot 1) and the first batch of composed Domain
Actions in `e2e-shared/actions/rules-import-export.ts`
(`openRulesImportWizard`, `openRulesExportWizard`, `importRulesViaText`,
`importRulesViaFile`, `exportRulesToFile`, `exportRulesToClipboard`).

`tests/e2e/import-export.spec.ts` is rewritten on top of the new
architecture: useful lines drop from 753 to 484 (36% reduction) while
keeping the exact same 31 tests and US-IE001..US-IE009 coverage.

The `goToImportExportSection` helper moves to
`tests/e2e/helpers/navigation.ts` so it can be reused by the
shortcuts spec as well.

ESLint: extend `playwright/expect-expect` with an
`assertFunctionPatterns: ['^expect[A-Z]']` rule so Page Object wrapper
methods (`wizard.expectInvalidJsonError()`, ...) count as assertions.

https://claude.ai/code/session_01H8nQm9p88TPLKktnHjDcCs