### PR TITLE
test(e2e-shared): add Page Objects + Domain Actions for Rule/Snapshot/Restore/SessionsExport wizards

### DIFF
--- a/e2e-shared/actions/index.ts
+++ b/e2e-shared/actions/index.ts
@@ -3,9 +3,9 @@
  * `e2e-doc-scenarios/`. Consumes Page Objects from `../pages/`.
  *
  * Each action narrates a single business outcome ("import rules from
- * JSON text", "export rules to a file") and hides the wizard step
- * plumbing so specs read as business intent rather than a sequence of
- * clicks.
+ * JSON text", "create a snapshot with these tabs", "export sessions to a
+ * file") and hides the wizard step plumbing so specs read as business
+ * intent rather than a sequence of clicks.
  */
 export {
   openRulesImportWizard,
@@ -16,3 +16,34 @@ export {
   exportRulesToClipboard,
   type ExportRulesOptions,
 } from './rules-import-export.js';
+
+export {
+  openRuleWizard,
+  openEditRuleWizard,
+  createRuleViaWizard,
+  editRule,
+  type RuleWizardCreateConfig,
+  type RuleWizardEditPatch,
+} from './rules-management.js';
+
+export {
+  openSnapshotWizard,
+  createSnapshotWithTabs,
+  pinSession,
+  type CreateSnapshotOptions,
+} from './sessions-snapshot.js';
+
+export {
+  openCustomizeRestoreWizard,
+  restoreSessionAsReplace,
+  restoreSessionAsMerge,
+  type RestoreReplaceOptions,
+  type RestoreMergeOptions,
+} from './sessions-restore.js';
+
+export {
+  openSessionsExportWizard,
+  exportSessionsToFile,
+  exportSessionsToClipboard,
+  type ExportSessionsOptions,
+} from './sessions-export.js';

--- a/e2e-shared/actions/rules-management.ts
+++ b/e2e-shared/actions/rules-management.ts
@@ -1,0 +1,187 @@
+/**
+ * Composed domain actions for the Rule Wizard (creation + edit).
+ *
+ * Each action narrates a single business outcome ("create a rule with this
+ * config", "edit an existing rule's label") and hides the wizard step
+ * plumbing. Consumes `RuleWizardPage`; never reaches into raw locators.
+ *
+ * Callers are expected to have already navigated to the Domain Rules
+ * section before invoking these helpers (this keeps the action layer
+ * symmetric with `rules-import-export.ts`, which also assumes the caller
+ * is already on the relevant options page).
+ *
+ * Shared between `tests/e2e/` (functional suite, US-R001..US-R005,
+ * US-R007..US-R008) and `e2e-doc-scenarios/` (narrative captures that walk
+ * the same flows for screenshots / docs).
+ */
+import type { Page } from '@playwright/test';
+import {
+  RuleWizardPage,
+  type RuleWizardConfigMode,
+  type RuleWizardGroupNameSource,
+} from '../pages/RuleWizardPage.js';
+
+export interface RuleWizardCreateConfig {
+  /** Rule label (must be unique). */
+  label: string;
+  /** Domain filter (e.g. `example.com`). */
+  domainFilter: string;
+  /** Configuration mode (defaults to `'ask'` when omitted). */
+  configMode?: RuleWizardConfigMode;
+  /** Required when `configMode === 'preset'`: the preset to apply. */
+  presetId?: string;
+  /** Optional override for the manual mode's group-name source. */
+  groupNameSource?: RuleWizardGroupNameSource;
+  /** Optional deduplication toggle (default left untouched, dedup enabled). */
+  deduplicationEnabled?: boolean;
+  /** Optional category to assign via the picker. */
+  categoryLabel?: string | null;
+}
+
+export interface RuleWizardEditPatch {
+  label?: string;
+  domainFilter?: string;
+  configMode?: RuleWizardConfigMode;
+  presetId?: string;
+  groupNameSource?: RuleWizardGroupNameSource;
+  deduplicationEnabled?: boolean;
+}
+
+/**
+ * Open the rule creation wizard from the Domain Rules options page.
+ * Returns the `RuleWizardPage` instance so callers can interact with the
+ * open dialog without re-instantiating it.
+ *
+ * Relevant US: US-R001 (wizard entry point).
+ */
+export async function openRuleWizard(page: Page): Promise<RuleWizardPage> {
+  await page.getByTestId('page-rules-btn-add').click();
+  const wizard = new RuleWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * Open the rule edit wizard for an existing rule, identified by its id.
+ * The wizard lands directly on the summary view (no stepper).
+ *
+ * Relevant US: US-R004 (edit entry point).
+ */
+export async function openEditRuleWizard(
+  page: Page,
+  ruleId: string,
+): Promise<RuleWizardPage> {
+  await page.getByTestId(`rule-card-${ruleId}-btn-dropdown`).click();
+  await page.getByTestId(`rule-card-${ruleId}-menu-edit`).click();
+  const wizard = new RuleWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  await wizard.expectInEditMode(ruleId);
+  return wizard;
+}
+
+/**
+ * End-to-end "create a rule with this config" flow.
+ *
+ * Walks every step of the wizard, applying the supplied configuration, and
+ * closes the dialog by clicking "Create" on the summary step. The default
+ * `configMode` is `'ask'` because it is the only mode that doesn't require
+ * an extra preset / regex input on step 2.
+ *
+ * Relevant US: US-R001 (creation flow), US-R002 (step validation).
+ */
+export async function createRuleViaWizard(
+  page: Page,
+  config: RuleWizardCreateConfig,
+): Promise<void> {
+  const wizard = await openRuleWizard(page);
+
+  // Step 1: identity.
+  await wizard.fillLabel(config.label);
+  await wizard.fillDomainFilter(config.domainFilter);
+  if (config.categoryLabel !== undefined) {
+    await wizard.selectCategory(config.categoryLabel);
+  }
+  await wizard.clickNext();
+  await wizard.expectOnStep(2);
+
+  // Step 2: configuration.
+  const mode: RuleWizardConfigMode = config.configMode ?? 'ask';
+  await wizard.selectConfigMode(mode);
+  if (mode === 'preset' && config.presetId) {
+    await wizard.selectPreset(config.presetId);
+  } else if (mode === 'manual' && config.groupNameSource) {
+    await wizard.setGroupNameSource(config.groupNameSource);
+  }
+  await wizard.clickNext();
+  await wizard.expectOnStep(3);
+
+  // Step 3: options.
+  if (config.deduplicationEnabled !== undefined) {
+    await wizard.setDeduplicationEnabled(config.deduplicationEnabled);
+  }
+  await wizard.clickNext();
+  await wizard.expectOnStep(4);
+
+  // Step 4: summary -> create.
+  await wizard.clickCreate();
+  await wizard.expectHidden();
+}
+
+/**
+ * End-to-end "edit an existing rule" flow.
+ *
+ * Opens the edit summary, opens the matching sub-dialog for each changed
+ * field (`IdentityEditModal` / `ConfigEditModal` / `OptionsEditModal`),
+ * applies the patch and saves the parent dialog. Callers may pass any
+ * subset of the patch keys; untouched sections are left as-is.
+ *
+ * Relevant US: US-R004 (edit flow), US-R005 (per-section sub-dialogs).
+ */
+export async function editRule(
+  page: Page,
+  ruleId: string,
+  patch: RuleWizardEditPatch,
+): Promise<void> {
+  const wizard = await openEditRuleWizard(page, ruleId);
+
+  if (patch.label !== undefined || patch.domainFilter !== undefined) {
+    await wizard.clickModifySection(0);
+    const modal = page.getByTestId('modal-edit-identity');
+    if (patch.label !== undefined) {
+      await modal.getByTestId('modal-edit-identity-field-label').fill(patch.label);
+    }
+    if (patch.domainFilter !== undefined) {
+      await modal.getByTestId('modal-edit-identity-field-domain').fill(patch.domainFilter);
+    }
+    await modal.getByTestId('modal-edit-identity-btn-apply').click();
+  }
+
+  if (
+    patch.configMode !== undefined
+    || patch.presetId !== undefined
+    || patch.groupNameSource !== undefined
+  ) {
+    await wizard.clickModifySection(1);
+    const modal = page.getByTestId('modal-edit-config');
+    if (patch.configMode !== undefined) {
+      await modal.getByTestId(`config-mode-${patch.configMode}`).click();
+    }
+    if (patch.configMode === 'preset' && patch.presetId) {
+      await modal.locator(`[data-value="${patch.presetId}"]`).first().click();
+    }
+    await modal.getByRole('button', { name: /apply|save/i }).click();
+  }
+
+  if (patch.deduplicationEnabled !== undefined) {
+    await wizard.clickModifySection(2);
+    const modal = page.getByTestId('modal-edit-options');
+    const sw = modal.locator('[role="switch"]');
+    const state = await sw.getAttribute('data-state');
+    const isOn = state === 'checked';
+    if (isOn !== patch.deduplicationEnabled) await sw.click();
+    await modal.getByRole('button', { name: /apply|save/i }).click();
+  }
+
+  await wizard.clickSave();
+  await wizard.expectHidden();
+}

--- a/e2e-shared/actions/sessions-export.ts
+++ b/e2e-shared/actions/sessions-export.ts
@@ -1,0 +1,157 @@
+/**
+ * Composed domain actions for the sessions Export wizard.
+ *
+ * Each action narrates a single business outcome ("export the selected
+ * sessions to a JSON file", "... to the clipboard") and hides the wizard
+ * plumbing. Consumes `SessionsExportWizardPage`; never reaches into raw
+ * locators.
+ *
+ * Mirrors the rules-flavoured `exportRulesToFile` / `exportRulesToClipboard`
+ * helpers in `rules-import-export.ts`. Both surfaces inherit the same
+ * footer split-button from `ExportWizardPageBase`.
+ *
+ * Callers are expected to have already navigated to the Import/Export
+ * section (or any surface that exposes the export-sessions card) before
+ * invoking these helpers.
+ *
+ * Relevant US: US-IE012 (sessions export envelope), US-IE013 (pinned vs
+ * normal sub-groups).
+ */
+import { expect, type Page } from '@playwright/test';
+import { SessionsExportWizardPage } from '../pages/SessionsExportWizardPage.js';
+
+export interface ExportSessionsOptions {
+  /** Optional free-form note persisted at the top of the JSON payload. */
+  note?: string;
+  /**
+   * Subset to keep. When omitted the wizard exports everything that was
+   * pre-selected on open. Use `pinnedOnly` / `unpinnedOnly` for the
+   * common group-level toggles, or pass `sessions` to toggle individual
+   * sessions by name.
+   */
+  pinnedOnly?: boolean;
+  unpinnedOnly?: boolean;
+  sessions?: string[];
+}
+
+/**
+ * Open the sessions export wizard from the Import/Export cards page.
+ *
+ * Relevant US: US-IE012 (entry point).
+ */
+export async function openSessionsExportWizard(
+  page: Page,
+): Promise<SessionsExportWizardPage> {
+  await page
+    .getByTestId('page-import-export-card-export-sessions')
+    .getByRole('button', { name: /^export$/i })
+    .click();
+  const wizard = new SessionsExportWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * Stub `window.showSaveFilePicker` so the Chrome native Save As dialog
+ * does not block the export flow under Playwright. The stub returns an
+ * in-memory writer whose contents are exposed via the returned `getJson`
+ * function (useful for asserting the payload shape).
+ *
+ * Idempotent: re-installs the stub on every call so tests do not need to
+ * track installation state. Duplicated from `rules-import-export.ts`'s
+ * private helper because each action module owns its own browser-side
+ * scaffolding (avoids a leaky cross-module dependency).
+ */
+async function stubShowSaveFilePicker(page: Page): Promise<() => Promise<string>> {
+  await page.evaluate(() => {
+    const w = window as unknown as {
+      __exportedJson?: string;
+      showSaveFilePicker: (opts: unknown) => Promise<{
+        createWritable: () => Promise<{
+          write: (data: string) => Promise<void>;
+          close: () => Promise<void>;
+        }>;
+      }>;
+    };
+    w.__exportedJson = '';
+    w.showSaveFilePicker = async () => ({
+      createWritable: async () => ({
+        write: async (data: string) => {
+          w.__exportedJson = data;
+        },
+        close: async () => undefined,
+      }),
+    });
+  });
+  return async () => {
+    return (await page.evaluate(
+      () => (window as unknown as { __exportedJson?: string }).__exportedJson ?? '',
+    )) as string;
+  };
+}
+
+/**
+ * Apply the selection options to an open `SessionsExportWizardPage`. The
+ * wizard pre-selects every session on open, so the helpers below only need
+ * to toggle the buckets the caller wants to exclude.
+ */
+async function applySelectionOptions(
+  wizard: SessionsExportWizardPage,
+  opts: ExportSessionsOptions,
+): Promise<void> {
+  if (opts.pinnedOnly) {
+    await wizard.toggleNormalGroup();
+  }
+  if (opts.unpinnedOnly) {
+    await wizard.togglePinnedGroup();
+  }
+  if (opts.sessions) {
+    await wizard.deselectAll();
+    for (const name of opts.sessions) {
+      await wizard.toggleSession(name);
+    }
+  }
+}
+
+/**
+ * End-to-end "export the selected sessions to a JSON file" flow.
+ *
+ * Steps: open wizard, optionally fill the note, toggle the requested
+ * selection buckets, stub the OS save picker, click the primary Export
+ * button, wait for the dialog to close. The caller can use the returned
+ * `getJson()` to inspect the written payload.
+ *
+ * Relevant US: US-IE012 (export to file + dialog closes on success).
+ */
+export async function exportSessionsToFile(
+  page: Page,
+  opts: ExportSessionsOptions = {},
+): Promise<{ getJson: () => Promise<string> }> {
+  const wizard = await openSessionsExportWizard(page);
+  if (opts.note !== undefined) await wizard.fillNote(opts.note);
+  await applySelectionOptions(wizard, opts);
+  const getJson = await stubShowSaveFilePicker(page);
+  await wizard.clickExportToFile();
+  await wizard.expectHidden();
+  return { getJson };
+}
+
+/**
+ * End-to-end "export the selected sessions to the clipboard" flow.
+ *
+ * Steps: open wizard, optionally fill the note, toggle the requested
+ * selection buckets, open the split-button popover, click the "Clipboard"
+ * entry, wait for the dialog to close.
+ *
+ * Relevant US: US-IE012 (export to clipboard + dialog closes on success).
+ */
+export async function exportSessionsToClipboard(
+  page: Page,
+  opts: ExportSessionsOptions = {},
+): Promise<void> {
+  const wizard = await openSessionsExportWizard(page);
+  if (opts.note !== undefined) await wizard.fillNote(opts.note);
+  await applySelectionOptions(wizard, opts);
+  await wizard.clickExportToClipboard();
+  await expect(wizard.dialog()).toBeHidden();
+}

--- a/e2e-shared/actions/sessions-restore.ts
+++ b/e2e-shared/actions/sessions-restore.ts
@@ -1,0 +1,129 @@
+/**
+ * Composed domain actions for session restoration.
+ *
+ * Each action narrates a single business outcome ("restore this session as
+ * Replace", "restore this session merging with the current window") and
+ * hides the wizard step plumbing. Consumes `RestoreWizardPage`; never
+ * reaches into raw locators.
+ *
+ * Callers are expected to have already navigated to the Sessions section
+ * before invoking these helpers.
+ *
+ * Relevant US: US-S003 (restore in new window), US-S004 (restore in
+ * current window), US-S005 (conflict resolution), US-S011 (restore
+ * split-button options), US-S017 (collapsed groups).
+ */
+import type { Page } from '@playwright/test';
+import {
+  RestoreWizardPage,
+  type DuplicateTabAction,
+  type GroupConflictAction,
+} from '../pages/RestoreWizardPage.js';
+
+export interface RestoreReplaceOptions {
+  /** Tab titles to deselect before clicking Restore. */
+  deselect?: string[];
+}
+
+export interface RestoreMergeOptions extends RestoreReplaceOptions {
+  /** Action to apply on duplicate tabs (default: 'skip'). */
+  duplicateTabAction?: DuplicateTabAction;
+  /**
+   * Per-group conflict actions, keyed by the conflicting group's title.
+   * Groups not listed keep their default action ('merge').
+   */
+  groupActions?: Record<string, GroupConflictAction>;
+}
+
+/**
+ * Open the Customize-restoration wizard for a given session by clicking
+ * the SplitButton chevron on its card and selecting the "Customize" item.
+ *
+ * Relevant US: US-S004 (entry point), US-S011 (split-button options).
+ */
+export async function openCustomizeRestoreWizard(
+  page: Page,
+  sessionId: string,
+): Promise<RestoreWizardPage> {
+  const card = page.getByTestId(`session-card-${sessionId}`);
+  await card.getByRole('button', { name: /restore options/i }).click();
+  await page.getByTestId('session-restore-menu-customize').click();
+  const wizard = new RestoreWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * End-to-end "restore this session as Replace" flow.
+ *
+ * Steps: open the customize wizard, select the Replace destination radio,
+ * optionally deselect a subset of tabs, click Restore, wait for the
+ * dialog to close. Replace mode wipes the current window so there is no
+ * conflict resolution step.
+ *
+ * Relevant US: US-S004 (replace current window outcome).
+ */
+export async function restoreSessionAsReplace(
+  page: Page,
+  sessionId: string,
+  opts: RestoreReplaceOptions = {},
+): Promise<void> {
+  const wizard = await openCustomizeRestoreWizard(page, sessionId);
+  await wizard.selectReplaceMode();
+  if (opts.deselect) {
+    for (const title of opts.deselect) {
+      await wizard.toggleTab(title);
+    }
+  }
+  await wizard.clickRestore();
+  await wizard.expectHidden({ timeout: 10_000 });
+}
+
+/**
+ * End-to-end "restore this session merging with the current window" flow.
+ *
+ * Steps: open the customize wizard, select the current-window destination,
+ * optionally deselect a subset of tabs, click Restore. If no conflicts are
+ * detected the wizard closes immediately; otherwise the helper drives the
+ * conflict-resolution step using the supplied duplicate/group actions and
+ * then submits the final Restore.
+ *
+ * Relevant US: US-S004 (merge into current window), US-S005 (conflict
+ * resolution choices).
+ */
+export async function restoreSessionAsMerge(
+  page: Page,
+  sessionId: string,
+  opts: RestoreMergeOptions = {},
+): Promise<void> {
+  const wizard = await openCustomizeRestoreWizard(page, sessionId);
+  await wizard.selectMergeMode();
+  if (opts.deselect) {
+    for (const title of opts.deselect) {
+      await wizard.toggleTab(title);
+    }
+  }
+  await wizard.clickRestore();
+
+  // The wizard advances to step 1 only when conflicts were detected. Wait
+  // for either outcome with a short race so callers don't pay a hard delay.
+  const onConflictStep = await wizard
+    .step1Conflicts()
+    .waitFor({ state: 'visible', timeout: 2_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!onConflictStep) {
+    await wizard.expectHidden({ timeout: 10_000 });
+    return;
+  }
+
+  if (opts.duplicateTabAction) {
+    await wizard.setDuplicateTabAction(opts.duplicateTabAction);
+  }
+  for (const [groupTitle, action] of Object.entries(opts.groupActions ?? {})) {
+    await wizard.setGroupConflictAction(groupTitle, action);
+  }
+  await wizard.clickRestore();
+  await wizard.expectHidden({ timeout: 10_000 });
+}

--- a/e2e-shared/actions/sessions-snapshot.ts
+++ b/e2e-shared/actions/sessions-snapshot.ts
@@ -1,0 +1,104 @@
+/**
+ * Composed domain actions for session snapshots (creation + pin).
+ *
+ * Each action narrates a single business outcome ("create a snapshot with
+ * these tabs", "pin an existing session") and hides the wizard / card
+ * dropdown plumbing. Consumes `SnapshotWizardPage`; never reaches into
+ * raw locators.
+ *
+ * Callers are expected to have already navigated to the Sessions section
+ * before invoking these helpers.
+ *
+ * Relevant US: US-S001 (snapshot wizard), US-S008 (pinned sessions).
+ */
+import { expect, type Page } from '@playwright/test';
+import { SnapshotWizardPage } from '../pages/SnapshotWizardPage.js';
+
+export interface CreateSnapshotOptions {
+  /** Optional free-form note persisted with the session. */
+  note?: string;
+  /**
+   * Optional list of tab titles to deselect from the default "everything
+   * selected" state before saving. Use this to capture a subset of the
+   * currently open tabs.
+   */
+  deselect?: string[];
+  /**
+   * Optional list of tab titles to (re-)select (e.g. after a manual
+   * `deselectAll`). When provided, the helper first deselects everything,
+   * then re-selects the listed tabs.
+   */
+  selectOnly?: string[];
+}
+
+/**
+ * Open the snapshot wizard from the Sessions options page. Returns the
+ * `SnapshotWizardPage` instance.
+ *
+ * Relevant US: US-S001 (wizard entry point), US-S010 (empty-state CTA).
+ */
+export async function openSnapshotWizard(page: Page): Promise<SnapshotWizardPage> {
+  await page.getByTestId('page-sessions-btn-snapshot').click();
+  const wizard = new SnapshotWizardPage(page);
+  await wizard.expectVisible({ timeout: 5000 });
+  return wizard;
+}
+
+/**
+ * End-to-end "create a snapshot with these tabs" flow.
+ *
+ * Steps: open wizard, wait for the asynchronous tab capture to resolve
+ * (Save becomes enabled), set the name, adjust selection if requested,
+ * optionally fill the note, save and wait for the dialog to close.
+ *
+ * Relevant US: US-S001 (snapshot creation, default-select-all behavior).
+ */
+export async function createSnapshotWithTabs(
+  page: Page,
+  name: string,
+  options: CreateSnapshotOptions = {},
+): Promise<void> {
+  const wizard = await openSnapshotWizard(page);
+  await wizard.expectSaveButtonEnabled();
+  await wizard.fillName(name);
+
+  if (options.selectOnly) {
+    await wizard.deselectAllTabs();
+    for (const title of options.selectOnly) {
+      await wizard.toggleTab(title);
+    }
+  } else if (options.deselect) {
+    for (const title of options.deselect) {
+      await wizard.toggleTab(title);
+    }
+  }
+
+  if (options.note !== undefined) {
+    await wizard.fillNote(options.note);
+  }
+
+  await wizard.clickSave();
+  await wizard.expectHidden();
+}
+
+/**
+ * Pin an existing session by clicking the dedicated pin icon-button on its
+ * card. The button toggles between "Pin" and "Unpin" via its `aria-label`,
+ * so the helper anchors on the pin (not unpin) label to stay idempotent
+ * when the session is already unpinned.
+ *
+ * Drives the real UI path rather than seeding storage so the action
+ * exercises the same code path users go through.
+ *
+ * Relevant US: US-S008 (pinned sessions appear in their own section).
+ */
+export async function pinSession(page: Page, sessionId: string): Promise<void> {
+  const card = page.getByTestId(`session-card-${sessionId}`);
+  // The pin button uses `aria-label="Pin"` when the session is unpinned and
+  // `aria-label="Unpin"` once pinned. Match exactly to avoid hitting the
+  // latter after the click resolves.
+  await card.getByRole('button', { name: 'Pin', exact: true }).click();
+  await expect(
+    card.getByRole('button', { name: 'Unpin', exact: true }),
+  ).toBeVisible({ timeout: 5000 });
+}

--- a/e2e-shared/pages/ExportWizardPage.ts
+++ b/e2e-shared/pages/ExportWizardPage.ts
@@ -1,159 +1,46 @@
 /**
- * Page Object for the rules / sessions Export wizard.
+ * Page Object for the rules Export wizard.
  *
- * Pendant of `ImportWizardPage`. Wraps the Radix dialog opened from the
- * Import/Export options page (rules) and from the Sessions page
- * (sessions). The wizard is single-step:
+ * Wraps the Radix dialog opened from the Import/Export options page when
+ * the user picks "Export rules". Extends `ExportWizardPageBase` for the
+ * generic surface (note field, toolbar, footer split-button) and adds
+ * rule-specific helpers (`toggleRule`, `expectAllRulesSelected`).
  *
- * - an optional note `TextArea`,
- * - a "Select all / Deselect all" toolbar,
- * - a list of selectable rows (flat for rules, grouped Pinned/Sessions
- *   for sessions, cf. US-IE013),
- * - a "{n} rule(s) selected" / "{n} session(s) selected" count label,
- * - a footer split-button (`Export` + chevron menu with "JSON File" /
- *   "Clipboard").
+ * The sessions-flavoured sibling lives in `SessionsExportWizardPage`.
  *
- * As with the import wizard, this class exposes **atomic** building
- * blocks. Composed flows (`exportRulesToFile`, ...) live in
- * `e2e-shared/actions/rules-import-export.ts`.
+ * Selectors target the English UI (`--lang=en-US`). Subclass and override
+ * the locator getters to retarget another locale.
  *
- * Selectors target the English UI (`--lang=en-US`). Sub-class and
- * override the locator getters to retarget another locale.
+ * Relevant US: US-IE008 (entry point), US-IE009 (export to file / clipboard).
  */
-import { expect, type Locator, type Page } from '@playwright/test';
-import { DialogPage } from './DialogPage.js';
+import { expect, type Page } from '@playwright/test';
+import { ExportWizardPageBase } from './ExportWizardPageBase.js';
 
-export class ExportWizardPage extends DialogPage {
+export class ExportWizardPage extends ExportWizardPageBase {
   constructor(page: Page) {
     super(page);
   }
 
-  // ─── Locators ────────────────────────────────────────────────────────────
-
-  /** Every selectable row checkbox (rules or sessions). */
-  selectionList(): Locator {
-    return this.dialog().getByRole('checkbox');
-  }
-
-  /** Free-form export note textarea. */
-  noteField(): Locator {
-    return this.dialog().locator('textarea').first();
-  }
-
-  /** Primary "Export" button (opens the OS file save picker on Chrome). */
-  exportFileButton(): Locator {
-    return this.dialog().getByRole('button', { name: /^export$/i });
-  }
-
-  /**
-   * Chevron / "Export options" button that opens the split-button popover
-   * (file vs clipboard).
-   */
-  exportOptionsButton(): Locator {
-    return this.dialog().getByRole('button', { name: /export.*option|chevron/i });
-  }
-
-  /**
-   * Clipboard menu item inside the split-button popover. Lives outside
-   * the dialog (Radix Popover.Content is portalled), so we anchor on the
-   * page, not on `dialog()`.
-   */
-  exportClipboardButton(): Locator {
-    return this.page.getByRole('menuitem', { name: /clipboard/i });
-  }
-
-  /** "Select all" toolbar button (exact match to avoid the "Deselect all" sibling). */
-  selectAllButton(): Locator {
-    return this.dialog().getByRole('button', { name: 'Select All', exact: true });
-  }
-
-  /** "Deselect all" toolbar button. */
-  deselectAllButton(): Locator {
-    return this.dialog().getByRole('button', { name: /deselect all/i });
-  }
-
-  /**
-   * "Pinned Sessions" sub-group header checkbox (US-IE013). Locates the
-   * group-level checkbox by its accessible label so it does not collide
-   * with the per-session row checkboxes.
-   */
-  pinnedSessionsGroup(): Locator {
-    return this.dialog().getByRole('checkbox', { name: /pinned sessions/i });
-  }
-
-  /** "Sessions" sub-group header checkbox (US-IE013). */
-  sessionsGroup(): Locator {
-    return this.dialog().getByRole('checkbox', { name: /^sessions$/i });
-  }
-
   // ─── Atomic actions ──────────────────────────────────────────────────────
 
-  /** Type a note into the optional note field. */
-  async fillNote(text: string): Promise<void> {
-    await this.noteField().fill(text);
-  }
-
-  /** Click the "Select All" toolbar button. */
-  async selectAll(): Promise<void> {
-    await this.selectAllButton().click();
-  }
-
-  /** Click the "Deselect All" toolbar button. */
-  async deselectAll(): Promise<void> {
-    await this.deselectAllButton().click();
-  }
-
   /**
-   * Toggle a single row by its accessible label (rule label or session
-   * name). Uses the dialog-scoped checkbox lookup so headers and toolbar
-   * buttons cannot interfere.
+   * Toggle a rule row by its accessible label (the rule's `label` property).
+   * Uses the dialog-scoped checkbox lookup so headers and toolbar buttons
+   * cannot interfere.
    */
   async toggleRule(label: string): Promise<void> {
     await this.dialog().getByRole('checkbox', { name: label }).click();
   }
 
-  /** Click the primary "Export" button (file save path). */
-  async clickExportToFile(): Promise<void> {
-    await this.exportFileButton().click();
-  }
-
-  /** Open the split-button popover and click the "Clipboard" entry. */
-  async clickExportToClipboard(): Promise<void> {
-    await this.exportOptionsButton().click();
-    await this.exportClipboardButton().click();
-  }
-
-  /** Close the wizard via the "Cancel" button. */
-  async cancel(): Promise<void> {
-    await this.clickButton(/cancel/i);
-  }
-
   // ─── Atomic assertions ───────────────────────────────────────────────────
 
   /**
-   * Assert the wizard opened with every item pre-selected, by checking
-   * the count label matches `total`. Pass the known number of items so
-   * the assertion stays explicit (the page object never queries storage).
+   * Assert the wizard opened with every rule pre-selected, by checking the
+   * count label matches `total`. Pass the known number of rules so the
+   * assertion stays explicit (the page object never queries storage).
    */
   async expectAllRulesSelected(total: number): Promise<void> {
-    await expect(
-      this.dialog().getByText(new RegExp(`${total} rule.*selected`, 'i')),
-    ).toBeVisible();
-  }
-
-  /** Assert a previously typed note is reflected in the note field value. */
-  async expectNoteVisible(text: string): Promise<void> {
-    await expect(this.noteField()).toHaveValue(text);
-  }
-
-  /** Assert the primary Export button is enabled (selection non-empty). */
-  async expectExportButtonEnabled(): Promise<void> {
-    await expect(this.exportFileButton()).toBeEnabled();
-  }
-
-  /** Assert the primary Export button is disabled (no selection). */
-  async expectExportButtonDisabled(): Promise<void> {
-    await expect(this.exportFileButton()).toBeDisabled();
+    await this.expectSelectedCount(total);
   }
 
   /**

--- a/e2e-shared/pages/ExportWizardPageBase.ts
+++ b/e2e-shared/pages/ExportWizardPageBase.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared abstract base for export wizard Page Objects.
+ *
+ * Both `ExportWizardPage` (rules, US-IE008..US-IE009) and
+ * `SessionsExportWizardPage` (sessions, US-IE012..US-IE013) wrap the same
+ * `ExportWizardShell` UI surface: an optional note textarea, a
+ * "Select all / Deselect all" toolbar, a selectable list (flat for rules,
+ * Pinned/Sessions sub-groups for sessions) and a footer split-button
+ * (Export to JSON file / clipboard).
+ *
+ * This base captures the genuinely common parts only: note field, toolbar,
+ * primary footer split-button and Cancel button. Anything list-shape
+ * specific (rule labels, session group headers, pinned separator, ...)
+ * stays in the concrete subclasses to keep the inheritance lean.
+ *
+ * Subclasses customise the count-label assertion by overriding
+ * `expectSelectedCount(count)`, since the message ("rule(s) selected" vs
+ * "session(s) selected") is the only count-label difference between the
+ * two surfaces.
+ */
+import { expect, type Locator } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export abstract class ExportWizardPageBase extends DialogPage {
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Optional free-form export note textarea. */
+  noteField(): Locator {
+    return this.dialog().locator('textarea').first();
+  }
+
+  /** Primary "Export" button (defaults to JSON file). */
+  exportFileButton(): Locator {
+    return this.dialog().getByRole('button', { name: /^export$/i });
+  }
+
+  /**
+   * Chevron / "Export options" button that opens the split-button popover
+   * (file vs. clipboard).
+   */
+  exportOptionsButton(): Locator {
+    return this.dialog().getByRole('button', { name: /export.*option|chevron/i });
+  }
+
+  /**
+   * Clipboard menu item inside the split-button popover. Lives outside the
+   * dialog (Radix Popover.Content is portalled), so we anchor on the page,
+   * not on `dialog()`.
+   */
+  exportClipboardButton(): Locator {
+    return this.page.getByRole('menuitem', { name: /clipboard/i });
+  }
+
+  /** "Select all" toolbar button (exact match to avoid the sibling "Deselect all"). */
+  selectAllButton(): Locator {
+    return this.dialog().getByRole('button', { name: 'Select All', exact: true });
+  }
+
+  /** "Deselect all" toolbar button. */
+  deselectAllButton(): Locator {
+    return this.dialog().getByRole('button', { name: /deselect all/i });
+  }
+
+  /** Every selectable row checkbox inside the dialog (flat or grouped). */
+  selectionList(): Locator {
+    return this.dialog().getByRole('checkbox');
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /** Type into the optional note field. */
+  async fillNote(text: string): Promise<void> {
+    await this.noteField().fill(text);
+  }
+
+  /** Click the toolbar "Select All" button. */
+  async selectAll(): Promise<void> {
+    await this.selectAllButton().click();
+  }
+
+  /** Click the toolbar "Deselect All" button. */
+  async deselectAll(): Promise<void> {
+    await this.deselectAllButton().click();
+  }
+
+  /** Click the primary "Export" button (writes a JSON file). */
+  async clickExportToFile(): Promise<void> {
+    await this.exportFileButton().click();
+  }
+
+  /** Open the split-button popover and click the "Clipboard" entry. */
+  async clickExportToClipboard(): Promise<void> {
+    await this.exportOptionsButton().click();
+    await this.exportClipboardButton().click();
+  }
+
+  /** Close the wizard via its "Cancel" button. */
+  async cancel(): Promise<void> {
+    await this.clickButton(/cancel/i);
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /** Assert the primary Export button is enabled (selection non-empty). */
+  async expectExportButtonEnabled(): Promise<void> {
+    await expect(this.exportFileButton()).toBeEnabled();
+  }
+
+  /** Assert the primary Export button is disabled (no selection). */
+  async expectExportButtonDisabled(): Promise<void> {
+    await expect(this.exportFileButton()).toBeDisabled();
+  }
+
+  /** Assert the previously typed note is reflected in the note field value. */
+  async expectNoteVisible(text: string): Promise<void> {
+    await expect(this.noteField()).toHaveValue(text);
+  }
+
+  /**
+   * Subclasses know which i18n string to match for the "{n} item(s) selected"
+   * count label (rule vs. session), so the base only declares the contract.
+   */
+  abstract expectSelectedCount(count: number): Promise<void>;
+}

--- a/e2e-shared/pages/RestoreWizardPage.ts
+++ b/e2e-shared/pages/RestoreWizardPage.ts
@@ -1,0 +1,205 @@
+/**
+ * Page Object for the Restore wizard (US-S004, US-S005, US-S017).
+ *
+ * Wraps the Radix dialog opened by "Customize" on a session card's restore
+ * split-button. The wizard has two steps:
+ *
+ * - Step 0 (Selection): tab selection via TabTree + destination radio
+ *   (current window / new window / replace current window).
+ * - Step 1 (Conflict resolution, only when restoring into the current
+ *   window with detected conflicts): duplicate-tab action + per-group
+ *   merge/create_new/skip selectors.
+ *
+ * The "Replace" mode wipes the current window; the "Merge" mode is the
+ * combination of selecting `current` as destination plus picking the
+ * merge action on each conflicting group on step 1. Composed flows
+ * (`restoreSessionAsReplace`, `restoreSessionAsMerge`) live in
+ * `e2e-shared/actions/sessions-restore.ts`.
+ *
+ * Selectors target the English UI (`--lang=en-US`).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export type RestoreTargetMode = 'current' | 'new' | 'replace';
+
+export type DuplicateTabAction = 'skip' | 'open_anyway';
+
+export type GroupConflictAction = 'merge' | 'create_new' | 'skip';
+
+export class RestoreWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override dialog(): Locator {
+    return this.page.getByTestId('wizard-restore');
+  }
+
+  // ─── Locators: step containers ───────────────────────────────────────────
+
+  /** Step 0 (selection + destination). */
+  step0Selection(): Locator {
+    return this.dialog().getByTestId('wizard-restore-step-0');
+  }
+
+  /** Step 1 (conflict resolution), visible only when conflicts are detected. */
+  step1Conflicts(): Locator {
+    return this.dialog().getByTestId('wizard-restore-step-1');
+  }
+
+  // ─── Locators: step 0 ────────────────────────────────────────────────────
+
+  /** Radio group for the restore destination. */
+  modeSelector(): Locator {
+    return this.dialog().getByTestId('wizard-restore-radio-destination');
+  }
+
+  /** Restore-into-current-window radio. */
+  currentWindowRadio(): Locator {
+    return this.dialog().getByTestId('wizard-restore-radio-current-window');
+  }
+
+  /** Restore-into-new-window radio. */
+  newWindowRadio(): Locator {
+    return this.dialog().getByTestId('wizard-restore-radio-new-window');
+  }
+
+  /** Replace-current-window radio. */
+  replaceWindowRadio(): Locator {
+    return this.dialog().getByTestId('wizard-restore-radio-replace-window');
+  }
+
+  /** TabTree container for picking which tabs to restore. */
+  tabSelectionList(): Locator {
+    return this.dialog().getByTestId('tab-tree');
+  }
+
+  /** Primary "Restore" button (step 0 + step 1). */
+  restoreButton(): Locator {
+    return this.dialog().getByTestId('wizard-restore-btn-restore');
+  }
+
+  // ─── Locators: step 1 ────────────────────────────────────────────────────
+
+  /** Duplicate-tab action radio for "skip" (default). */
+  duplicateSkipRadio(): Locator {
+    return this.step1Conflicts().locator('[role="radio"][value="skip"]');
+  }
+
+  /** Duplicate-tab action radio for "open_anyway". */
+  duplicateOpenAnywayRadio(): Locator {
+    return this.step1Conflicts().locator('[role="radio"][value="open_anyway"]');
+  }
+
+  /**
+   * "Back" button visible on step 1 (returns to step 0). The button label
+   * is the same "Previous" string used by other wizards.
+   */
+  backButton(): Locator {
+    return this.dialog().getByRole('button', { name: /previous/i });
+  }
+
+  // ─── Atomic actions: destination ─────────────────────────────────────────
+
+  /** Select the "current window" destination radio. */
+  async selectCurrentWindowMode(): Promise<void> {
+    await this.currentWindowRadio().click();
+  }
+
+  /** Select the "new window" destination radio. */
+  async selectNewWindowMode(): Promise<void> {
+    await this.newWindowRadio().click();
+  }
+
+  /** Select the "replace current window" destination radio (US-RF Replace). */
+  async selectReplaceMode(): Promise<void> {
+    await this.replaceWindowRadio().click();
+  }
+
+  /**
+   * Select the "Merge" outcome: equivalent to picking `current` as the
+   * destination, then resolving conflicts via the merge action on the
+   * conflict step (cf. `setGroupConflictAction`).
+   *
+   * Picking the destination only; callers drive the conflict step explicitly.
+   */
+  async selectMergeMode(): Promise<void> {
+    await this.currentWindowRadio().click();
+  }
+
+  // ─── Atomic actions: tab selection ───────────────────────────────────────
+
+  /**
+   * Toggle a single tab by its title. Each row exposes a Radix Checkbox
+   * with `aria-label="Select tab {title}"` (cf. `tabTreeSelectTab` message).
+   */
+  async toggleTab(title: string): Promise<void> {
+    await this.tabSelectionList()
+      .getByRole('checkbox', { name: new RegExp(`select tab.*${escapeRegExp(title)}`, 'i') })
+      .first()
+      .click();
+  }
+
+  // ─── Atomic actions: navigation ──────────────────────────────────────────
+
+  /**
+   * Click the primary "Restore" button. From step 0 with no conflicts the
+   * wizard closes; with conflicts it advances to step 1 instead.
+   */
+  async clickRestore(): Promise<void> {
+    await this.restoreButton().click();
+  }
+
+  /** Return to step 0 from the conflict resolution step. */
+  async clickBack(): Promise<void> {
+    await this.backButton().click();
+  }
+
+  // ─── Atomic actions: conflict resolution (step 1) ────────────────────────
+
+  /** Pick the duplicate-tab action (skip / open anyway). */
+  async setDuplicateTabAction(action: DuplicateTabAction): Promise<void> {
+    if (action === 'skip') {
+      await this.duplicateSkipRadio().click();
+    } else {
+      await this.duplicateOpenAnywayRadio().click();
+    }
+  }
+
+  /**
+   * Pick the conflict action for a specific group, identified by its title.
+   * The conflict row renders the group title; the Select sits next to it
+   * with an `aria-label` localized to "Group action". The selector below
+   * scopes by row to disambiguate when several groups conflict.
+   */
+  async setGroupConflictAction(groupTitle: string, action: GroupConflictAction): Promise<void> {
+    const row = this.step1Conflicts().locator('div', { hasText: groupTitle }).first();
+    await row.locator('button[role="combobox"], .rt-SelectTrigger').first().click();
+    const labels: Record<GroupConflictAction, RegExp> = {
+      merge: /merge/i,
+      create_new: /create.*new|new group/i,
+      skip: /skip/i,
+    };
+    await this.page.getByRole('option', { name: labels[action] }).first().click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  async expectOnStep(step: 0 | 1): Promise<void> {
+    if (step === 0) {
+      await expect(this.step0Selection()).toBeVisible();
+    } else {
+      await expect(this.step1Conflicts()).toBeVisible();
+    }
+  }
+
+  /** Assert the current-window radio is the active destination. */
+  async expectCurrentWindowSelected(): Promise<void> {
+    await expect(this.currentWindowRadio()).toBeChecked();
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/e2e-shared/pages/RuleWizardPage.ts
+++ b/e2e-shared/pages/RuleWizardPage.ts
@@ -1,0 +1,297 @@
+/**
+ * Page Object for the Rule Wizard (create + edit).
+ *
+ * Wraps the Radix dialog opened from the Domain Rules options page when
+ * the user clicks "Add rule" (creation) or "Edit" on a rule's menu (edit).
+ * In creation mode the wizard walks through four steps (Identity, Config,
+ * Options, Summary). In edit mode the wizard lands directly on the summary
+ * view and exposes one "Modify" button per section, each opening a
+ * dedicated sub-dialog (`IdentityEditModal`, `ConfigEditModal`,
+ * `OptionsEditModal`).
+ *
+ * Exposes atomic building blocks only: step-scoped locators, per-step
+ * actions (`fillIdentity`, `selectConfigMode`, ...), navigation
+ * (`clickNext`, `clickBack`) and submission (`clickCreate`, `clickSave`).
+ * Composed flows belong in `e2e-shared/actions/rules-management.ts`.
+ *
+ * Selectors target the English UI (`--lang=en-US`). Subclass and override
+ * the locator getters to retarget another locale.
+ *
+ * Note on `ConfigMode`: the codebase uses `'preset' | 'ask' | 'manual'`;
+ * the Page Object exposes the same triplet (some legacy wording calls the
+ * "ask" mode "custom", they are equivalent at the UI level).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export type RuleWizardConfigMode = 'preset' | 'ask' | 'manual';
+
+/**
+ * Group-name sources exposed in the manual configuration mode (mirrors
+ * `GroupNameSourceValue` in the codebase, omitting variants users cannot
+ * select from the wizard's select).
+ */
+export type RuleWizardGroupNameSource =
+  | 'title'
+  | 'url'
+  | 'manual'
+  | 'smart'
+  | 'smart_manual'
+  | 'smart_preset'
+  | 'smart_label';
+
+export class RuleWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override dialog(): Locator {
+    return this.page.getByTestId('wizard-rule');
+  }
+
+  // ─── Locators: step containers ───────────────────────────────────────────
+
+  /** Step 1 container (Identity inputs). */
+  step1Identity(): Locator {
+    return this.dialog().getByTestId('wizard-rule-step-1');
+  }
+
+  /** Step 2 container (Configuration mode + preset/manual fields). */
+  step2Config(): Locator {
+    return this.dialog().getByTestId('wizard-rule-step-2');
+  }
+
+  /** Step 3 container (Options: deduplication toggle + match mode). */
+  step3Options(): Locator {
+    return this.dialog().getByTestId('wizard-rule-step-3');
+  }
+
+  /** Step 4 container (Summary cards + Create button). */
+  step4Summary(): Locator {
+    return this.dialog().getByTestId('wizard-rule-step-4');
+  }
+
+  /** Summary view rendered in edit mode (no stepper). */
+  editSummary(): Locator {
+    return this.dialog().getByTestId('wizard-rule-edit-summary');
+  }
+
+  /** Wizard stepper component (creation mode only). */
+  stepper(): Locator {
+    return this.dialog().getByTestId('wizard-rule-stepper');
+  }
+
+  // ─── Locators: identity fields ───────────────────────────────────────────
+
+  /** Rule label text input. */
+  labelInput(): Locator {
+    return this.dialog().getByTestId('wizard-rule-field-label');
+  }
+
+  /** Rule domain filter text input. */
+  domainFilterInput(): Locator {
+    return this.dialog().getByTestId('wizard-rule-field-domain');
+  }
+
+  /**
+   * Category picker trigger button (the colored swatch shown next to the
+   * label input). Opens a Radix Popover containing the category radios.
+   */
+  categoryPicker(): Locator {
+    // The CategoryPicker is rendered next to the label input; its trigger is
+    // a `<button type="button">` with an `aria-label` matching the currently
+    // selected category. The only stable anchor across locales is the
+    // sibling structure of TextFieldWithCategory.
+    return this.step1Identity().locator('button[type="button"]').first();
+  }
+
+  // ─── Locators: config & options ──────────────────────────────────────────
+
+  /** Configuration mode radio (one of `preset`, `ask`, `manual`). */
+  configModeRadio(mode: RuleWizardConfigMode): Locator {
+    return this.dialog().getByTestId(`config-mode-${mode}`);
+  }
+
+  /** SearchableSelect trigger for picking a preset in preset mode. */
+  presetTrigger(): Locator {
+    return this.dialog().locator('#presetId');
+  }
+
+  /** Deduplication enable/disable switch on step 3. */
+  deduplicationSwitch(): Locator {
+    return this.dialog().locator('[role="switch"]');
+  }
+
+  /**
+   * `radiogroup` for the deduplication match mode (visible only when
+   * deduplication is enabled).
+   */
+  deduplicationMatchModeGroup(): Locator {
+    return this.dialog().locator('[role="radiogroup"]');
+  }
+
+  // ─── Locators: footer buttons ────────────────────────────────────────────
+
+  nextButton(): Locator {
+    return this.dialog().getByTestId('wizard-rule-btn-next');
+  }
+
+  /** Previous button (visible from step 2 onwards). */
+  backButton(): Locator {
+    return this.dialog().getByRole('button', { name: /previous/i });
+  }
+
+  /** Create button (creation mode, only on step 4). */
+  createButton(): Locator {
+    return this.dialog().getByTestId('wizard-rule-btn-create');
+  }
+
+  /** Save button (edit mode). */
+  saveButton(): Locator {
+    return this.dialog().getByTestId('wizard-rule-btn-save');
+  }
+
+  /** Cancel button (creation step 1 and edit mode). */
+  cancelButton(): Locator {
+    return this.dialog().getByRole('button', { name: /cancel/i });
+  }
+
+  /**
+   * "Modify" button in the summary, scoped to a given section (0 = Identity,
+   * 1 = Config, 2 = Options). In creation mode it jumps back to the step;
+   * in edit mode it opens the matching sub-dialog.
+   */
+  modifyButton(stepIndex: 0 | 1 | 2): Locator {
+    return this.dialog().getByTestId(`wizard-rule-edit-modify-step-${stepIndex}`);
+  }
+
+  // ─── Atomic actions: identity (step 1) ───────────────────────────────────
+
+  /** Fill the rule label input. */
+  async fillLabel(label: string): Promise<void> {
+    await this.labelInput().fill(label);
+  }
+
+  /** Fill the domain filter input. */
+  async fillDomainFilter(domain: string): Promise<void> {
+    await this.domainFilterInput().fill(domain);
+  }
+
+  /**
+   * Open the category picker popover and select a category by its
+   * accessible label. Pass `null` to clear the selection.
+   */
+  async selectCategory(label: string | null): Promise<void> {
+    await this.categoryPicker().click();
+    const popover = this.page.locator('[role="radiogroup"]').last();
+    const target = label === null ? /no category|none/i : new RegExp(label, 'i');
+    await popover.getByRole('radio', { name: target }).click();
+  }
+
+  // ─── Atomic actions: configuration (step 2) ──────────────────────────────
+
+  /** Pick a configuration mode in step 2. */
+  async selectConfigMode(mode: RuleWizardConfigMode): Promise<void> {
+    await this.configModeRadio(mode).click();
+  }
+
+  /**
+   * Pick a preset by its id. The SearchableInlineList renders one button
+   * per preset whose `data-value` carries the preset id; click it directly
+   * to avoid filtering by visible name (which depends on the preset catalog
+   * and the active locale).
+   */
+  async selectPreset(presetId: string): Promise<void> {
+    await this.dialog().locator(`[data-value="${presetId}"]`).first().click();
+  }
+
+  /**
+   * Pick a group-name source (manual mode only). The enum values map to
+   * the visible English labels rendered by the Radix Select. Override this
+   * method in a subclass to retarget another locale.
+   */
+  async setGroupNameSource(source: RuleWizardGroupNameSource): Promise<void> {
+    const labels: Record<RuleWizardGroupNameSource, string> = {
+      title: 'Title',
+      url: 'URL',
+      manual: 'Ask',
+      smart: 'Smart',
+      smart_manual: 'Smart + Ask',
+      smart_preset: 'Smart + Preset',
+      smart_label: 'Smart + Label',
+    };
+    await this.dialog().locator('.rt-SelectTrigger').first().click();
+    // Radix Select.Content portals the options outside the dialog; anchor on
+    // the page and match the option's accessible name.
+    await this.page
+      .getByRole('option', { name: new RegExp(`^${labels[source]}`, 'i') })
+      .first()
+      .click();
+  }
+
+  // ─── Atomic actions: options (step 3) ────────────────────────────────────
+
+  /** Toggle the deduplication switch on step 3 to match `enabled`. */
+  async setDeduplicationEnabled(enabled: boolean): Promise<void> {
+    const sw = this.deduplicationSwitch();
+    const state = await sw.getAttribute('data-state');
+    const isOn = state === 'checked';
+    if (isOn !== enabled) await sw.click();
+  }
+
+  // ─── Atomic actions: navigation ──────────────────────────────────────────
+
+  async clickNext(): Promise<void> {
+    await this.nextButton().click();
+  }
+
+  async clickBack(): Promise<void> {
+    await this.backButton().click();
+  }
+
+  /** Submit the creation wizard from step 4. */
+  async clickCreate(): Promise<void> {
+    await this.createButton().click();
+  }
+
+  /** Save the edit wizard (commits the summary). */
+  async clickSave(): Promise<void> {
+    await this.saveButton().click();
+  }
+
+  /** Close the wizard via its Cancel button. */
+  async clickCancel(): Promise<void> {
+    await this.cancelButton().click();
+  }
+
+  /**
+   * Click the "Modify" button for the given summary section (0 = Identity,
+   * 1 = Config, 2 = Options).
+   */
+  async clickModifySection(stepIndex: 0 | 1 | 2): Promise<void> {
+    await this.modifyButton(stepIndex).click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /** Assert the wizard is on a given step container (1-based). */
+  async expectOnStep(step: 1 | 2 | 3 | 4): Promise<void> {
+    const containers = [
+      this.step1Identity(),
+      this.step2Config(),
+      this.step3Options(),
+      this.step4Summary(),
+    ];
+    await expect(containers[step - 1]).toBeVisible();
+  }
+
+  /**
+   * Assert the wizard opened in edit mode for `ruleId`. The wizard does not
+   * surface the rule id directly; the contract is "no stepper, summary view
+   * visible" which the edit-mode rendering enforces.
+   */
+  async expectInEditMode(_ruleId?: string): Promise<void> {
+    await expect(this.editSummary()).toBeVisible();
+    await expect(this.stepper()).toHaveCount(0);
+  }
+}

--- a/e2e-shared/pages/SessionsExportWizardPage.ts
+++ b/e2e-shared/pages/SessionsExportWizardPage.ts
@@ -1,0 +1,108 @@
+/**
+ * Page Object for the sessions Export wizard.
+ *
+ * Wraps the Radix dialog opened from the Import/Export options page when
+ * the user picks "Export sessions" (and from the Sessions page in some
+ * narrative flows). Distinct from `ExportWizardPage` (rules) because the
+ * selectable list is split in two sub-groups: Pinned Sessions (US-IE013)
+ * and Sessions, each with its own indeterminate header checkbox and a
+ * `Separator` between them when both buckets are non-empty.
+ *
+ * Inherits the common note field, toolbar and footer split-button from
+ * `ExportWizardPageBase`. Only the list shape and the count label differ.
+ *
+ * Selectors target the English UI (`--lang=en-US`). Subclass and override
+ * the locator getters to retarget another locale.
+ *
+ * Relevant US: US-IE012 (export sessions envelope), US-IE013 (pinned vs
+ * normal sub-groups).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { ExportWizardPageBase } from './ExportWizardPageBase.js';
+
+export class SessionsExportWizardPage extends ExportWizardPageBase {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /**
+   * Group-level checkbox for the Pinned Sessions sub-group (US-IE013).
+   * Located by its accessible label so it doesn't collide with the
+   * per-session row checkboxes.
+   */
+  pinnedGroupCheckbox(): Locator {
+    return this.dialog().getByRole('checkbox', { name: /pinned sessions/i });
+  }
+
+  /** Group-level checkbox for the Sessions (unpinned) sub-group. */
+  normalGroupCheckbox(): Locator {
+    return this.dialog().getByRole('checkbox', { name: /^sessions$/i });
+  }
+
+  /**
+   * The "Pinned Sessions" section header text. Use it to assert the section
+   * is rendered (it is hidden when no pinned sessions exist).
+   */
+  pinnedGroup(): Locator {
+    return this.dialog().getByText(/pinned sessions/i).first();
+  }
+
+  /**
+   * The "Sessions" section header text. Use it to assert the unpinned
+   * section is rendered.
+   */
+  normalGroup(): Locator {
+    return this.dialog().getByText(/^sessions$/i).first();
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /**
+   * Toggle a single session row by its accessible label (the session's
+   * `name` property).
+   */
+  async toggleSession(name: string): Promise<void> {
+    await this.dialog().getByRole('checkbox', { name }).click();
+  }
+
+  /** Toggle the group-level checkbox of the Pinned Sessions section. */
+  async togglePinnedGroup(): Promise<void> {
+    await this.pinnedGroupCheckbox().click();
+  }
+
+  /** Toggle the group-level checkbox of the Sessions (unpinned) section. */
+  async toggleNormalGroup(): Promise<void> {
+    await this.normalGroupCheckbox().click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /**
+   * Assert the visual separator between Pinned and Sessions is present.
+   * Rendered as a Radix Separator inside the dialog body, distinct from the
+   * footer separator which sits below the Cancel/Export buttons. Asserting
+   * both section headers cover the visual contract without depending on a
+   * brittle DOM index.
+   */
+  async expectPinnedSeparator(): Promise<void> {
+    await expect(this.pinnedGroup()).toBeVisible();
+    await expect(this.normalGroup()).toBeVisible();
+  }
+
+  /** Assert the wizard opened with every session pre-selected. */
+  async expectAllSessionsSelected(total: number): Promise<void> {
+    await this.expectSelectedCount(total);
+  }
+
+  /**
+   * Assert the "{count} session(s) selected" label reflects `count`.
+   * Counterpart of `ExportWizardPage.expectSelectedCount` for sessions.
+   */
+  async expectSelectedCount(count: number): Promise<void> {
+    await expect(
+      this.dialog().getByText(new RegExp(`${count} session.*selected`, 'i')),
+    ).toBeVisible();
+  }
+}

--- a/e2e-shared/pages/SnapshotWizardPage.ts
+++ b/e2e-shared/pages/SnapshotWizardPage.ts
@@ -1,0 +1,157 @@
+/**
+ * Page Object for the Snapshot wizard (session creation, US-S001).
+ *
+ * Wraps the Radix dialog opened by "Take Snapshot" on the Sessions page.
+ * Exposes the session-name input, the TabTree selection (with its
+ * Select all / Deselect all toolbar), the note field and the Save button.
+ *
+ * The wizard pre-selects every captured tab on open; `expectSaveEnabled`
+ * is the most reliable way to wait for the asynchronous capture to finish
+ * (the Save button is disabled until the capture resolves and at least
+ * one tab is selected).
+ *
+ * Composed flows (`createSnapshotWithTabs`, ...) live in
+ * `e2e-shared/actions/sessions-snapshot.ts`.
+ *
+ * Selectors target the English UI (`--lang=en-US`).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export class SnapshotWizardPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override dialog(): Locator {
+    return this.page.getByTestId('wizard-snapshot');
+  }
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Session name input. */
+  sessionNameInput(): Locator {
+    return this.dialog().getByTestId('wizard-snapshot-field-name');
+  }
+
+  /** Optional note textarea. */
+  noteField(): Locator {
+    return this.dialog().getByTestId('wizard-snapshot-field-notes');
+  }
+
+  /** TabTree container holding every selectable row. */
+  tabList(): Locator {
+    return this.dialog().getByTestId('tab-tree');
+  }
+
+  /**
+   * Collection of selectable checkboxes inside the TabTree (one per tab
+   * plus one per group header). Used to count selection state.
+   */
+  tabCheckboxes(): Locator {
+    return this.tabList().getByRole('checkbox');
+  }
+
+  /** "Select all" button rendered inside the TabTree action bar. */
+  selectAllButton(): Locator {
+    return this.tabList().getByRole('button', { name: 'Select All', exact: true });
+  }
+
+  /** "Deselect all" button (replaces Select All when everything is checked). */
+  deselectAllButton(): Locator {
+    return this.tabList().getByRole('button', { name: 'Deselect All', exact: true });
+  }
+
+  /** Primary "Save Session" button in the footer. */
+  saveButton(): Locator {
+    return this.dialog().getByTestId('wizard-snapshot-btn-save');
+  }
+
+  /** "Cancel" button in the footer. */
+  cancelButton(): Locator {
+    return this.dialog().getByTestId('wizard-snapshot-btn-cancel');
+  }
+
+  /**
+   * Blue Callout shown when the wizard was opened from a Chrome tab group
+   * (only a subset of tabs is preselected).
+   */
+  activeGroupCallout(): Locator {
+    return this.dialog().getByTestId('wizard-snapshot-group-callout');
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /** Fill the session name input. */
+  async fillName(name: string): Promise<void> {
+    await this.sessionNameInput().fill(name);
+  }
+
+  /** Fill the optional note textarea. */
+  async fillNote(text: string): Promise<void> {
+    await this.noteField().fill(text);
+  }
+
+  /**
+   * Toggle a single tab by its title. Each TabTree row exposes a Radix
+   * Checkbox with `aria-label="Select tab {title}"` (cf. `tabTreeSelectTab`
+   * message). When the wizard contains multiple tabs sharing the same
+   * title, only the first match is toggled.
+   */
+  async toggleTab(title: string): Promise<void> {
+    await this.tabList()
+      .getByRole('checkbox', { name: new RegExp(`select tab.*${escapeRegExp(title)}`, 'i') })
+      .first()
+      .click();
+  }
+
+  /** Click the TabTree "Select all" button. */
+  async selectAllTabs(): Promise<void> {
+    await this.selectAllButton().click();
+  }
+
+  /** Click the TabTree "Deselect all" button. */
+  async deselectAllTabs(): Promise<void> {
+    await this.deselectAllButton().click();
+  }
+
+  /** Submit the wizard via "Save Session". */
+  async clickSave(): Promise<void> {
+    await this.saveButton().click();
+  }
+
+  /** Cancel the wizard. */
+  async clickCancel(): Promise<void> {
+    await this.cancelButton().click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /**
+   * Assert the Save button is enabled. Useful to wait for the asynchronous
+   * `captureCurrentTabs()` call to resolve before driving the wizard.
+   */
+  async expectSaveButtonEnabled(): Promise<void> {
+    await expect(this.saveButton()).toBeEnabled({ timeout: 10_000 });
+  }
+
+  /** Assert the Save button is disabled (capture pending or no tab selected). */
+  async expectSaveButtonDisabled(): Promise<void> {
+    await expect(this.saveButton()).toBeDisabled();
+  }
+
+  /**
+   * Assert the TabTree exposes exactly `count` tab rows (groups excluded).
+   * Tab rows are identified by their `aria-label` starting with
+   * `Select tab` (group headers use `Select group`).
+   */
+  async expectCapturedTabsCount(count: number): Promise<void> {
+    await expect(
+      this.tabList().getByRole('checkbox', { name: /^select tab/i }),
+    ).toHaveCount(count);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -8,4 +8,18 @@ export {
   ImportWizardPage,
   type ImportClassificationCounts,
 } from './ImportWizardPage.js';
+export { ExportWizardPageBase } from './ExportWizardPageBase.js';
 export { ExportWizardPage } from './ExportWizardPage.js';
+export { SessionsExportWizardPage } from './SessionsExportWizardPage.js';
+export {
+  RuleWizardPage,
+  type RuleWizardConfigMode,
+  type RuleWizardGroupNameSource,
+} from './RuleWizardPage.js';
+export { SnapshotWizardPage } from './SnapshotWizardPage.js';
+export {
+  RestoreWizardPage,
+  type RestoreTargetMode,
+  type DuplicateTabAction,
+  type GroupConflictAction,
+} from './RestoreWizardPage.js';


### PR DESCRIPTION
Closes #307 (Lot 4 of the E2E Page Objects migration epic).

Page Objects added under `e2e-shared/pages/`:
- `RuleWizardPage` covers the 4 creation steps and the edit-mode summary
  view, exposing step-scoped locators, mode selection (`preset`/`ask`/
  `manual`), preset/group-name source pickers, navigation and submission.
- `SnapshotWizardPage` wraps the session-snapshot wizard with name input,
  TabTree selection helpers and Save-readiness assertion.
- `RestoreWizardPage` covers both wizard steps (selection + conflict
  resolution) with destination mode helpers (Replace / Merge / new
  window) and per-group conflict actions.
- `SessionsExportWizardPage` wraps the sessions export wizard with
  Pinned / Sessions sub-group helpers (US-IE013).
- `ExportWizardPageBase` extracts the truly shared surface (note field,
  Select-all toolbar, footer split-button, Cancel) between rules export
  (`ExportWizardPage`) and sessions export. Inheritance stays minimal:
  list-shape and count-label specifics remain in each subclass.

Domain Actions added under `e2e-shared/actions/`:
- `rules-management.ts`: `createRuleViaWizard`, `editRule`, plus open
  helpers; JSDoc references US-R001..US-R005.
- `sessions-snapshot.ts`: `createSnapshotWithTabs`, `pinSession`,
  `openSnapshotWizard`; JSDoc references US-S001 / US-S008.
- `sessions-restore.ts`: `restoreSessionAsReplace`,
  `restoreSessionAsMerge` (auto-handles the conflict step when
  conflicts are detected); JSDoc references US-S003..US-S005 / US-S011.
- `sessions-export.ts`: `exportSessionsToFile`,
  `exportSessionsToClipboard`; JSDoc references US-IE012 / US-IE013.

No spec is migrated in this lot (cf. issue #307: spec migration lands
in lot 5). `pnpm compile` passes; existing
`tests/e2e/import-export.spec.ts` usage of `ExportWizardPage` is
preserved via the new base class.