### PR TITLE
test(e2e): migrate Sessions, Rules, Combined specs to Page Objects (lot 5)

### DIFF
--- a/e2e-shared/actions/index.ts
+++ b/e2e-shared/actions/index.ts
@@ -47,3 +47,34 @@ export {
   exportSessionsToClipboard,
   type ExportSessionsOptions,
 } from './sessions-export.js';
+
+export {
+  openPopup,
+  triggerOrganizeFromPopup,
+} from './popup-actions.js';
+
+export {
+  openChildTabViaMiddleClick,
+  openChildTabViaContextMenu,
+  waitForGroupCreated,
+  type GroupingHelpers,
+  type TabGroupInfo,
+} from './tabs-grouping.js';
+
+export {
+  expectTabDeduplicated,
+  undoLastDeduplication,
+  type DeduplicationHelpers,
+} from './tabs-deduplication.js';
+
+export {
+  getServiceWorker,
+  getServiceWorkerWithUndoFn,
+  getServiceWorkerWithOrganizeFn,
+  getNotificationIds,
+  getSmartTabNotificationIds,
+  clearAllNotifications,
+  setNotificationPrefs,
+  executeNotificationUndo,
+  triggerOrganizeAllTabsViaSW,
+} from './notifications.js';

--- a/e2e-shared/actions/notifications.ts
+++ b/e2e-shared/actions/notifications.ts
@@ -1,0 +1,181 @@
+/**
+ * Composed flows for native browser notifications driven by the extension
+ * service worker.
+ *
+ * The notifications domain is one of the few corners of the test suite
+ * that talks to the service worker directly rather than the DOM (Chrome
+ * does not expose notification chrome to Playwright). These helpers wrap
+ * the recurring SW dance so notification-aware specs stop duplicating the
+ * same `evaluate` payloads.
+ *
+ * Relevant US: US-N001..US-N005.
+ */
+import type { BrowserContext, Page } from '@playwright/test';
+
+// Minimal Chrome typings used inside `evaluate` callbacks. The full
+// `@types/chrome` is not a dependency of the shared bundle, so we model
+// only the surface this file needs (notifications + storage + windows).
+declare const chrome: {
+  notifications: {
+    getAll(cb: (notifications: Record<string, unknown>) => void): void;
+    clear(id: string): void;
+  };
+  storage: {
+    local: {
+      set(items: Record<string, unknown>): Promise<void>;
+    };
+  };
+  windows: {
+    getCurrent(): Promise<{ id?: number }>;
+  };
+};
+
+/**
+ * Resolve the running service worker, retrying briefly when Chrome has
+ * idle-terminated it between tests. Returns the SW page or throws after
+ * `timeoutMs`.
+ */
+export async function getServiceWorker(
+  context: BrowserContext,
+  timeoutMs = 5_000,
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+  let sw = context.serviceWorkers()[0];
+  while (!sw && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+    sw = context.serviceWorkers()[0];
+  }
+  if (!sw) throw new Error('Service worker not available (idle termination?)');
+  return sw as unknown as Page;
+}
+
+/**
+ * Polls until `executeNotificationUndoById` is exposed on the SW's
+ * `globalThis`. Needed because the SW may be idle-terminated and
+ * restarting; the test would race the SW's re-initialisation otherwise.
+ */
+export async function getServiceWorkerWithUndoFn(
+  context: BrowserContext,
+  timeoutMs = 5_000,
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const sw = context.serviceWorkers()[0];
+    if (sw) {
+      const ready = await sw
+        .evaluate(() => typeof (globalThis as unknown as { executeNotificationUndoById?: unknown }).executeNotificationUndoById === 'function')
+        .catch(() => false);
+      if (ready) return sw as unknown as Page;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error('executeNotificationUndoById not available on SW globalThis after timeout');
+}
+
+/**
+ * Polls until `handleOrganizeAllTabs` is exposed on the SW's `globalThis`.
+ * Used by popup-organize specs that bypass the popup UI and call the
+ * handler directly.
+ */
+export async function getServiceWorkerWithOrganizeFn(
+  context: BrowserContext,
+  timeoutMs = 5_000,
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const sw = context.serviceWorkers()[0];
+    if (sw) {
+      const ready = await sw
+        .evaluate(() => typeof (globalThis as unknown as { handleOrganizeAllTabs?: unknown }).handleOrganizeAllTabs === 'function')
+        .catch(() => false);
+      if (ready) return sw as unknown as Page;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error('handleOrganizeAllTabs not available on SW globalThis after timeout');
+}
+
+/** Returns every notification id currently registered with Chrome. */
+export async function getNotificationIds(sw: Page): Promise<string[]> {
+  return sw.evaluate(async () => {
+    return new Promise<string[]>((resolve) =>
+      chrome.notifications.getAll((n) => resolve(Object.keys(n ?? {}))),
+    );
+  });
+}
+
+/**
+ * Returns notification ids whose prefix matches `prefix` (defaults to
+ * `smarttab-`, the prefix used by the extension). Filters out ids
+ * registered by other extensions / Chrome internals.
+ */
+export async function getSmartTabNotificationIds(
+  sw: Page,
+  prefix = 'smarttab-',
+): Promise<string[]> {
+  const all = await getNotificationIds(sw);
+  return all.filter((id) => id.startsWith(prefix));
+}
+
+/** Clears every Chrome notification registered for the current profile. */
+export async function clearAllNotifications(sw: Page): Promise<void> {
+  await sw.evaluate(async () => {
+    const all = await new Promise<Record<string, unknown>>((resolve) =>
+      chrome.notifications.getAll((n) => resolve(n ?? {})),
+    );
+    await Promise.all(Object.keys(all).map((id) => chrome.notifications.clear(id)));
+  });
+}
+
+/**
+ * Writes notification preferences directly to `chrome.storage.local`.
+ * Accepts a partial patch; omitted keys keep their stored value.
+ */
+export async function setNotificationPrefs(
+  sw: Page,
+  prefs: { notifyOnGrouping?: boolean; notifyOnDeduplication?: boolean },
+): Promise<void> {
+  await sw.evaluate(async (p: Record<string, unknown>) => {
+    await chrome.storage.local.set(p);
+  }, prefs as Record<string, unknown>);
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+/**
+ * Executes the SW-exposed `executeNotificationUndoById` helper for the
+ * supplied notification id. Resolves once the SW has finished running the
+ * undo handler (no fixed wait; callers add their own settle if needed).
+ */
+export async function executeNotificationUndo(
+  context: BrowserContext,
+  notificationId: string,
+): Promise<void> {
+  const sw = await getServiceWorkerWithUndoFn(context);
+  await sw.evaluate(async (id: string) => {
+    const fn = (globalThis as unknown as {
+      executeNotificationUndoById: (id: string) => Promise<void>;
+    }).executeNotificationUndoById;
+    await fn(id);
+  }, notificationId);
+}
+
+/**
+ * Trigger the batch organize-all-tabs handler via the service worker.
+ *
+ * The popup-organize tests historically bypassed the popup UI (which
+ * closes itself via `window.close()` and detaches Playwright before the
+ * SW finishes) and called `handleOrganizeAllTabs` directly. This helper
+ * keeps that pattern available as a domain action so specs don't repeat
+ * the SW-readiness handshake.
+ */
+export async function triggerOrganizeAllTabsViaSW(context: BrowserContext): Promise<void> {
+  const sw = await getServiceWorkerWithOrganizeFn(context);
+  await sw.evaluate(async () => {
+    const win = await chrome.windows.getCurrent();
+    const fn = (globalThis as unknown as {
+      handleOrganizeAllTabs: (windowId: number | undefined) => Promise<void>;
+    }).handleOrganizeAllTabs;
+    await fn(win.id);
+  });
+  await new Promise((r) => setTimeout(r, 2_000));
+}

--- a/e2e-shared/actions/popup-actions.ts
+++ b/e2e-shared/actions/popup-actions.ts
@@ -1,0 +1,38 @@
+/**
+ * Composed flows for the extension popup.
+ *
+ * Each action narrates a single business outcome ("open the popup",
+ * "trigger organize from the popup", "open settings from the popup")
+ * and hides the navigation plumbing. Consumes `PopupPage`; never reaches
+ * into raw locators.
+ *
+ * Relevant US: US-PO006..US-PO009.
+ */
+import type { BrowserContext, Page } from '@playwright/test';
+import { PopupPage } from '../pages/PopupPage.js';
+
+/**
+ * Navigate the supplied page to the popup URL and return a ready
+ * `PopupPage` instance.
+ */
+export async function openPopup(page: Page, extensionId: string): Promise<PopupPage> {
+  const popup = new PopupPage(page);
+  await popup.open(extensionId);
+  return popup;
+}
+
+/**
+ * Click the "Organize all tabs" button from the popup. The button sends an
+ * `ORGANIZE_ALL_TABS` message to the service worker and then closes the
+ * popup window via `window.close()`. The optional `extensionContext` is
+ * accepted purely so callers can pass it for future side-effect waits;
+ * the helper currently returns once the click resolves.
+ */
+export async function triggerOrganizeFromPopup(
+  page: Page,
+  extensionId: string,
+  _extensionContext?: BrowserContext,
+): Promise<void> {
+  const popup = await openPopup(page, extensionId);
+  await popup.clickOrganize();
+}

--- a/e2e-shared/actions/tabs-deduplication.ts
+++ b/e2e-shared/actions/tabs-deduplication.ts
@@ -1,0 +1,59 @@
+/**
+ * Composed flows for tab deduplication (US-D family).
+ *
+ * Mirrors the philosophy of `tabs-grouping.ts`: thin narrative wrappers
+ * around the helper-fixture primitives so combined/notifications specs
+ * stop spelling out the "open duplicate, wait for dedup, assert tab
+ * count" recipe inline.
+ */
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+import {
+  executeNotificationUndo,
+  getServiceWorker,
+  getSmartTabNotificationIds,
+} from './notifications.js';
+
+export interface DeduplicationHelpers {
+  createTab(url: string): Promise<Page>;
+  getTabCount(): Promise<number>;
+  waitForDeduplication(timeoutMs?: number): Promise<void>;
+}
+
+/**
+ * Open a duplicate tab on `url` and assert that the tab count did NOT
+ * grow. The assertion is best-effort: when deduplication is disabled,
+ * Chrome briefly shows two tabs before any cleanup, so we compare the
+ * post-settle count against the pre-duplicate snapshot.
+ */
+export async function expectTabDeduplicated(
+  helpers: DeduplicationHelpers,
+  url: string,
+): Promise<void> {
+  const before = await helpers.getTabCount();
+  await helpers.createTab(url);
+  await helpers.waitForDeduplication();
+  const after = await helpers.getTabCount();
+  expect(after).toBeLessThanOrEqual(before);
+}
+
+/**
+ * Undo the most recent deduplication notification via the SW-exposed
+ * `executeNotificationUndoById` helper. Resolves once Chrome has
+ * reopened the closed tab (returns the SW page so callers can keep
+ * driving it if needed).
+ *
+ * Returns the notification id that was undone (useful for follow-up
+ * assertions on `shouldSkipDeduplication`).
+ */
+export async function undoLastDeduplication(
+  context: BrowserContext,
+): Promise<string> {
+  const sw = await getServiceWorker(context);
+  const ids = await getSmartTabNotificationIds(sw);
+  const notifId = ids[ids.length - 1];
+  if (!notifId) {
+    throw new Error('undoLastDeduplication: no smarttab-* notification found.');
+  }
+  await executeNotificationUndo(context, notifId);
+  return notifId;
+}

--- a/e2e-shared/actions/tabs-grouping.ts
+++ b/e2e-shared/actions/tabs-grouping.ts
@@ -1,0 +1,75 @@
+/**
+ * Composed flows for automatic tab grouping (US-G family).
+ *
+ * Wraps the recurring "open a child tab, wait for grouping to settle" dance
+ * around the helper-fixture primitives. The action layer doesn't talk to
+ * the SW directly here: the `helpers` fixture already exposes well-tested
+ * `createTabFromOpener` / `waitForTabGrouped` primitives, this module just
+ * narrates the business intent so specs read as "given an opener, open a
+ * grouped child" rather than a sequence of micro-steps.
+ */
+import type { Page } from '@playwright/test';
+
+export interface TabGroupInfo {
+  id: number;
+  title: string;
+  color: string;
+  tabCount: number;
+  tabIds: number[];
+}
+
+/**
+ * Helper-fixture surface consumed by these actions. Mirrors the relevant
+ * subset of `tests/e2e/fixtures.ts#ExtensionHelpers` so this module can
+ * be imported from anywhere without a transitive Playwright-fixtures
+ * dependency.
+ */
+export interface GroupingHelpers {
+  createTab(url: string): Promise<Page>;
+  createTabFromOpener(openerPage: Page, url: string): Promise<Page>;
+  waitForGrouping(timeoutMs?: number): Promise<void>;
+  waitForTabGrouped(expectedTitle?: string, timeoutMs?: number): Promise<TabGroupInfo[]>;
+}
+
+/**
+ * Simulate opening a child tab via the middle-click flow (auxclick): a
+ * tab opened from another tab using a synthetic "middle click" hint that
+ * the content script normally injects. The child is created with the
+ * opener's tab id so the grouping engine treats it as a related tab.
+ *
+ * Returns the new `Page` so callers can drive the child if needed.
+ */
+export async function openChildTabViaMiddleClick(
+  helpers: GroupingHelpers,
+  parent: Page,
+  url: string,
+): Promise<Page> {
+  return helpers.createTabFromOpener(parent, url);
+}
+
+/**
+ * Simulate opening a child tab via the "open in new tab" context-menu
+ * entry. At the SW level the flow is identical to middle-click (same
+ * `createTabFromOpener` invocation); the helper is exposed separately to
+ * document intent in tests where the user gesture matters.
+ */
+export async function openChildTabViaContextMenu(
+  helpers: GroupingHelpers,
+  parent: Page,
+  url: string,
+): Promise<Page> {
+  return helpers.createTabFromOpener(parent, url);
+}
+
+/**
+ * Wait for at least one Chrome tab group to exist (optionally with a
+ * specific title). Returns the snapshot of groups available at resolve
+ * time, so callers can assert further details.
+ */
+export async function waitForGroupCreated(
+  helpers: GroupingHelpers,
+  title?: string,
+  timeoutMs = 8_000,
+): Promise<TabGroupInfo[]> {
+  return helpers.waitForTabGrouped(title, timeoutMs);
+}

--- a/e2e-shared/pages/PopupPage.ts
+++ b/e2e-shared/pages/PopupPage.ts
@@ -1,0 +1,114 @@
+/**
+ * Page Object for the extension popup (popup.html).
+ *
+ * The popup is not a Radix dialog (`role="dialog"`); it is the top-level
+ * `<Box data-testid="popup">` rendered by `src/pages/popup.tsx`. We keep
+ * the same Page Object shape used by the dialog wizards (locators + atomic
+ * actions + atomic assertions) so callers stay symmetric.
+ *
+ * Selectors target the English UI (`--lang=en-US`).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class PopupPage {
+  constructor(protected readonly page: Page) {}
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Root popup container. */
+  root(): Locator {
+    return this.page.getByTestId('popup');
+  }
+
+  /** Popup header (title + settings button). */
+  header(): Locator {
+    return this.page.getByTestId('popup-header');
+  }
+
+  /** "Open settings" gear button in the popup header. */
+  settingsButton(): Locator {
+    return this.page.getByTestId('popup-header-btn-settings');
+  }
+
+  /** "Organize all tabs" hero button in the toolbar. */
+  organizeButton(): Locator {
+    return this.page.getByTestId('popup-toolbar-btn-organize');
+  }
+
+  /** "Save session" button in the toolbar. */
+  saveSessionButton(): Locator {
+    return this.page.getByTestId('popup-toolbar-btn-save');
+  }
+
+  /** "Restore session" button in the toolbar. */
+  restoreSessionButton(): Locator {
+    return this.page.getByTestId('popup-toolbar-btn-restore');
+  }
+
+  /** Pinned-sessions list rendered below the toolbar. */
+  sessionsList(): Locator {
+    return this.page.getByTestId('popup-profiles-list');
+  }
+
+  /** Empty-state callout shown when no pinned profile exists. */
+  pinnedEmptyState(): Locator {
+    return this.page.getByTestId('popup-pinned-empty');
+  }
+
+  /**
+   * Toolbar wrapper (`popup-toolbar`). Useful as a stand-in for the
+   * "statistics panel" referenced by the lot-5 plan: the popup no longer
+   * surfaces tab-group / dedup counters, so this is the closest section
+   * carrying actionable popup state.
+   */
+  statisticsPanel(): Locator {
+    return this.page.getByTestId('popup-toolbar');
+  }
+
+  // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /**
+   * Navigate to the popup URL and wait for the settings button to appear.
+   * Returns the `PopupPage` so callers can chain locators.
+   */
+  async open(extensionId: string): Promise<this> {
+    await this.page.goto(`chrome-extension://${extensionId}/popup.html`);
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.settingsButton().waitFor({ state: 'visible', timeout: 10_000 });
+    return this;
+  }
+
+  /** Click the "Organize all tabs" button. */
+  async clickOrganize(): Promise<void> {
+    await this.organizeButton().click();
+  }
+
+  /** Open the options page by clicking the gear icon. */
+  async openSettings(): Promise<void> {
+    await this.settingsButton().click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /** Assert the popup root is visible (popup actually mounted). */
+  async expectVisible(): Promise<void> {
+    await expect(this.root()).toBeVisible({ timeout: 10_000 });
+  }
+
+  /** Assert the Organize button is enabled (not in an `aria-disabled` state). */
+  async expectOrganizeEnabled(): Promise<void> {
+    await expect(this.organizeButton()).not.toHaveAttribute('aria-disabled', 'true');
+  }
+
+  /**
+   * Assert a single popup-surfaced statistic field matches `value`. The
+   * popup does not currently render numeric counters; this helper anchors
+   * on the toolbar text so callers stay forward-compatible if/when stats
+   * land back in the popup. It accepts any substring (case-insensitive).
+   */
+  async expectStatistic(name: string, value: string | number): Promise<void> {
+    const panel = this.statisticsPanel();
+    await expect(panel).toContainText(new RegExp(String(name), 'i'));
+    await expect(panel).toContainText(new RegExp(String(value), 'i'));
+  }
+}

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -4,6 +4,7 @@
  * template used to create a new Page Object.
  */
 export { DialogPage } from './DialogPage.js';
+export { PopupPage } from './PopupPage.js';
 export {
   ImportWizardPage,
   type ImportClassificationCounts,

--- a/tests/e2e/combined.spec.ts
+++ b/tests/e2e/combined.spec.ts
@@ -2,6 +2,12 @@
  * E2E Tests for Combined Deduplication and Grouping
  *
  * Tests scenarios where both features work together or interact with each other.
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 5): the
+ * grouping / deduplication flows in this spec already go through the
+ * `helpers` fixture primitives (no UI driving), so the migration mostly
+ * narrows imports and assertions to the shared matcher
+ * (`toHaveStatistic`).
  */
 
 import { test, expect } from './fixtures';
@@ -23,7 +29,7 @@ test.describe('Combined Deduplication and Grouping', () => {
   // ── 1. Both Features Enabled ──────────────────────────────────────────────
 
   test.describe('Both Features Enabled', () => {
-    test('groups a child tab AND deduplicates a subsequent duplicate [US-C001]', async ({ helpers }) => {
+    test('groups a child tab AND deduplicates a subsequent duplicate [US-C001]', async ({ helpers, extensionContext }) => {
       await helpers.addDomainRule({
         label: 'Combined Rule',
         domainFilter: 'example.com',
@@ -35,20 +41,18 @@ test.describe('Combined Deduplication and Grouping', () => {
         groupNameSource: 'label',
       });
 
-      // Opener + child → group is created
       const opener = await helpers.createTab('https://example.com/opener');
       await helpers.waitForGrouping();
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
       await helpers.waitForGrouping();
 
-      let stats = await helpers.getStatistics();
-      expect(stats.tabGroupsCreatedCount).toBe(1);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 1);
 
       // Duplicate of child → deduplicated
       await helpers.createTab('https://example.com/child');
       await helpers.waitForDeduplication();
 
-      stats = await helpers.getStatistics();
+      const stats = await helpers.getStatistics();
       expect(stats.tabsDeduplicatedCount).toBeGreaterThan(0);
     });
 
@@ -79,7 +83,7 @@ test.describe('Combined Deduplication and Grouping', () => {
   // ── 2. Different Settings Per Feature ────────────────────────────────────
 
   test.describe('Different Settings Per Feature', () => {
-    test('grouping enabled, deduplication disabled: groups child, keeps duplicate [US-C002]', async ({ helpers }) => {
+    test('grouping enabled, deduplication disabled: groups child, keeps duplicate [US-C002]', async ({ helpers, extensionContext }) => {
       await helpers.addDomainRule({
         label: 'Group Only',
         domainFilter: 'example.com',
@@ -95,16 +99,15 @@ test.describe('Combined Deduplication and Grouping', () => {
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
       await helpers.waitForGrouping();
 
-      // Duplicate of opener — should NOT be deduplicated
+      // Duplicate of opener — should NOT be deduplicated.
       await helpers.createTab('https://example.com/opener');
       await helpers.waitForDeduplication();
 
-      const stats = await helpers.getStatistics();
-      expect(stats.tabGroupsCreatedCount).toBe(1);
-      expect(stats.tabsDeduplicatedCount).toBe(0);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 1);
+      await expect(extensionContext).toHaveStatistic('tabsDeduplicatedCount', 0);
     });
 
-    test('deduplication enabled, grouping disabled: deduplicates but creates no groups [US-C002]', async ({ helpers }) => {
+    test('deduplication enabled, grouping disabled: deduplicates but creates no groups [US-C002]', async ({ helpers, extensionContext }) => {
       await helpers.addDomainRule({
         label: 'Dedup Only',
         domainFilter: 'example.com',
@@ -119,15 +122,14 @@ test.describe('Combined Deduplication and Grouping', () => {
       await helpers.createTabFromOpener(opener, 'https://example.com/child');
       await helpers.waitForGrouping();
 
-      // Duplicate of child → deduplicated
       await helpers.createTab('https://example.com/child');
       await helpers.waitForDeduplication();
 
-      const stats = await helpers.getStatistics();
       const groups = await helpers.getTabGroups();
-
-      expect(stats.tabGroupsCreatedCount).toBe(0);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 0);
       expect(groups).toHaveLength(0);
+
+      const stats = await helpers.getStatistics();
       expect(stats.tabsDeduplicatedCount).toBeGreaterThan(0);
     });
   });
@@ -181,7 +183,7 @@ test.describe('Combined Deduplication and Grouping', () => {
   // ── 4. Global vs Rule Settings ────────────────────────────────────────────
 
   test.describe('Global vs Rule Settings', () => {
-    test('rule settings override global: both disabled per rule → no action [US-C004]', async ({ helpers }) => {
+    test('rule settings override global: both disabled per rule → no action [US-C004]', async ({ helpers, extensionContext }) => {
       await helpers.setGlobalGroupingEnabled(true);
       await helpers.setGlobalDeduplicationEnabled(true);
 
@@ -202,16 +204,14 @@ test.describe('Combined Deduplication and Grouping', () => {
       await helpers.createTab('https://example.com/page');
       await helpers.waitForDeduplication();
 
-      const stats = await helpers.getStatistics();
-      expect(stats.tabGroupsCreatedCount).toBe(0);
-      expect(stats.tabsDeduplicatedCount).toBe(0);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 0);
+      await expect(extensionContext).toHaveStatistic('tabsDeduplicatedCount', 0);
     });
 
     test('unmatched domains fall back to global settings [US-C004]', async ({ helpers }) => {
       await helpers.setGlobalGroupingEnabled(true);
       await helpers.setGlobalDeduplicationEnabled(true);
 
-      // Rule only for example.com — both features disabled for it
       await helpers.addDomainRule({
         label: 'Example Only',
         domainFilter: 'example.com',
@@ -219,7 +219,7 @@ test.describe('Combined Deduplication and Grouping', () => {
         deduplicationEnabled: false,
       });
 
-      // example.net has no rule → global (enabled) applies
+      // example.net has no rule → global (enabled) applies.
       const _tab1 = await helpers.createTab('https://example.net/page');
       await helpers.waitForDeduplication();
 
@@ -234,7 +234,7 @@ test.describe('Combined Deduplication and Grouping', () => {
   // ── 5. Complex Workflows ──────────────────────────────────────────────────
 
   test.describe('Complex Workflows', () => {
-    test('simulate browsing a GitHub repo: group files, dedup duplicate tabs [US-C005]', async ({ helpers }) => {
+    test('simulate browsing a GitHub repo: group files, dedup duplicate tabs [US-C005]', async ({ helpers, extensionContext }) => {
       await helpers.addDomainRule({
         label: 'GitHub Project',
         domainFilter: 'github.com',
@@ -246,31 +246,27 @@ test.describe('Combined Deduplication and Grouping', () => {
         urlParsingRegEx: 'github\\.com/([^/]+/[^/]+)',
       });
 
-      // Main repo page
       const repoPage = await helpers.createTab('https://github.com/facebook/react');
       await helpers.waitForGrouping();
 
-      // Open README (should be grouped)
       await helpers.createTabFromOpener(repoPage, 'https://github.com/facebook/react/blob/main/README.md');
       await helpers.waitForGrouping();
 
-      // Open another file (added to group)
       await helpers.createTabFromOpener(repoPage, 'https://github.com/facebook/react/blob/main/src/index.ts');
       await helpers.waitForGrouping();
 
-      // Try to open duplicate of README → deduplicated
+      // Try to open duplicate of README → deduplicated.
       await helpers.createTab('https://github.com/facebook/react/blob/main/README.md');
       await helpers.waitForDeduplication();
 
-      const stats = await helpers.getStatistics();
       const groups = await helpers.getTabGroups();
-
-      expect(stats.tabGroupsCreatedCount).toBe(1);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 1);
+      const stats = await helpers.getStatistics();
       expect(stats.tabsDeduplicatedCount).toBeGreaterThan(0);
       expect(groups).toHaveLength(1);
     });
 
-    test('simulate two projects each getting their own group [US-C005]', async ({ helpers }) => {
+    test('simulate two projects each getting their own group [US-C005]', async ({ helpers, extensionContext }) => {
       await helpers.addDomainRule({
         label: 'Multi-Project',
         domainFilter: 'example.com',
@@ -294,10 +290,8 @@ test.describe('Combined Deduplication and Grouping', () => {
       await helpers.waitForGrouping();
 
       const groups = await helpers.getTabGroups();
-      const stats = await helpers.getStatistics();
-
       expect(groups).toHaveLength(2);
-      expect(stats.tabGroupsCreatedCount).toBe(2);
+      await expect(extensionContext).toHaveStatistic('tabGroupsCreatedCount', 2);
     });
   });
 });

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -10,53 +10,22 @@
  *
  * Because native browser notifications cannot be intercepted by Playwright DOM
  * queries, these tests verify notification behaviour at the service-worker level
- * using chrome.notifications.getAll() and by inspecting observable side-effects
- * (tab count changes, group count changes, skip-list state).
+ * using `chrome.notifications.getAll()` and by inspecting observable
+ * side-effects (tab count changes, group count changes, skip-list state).
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 5):
+ * the SW handshake, the smarttab-id filter and the undo trigger now live
+ * in `e2e-shared/actions/notifications.ts`.
  */
 
 import { test, expect } from './fixtures';
-
-// ─── helpers ────────────────────────────────────────────────────────────────
-
-/** Returns all currently visible notification IDs from the service worker. */
-async function getNotificationIds(sw: any): Promise<string[]> {
-  return sw.evaluate(async () => {
-    return new Promise<string[]>(resolve => {
-      chrome.notifications.getAll(notifications => resolve(Object.keys(notifications)));
-    });
-  });
-}
-
-/** Sets notifyOnGrouping and notifyOnDeduplication via storage. */
-async function setNotificationPrefs(
-  sw: any,
-  prefs: { notifyOnGrouping?: boolean; notifyOnDeduplication?: boolean },
-) {
-  await sw.evaluate(async (p: { notifyOnGrouping?: boolean; notifyOnDeduplication?: boolean }) => {
-    await chrome.storage.local.set(p);
-  }, prefs);
-  await new Promise(r => setTimeout(r, 100));
-}
-
-/**
- * Polls until executeNotificationUndoById is available on the SW's globalThis.
- * Needed because the SW may be idle-terminated and restarting while the test waits,
- * causing a race condition where background.ts hasn't finished re-initializing yet.
- */
-async function getSwWithUndoFn(extensionContext: any, timeoutMs = 5000): Promise<any> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const sw = extensionContext.serviceWorkers()[0];
-    if (sw) {
-      const ready = await sw.evaluate(
-        () => typeof (globalThis as any).executeNotificationUndoById === 'function',
-      ).catch(() => false);
-      if (ready) return sw;
-    }
-    await new Promise(r => setTimeout(r, 200));
-  }
-  throw new Error('executeNotificationUndoById not available on SW globalThis after timeout');
-}
+import {
+  clearAllNotifications,
+  executeNotificationUndo,
+  getServiceWorker,
+  getSmartTabNotificationIds,
+  setNotificationPrefs,
+} from '../../e2e-shared/actions/index.js';
 
 // ─── suite ──────────────────────────────────────────────────────────────────
 
@@ -82,7 +51,7 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true });
 
       await helpers.addDomainRule({
@@ -101,9 +70,7 @@ test.describe('Notifications', () => {
       // Give the notification a moment to be created
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      // At least one notification should have been created with the smarttab prefix
-      const smartTabNotifs = notificationIds.filter(id => id.startsWith('smarttab-'));
+      const smartTabNotifs = await getSmartTabNotificationIds(sw);
       expect(smartTabNotifs.length).toBeGreaterThan(0);
     });
 
@@ -111,18 +78,9 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: false });
-
-      // Clear any pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       await helpers.addDomainRule({
         label: 'No Notify Group',
@@ -139,8 +97,7 @@ test.describe('Notifications', () => {
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const smartTabNotifs = notificationIds.filter(id => id.startsWith('smarttab-'));
+      const smartTabNotifs = await getSmartTabNotificationIds(sw);
       expect(smartTabNotifs).toHaveLength(0);
     });
 
@@ -148,7 +105,7 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true });
 
       await helpers.addDomainRule({
@@ -166,20 +123,14 @@ test.describe('Notifications', () => {
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const notifId = notificationIds.find(id => id.startsWith('smarttab-'));
+      const smartTabNotifs = await getSmartTabNotificationIds(sw);
+      const notifId = smartTabNotifs[0];
       expect(notifId).toBeDefined();
 
-      // Trigger the Undo action via the exposed globalThis helper
-      const undoSw = await getSwWithUndoFn(extensionContext);
-      await undoSw.evaluate(async (id: string) => {
-        await (globalThis as any).executeNotificationUndoById(id);
-      }, notifId!);
-
+      await executeNotificationUndo(extensionContext, notifId);
       await new Promise(r => setTimeout(r, 1000));
 
       const groups = await helpers.getTabGroups();
-      // Undo should have ungrouped the tabs
       expect(groups).toHaveLength(0);
     });
   });
@@ -191,20 +142,11 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnDeduplication: true });
       await helpers.setGlobalDeduplicationEnabled(true);
       await helpers.setGlobalGroupingEnabled(false);
-
-      // Clear any pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       const _tab1 = await helpers.createTab('https://example.com/page-dedup');
       await helpers.waitForDeduplication();
@@ -214,13 +156,11 @@ test.describe('Notifications', () => {
       await helpers.waitForDeduplication();
 
       const finalCount = await helpers.getTabCount();
-      // Deduplication should have removed the duplicate tab
       expect(finalCount).toBeLessThanOrEqual(initialCount);
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const smartTabNotifs = notificationIds.filter(id => id.startsWith('smarttab-'));
+      const smartTabNotifs = await getSmartTabNotificationIds(sw);
       expect(smartTabNotifs.length).toBeGreaterThan(0);
     });
 
@@ -228,31 +168,20 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnDeduplication: false });
       await helpers.setGlobalDeduplicationEnabled(true);
       await helpers.setGlobalGroupingEnabled(false);
+      await clearAllNotifications(sw);
 
-      // Clear any pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
-
-      const _tab1 = await helpers.createTab('https://example.com/page-nodedup');
+      await helpers.createTab('https://example.com/page-nodedup');
       await helpers.waitForDeduplication();
-
       await helpers.createTab('https://example.com/page-nodedup');
       await helpers.waitForDeduplication();
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const smartTabNotifs = notificationIds.filter(id => id.startsWith('smarttab-'));
+      const smartTabNotifs = await getSmartTabNotificationIds(sw);
       expect(smartTabNotifs).toHaveLength(0);
     });
 
@@ -260,20 +189,11 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnDeduplication: true });
       await helpers.setGlobalDeduplicationEnabled(true);
       await helpers.setGlobalGroupingEnabled(false);
-
-      // Clear pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       await helpers.createTab('https://example.com/undo-dedup');
       await helpers.waitForDeduplication();
@@ -286,20 +206,13 @@ test.describe('Notifications', () => {
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const notifId = notificationIds.find(id => id.startsWith('smarttab-'));
+      const notifId = (await getSmartTabNotificationIds(sw))[0];
       expect(notifId).toBeDefined();
 
-      // Trigger Undo to reopen the closed tab
-      const undoSw = await getSwWithUndoFn(extensionContext);
-      await undoSw.evaluate(async (id: string) => {
-        await (globalThis as any).executeNotificationUndoById(id);
-      }, notifId!);
-
+      await executeNotificationUndo(extensionContext, notifId);
       await new Promise(r => setTimeout(r, 1500));
 
       const countAfterUndo = await helpers.getTabCount();
-      // The undone tab should have been reopened, increasing count
       expect(countAfterUndo).toBeGreaterThan(countAfterDedup);
     });
   });
@@ -311,54 +224,40 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnDeduplication: true });
       await helpers.setGlobalDeduplicationEnabled(true);
       await helpers.setGlobalGroupingEnabled(false);
-
-      // Clear pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       const testUrl = 'https://example.com/protected-reopen';
 
       await helpers.createTab(testUrl);
       await helpers.waitForDeduplication();
 
-      // Create a duplicate — should be deduplicated
       await helpers.createTab(testUrl);
       await helpers.waitForDeduplication();
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const notifId = notificationIds.find(id => id.startsWith('smarttab-'));
+      const notifId = (await getSmartTabNotificationIds(sw))[0];
       expect(notifId).toBeDefined();
 
       const countBeforeUndo = await helpers.getTabCount();
-
-      // Trigger Undo to reopen the deduplicated tab
-      const undoSw = await getSwWithUndoFn(extensionContext);
-      await undoSw.evaluate(async (id: string) => {
-        await (globalThis as any).executeNotificationUndoById(id);
-      }, notifId!);
-
+      await executeNotificationUndo(extensionContext, notifId);
       await new Promise(r => setTimeout(r, 1500));
 
       const countAfterUndo = await helpers.getTabCount();
-      // The tab should have been reopened (count increased by at least 1)
       expect(countAfterUndo).toBeGreaterThan(countBeforeUndo);
 
       // The URL should be in the skip-deduplication list for 10 seconds.
-      // Use undoSw (same SW instance that ran the undo and owns the in-memory skip list).
+      // Re-resolve the SW to evaluate `shouldSkipDeduplication` on the
+      // same instance that owns the in-memory skip list.
+      const undoSw = await getServiceWorker(extensionContext);
       const isProtected = await undoSw.evaluate((url: string) => {
-        return globalThis.shouldSkipDeduplication(url);
+        return (globalThis as unknown as {
+          shouldSkipDeduplication: (url: string) => boolean;
+        }).shouldSkipDeduplication(url);
       }, testUrl);
       expect(isProtected).toBe(true);
     });
@@ -371,18 +270,9 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true });
-
-      // Clear pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       await helpers.addDomainRule({
         label: 'Cleanup Test',
@@ -399,12 +289,10 @@ test.describe('Notifications', () => {
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const notifId = notificationIds.find(id => id.startsWith('smarttab-'));
+      const notifId = (await getSmartTabNotificationIds(sw))[0];
       expect(notifId).toBeDefined();
 
-      // Verify the format: smarttab-{numeric timestamp}
-      const parts = notifId!.split('-');
+      const parts = notifId.split('-');
       expect(parts[0]).toBe('smarttab');
       expect(Number(parts[1])).toBeGreaterThan(0);
     });
@@ -413,7 +301,7 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true });
 
       await helpers.addDomainRule({
@@ -431,20 +319,19 @@ test.describe('Notifications', () => {
 
       await new Promise(r => setTimeout(r, 500));
 
-      const notificationIds = await getNotificationIds(sw);
-      const notifId = notificationIds.find(id => id.startsWith('smarttab-'));
+      const notifId = (await getSmartTabNotificationIds(sw))[0];
       expect(notifId).toBeDefined();
 
-      // Close the notification (simulate manual close / timeout via chrome.notifications.clear,
-      // which triggers the onClosed listener that cleans up pendingUndoActions)
+      // Close the notification (simulate manual close / timeout via
+      // chrome.notifications.clear, which triggers the onClosed listener
+      // that cleans up pendingUndoActions).
       await sw.evaluate(async (id: string) => {
         await chrome.notifications.clear(id);
-      }, notifId!);
+      }, notifId);
 
       await new Promise(r => setTimeout(r, 300));
 
-      // After close, the notification should no longer be visible
-      const remainingIds = await getNotificationIds(sw);
+      const remainingIds = await getSmartTabNotificationIds(sw);
       expect(remainingIds).not.toContain(notifId);
     });
   });
@@ -456,16 +343,13 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
-
-      // Set them independently
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true, notifyOnDeduplication: false });
 
       const settings = await helpers.getSettings();
       expect(settings.notifyOnGrouping).toBe(true);
       expect(settings.notifyOnDeduplication).toBe(false);
 
-      // Change only deduplication
       await setNotificationPrefs(sw, { notifyOnDeduplication: true });
 
       const updated = await helpers.getSettings();
@@ -477,20 +361,11 @@ test.describe('Notifications', () => {
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: true, notifyOnDeduplication: false });
       await helpers.setGlobalGroupingEnabled(true);
       await helpers.setGlobalDeduplicationEnabled(true);
-
-      // Clear pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       // Trigger deduplication first (should NOT generate a notification)
       await helpers.createTab('https://example.com/only-dedup');
@@ -499,9 +374,7 @@ test.describe('Notifications', () => {
       await helpers.waitForDeduplication();
 
       await new Promise(r => setTimeout(r, 500));
-      const afterDedup = await getNotificationIds(sw);
-      const smartTabAfterDedup = afterDedup.filter(id => id.startsWith('smarttab-'));
-      expect(smartTabAfterDedup).toHaveLength(0);
+      expect(await getSmartTabNotificationIds(sw)).toHaveLength(0);
 
       // Now trigger grouping (SHOULD generate a notification)
       await helpers.clearDomainRules();
@@ -519,29 +392,19 @@ test.describe('Notifications', () => {
       await helpers.waitForTabGrouped('Only Grouping Notif');
 
       await new Promise(r => setTimeout(r, 500));
-      const afterGrouping = await getNotificationIds(sw);
-      const smartTabAfterGrouping = afterGrouping.filter(id => id.startsWith('smarttab-'));
-      expect(smartTabAfterGrouping.length).toBeGreaterThan(0);
+      const afterGrouping = await getSmartTabNotificationIds(sw);
+      expect(afterGrouping.length).toBeGreaterThan(0);
     });
 
     test('notifyOnGrouping=false, notifyOnDeduplication=true: only deduplication creates notifications [US-N005]', async ({
       helpers,
       extensionContext,
     }) => {
-      const sw = extensionContext.serviceWorkers()[0];
+      const sw = await getServiceWorker(extensionContext);
       await setNotificationPrefs(sw, { notifyOnGrouping: false, notifyOnDeduplication: true });
       await helpers.setGlobalGroupingEnabled(true);
       await helpers.setGlobalDeduplicationEnabled(true);
-
-      // Clear pre-existing notifications
-      await sw.evaluate(async () => {
-        const notifs = await new Promise<Record<string, any>>(resolve =>
-          chrome.notifications.getAll(resolve),
-        );
-        for (const id of Object.keys(notifs)) {
-          chrome.notifications.clear(id);
-        }
-      });
+      await clearAllNotifications(sw);
 
       // Trigger grouping (should NOT generate a notification)
       await helpers.addDomainRule({
@@ -558,9 +421,7 @@ test.describe('Notifications', () => {
       await helpers.waitForTabGrouped('No Grouping Notif');
 
       await new Promise(r => setTimeout(r, 500));
-      const afterGrouping = await getNotificationIds(sw);
-      const smartTabAfterGrouping = afterGrouping.filter(id => id.startsWith('smarttab-'));
-      expect(smartTabAfterGrouping).toHaveLength(0);
+      expect(await getSmartTabNotificationIds(sw)).toHaveLength(0);
 
       // Now trigger deduplication (SHOULD generate a notification)
       await helpers.clearAllTabGroups();
@@ -572,9 +433,8 @@ test.describe('Notifications', () => {
       await helpers.waitForDeduplication();
 
       await new Promise(r => setTimeout(r, 500));
-      const afterDedup = await getNotificationIds(sw);
-      const smartTabAfterDedup = afterDedup.filter(id => id.startsWith('smarttab-'));
-      expect(smartTabAfterDedup.length).toBeGreaterThan(0);
+      const afterDedup = await getSmartTabNotificationIds(sw);
+      expect(afterDedup.length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/e2e/options-toasts.spec.ts
+++ b/tests/e2e/options-toasts.spec.ts
@@ -12,42 +12,17 @@
  * The import rules flow (Text mode paste + Next + Import) is the simplest
  * user trigger that produces a toast without needing any browser permission
  * (clipboard, filesystem...). We use it to assert toast behaviour.
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 5).
  */
-
 import { test, expect } from './fixtures';
-
-async function goToImportExportSection(page: any, extensionId: string): Promise<void> {
-  await page.goto(`chrome-extension://${extensionId}/options.html`);
-  await page.waitForLoadState('domcontentloaded');
-  await page.waitForFunction(
-    () => {
-      const body = document.body.textContent ?? '';
-      return !body.includes('Chargement') && body.length > 50;
-    },
-    null,
-    { timeout: 10_000 },
-  );
-  await page.getByTestId('sidebar-nav-item-importexport').click();
-  await page.getByTestId('page-import-export-card-import-rules').waitFor({ state: 'visible' });
-}
-
-async function clearDomainRules(extensionContext: any): Promise<void> {
-  const sw = extensionContext.serviceWorkers()[0];
-  await sw.evaluate(async () => {
-    await chrome.storage.local.set({ domainRules: [] });
-  });
-  await new Promise((r) => setTimeout(r, 200));
-}
-
-async function getSmartTabNotificationIds(extensionContext: any): Promise<string[]> {
-  const sw = extensionContext.serviceWorkers()[0];
-  const all: string[] = await sw.evaluate(async () => {
-    return await new Promise<string[]>((resolve) => {
-      chrome.notifications.getAll((n) => resolve(Object.keys(n ?? {})));
-    });
-  });
-  return all.filter((id) => id.startsWith('smarttab-'));
-}
+import { goToImportExportSection } from './helpers/navigation';
+import {
+  getServiceWorker,
+  getSmartTabNotificationIds,
+  openRulesImportWizard,
+} from '../../e2e-shared/actions/index.js';
+import type { ImportWizardPage } from '../../e2e-shared/pages/index.js';
 
 function makeRuleJson(label: string, domainFilter: string): string {
   return JSON.stringify({
@@ -70,27 +45,22 @@ function makeRuleJson(label: string, domainFilter: string): string {
   });
 }
 
+/** Drive the wizard through Text-mode import. Optionally bring your own wizard. */
 async function submitTextImport(
-  page: any,
+  wizard: ImportWizardPage,
   json: string,
-  options: { skipOpen?: boolean } = {},
 ): Promise<void> {
-  if (!options.skipOpen) {
-    await page.getByTestId('page-import-export-card-import-rules').getByRole('button', { name: /^import$/i }).click();
-  }
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible({ timeout: 5000 });
-  await dialog.getByRole('radio', { name: 'Text' }).locator('..').click();
-  await dialog.locator('textarea').fill(json);
-  await expect(dialog.getByRole('button', { name: /next/i })).toBeEnabled();
-  await dialog.getByRole('button', { name: /next/i }).click();
-  await expect(dialog.getByRole('button', { name: /confirm.*import/i })).toBeVisible();
-  await dialog.getByRole('button', { name: /confirm.*import/i }).click();
+  await wizard.selectTextMode();
+  await wizard.pasteJson(json);
+  await expect(wizard.nextButton()).toBeEnabled();
+  await wizard.clickNext();
+  await expect(wizard.confirmButton()).toBeVisible();
+  await wizard.confirmImport();
 }
 
 test.describe('Options page toasts', () => {
-  test.beforeEach(async ({ extensionContext }) => {
-    await clearDomainRules(extensionContext);
+  test.beforeEach(async ({ helpers }) => {
+    await helpers.clearDomainRules();
   });
 
   test('rule import shows an in-page toast and no native notification', async ({
@@ -100,21 +70,18 @@ test.describe('Options page toasts', () => {
   }) => {
     await goToImportExportSection(extensionPage, extensionId);
 
-    const notifBefore = await getSmartTabNotificationIds(extensionContext);
+    const sw = await getServiceWorker(extensionContext);
+    const notifBefore = await getSmartTabNotificationIds(sw);
 
-    await extensionPage.getByTestId('page-import-export-card-import-rules')
-      .getByRole('button', { name: /^import$/i })
-      .click();
+    const wizard = await openRulesImportWizard(extensionPage);
     await expect(extensionPage).toHaveDialogOpen();
 
-    await submitTextImport(extensionPage, makeRuleJson('Toast Rule', 'toast-visible.com'), {
-      skipOpen: true,
-    });
+    await submitTextImport(wizard, makeRuleJson('Toast Rule', 'toast-visible.com'));
 
     await expect(extensionPage).toHaveToast('success');
     await expect(extensionContext).toHaveDomainRulesCount(1);
 
-    const notifAfter = await getSmartTabNotificationIds(extensionContext);
+    const notifAfter = await getSmartTabNotificationIds(sw);
     expect(notifAfter).toEqual(notifBefore);
   });
 
@@ -124,7 +91,8 @@ test.describe('Options page toasts', () => {
   }) => {
     await goToImportExportSection(extensionPage, extensionId);
 
-    await submitTextImport(extensionPage, makeRuleJson('Toast Close Rule', 'toast-close.com'));
+    const wizard = await openRulesImportWizard(extensionPage);
+    await submitTextImport(wizard, makeRuleJson('Toast Close Rule', 'toast-close.com'));
 
     await expect(extensionPage).toHaveToast('success');
 

--- a/tests/e2e/popup-organize.spec.ts
+++ b/tests/e2e/popup-organize.spec.ts
@@ -6,66 +6,23 @@
  * - US-PO007: Batch deduplication
  * - US-PO008: Batch grouping (plan + apply + reposition + collapse)
  * - US-PO009: Existing auto-grouping behaviour unaffected
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 5):
+ * `PopupPage` replaces the manual `goToPopup` flow, and the SW
+ * handshake + notification helpers live in `e2e-shared/actions/`.
  */
 
 import { test, expect } from './fixtures';
-import { goToPopup } from './helpers/navigation';
-import type { BrowserContext, Page } from '@playwright/test';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Returns the service worker page, waiting up to 5 s for handleOrganizeAllTabs
- * to be available on globalThis (set during SW initialisation).
- */
-async function getServiceWorker(extensionContext: BrowserContext): Promise<Page> {
-  const deadline = Date.now() + 5000;
-  while (Date.now() < deadline) {
-    const sw = extensionContext.serviceWorkers()[0];
-    if (sw) {
-      const ready = await sw
-        .evaluate(() => typeof (globalThis as any).handleOrganizeAllTabs === 'function')
-        .catch(() => false);
-      if (ready) return sw;
-    }
-    await new Promise(r => setTimeout(r, 200));
-  }
-  throw new Error('handleOrganizeAllTabs not available on SW globalThis after 5 s');
-}
-
-/**
- * Triggers the organize operation directly via the service worker
- * and waits for async operations to settle.
- */
-async function triggerOrganize(sw: Page): Promise<void> {
-  await sw.evaluate(async () => {
-    const win = await chrome.windows.getCurrent();
-    await (globalThis as any).handleOrganizeAllTabs(win.id);
-  });
-  // Allow time for Chrome API calls and state to settle
-  await new Promise(r => setTimeout(r, 2000));
-}
-
-/** Clears all Chrome notifications via the service worker. */
-async function clearNotifications(sw: Page): Promise<void> {
-  await sw.evaluate(async () => {
-    const all = await new Promise<Record<string, any>>(resolve =>
-      chrome.notifications.getAll(n => resolve(n)),
-    );
-    await Promise.all(Object.keys(all).map(id => chrome.notifications.clear(id)));
-  });
-}
-
-/** Returns all current notification IDs. */
-async function getNotificationIds(sw: Page): Promise<string[]> {
-  return sw.evaluate(async () => {
-    return new Promise<string[]>(resolve =>
-      chrome.notifications.getAll(n => resolve(Object.keys(n))),
-    );
-  });
-}
+import {
+  PopupPage,
+} from '../../e2e-shared/pages/index.js';
+import {
+  clearAllNotifications,
+  getNotificationIds,
+  getServiceWorkerWithOrganizeFn,
+  setNotificationPrefs,
+  triggerOrganizeAllTabsViaSW,
+} from '../../e2e-shared/actions/index.js';
 
 // ---------------------------------------------------------------------------
 // [US-PO006] Button visibility
@@ -74,9 +31,10 @@ async function getNotificationIds(sw: Page): Promise<string[]> {
 test.describe('[US-PO006] Organize button in popup', () => {
   test('Organize button is visible in popup', async ({ extensionContext, extensionId }) => {
     const page = await extensionContext.newPage();
-    await goToPopup(page, extensionId);
+    const popup = new PopupPage(page);
+    await popup.open(extensionId);
 
-    await expect(page.getByRole('button', { name: /organize/i })).toBeVisible();
+    await expect(popup.organizeButton()).toBeVisible();
 
     await page.close();
   });
@@ -102,8 +60,8 @@ test.describe('[US-PO007] Batch deduplication', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-    await clearNotifications(sw);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
+    await clearAllNotifications(sw);
 
     await helpers.addDomainRule({
       label: 'Dedup Rule',
@@ -119,7 +77,7 @@ test.describe('[US-PO007] Batch deduplication', () => {
     await new Promise(r => setTimeout(r, 500));
 
     const beforeCount = await helpers.getTabCount();
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
     const afterCount = await helpers.getTabCount();
     const stats = await helpers.getStatistics();
 
@@ -131,7 +89,7 @@ test.describe('[US-PO007] Batch deduplication', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
 
     await helpers.addDomainRule({
       label: 'Dedup Rule',
@@ -146,12 +104,12 @@ test.describe('[US-PO007] Batch deduplication', () => {
     await helpers.createTab('https://example.com/keep-me');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     // Exactly one tab with this URL should remain
     const remaining = await sw.evaluate(async () => {
       const tabs = await chrome.tabs.query({});
-      return tabs.filter((t: any) => t.url === 'https://example.com/keep-me').length;
+      return tabs.filter((t) => t.url === 'https://example.com/keep-me').length;
     });
     expect(remaining).toBe(1);
 
@@ -162,7 +120,6 @@ test.describe('[US-PO007] Batch deduplication', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
     await helpers.setDeduplicateUnmatchedDomains(true);
 
     // No domain rules — batch dedup still handles unmatched tabs (exact match).
@@ -171,7 +128,7 @@ test.describe('[US-PO007] Batch deduplication', () => {
     await new Promise(r => setTimeout(r, 500));
 
     const beforeCount = await helpers.getTabCount();
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
     const afterCount = await helpers.getTabCount();
     const stats = await helpers.getStatistics();
 
@@ -183,16 +140,14 @@ test.describe('[US-PO007] Batch deduplication', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
     await helpers.setDeduplicateUnmatchedDomains(false);
 
-    // No domain rules and unmatched-scope opt-out → nothing should be closed.
     await helpers.createTab('https://example.org/page');
     await helpers.createTab('https://example.org/page');
     await new Promise(r => setTimeout(r, 500));
 
     const beforeCount = await helpers.getTabCount();
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
     const afterCount = await helpers.getTabCount();
     const stats = await helpers.getStatistics();
 
@@ -204,11 +159,9 @@ test.describe('[US-PO007] Batch deduplication', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-    await sw.evaluate(async () => {
-      await chrome.storage.local.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
-    });
-    await clearNotifications(sw);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
+    await setNotificationPrefs(sw, { notifyOnDeduplication: true, notifyOnGrouping: false });
+    await clearAllNotifications(sw);
 
     await helpers.addDomainRule({
       label: 'Dedup Rule',
@@ -224,22 +177,18 @@ test.describe('[US-PO007] Batch deduplication', () => {
     await helpers.createTab('https://example.com/b'); // dup
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
-    const ids = await getNotificationIds(sw);
-    // One notification for all duplicates (not one per duplicate)
-    expect(ids).toHaveLength(1);
+    expect(await getNotificationIds(sw)).toHaveLength(1);
   });
 
   test('no notification when no duplicates found [US-PO007]', async ({
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-    await sw.evaluate(async () => {
-      await chrome.storage.local.set({ notifyOnDeduplication: true, notifyOnGrouping: false });
-    });
-    await clearNotifications(sw);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
+    await setNotificationPrefs(sw, { notifyOnDeduplication: true, notifyOnGrouping: false });
+    await clearAllNotifications(sw);
 
     await helpers.addDomainRule({
       label: 'Dedup Rule',
@@ -252,10 +201,9 @@ test.describe('[US-PO007] Batch deduplication', () => {
     await helpers.createTab('https://example.com/unique2');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
-    const ids = await getNotificationIds(sw);
-    expect(ids).toHaveLength(0);
+    expect(await getNotificationIds(sw)).toHaveLength(0);
   });
 });
 
@@ -275,8 +223,6 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-
     await helpers.addDomainRule({
       label: 'Example',
       domainFilter: 'example.com',
@@ -289,7 +235,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://example.com/b');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const groups = await helpers.getTabGroups();
     expect(groups.some(g => g.title === 'Example')).toBe(true);
@@ -301,8 +247,6 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-
     await helpers.addDomainRule({
       label: 'Solo',
       domainFilter: 'httpbin.org',
@@ -323,10 +267,10 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://example.com/b');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const groups = await helpers.getTabGroups();
-    expect(groups.some(g => g.title === 'Solo')).toBe(false); // solo tab not grouped
+    expect(groups.some(g => g.title === 'Solo')).toBe(false);
     expect(groups.some(g => g.title === 'Pair')).toBe(true);
   });
 
@@ -334,7 +278,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
 
     await helpers.addDomainRule({
       label: 'MyGroup',
@@ -344,7 +288,6 @@ test.describe('[US-PO008] Batch grouping', () => {
       groupNameSource: 'label',
     });
 
-    // Manually put one tab into an existing group before triggering organize
     const tab = await helpers.createTab('https://example.com/alone');
     await new Promise(r => setTimeout(r, 300));
 
@@ -352,13 +295,12 @@ test.describe('[US-PO008] Batch grouping', () => {
       const tabs = await chrome.tabs.query({ url: 'https://example.com/alone' });
       if (tabs[0]?.id != null) {
         const gid = await chrome.tabs.group({ tabIds: [tabs[0].id] });
-        await (chrome as any).tabGroups.update(gid, { title: 'PreviousGroup' });
+        await chrome.tabGroups.update(gid, { title: 'PreviousGroup' });
       }
     });
     await new Promise(r => setTimeout(r, 300));
 
-    // No second example.com tab → plan count < 2 → tab must stay in PreviousGroup
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const stillGrouped = await sw.evaluate(async () => {
       const tabs = await chrome.tabs.query({ url: 'https://example.com/alone' });
@@ -373,7 +315,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
 
     await helpers.addDomainRule({
       label: 'CollapseTest',
@@ -387,11 +329,11 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://example.com/b');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const allCollapsed = await sw.evaluate(async () => {
-      const groups = await (chrome as any).tabGroups.query({});
-      return groups.length > 0 && groups.every((g: any) => g.collapsed === true);
+      const groups = await chrome.tabGroups.query({});
+      return groups.length > 0 && groups.every((g) => g.collapsed === true);
     });
     expect(allCollapsed).toBe(true);
   });
@@ -400,7 +342,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
 
     await helpers.addDomainRule({
       label: 'Front',
@@ -412,18 +354,18 @@ test.describe('[US-PO008] Batch grouping', () => {
 
     await helpers.createTab('https://example.com/a');
     await helpers.createTab('https://example.com/b');
-    await helpers.createTab('https://httpbin.org/ungrouped'); // no rule → stays ungrouped
+    await helpers.createTab('https://httpbin.org/ungrouped');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const result = await sw.evaluate(async () => {
-      const groups = await (chrome as any).tabGroups.query({});
+      const groups = await chrome.tabGroups.query({});
       if (groups.length === 0) return { groupMinIndex: -1, ungroupedIndex: -1 };
       const groupTabs = await chrome.tabs.query({ groupId: groups[0].id });
-      const groupMinIndex = Math.min(...groupTabs.map((t: any) => t.index));
+      const groupMinIndex = Math.min(...groupTabs.map((t) => t.index));
       const ungroupedTabs = await chrome.tabs.query({ groupId: chrome.tabs.TAB_ID_NONE });
-      const httpbinTab = ungroupedTabs.find((t: any) => t.url?.includes('httpbin.org'));
+      const httpbinTab = ungroupedTabs.find((t) => t.url?.includes('httpbin.org'));
       return { groupMinIndex, ungroupedIndex: httpbinTab?.index ?? -1 };
     });
 
@@ -435,7 +377,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
 
     await helpers.addDomainRule({
       label: 'Example',
@@ -450,11 +392,11 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://httpbin.org/no-rule');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const httpbinGrouped = await sw.evaluate(async () => {
       const tabs = await chrome.tabs.query({});
-      const httpbin = tabs.find((t: any) => t.url?.includes('httpbin.org'));
+      const httpbin = tabs.find((t) => t.url?.includes('httpbin.org'));
       return httpbin != null && httpbin.groupId != null && httpbin.groupId > 0;
     });
     expect(httpbinGrouped).toBe(false);
@@ -464,11 +406,9 @@ test.describe('[US-PO008] Batch grouping', () => {
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-    await sw.evaluate(async () => {
-      await chrome.storage.local.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
-    });
-    await clearNotifications(sw);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
+    await setNotificationPrefs(sw, { notifyOnGrouping: true, notifyOnDeduplication: false });
+    await clearAllNotifications(sw);
 
     await helpers.addDomainRule({
       label: 'Notif',
@@ -482,21 +422,18 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://example.com/b');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
-    const ids = await getNotificationIds(sw);
-    expect(ids).toHaveLength(1);
+    expect(await getNotificationIds(sw)).toHaveLength(1);
   });
 
   test('no grouping notification when no tabs are grouped [US-PO008]', async ({
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-    await sw.evaluate(async () => {
-      await chrome.storage.local.set({ notifyOnGrouping: true, notifyOnDeduplication: false });
-    });
-    await clearNotifications(sw);
+    const sw = await getServiceWorkerWithOrganizeFn(extensionContext);
+    await setNotificationPrefs(sw, { notifyOnGrouping: true, notifyOnDeduplication: false });
+    await clearAllNotifications(sw);
 
     await helpers.addDomainRule({
       label: 'Solo',
@@ -506,21 +443,18 @@ test.describe('[US-PO008] Batch grouping', () => {
       groupNameSource: 'label',
     });
 
-    await helpers.createTab('https://example.com/only-one'); // single tab → not grouped
+    await helpers.createTab('https://example.com/only-one');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
-    const ids = await getNotificationIds(sw);
-    expect(ids).toHaveLength(0);
+    expect(await getNotificationIds(sw)).toHaveLength(0);
   });
 
   test('tabGroupsCreatedCount incremented for new groups [US-PO008]', async ({
     extensionContext,
     helpers,
   }) => {
-    const sw = await getServiceWorker(extensionContext);
-
     await helpers.addDomainRule({
       label: 'StatTest',
       domainFilter: 'example.com',
@@ -533,7 +467,7 @@ test.describe('[US-PO008] Batch grouping', () => {
     await helpers.createTab('https://example.com/b');
     await new Promise(r => setTimeout(r, 500));
 
-    await triggerOrganize(sw);
+    await triggerOrganizeAllTabsViaSW(extensionContext);
 
     const stats = await helpers.getStatistics();
     expect(stats.tabGroupsCreatedCount).toBeGreaterThan(0);
@@ -554,10 +488,8 @@ test.describe('[US-PO009] Automatic grouping unaffected by organize rules', () =
   });
 
   test('auto-grouping still creates a group with a single new tab [US-PO009]', async ({
-    extensionContext,
     helpers,
   }) => {
-    void extensionContext; // injected to guarantee fixture setup order, not used directly
     await helpers.addDomainRule({
       label: 'AutoGroup',
       domainFilter: 'example.com',
@@ -566,7 +498,6 @@ test.describe('[US-PO009] Automatic grouping unaffected by organize rules', () =
       groupNameSource: 'label',
     });
 
-    // createTabFromOpener invokes processGroupingForNewTab directly (no min-member check)
     const openerPage = await helpers.createTab('https://example.com/opener');
     await helpers.createTabFromOpener(openerPage, 'https://example.com/child');
 

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -3,34 +3,35 @@
  * Covers: step navigation, per-step validation, mode switching, summary,
  * edit mode identity/config/options, keyboard navigation.
  *
- * Tests use `test.beforeEach` to clear domain rules and start from a clean state.
+ * Migrated to the Page Object / Domain Action architecture (lot 5):
+ * `RuleWizardPage` from `e2e-shared/pages/` replaces the inline locators
+ * and the local `openCreateWizard` / `goToStep2` helpers.
  */
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { goToDomainRulesSection } from './helpers/navigation';
 import { auditPage } from './helpers/a11y';
+import { RuleWizardPage } from '../../e2e-shared/pages/index.js';
+import { openRuleWizard } from '../../e2e-shared/actions/index.js';
 
 test.beforeEach(async ({ helpers }) => {
   await helpers.clearDomainRules();
 });
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+// ─── Local fixtures ────────────────────────────────────────────────────────
 
-/** Open the "Add Rule" wizard dialog from the Domain Rules section. */
-async function openCreateWizard(page: import('@playwright/test').Page, extensionId: string) {
+/** Open the "Add Rule" wizard from the Domain Rules section. */
+async function openCreateWizard(page: Page, extensionId: string): Promise<RuleWizardPage> {
   await goToDomainRulesSection(page, extensionId);
-  await page.getByTestId('page-rules-btn-add').click();
-  await page.getByTestId('wizard-rule').waitFor({ state: 'visible' });
-  return page.getByTestId('wizard-rule');
+  return openRuleWizard(page);
 }
 
-/** Fill step 1 with valid unique data and click Next to reach step 2. */
-async function goToStep2(dialog: import('@playwright/test').Locator) {
-  await dialog.getByTestId('wizard-rule-field-label').fill('My New Rule');
-  await dialog.getByTestId('wizard-rule-field-domain').fill('mynew.com');
-  await dialog.getByRole('button', { name: /next/i }).click();
-  await dialog.getByTestId('wizard-rule-step-2').waitFor({ state: 'visible' });
+/** Fill step 1 with valid unique data and advance to step 2. */
+async function advanceToStep2(wizard: RuleWizardPage): Promise<void> {
+  await wizard.fillLabel('My New Rule');
+  await wizard.fillDomainFilter('mynew.com');
+  await wizard.clickNext();
+  await wizard.expectOnStep(2);
 }
 
 // ---------------------------------------------------------------------------
@@ -41,14 +42,12 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    await expect(dialog).toBeVisible();
-    // Step 1 inputs present
-    await expect(dialog.getByTestId('wizard-rule-field-label')).toBeVisible();
-    await expect(dialog.getByTestId('wizard-rule-field-domain')).toBeVisible();
-    // WizardStepper visible with 4 steps
-    await expect(dialog.getByTestId('wizard-rule-stepper')).toBeVisible();
+    await wizard.expectVisible();
+    await expect(wizard.labelInput()).toBeVisible();
+    await expect(wizard.domainFilterInput()).toBeVisible();
+    await expect(wizard.stepper()).toBeVisible();
     await auditPage(page, 'rule-wizard-step-1-identity', { include: '[role="dialog"]' });
     await page.close();
   });
@@ -57,14 +56,13 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    // Fill domain but leave label empty
-    await dialog.getByTestId('wizard-rule-field-domain').fill('test.com');
-    await dialog.getByRole('button', { name: /next/i }).click();
+    await wizard.fillDomainFilter('test.com');
+    await wizard.clickNext();
 
-    // Still on step 1 (label input still visible)
-    await expect(dialog.getByTestId('wizard-rule-field-label')).toBeVisible();
+    // Still on step 1.
+    await expect(wizard.labelInput()).toBeVisible();
     await page.close();
   });
 
@@ -72,14 +70,13 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    await dialog.getByTestId('wizard-rule-field-label').fill('Test');
-    await dialog.getByTestId('wizard-rule-field-domain').fill('not a domain!!!');
-    await dialog.getByRole('button', { name: /next/i }).click();
+    await wizard.fillLabel('Test');
+    await wizard.fillDomainFilter('not a domain!!!');
+    await wizard.clickNext();
 
-    // Still on step 1
-    await expect(dialog.getByTestId('wizard-rule-field-label')).toBeVisible();
+    await expect(wizard.labelInput()).toBeVisible();
     await page.close();
   });
 
@@ -89,14 +86,13 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     await helpers.addDomainRule({ label: 'Existing', domainFilter: 'existing.com' });
 
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    await dialog.getByTestId('wizard-rule-field-label').fill('existing'); // case-insensitive duplicate
-    await dialog.getByTestId('wizard-rule-field-domain').fill('new.com');
-    await dialog.getByRole('button', { name: /next/i }).click();
+    await wizard.fillLabel('existing'); // case-insensitive duplicate
+    await wizard.fillDomainFilter('new.com');
+    await wizard.clickNext();
 
-    // Still on step 1
-    await expect(dialog.getByTestId('wizard-rule-field-label')).toBeVisible();
+    await expect(wizard.labelInput()).toBeVisible();
     await page.close();
   });
 
@@ -104,14 +100,13 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    await dialog.getByTestId('wizard-rule-field-label').fill('Valid Rule');
-    await dialog.getByTestId('wizard-rule-field-domain').fill('valid.com');
-    await dialog.getByRole('button', { name: /next/i }).click();
+    await wizard.fillLabel('Valid Rule');
+    await wizard.fillDomainFilter('valid.com');
+    await wizard.clickNext();
 
-    // Config mode selector is visible at step 2
-    await expect(dialog.getByTestId('wizard-rule-step-2')).toBeVisible();
+    await wizard.expectOnStep(2);
     await page.close();
   });
 
@@ -119,9 +114,9 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
+    const wizard = await openCreateWizard(page, extensionId);
 
-    await expect(dialog.getByRole('button', { name: /previous/i })).not.toBeAttached();
+    await expect(wizard.backButton()).not.toBeAttached();
     await page.close();
   });
 });
@@ -134,13 +129,10 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep2(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep2(wizard);
 
-    // Preset is the default mode — SearchableSelect button should be present
-    // (it renders a trigger button with the placeholder text)
-    const presetTrigger = dialog.locator('#presetId');
-    await expect(presetTrigger).toBeVisible();
+    await expect(wizard.presetTrigger()).toBeVisible();
     await auditPage(page, 'rule-wizard-step-2-configuration', { include: '[role="dialog"]' });
     await page.close();
   });
@@ -149,21 +141,15 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep2(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep2(wizard);
 
-    // Click Ask radio and assert the Ask radio is now checked (locale-agnostic).
-    // The description text and absence of regex inputs are NOT Ask-specific
-    // (description renders for all modes; regex inputs are also absent in default Preset),
-    // so we anchor the test on the radio's data-state.
-    await dialog.getByTestId('config-mode-ask').click();
-    await expect(dialog.getByTestId('config-mode-ask')).toHaveAttribute('data-state', 'checked');
+    await wizard.selectConfigMode('ask');
+    await expect(wizard.configModeRadio('ask')).toHaveAttribute('data-state', 'checked');
 
-    // Description heading visible (sanity check)
-    await expect(dialog.getByTestId('config-mode-description')).toBeVisible();
-    // No regex input fields
-    await expect(dialog.locator('input[name="titleParsingRegEx"]')).not.toBeAttached();
-    await expect(dialog.locator('input[name="urlParsingRegEx"]')).not.toBeAttached();
+    await expect(wizard.dialog().getByTestId('config-mode-description')).toBeVisible();
+    await expect(wizard.dialog().locator('input[name="titleParsingRegEx"]')).not.toBeAttached();
+    await expect(wizard.dialog().locator('input[name="urlParsingRegEx"]')).not.toBeAttached();
     await page.close();
   });
 
@@ -171,15 +157,11 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep2(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep2(wizard);
 
-    // Click Manual segment
-    await dialog.getByTestId('config-mode-manual').click();
-
-    // Group name source select trigger visible
-    const selectTrigger = dialog.locator('.rt-SelectTrigger');
-    await expect(selectTrigger).toBeVisible();
+    await wizard.selectConfigMode('manual');
+    await expect(wizard.dialog().locator('.rt-SelectTrigger')).toBeVisible();
     await page.close();
   });
 
@@ -187,16 +169,16 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await dialog.getByTestId('wizard-rule-field-label').fill('Preserved Label');
-    await dialog.getByTestId('wizard-rule-field-domain').fill('preserved.com');
-    await dialog.getByRole('button', { name: /next/i }).click();
-    await dialog.getByTestId('wizard-rule-step-2').waitFor({ state: 'visible' });
+    const wizard = await openCreateWizard(page, extensionId);
+    await wizard.fillLabel('Preserved Label');
+    await wizard.fillDomainFilter('preserved.com');
+    await wizard.clickNext();
+    await wizard.expectOnStep(2);
 
-    await dialog.getByRole('button', { name: /previous/i }).click();
+    await wizard.clickBack();
 
-    await expect(dialog.getByTestId('wizard-rule-field-label')).toHaveValue('Preserved Label');
-    await expect(dialog.getByTestId('wizard-rule-field-domain')).toHaveValue('preserved.com');
+    await expect(wizard.labelInput()).toHaveValue('Preserved Label');
+    await expect(wizard.domainFilterInput()).toHaveValue('preserved.com');
     await page.close();
   });
 });
@@ -205,23 +187,21 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
 // Creation — Step 3: Options
 // ---------------------------------------------------------------------------
 test.describe('Creation wizard — Step 3: Options', () => {
-  async function goToStep3(dialog: import('@playwright/test').Locator) {
-    await goToStep2(dialog);
-    await dialog.getByRole('button', { name: /next/i }).click();
-    await dialog.locator('[role="switch"]').waitFor({ state: 'visible' });
+  async function advanceToStep3(wizard: RuleWizardPage): Promise<void> {
+    await advanceToStep2(wizard);
+    await wizard.clickNext();
+    await wizard.deduplicationSwitch().waitFor({ state: 'visible' });
   }
 
   test('step 3 — dedup switch visible and enabled by default', async ({
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep3(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep3(wizard);
 
-    const switchEl = dialog.locator('[role="switch"]');
-    await expect(switchEl).toBeVisible();
-    // Switch is checked (dedup enabled by default)
-    await expect(switchEl).toHaveAttribute('data-state', 'checked');
+    await expect(wizard.deduplicationSwitch()).toBeVisible();
+    await expect(wizard.deduplicationSwitch()).toHaveAttribute('data-state', 'checked');
     await auditPage(page, 'rule-wizard-step-3-options', { include: '[role="dialog"]' });
     await page.close();
   });
@@ -230,14 +210,11 @@ test.describe('Creation wizard — Step 3: Options', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep3(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep3(wizard);
 
-    // Click switch to disable dedup
-    await dialog.locator('[role="switch"]').click();
-
-    // RadioGroup not visible
-    await expect(dialog.locator('[role="radiogroup"]')).not.toBeAttached();
+    await wizard.setDeduplicationEnabled(false);
+    await expect(wizard.deduplicationMatchModeGroup()).not.toBeAttached();
     await page.close();
   });
 
@@ -245,13 +222,11 @@ test.describe('Creation wizard — Step 3: Options', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep3(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep3(wizard);
 
-    await dialog.getByRole('button', { name: /previous/i }).click();
-
-    // Back at step 2 — config mode selector visible
-    await expect(dialog.getByTestId('wizard-rule-step-2')).toBeVisible();
+    await wizard.clickBack();
+    await wizard.expectOnStep(2);
     await page.close();
   });
 
@@ -259,13 +234,11 @@ test.describe('Creation wizard — Step 3: Options', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep3(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep3(wizard);
 
-    await dialog.getByRole('button', { name: /next/i }).click();
-
-    // Step 4: "Create" button visible
-    await expect(dialog.getByRole('button', { name: /create/i })).toBeVisible();
+    await wizard.clickNext();
+    await expect(wizard.createButton()).toBeVisible();
     await page.close();
   });
 });
@@ -274,24 +247,22 @@ test.describe('Creation wizard — Step 3: Options', () => {
 // Creation — Step 4: Summary
 // ---------------------------------------------------------------------------
 test.describe('Creation wizard — Step 4: Summary', () => {
-  async function goToStep4(dialog: import('@playwright/test').Locator) {
-    await goToStep2(dialog);
-    await dialog.getByRole('button', { name: /next/i }).click(); // step 3
-    await dialog.locator('[role="switch"]').waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: /next/i }).click(); // step 4
-    await dialog.getByRole('button', { name: /create/i }).waitFor({ state: 'visible' });
+  async function advanceToStep4(wizard: RuleWizardPage): Promise<void> {
+    await advanceToStep2(wizard);
+    await wizard.clickNext(); // step 3
+    await wizard.deduplicationSwitch().waitFor({ state: 'visible' });
+    await wizard.clickNext(); // step 4
+    await wizard.createButton().waitFor({ state: 'visible' });
   }
 
   test('step 4 — shows summary sections', async ({
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep4(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep4(wizard);
 
-    // Three "Modify" buttons (one per section)
-    const modifyButtons = dialog.getByRole('button', { name: /modify/i });
-    await expect(modifyButtons).toHaveCount(3);
+    await expect(wizard.dialog().getByRole('button', { name: /modify/i })).toHaveCount(3);
     await auditPage(page, 'rule-wizard-step-4-summary', { include: '[role="dialog"]' });
     await page.close();
   });
@@ -300,14 +271,11 @@ test.describe('Creation wizard — Step 4: Summary', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await goToStep4(dialog);
+    const wizard = await openCreateWizard(page, extensionId);
+    await advanceToStep4(wizard);
 
-    // Click first Modify button (Identity section)
-    await dialog.getByRole('button', { name: /modify/i }).first().click();
-
-    // Back at step 1 — label input visible
-    await expect(dialog.locator('input[name="label"]')).toBeVisible();
+    await wizard.clickModifySection(0);
+    await expect(wizard.labelInput()).toBeVisible();
     await page.close();
   });
 
@@ -315,23 +283,20 @@ test.describe('Creation wizard — Step 4: Summary', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    // Navigate through all steps to step 4 then in Ask mode (no preset required)
-    await dialog.locator('input[name="label"]').fill('Brand New Rule');
-    await dialog.locator('input[name="domainFilter"]').fill('brandnew.com');
-    await dialog.getByRole('button', { name: /next/i }).click();
-    // Switch to Ask mode so no preset is required
-    await dialog.getByTestId('config-mode-ask').click();
-    await dialog.getByRole('button', { name: /next/i }).click();
-    await dialog.locator('[role="switch"]').waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: /next/i }).click();
-    await dialog.getByRole('button', { name: /create/i }).waitFor({ state: 'visible' });
+    const wizard = await openCreateWizard(page, extensionId);
+    await wizard.fillLabel('Brand New Rule');
+    await wizard.fillDomainFilter('brandnew.com');
+    await wizard.clickNext();
+    // Switch to Ask mode so no preset is required.
+    await wizard.selectConfigMode('ask');
+    await wizard.clickNext();
+    await wizard.deduplicationSwitch().waitFor({ state: 'visible' });
+    await wizard.clickNext();
+    await wizard.createButton().waitFor({ state: 'visible' });
 
-    await dialog.getByRole('button', { name: /create/i }).click();
+    await wizard.clickCreate();
 
-    // Dialog closed
-    await expect(dialog).toBeHidden();
-    // Rule appears in list
+    await wizard.expectHidden();
     await expect(page.getByRole('listitem', { name: /Brand New Rule/i })).toBeVisible();
     await page.close();
   });
@@ -341,6 +306,16 @@ test.describe('Creation wizard — Step 4: Summary', () => {
 // Edit mode
 // ---------------------------------------------------------------------------
 test.describe('Edit mode — Summary View', () => {
+  /** Open the edit wizard for a rule identified by its label (looked up in the listitem). */
+  async function openEditByLabel(page: Page, label: string | RegExp): Promise<RuleWizardPage> {
+    const labelRe = label instanceof RegExp ? label : new RegExp(label, 'i');
+    await page.getByRole('listitem', { name: labelRe }).getByLabel('More actions').click();
+    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const wizard = new RuleWizardPage(page);
+    await wizard.expectVisible();
+    return wizard;
+  }
+
   test('edit opens on summary view (no wizard stepper, no inline fields)', async ({
     extensionContext, extensionId, helpers,
   }) => {
@@ -348,20 +323,13 @@ test.describe('Edit mode — Summary View', () => {
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
+    const wizard = await openEditByLabel(page, 'Edit Me');
 
-    await page.getByRole('listitem', { name: /Edit Me/i }).getByLabel('More actions').click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
-
-    const dialog = page.getByTestId('wizard-rule');
-    await expect(dialog).toBeVisible();
-    // No wizard stepper
-    await expect(dialog.getByTestId('wizard-rule-stepper')).not.toBeAttached();
-    // Summary view rendered (no inline editable identity fields).
-    await expect(dialog.getByTestId('wizard-rule-edit-summary')).toBeVisible();
-    await expect(dialog.getByTestId('wizard-rule-field-label')).not.toBeAttached();
-    await expect(dialog.getByTestId('wizard-rule-field-domain')).not.toBeAttached();
-    // Three "Modify" buttons (one per section).
-    await expect(dialog.getByRole('button', { name: /modify/i })).toHaveCount(3);
+    await expect(wizard.stepper()).not.toBeAttached();
+    await expect(wizard.editSummary()).toBeVisible();
+    await expect(wizard.labelInput()).not.toBeAttached();
+    await expect(wizard.domainFilterInput()).not.toBeAttached();
+    await expect(wizard.dialog().getByRole('button', { name: /modify/i })).toHaveCount(3);
     await page.close();
   });
 
@@ -372,26 +340,18 @@ test.describe('Edit mode — Summary View', () => {
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
+    const wizard = await openEditByLabel(page, 'Rename Me');
 
-    await page.getByRole('listitem', { name: /Rename Me/i }).getByLabel('More actions').click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
-
-    const dialog = page.getByTestId('wizard-rule');
-    await dialog.waitFor({ state: 'visible' });
-
-    // Open the identity sub-dialog via the first Modify button.
-    await dialog.getByRole('button', { name: /modify/i }).first().click();
+    await wizard.clickModifySection(0);
     const identityModal = page.getByTestId('modal-edit-identity');
     await expect(identityModal).toBeVisible();
 
-    // Rename and apply.
     await identityModal.getByTestId('modal-edit-identity-field-label').fill('Renamed Rule');
     await identityModal.getByTestId('modal-edit-identity-btn-apply').click();
     await expect(identityModal).toBeHidden();
 
-    // Save the parent dialog to commit.
-    await dialog.getByRole('button', { name: /save/i }).click();
-    await expect(dialog).toBeHidden();
+    await wizard.clickSave();
+    await wizard.expectHidden();
     await expect(page.getByRole('listitem', { name: /Renamed Rule/i })).toBeVisible();
     await page.close();
   });
@@ -403,17 +363,10 @@ test.describe('Edit mode — Summary View', () => {
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
+    const wizard = await openEditByLabel(page, 'Config Test');
 
-    await page.getByRole('listitem', { name: /Config Test/i }).getByLabel('More actions').click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    await wizard.clickModifySection(1);
 
-    const dialog = page.getByTestId('wizard-rule');
-    await dialog.waitFor({ state: 'visible' });
-
-    // The second Modify button targets the Configuration section.
-    await dialog.getByRole('button', { name: /modify/i }).nth(1).click();
-
-    // A second dialog opens.
     const dialogs = page.locator('[role="dialog"]');
     await expect(dialogs).toHaveCount(2);
     await page.close();
@@ -426,20 +379,13 @@ test.describe('Edit mode — Summary View', () => {
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
+    const wizard = await openEditByLabel(page, 'Options Test');
 
-    await page.getByRole('listitem', { name: /Options Test/i }).getByLabel('More actions').click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    // No inline switch in the summary view.
+    await expect(wizard.deduplicationSwitch()).toBeHidden();
 
-    const dialog = page.getByTestId('wizard-rule');
-    await dialog.waitFor({ state: 'visible' });
+    await wizard.clickModifySection(2);
 
-    // Dedup switch not visible (no inline form in the summary).
-    await expect(dialog.locator('[role="switch"]')).toBeHidden();
-
-    // The third Modify button targets the Options section.
-    await dialog.getByRole('button', { name: /modify/i }).nth(2).click();
-
-    // The options modal opens and exposes the dedup switch.
     const optionsModal = page.getByTestId('modal-edit-options');
     await expect(optionsModal).toBeVisible();
     await expect(optionsModal.locator('[role="switch"]')).toBeVisible();
@@ -453,21 +399,15 @@ test.describe('Edit mode — Summary View', () => {
 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
+    const wizard = await openEditByLabel(page, 'Keep Me');
 
-    await page.getByRole('listitem', { name: /Keep Me/i }).getByLabel('More actions').click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
-
-    const dialog = page.getByTestId('wizard-rule');
-    await dialog.getByRole('button', { name: /modify/i }).first().click();
-
+    await wizard.clickModifySection(0);
     const identityModal = page.getByTestId('modal-edit-identity');
     await identityModal.getByTestId('modal-edit-identity-field-label').fill('Discarded Label');
-    // Cancel the sub-dialog: nothing is applied to the parent form.
     await identityModal.getByRole('button', { name: /cancel/i }).click();
     await expect(identityModal).toBeHidden();
 
-    // Close the parent dialog without saving: the rule is still named "Keep Me".
-    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await wizard.clickCancel();
     await expect(page.getByRole('listitem', { name: /Keep Me/i })).toBeVisible();
     await expect(page.getByRole('listitem', { name: /Discarded Label/i })).toHaveCount(0);
     await page.close();
@@ -482,12 +422,12 @@ test.describe('Keyboard navigation', () => {
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
-    const dialog = await openCreateWizard(page, extensionId);
-    await expect(dialog).toBeVisible();
+    const wizard = await openCreateWizard(page, extensionId);
+    await wizard.expectVisible();
 
     await page.keyboard.press('Escape');
 
-    await expect(dialog).toBeHidden();
+    await wizard.expectHidden();
     await page.close();
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -1,6 +1,11 @@
 /**
  * E2E tests for the Sessions feature (Options page → Sessions section).
  * Covers: empty state, session list, snapshot creation, rename, delete, restore.
+ *
+ * Migrated to the Page Object / Domain Action architecture (lot 5):
+ * `SnapshotWizardPage`, `RestoreWizardPage` and `openSnapshotWizard` /
+ * `openCustomizeRestoreWizard` replace the inline locators and the local
+ * helpers around the snapshot / restore wizards.
  */
 import { test, expect } from './fixtures';
 import { goToSessionsSection } from './helpers/navigation';
@@ -12,6 +17,10 @@ import {
   createPinnedSession,
 } from './helpers/seed';
 import { auditPage } from './helpers/a11y';
+import {
+  openCustomizeRestoreWizard,
+  openSnapshotWizard,
+} from '../../e2e-shared/actions/index.js';
 
 test.beforeEach(async ({ extensionContext }) => {
   await clearSessions(extensionContext);
@@ -29,9 +38,7 @@ test.describe('[US-O01] Empty state', () => {
     await goToSessionsSection(page, extensionId);
 
     await expect(page.getByText('No saved sessions.')).toBeVisible();
-    await expect(
-      page.getByText(/snapshot|profile/i).first(),
-    ).toBeVisible();
+    await expect(page.getByText(/snapshot|profile/i).first()).toBeVisible();
     await auditPage(page, 'sessions-empty-state');
     await page.close();
   });
@@ -103,7 +110,7 @@ test.describe('[US-S02] Session list', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // Pinned session appears before unpinned session because sections are separated
+    // Pinned session appears before unpinned session because sections are separated.
     const cards = page.getByText(/Session/i);
     const texts = await cards.allTextContents();
     const profileIdx = texts.findIndex(t => t.includes('Pinned Session'));
@@ -131,7 +138,7 @@ test.describe('[US-S02] Session list', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // The card no longer shows a formatted date — only name, counts and More actions menu
+    // The card no longer shows a formatted date — only name, counts and More actions menu.
     await expect(page.getByText('Dated Session')).toBeVisible();
     await expect(page.getByText(/3 tab/i)).toBeVisible();
     await page.close();
@@ -150,7 +157,6 @@ test.describe('[US-S08] Rename', () => {
     await goToSessionsSection(page, extensionId);
 
     await page.getByText('Original Name').dblclick();
-    // Rename input should be visible
     await expect(page.getByRole('textbox', { name: /session name/i })).toBeVisible();
     await page.close();
   });
@@ -216,7 +222,6 @@ test.describe('[US-S07] Delete', () => {
     await page.getByRole('button', { name: 'More actions' }).click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
 
-    // ConfirmDialog should appear
     await expect(page.getByRole('alertdialog')).toBeVisible();
     await page.close();
   });
@@ -230,11 +235,9 @@ test.describe('[US-S07] Delete', () => {
 
     await page.getByRole('button', { name: 'More actions' }).click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
-    // Click the red "Delete" confirm button
     await page.getByTestId('confirm-dialog-btn-confirm').click();
 
     await expect(page.getByText('To Be Deleted')).toBeHidden();
-    // Empty state should appear
     await expect(page.getByText('No saved sessions.')).toBeVisible();
     await page.close();
   });
@@ -266,9 +269,8 @@ test.describe('[US-S01] Snapshot creation', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-
-    await expect(page.getByTestId('wizard-snapshot')).toBeVisible();
+    const wizard = await openSnapshotWizard(page);
+    await wizard.expectVisible();
     await expect(page.getByText('Save Session Snapshot')).toBeVisible();
     await page.close();
   });
@@ -277,9 +279,8 @@ test.describe('[US-S01] Snapshot creation', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-
-    await expect(page.getByTestId('wizard-snapshot').getByText('Session name')).toBeVisible();
+    const wizard = await openSnapshotWizard(page);
+    await expect(wizard.dialog().getByText('Session name')).toBeVisible();
     await page.close();
   });
 
@@ -294,13 +295,11 @@ test.describe('[US-S01] Snapshot creation', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-    await expect(
-      page.getByTestId('wizard-snapshot').getByRole('button', { name: 'Save Session' }),
-    ).toBeEnabled({ timeout: 10_000 });
+    const wizard = await openSnapshotWizard(page);
+    await wizard.expectSaveButtonEnabled();
 
-    // All checkboxes in the tab tree should be checked (aria-checked="true")
-    const unchecked = page.getByTestId('wizard-snapshot').locator('[aria-checked="false"]');
+    // All checkboxes in the tab tree should be checked (no aria-checked="false").
+    const unchecked = wizard.dialog().locator('[aria-checked="false"]');
     await expect(unchecked).toHaveCount(0);
 
     await realTab.close();
@@ -318,33 +317,26 @@ test.describe('[US-S01] Snapshot creation', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-    await expect(
-      page.getByTestId('wizard-snapshot').getByRole('button', { name: 'Save Session' }),
-    ).toBeEnabled({ timeout: 10_000 });
+    const wizard = await openSnapshotWizard(page);
+    await wizard.expectSaveButtonEnabled();
 
-    const dialog = page.getByTestId('wizard-snapshot');
-    await expect(dialog.getByText(/chrome:\/\//)).toBeHidden();
-    await expect(dialog.getByText('about:blank')).toBeHidden();
+    await expect(wizard.dialog().getByText(/chrome:\/\//)).toBeHidden();
+    await expect(wizard.dialog().getByText('about:blank')).toBeHidden();
 
     await realTab.close();
     await page.close();
   });
 
   test('Save Session button is enabled after tab capture', async ({ extensionContext, extensionId }) => {
-    // captureCurrentTabs() filters out chrome-extension:// URLs, so open a real tab first
     const extraTab = await extensionContext.newPage();
     await extraTab.goto('data:text/html,<p>test tab for snapshot</p>');
 
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-    await expect(
-      page.getByTestId('wizard-snapshot').getByRole('button', { name: 'Save Session' }),
-    ).toBeEnabled({ timeout: 10_000 }); // wait for tab capture to complete
+    const wizard = await openSnapshotWizard(page);
+    await wizard.expectSaveButtonEnabled();
 
-    await expect(page.getByTestId('wizard-snapshot').getByRole('button', { name: 'Save Session' })).toBeEnabled();
     await extraTab.close();
     await page.close();
   });
@@ -353,22 +345,17 @@ test.describe('[US-S01] Snapshot creation', () => {
     extensionContext,
     extensionId,
   }) => {
-    // captureCurrentTabs() filters out chrome-extension:// URLs, so open a real tab first
     const extraTab = await extensionContext.newPage();
     await extraTab.goto('data:text/html,<p>test tab for snapshot</p>');
 
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByTestId('page-sessions-btn-snapshot').click();
-    await expect(
-      page.getByTestId('wizard-snapshot').getByRole('button', { name: 'Save Session' }),
-    ).toBeEnabled({ timeout: 10_000 });
+    const wizard = await openSnapshotWizard(page);
+    await wizard.expectSaveButtonEnabled();
 
-    await page.getByRole('button', { name: 'Save Session' }).click();
-
-    // Dialog auto-closes after saving
-    await expect(page.getByTestId('wizard-snapshot')).toBeHidden();
+    await wizard.clickSave();
+    await wizard.expectHidden();
 
     const sessions = await getSessionsFromStorage(extensionContext);
     expect(sessions).toHaveLength(1);
@@ -389,7 +376,6 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // The 3-dot More actions button should be visible on the card
     await expect(page.getByRole('button', { name: 'More actions' }).first()).toBeVisible();
     await page.close();
   });
@@ -434,11 +420,9 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /restore options/i }).click();
-    await page.getByTestId('session-restore-menu-customize').click();
-
-    await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('dialog').getByText(/Restore/).first()).toBeVisible();
+    const wizard = await openCustomizeRestoreWizard(page, session.id);
+    await wizard.expectVisible();
+    await expect(wizard.dialog().getByText(/Restore/).first()).toBeVisible();
     await auditPage(page, 'sessions-restore-wizard-dialog', { include: '[role="dialog"]' });
     await page.close();
   });
@@ -457,7 +441,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByTestId('session-restore-menu-new-window').click();
 
-    // Session has 3 tabs — at least one new page should be created
+    // Session has 3 tabs — at least one new page should be created.
     await newPagePromise;
     expect(extensionContext.pages().length).toBeGreaterThan(pagesBefore);
     await page.close();
@@ -478,13 +462,8 @@ test.describe('[US-S04] Restore in current window', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /restore options/i }).click();
-    await page.getByTestId('session-restore-menu-customize').click();
-
-    const dialog = page.getByRole('dialog');
-    // "In the current window" radio should be checked by default
-    const currentRadio = dialog.getByTestId('wizard-restore-radio-current-window');
-    await expect(currentRadio).toBeChecked();
+    const wizard = await openCustomizeRestoreWizard(page, session.id);
+    await wizard.expectCurrentWindowSelected();
     await page.close();
   });
 });
@@ -500,13 +479,10 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /restore options/i }).click();
-    await page.getByTestId('session-restore-menu-customize').click();
-
-    const dialog = page.getByRole('dialog');
-    await expect(dialog.getByTestId('wizard-restore-radio-current-window')).toBeVisible();
-    await expect(dialog.getByTestId('wizard-restore-radio-new-window')).toBeVisible();
-    await expect(dialog.getByTestId('wizard-restore-radio-replace-window')).toBeVisible();
+    const wizard = await openCustomizeRestoreWizard(page, session.id);
+    await expect(wizard.currentWindowRadio()).toBeVisible();
+    await expect(wizard.newWindowRadio()).toBeVisible();
+    await expect(wizard.replaceWindowRadio()).toBeVisible();
     await page.close();
   });
 
@@ -525,14 +501,10 @@ test.describe('[US-S05] Restore with conflict resolution', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /restore options/i }).click();
-    await page.getByTestId('session-restore-menu-customize').click();
+    const wizard = await openCustomizeRestoreWizard(page, session.id);
+    await wizard.clickRestore();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('button', { name: /restore/i }).click();
-
-    // Without conflicting tabs, restore executes directly and dialog closes
-    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+    await wizard.expectHidden({ timeout: 10_000 });
     await page.close();
   });
 });
@@ -555,7 +527,6 @@ test.describe('[US-S017] Restore with collapsed group state', () => {
     await page.getByRole('button', { name: /restore options/i }).click();
     await page.getByTestId('session-restore-menu-current-window').click();
 
-    // Restore should show success message
     await expect(page.getByText(/tab.*opened/i)).toBeVisible({ timeout: 5000 });
     await page.close();
   });


### PR DESCRIPTION
Adds PopupPage and four new domain-action modules (popup-actions,
tabs-grouping, tabs-deduplication, notifications), then migrates the six
remaining lot-5 specs (options-toasts, notifications, popup-organize,
rule-wizard, sessions, combined) to consume the shared Page Object and
Domain Action surface. Custom matchers (toHaveStatistic, toHaveToast,
toHaveDialogOpen) replace the inline stats and dialog assertions.

Net effect: 2650 → 2314 lines across the migrated specs and the SW
handshake / smarttab-* notification filtering no longer lives inline in
spec files.

Refs #308