### PR TITLE
test(e2e): migrate residual specs to Page Objects + grep guard (lot 7, #325)

### DIFF
--- a/.github/scripts/e2e-inline-dom-allowlist.txt
+++ b/.github/scripts/e2e-inline-dom-allowlist.txt
@@ -1,0 +1,14 @@
+# File-level allow-list for `e2e-no-inline-dom.sh`.
+#
+# One path per line. Files listed here may use `page.getByRole('dialog')`
+# and `page.locator(...)` freely because their subject IS the raw dialog
+# element (meta-tests on Radix focus, dialog-stacking, etc.).
+#
+# Prefer the inline `// allow-inline-dom` marker for one-off legitimate
+# cases (drag-handle selectors, <mark> highlights, body.click() gestures).
+# Use this file only when the entire spec is a meta-test on dialogs.
+
+# `dialog-initial-focus.spec.ts` asserts that Radix dialogs land focus on
+# the right element on open. Wrapping `getByRole('dialog')` in a Page
+# Object would defeat the purpose of the spec.
+tests/e2e/dialog-initial-focus.spec.ts

--- a/.github/scripts/e2e-no-inline-dom.sh
+++ b/.github/scripts/e2e-no-inline-dom.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Grep guard: forbid direct DOM access in Playwright specs (lot 7, #325).
+#
+# Page Objects in `e2e-shared/pages/` own the locators that target Radix
+# dialogs and wizards. Specs and pipeline helpers must consume Page
+# Objects instead of reaching into the DOM with `page.getByRole('dialog')`
+# or `page.locator(...)`. This is what makes a UI refactor break every
+# spec at the same call site (the convergence guarantee documented in
+# `CLAUDE.md`).
+#
+# This script grep's `tests/e2e/` and `e2e-doc-scenarios/` for the two
+# forbidden patterns, then filters out:
+#
+# 1. Lines whose own content or whose immediately preceding line carries
+#    the marker `// allow-inline-dom`. Use the marker for one-off
+#    legitimate cases (a `<mark>` highlight, a drag-handle attribute
+#    selector, a `body.click()` gesture, ...).
+# 2. Entire files listed in `e2e-inline-dom-allowlist.txt` (meta-tests
+#    whose purpose IS to assert on the raw `role="dialog"` element).
+#
+# Run locally:
+#
+#   bash .github/scripts/e2e-no-inline-dom.sh
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ALLOWLIST="${ROOT}/.github/scripts/e2e-inline-dom-allowlist.txt"
+
+cd "${ROOT}"
+
+# Forbidden patterns:
+#   - getByRole('dialog' / "dialog"
+#   - page.locator(...) anchored on the `page` variable (helpers that
+#     receive a Locator and chain `.locator(...)` are not matched).
+PATTERN='getByRole\(['"'"'"]dialog|page\.locator\('
+MARKER='allow-inline-dom'
+
+# Use awk over each file: per match, accept if the current line OR any
+# of the contiguous comment / blank lines immediately preceding it carry
+# the marker. This makes the marker tolerant of multi-line comment
+# blocks ("// foo\n// bar\n// allow-inline-dom\nawait expect(...)").
+# Output mirrors `grep -rn` (`path:lineno:content`).
+collect_violations() {
+  local root="$1"
+  find "${root}" -type f \( -name '*.ts' -o -name '*.tsx' \) -print0 \
+    | while IFS= read -r -d '' file; do
+        awk -v file="${file}" -v pat="${PATTERN}" -v marker="${MARKER}" '
+          {
+            lines[NR] = $0
+          }
+          END {
+            for (i = 1; i <= NR; i++) {
+              if (lines[i] !~ pat) continue
+              if (lines[i] ~ marker) continue
+              found = 0
+              # Look back through contiguous comment / blank / continuation
+              # lines for the marker. Stop at the first non-comment code line.
+              for (j = i - 1; j >= 1 && j >= i - 8; j--) {
+                if (lines[j] ~ marker) { found = 1; break }
+                # Lines counted as "still attached to i": blank, // comment,
+                # /* ... */ block comment, or an opening `await expect(`
+                # / `await` line that wraps onto the next line.
+                if (lines[j] ~ /^[[:space:]]*$/) continue
+                if (lines[j] ~ /^[[:space:]]*\/\//) continue
+                if (lines[j] ~ /^[[:space:]]*\*/) continue
+                if (lines[j] ~ /^[[:space:]]*\/\*/) continue
+                if (lines[j] ~ /^[[:space:]]*await[[:space:]]+expect\([[:space:]]*$/) continue
+                if (lines[j] ~ /^[[:space:]]*expect\([[:space:]]*$/) continue
+                break
+              }
+              if (!found) {
+                printf("%s:%d:%s\n", file, i, lines[i])
+              }
+            }
+          }
+        ' "${file}"
+      done
+}
+
+matches=$(collect_violations tests/e2e; collect_violations e2e-doc-scenarios)
+
+# Apply the file-level allow-list (paths listed there are skipped wholesale).
+if [ -s "${ALLOWLIST}" ] && [ -n "${matches}" ]; then
+  while IFS= read -r entry; do
+    case "${entry}" in
+      ''|\#*) continue ;;
+    esac
+    matches=$(echo "${matches}" | grep -v -F "${entry}" || true)
+  done < "${ALLOWLIST}"
+fi
+
+if [ -z "${matches}" ]; then
+  echo "No inline DOM access detected."
+  exit 0
+fi
+
+echo "Inline DOM access detected outside Page Objects:"
+echo ""
+echo "${matches}"
+echo ""
+echo "Either wrap the locator in a Page Object under e2e-shared/pages/,"
+echo "or tag the offending line (or the line just above it) with:"
+echo ""
+echo "  // allow-inline-dom"
+echo ""
+echo "if the selector is legitimately local (e.g. <mark> highlight, drag"
+echo "handle, body.click()). For meta-tests that assert on the raw"
+echo "role='dialog' element, add the file path to:"
+echo ""
+echo "  .github/scripts/e2e-inline-dom-allowlist.txt"
+echo ""
+exit 1

--- a/.github/scripts/e2e-no-inline-dom.sh
+++ b/.github/scripts/e2e-no-inline-dom.sh
@@ -23,7 +23,7 @@
 #
 #   bash .github/scripts/e2e-no-inline-dom.sh
 #
-set -euo pipefail
+set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ALLOWLIST="${ROOT}/.github/scripts/e2e-inline-dom-allowlist.txt"
@@ -37,68 +37,88 @@ cd "${ROOT}"
 PATTERN='getByRole\(['"'"'"]dialog|page\.locator\('
 MARKER='allow-inline-dom'
 
-# Use awk over each file: per match, accept if the current line OR any
-# of the contiguous comment / blank lines immediately preceding it carry
-# the marker. This makes the marker tolerant of multi-line comment
-# blocks ("// foo\n// bar\n// allow-inline-dom\nawait expect(...)").
-# Output mirrors `grep -rn` (`path:lineno:content`).
-collect_violations() {
-  local root="$1"
-  find "${root}" -type f \( -name '*.ts' -o -name '*.tsx' \) -print0 \
-    | while IFS= read -r -d '' file; do
-        awk -v file="${file}" -v pat="${PATTERN}" -v marker="${MARKER}" '
-          {
-            lines[NR] = $0
-          }
-          END {
-            for (i = 1; i <= NR; i++) {
-              if (lines[i] !~ pat) continue
-              if (lines[i] ~ marker) continue
-              found = 0
-              # Look back through contiguous comment / blank / continuation
-              # lines for the marker. Stop at the first non-comment code line.
-              for (j = i - 1; j >= 1 && j >= i - 8; j--) {
-                if (lines[j] ~ marker) { found = 1; break }
-                # Lines counted as "still attached to i": blank, // comment,
-                # /* ... */ block comment, or an opening `await expect(`
-                # / `await` line that wraps onto the next line.
-                if (lines[j] ~ /^[[:space:]]*$/) continue
-                if (lines[j] ~ /^[[:space:]]*\/\//) continue
-                if (lines[j] ~ /^[[:space:]]*\*/) continue
-                if (lines[j] ~ /^[[:space:]]*\/\*/) continue
-                if (lines[j] ~ /^[[:space:]]*await[[:space:]]+expect\([[:space:]]*$/) continue
-                if (lines[j] ~ /^[[:space:]]*expect\([[:space:]]*$/) continue
-                break
-              }
-              if (!found) {
-                printf("%s:%d:%s\n", file, i, lines[i])
-              }
-            }
-          }
-        ' "${file}"
-      done
-}
+# Collect candidate violations: `grep -rnE` returns `path:lineno:content`
+# for every line matching the forbidden pattern. The `|| true` swallows
+# grep's exit code 1 (no matches), which is the success case for us.
+candidates=$(
+  grep -rnE "${PATTERN}" tests/e2e e2e-doc-scenarios \
+    --include='*.ts' --include='*.tsx' \
+    2>/dev/null || true
+)
 
-matches=$(collect_violations tests/e2e; collect_violations e2e-doc-scenarios)
+if [ -z "${candidates}" ]; then
+  echo "No inline DOM access detected."
+  exit 0
+fi
+
+# For each candidate `path:lineno:content`, accept it if:
+#  - the matched line itself carries the marker, or
+#  - any of the up-to-8 preceding non-code lines (comments, blanks,
+#    bare `await expect(` wrappers) carries the marker.
+violations=""
+while IFS= read -r line; do
+  # Skip blank entries (defensive).
+  [ -z "${line}" ] && continue
+
+  # Parse `path:lineno:content`. The content may itself contain colons,
+  # so cut just the first two fields.
+  file=${line%%:*}
+  rest=${line#*:}
+  lineno=${rest%%:*}
+  content=${rest#*:}
+
+  # Marker on the matched line itself.
+  case "${content}" in
+    *"${MARKER}"*) continue ;;
+  esac
+
+  # Look back up to 8 lines for the marker. Stop early at a code line
+  # (not a comment / blank / bare `await expect(` wrapper).
+  found_marker=0
+  start=$((lineno - 1))
+  end=$((lineno - 8))
+  [ "${end}" -lt 1 ] && end=1
+
+  for ((n = start; n >= end; n--)); do
+    prev_line=$(sed -n "${n}p" "${file}")
+    case "${prev_line}" in
+      *"${MARKER}"*) found_marker=1; break ;;
+    esac
+    # Trim leading whitespace for the "is this still attached" check.
+    trimmed=${prev_line#"${prev_line%%[![:space:]]*}"}
+    case "${trimmed}" in
+      ''|//*|'*'*|'/*'*) continue ;;
+      'await expect('|'expect(') continue ;;
+      *) break ;;
+    esac
+  done
+
+  if [ "${found_marker}" -eq 0 ]; then
+    violations="${violations}${line}"$'\n'
+  fi
+done <<< "${candidates}"
 
 # Apply the file-level allow-list (paths listed there are skipped wholesale).
-if [ -s "${ALLOWLIST}" ] && [ -n "${matches}" ]; then
+if [ -s "${ALLOWLIST}" ] && [ -n "${violations}" ]; then
   while IFS= read -r entry; do
     case "${entry}" in
       ''|\#*) continue ;;
     esac
-    matches=$(echo "${matches}" | grep -v -F "${entry}" || true)
+    violations=$(echo "${violations}" | grep -v -F "${entry}" || true)
   done < "${ALLOWLIST}"
 fi
 
-if [ -z "${matches}" ]; then
+# Trim trailing newline for the empty check.
+violations=$(printf '%s' "${violations}")
+
+if [ -z "${violations}" ]; then
   echo "No inline DOM access detected."
   exit 0
 fi
 
 echo "Inline DOM access detected outside Page Objects:"
 echo ""
-echo "${matches}"
+echo "${violations}"
 echo ""
 echo "Either wrap the locator in a Page Object under e2e-shared/pages/,"
 echo "or tag the offending line (or the line just above it) with:"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Run ESLint with CTRF reporter
         run: pnpm lint:ctrf
 
+      - name: E2E grep guard (no inline DOM access outside Page Objects)
+        run: bash .github/scripts/e2e-no-inline-dom.sh
+
       - name: Generate lint markdown summary
         if: always()
         run: node scripts/lint-markdown.mjs > ctrf/lint.md

--- a/e2e-doc-scenarios/helpers/ui-actions.ts
+++ b/e2e-doc-scenarios/helpers/ui-actions.ts
@@ -16,6 +16,7 @@
  */
 import type { BrowserContext, Page } from '@playwright/test';
 import { injectLocaleOverride } from '../../e2e-shared/locale-injector.js';
+import { DialogPage } from '../../e2e-shared/pages/index.js';
 import { applyTheme, type Theme } from '../../e2e-shared/theme.js';
 
 /**
@@ -84,9 +85,6 @@ export async function openMimeticTab(
  */
 export async function dismissDialog(page: Page): Promise<void> {
   await page.keyboard.press('Escape');
-  await page
-    .getByRole('dialog')
-    .first()
-    .waitFor({ state: 'hidden' })
-    .catch(() => undefined);
+  const dialog = new DialogPage(page);
+  await dialog.expectHidden().catch(() => undefined);
 }

--- a/e2e-shared/pages/DialogPage.ts
+++ b/e2e-shared/pages/DialogPage.ts
@@ -1,10 +1,16 @@
 /**
- * Abstract base for Page Objects that wrap a Radix `role="dialog"` element.
+ * Base Page Object for Radix `role="dialog"` elements.
  *
  * Subclasses provide locators, atomic actions and assertions specific to
  * their dialog. They may override `dialog()` when more than one dialog can
  * be visible at the same time (use `.first()`, `.nth(n)`, or a more
  * specific scope).
+ *
+ * Direct instantiation (`new DialogPage(page)`) is allowed when a spec
+ * only needs the generic "a Radix dialog is open" assertion (e.g.
+ * keyboard-shortcut sequences that fan out to several wizards and only
+ * check that one of them opened). For dialog-specific interactions,
+ * subclass instead.
  *
  * Page Objects in this folder stay close to the DOM: one method per
  * locator, one method per atomic action, one method per atomic
@@ -13,7 +19,7 @@
  */
 import { expect, type Locator, type Page } from '@playwright/test';
 
-export abstract class DialogPage {
+export class DialogPage {
   constructor(protected readonly page: Page) {}
 
   /**

--- a/e2e-shared/pages/README.md
+++ b/e2e-shared/pages/README.md
@@ -50,6 +50,12 @@ Subclass `DialogPage` (declared in this folder). It exposes:
 - `expectVisible()` / `expectHidden()`: parameterised waits,
 - `clickButton(name: RegExp | string)`: footer button shortcut.
 
+`DialogPage` is also directly instantiable for the rare case where a
+spec only needs the generic "a Radix dialog is open" assertion (e.g.
+keyboard-sequence specs that fan out to several wizards and only check
+that one of them opened). Subclass instead when the test needs
+dialog-specific interactions.
+
 Override `dialog()` in your subclass when **more than one dialog can be
 visible at a time** (nested confirmation, error overlay, ...) so each
 Page Object scopes its locators to its own dialog:

--- a/e2e-shared/pages/SessionEditorPage.ts
+++ b/e2e-shared/pages/SessionEditorPage.ts
@@ -1,0 +1,251 @@
+/**
+ * Page Object for the Session Editor dialog (`SessionEditDialog`).
+ *
+ * Wraps the Radix dialog opened from a session card's More-actions menu
+ * (`Edit` item). Covers the session name input, the note textarea, the
+ * tab tree (inline edit/delete/move tab, inline edit/delete group,
+ * collapse / expand), the unsaved-changes alert and the delete-group
+ * alert.
+ *
+ * Stays close to the DOM (locators + atomic actions + atomic
+ * assertions). Composed flows (e.g. "edit name + save and verify
+ * storage") belong in `e2e-shared/actions/` when reused across
+ * pipelines.
+ *
+ * Selectors target the English UI (`--lang=en-US`); subclass and
+ * override the locator getters to retarget another locale.
+ *
+ * Relevant US: US-E01 (edit session), US-E02 (delete group),
+ * US-S-NOTE-02 (edit note), US-S018 (collapsed groups).
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+import { DialogPage } from './DialogPage.js';
+
+export class SessionEditorPage extends DialogPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override dialog(): Locator {
+    return this.page.getByTestId('dialog-session-edit');
+  }
+
+  // ─── Locators: form fields ───────────────────────────────────────────────
+
+  /** Session name text input. */
+  nameInput(): Locator {
+    return this.dialog().getByTestId('dialog-session-edit-field-name');
+  }
+
+  /** Note textarea (single textarea inside the dialog). */
+  noteTextarea(): Locator {
+    return this.dialog().locator('textarea');
+  }
+
+  /** Primary "Save" button in the footer. */
+  saveButton(): Locator {
+    return this.dialog().getByTestId('dialog-session-edit-btn-save');
+  }
+
+  /** "Cancel" button in the footer. */
+  cancelButton(): Locator {
+    return this.dialog().getByTestId('dialog-session-edit-btn-cancel');
+  }
+
+  // ─── Locators: tab tree ──────────────────────────────────────────────────
+
+  /**
+   * A tab-tree row (group header or tab) filtered by its text content.
+   * Tab tree rows are rendered as `role="listitem"` by `TabTreeEditor`.
+   */
+  rowByText(text: string): Locator {
+    return this.dialog().getByRole('listitem').filter({ hasText: text });
+  }
+
+  /** Inline URL textbox revealed after clicking "Edit tab". */
+  tabUrlInput(): Locator {
+    return this.dialog().getByRole('textbox', { name: /url/i });
+  }
+
+  /** Inline group-name textbox revealed after clicking "Edit group". */
+  groupNameInput(): Locator {
+    return this.dialog().getByRole('textbox', { name: /group name/i });
+  }
+
+  // ─── Locators: secondary alert dialogs ───────────────────────────────────
+
+  /**
+   * Root of the unsaved-changes / delete-group AlertDialog (Radix
+   * renders both with `role="alertdialog"`, so they share the same
+   * locator). Only one can be visible at a time.
+   */
+  alertDialog(): Locator {
+    return this.page.getByRole('alertdialog');
+  }
+
+  // ─── Atomic actions: form ────────────────────────────────────────────────
+
+  /** Fill the session name input. */
+  async fillName(name: string): Promise<void> {
+    await this.nameInput().fill(name);
+  }
+
+  /** Fill the note textarea (use an empty string to clear it). */
+  async fillNote(note: string): Promise<void> {
+    await this.noteTextarea().fill(note);
+  }
+
+  /** Click "Save". */
+  async clickSave(): Promise<void> {
+    await this.saveButton().click();
+  }
+
+  /** Click "Cancel" (may surface the unsaved-changes alert if dirty). */
+  async clickCancel(): Promise<void> {
+    await this.cancelButton().click();
+  }
+
+  // ─── Atomic actions: opening ─────────────────────────────────────────────
+
+  /**
+   * Open the editor from the More-actions dropdown on the (only) visible
+   * session card. The seeded-then-rendered Sessions list exposes a single
+   * "More actions" trigger when one session is present; the menu item
+   * has the localised "Edit" label (regex tolerates extra whitespace and
+   * matches both English and French i18n variants of the same word).
+   */
+  async openFromFirstSessionMenu(): Promise<void> {
+    await this.page.getByRole('button', { name: /more actions/i }).click();
+    await this.page.getByRole('menuitem', { name: /^edit$/i }).click();
+    await this.expectVisible();
+  }
+
+  // ─── Atomic actions: tab tree ────────────────────────────────────────────
+
+  /**
+   * Hover the row matching `text` and click "Delete tab".
+   * Mirrors the spec pattern: hover the row, then click the destructive
+   * IconButton revealed in the hovered row's `rightSlot`.
+   */
+  async deleteTab(text: string): Promise<void> {
+    const row = this.rowByText(text);
+    await row.hover();
+    await row.getByRole('button', { name: 'Delete tab' }).click();
+  }
+
+  /**
+   * Hover the row matching `text` and click "Edit tab". Leaves the
+   * inline URL textbox open; use `tabUrlInput()` to interact with it.
+   */
+  async editTab(text: string): Promise<void> {
+    const row = this.rowByText(text);
+    await row.hover();
+    await row.getByRole('button', { name: 'Edit tab' }).click();
+  }
+
+  /** Replace the URL in the inline tab editor and commit with Enter. */
+  async fillTabUrlAndCommit(url: string): Promise<void> {
+    const input = this.tabUrlInput();
+    await input.clear();
+    await input.fill(url);
+    await input.press('Enter');
+  }
+
+  /**
+   * Hover the row matching `text` and open the Move-tab dropdown.
+   * Use `selectMoveTarget` to pick the destination group.
+   */
+  async openMoveTabDropdown(text: string): Promise<void> {
+    const row = this.rowByText(text);
+    await row.hover();
+    await row.getByRole('button', { name: 'Move tab to group' }).click();
+  }
+
+  /** Click a target group in the Move-tab dropdown menu. */
+  async selectMoveTarget(groupName: string): Promise<void> {
+    await this.page.getByRole('menuitem', { name: groupName }).click();
+  }
+
+  /**
+   * Hover the group header matching `groupName` and click "Edit group".
+   * Leaves the inline group-name textbox open; use `groupNameInput()`
+   * to interact with it.
+   */
+  async editGroup(groupName: string): Promise<void> {
+    const row = this.rowByText(groupName).first();
+    await row.hover();
+    await this.dialog().getByRole('button', { name: 'Edit group' }).click();
+  }
+
+  /** Replace the group name in the inline group editor and commit. */
+  async fillGroupNameAndCommit(name: string): Promise<void> {
+    const input = this.groupNameInput();
+    await input.clear();
+    await input.fill(name);
+    await input.press('Enter');
+  }
+
+  /**
+   * Hover the group header matching `groupName` and click "Delete
+   * group". Opens the secondary AlertDialog asking whether to keep or
+   * ungroup the tabs.
+   */
+  async openDeleteGroupAlert(groupName: string): Promise<void> {
+    const row = this.rowByText(groupName).first();
+    await row.hover();
+    await this.dialog().getByRole('button', { name: 'Delete group' }).click();
+  }
+
+  /** Toggle the first visible "Collapse group" button in the tab tree. */
+  async toggleCollapseGroup(): Promise<void> {
+    await this.dialog().getByRole('button', { name: /collapse group/i }).click();
+  }
+
+  // ─── Atomic actions: alerts ──────────────────────────────────────────────
+
+  /** Click "Leave" in the unsaved-changes alert. */
+  async confirmLeaveUnsaved(): Promise<void> {
+    await this.page.getByRole('button', { name: /leave/i }).click();
+  }
+
+  /** Confirm "Delete group and N tab(s)" in the delete-group alert. */
+  async confirmDeleteGroupAndTabs(): Promise<void> {
+    await this.page.getByRole('button', { name: /delete group and/i }).click();
+  }
+
+  /** Confirm "Ungroup tabs" in the delete-group alert. */
+  async confirmUngroupTabs(): Promise<void> {
+    await this.page.getByRole('button', { name: /ungroup/i }).click();
+  }
+
+  // ─── Atomic assertions ───────────────────────────────────────────────────
+
+  /** Assert a tab title / group name is visible inside the dialog. */
+  async expectTextVisible(text: string, options?: { exact?: boolean }): Promise<void> {
+    await expect(this.dialog().getByText(text, options)).toBeVisible();
+  }
+
+  /** Assert a tab title / group name is NOT visible inside the dialog. */
+  async expectTextHidden(text: string, options?: { exact?: boolean }): Promise<void> {
+    await expect(this.dialog().getByText(text, options)).toBeHidden();
+  }
+
+  /**
+   * Assert a counter line containing `text` (regex tolerant) is visible
+   * inside the dialog. Examples: `/3 tab/i`, `/1 group/i`.
+   */
+  async expectCounterVisible(text: RegExp): Promise<void> {
+    await expect(this.dialog().getByText(text)).toBeVisible();
+  }
+
+  /** Assert the unsaved-changes alert is visible. */
+  async expectUnsavedAlertVisible(): Promise<void> {
+    await expect(this.alertDialog()).toBeVisible();
+    await expect(this.alertDialog().getByText(/unsaved/i).first()).toBeVisible();
+  }
+
+  /** Assert the delete-group alert is visible. */
+  async expectDeleteGroupAlertVisible(): Promise<void> {
+    await expect(this.alertDialog()).toBeVisible();
+  }
+}

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -26,6 +26,7 @@ export {
   type GroupConflictAction,
 } from './RestoreWizardPage.js';
 export { SessionsListPage } from './SessionsListPage.js';
+export { SessionEditorPage } from './SessionEditorPage.js';
 export { DomainRulesListPage } from './DomainRulesListPage.js';
 export {
   OptionsEditModalPage,

--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -152,6 +152,7 @@ export function ConfigEditModal({
       onApply={handleApply}
       disabled={hasError}
       title={getMessage('editConfigTitle')}
+      data-testid="modal-edit-config"
       maxWidth={820}
       contentStyle={{
         display: 'flex',

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -123,3 +123,59 @@ Shared between this suite and `e2e-doc-scenarios/`:
 - Never `console.log()` from specs; use the existing logger conventions
   if debugging output is genuinely needed.
 - Group tests with `test.describe` only when a `beforeEach` is shared.
+
+## No inline DOM access (grep guard)
+
+Specs and pipeline helpers must consume Page Objects under
+`e2e-shared/pages/` instead of reaching for the DOM directly via
+`page.getByRole('dialog')` or `page.locator(...)`. The convergence
+guarantee documented in `CLAUDE.md` only holds when every spec breaks
+at the same call site after a UI refactor; inline locators dilute that
+guarantee.
+
+A CI grep guard enforces the contract:
+
+```bash
+bash .github/scripts/e2e-no-inline-dom.sh
+```
+
+The script runs inside the `Lint` job in `.github/workflows/tests.yml`
+and fails the build if a new violation is introduced.
+
+### When the selector is legitimately local
+
+Some selectors do not target a dialog or wizard surface and don't
+belong in a Page Object:
+
+- `<mark>` highlights produced by `AccessibleHighlight` (search
+  results),
+- attribute selectors for DnD atoms
+  (`[data-testid$="-drag-handle"]`),
+- `body.click()` gestures used to refocus the document so a follow-up
+  keyboard shortcut bubbles to `document`,
+- testid-scoped queries on a content surface that has no Page Object
+  (e.g. `[data-testid="shortcuts-content"] [data-group-id]`).
+
+Tag those lines with an inline marker comment:
+
+```ts
+// allow-inline-dom: <reason in one line>
+await expect(page.locator('mark').filter({ hasText: 'GitHub' }).first()).toBeVisible();
+```
+
+The marker is also recognised when it sits on a comment line above the
+flagged statement, including across multi-line `await expect(...)`
+wrappers.
+
+### When the entire file is a meta-test
+
+For specs whose subject IS the raw `role="dialog"` element (e.g.
+`dialog-initial-focus.spec.ts` asserts that Radix dialogs land focus on
+the right element on open), add the file path to:
+
+```
+.github/scripts/e2e-inline-dom-allowlist.txt
+```
+
+Keep that file as small as possible: file-level exemptions hide future
+violations from the grep guard.

--- a/tests/e2e/domain-rules-dnd.spec.ts
+++ b/tests/e2e/domain-rules-dnd.spec.ts
@@ -74,9 +74,11 @@ test.describe('Drag-and-drop reordering', () => {
 
     // Type in the search box to activate a filter
     await page.getByTestId('page-rules-search').fill('git');
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     await expect(page.locator('[data-testid$="-drag-handle"]').first()).toHaveAttribute('aria-disabled', 'true');
 
-    // All visible rule drag handles should be aria-disabled
+    // All visible rule drag handles should be aria-disabled.
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     const dragHandles = page.locator('[data-testid$="-drag-handle"]');
     const count = await dragHandles.count();
     expect(count).toBeGreaterThan(0);
@@ -98,6 +100,7 @@ test.describe('Drag-and-drop reordering', () => {
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
 
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     const dragHandle = page.locator('[data-testid$="-drag-handle"]').first();
     await expect(dragHandle).not.toHaveAttribute('aria-disabled', 'true');
 

--- a/tests/e2e/domain-rules-keyboard-dnd.spec.ts
+++ b/tests/e2e/domain-rules-keyboard-dnd.spec.ts
@@ -27,6 +27,7 @@ test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
 
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     const handle = page.locator('[data-testid$="-drag-handle"]').first();
     await expect(handle).toBeVisible();
 
@@ -119,6 +120,7 @@ test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
 
     await page.getByTestId('page-rules-search').fill('git');
 
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     const handle = page.locator('[data-testid$="-drag-handle"]').first();
     await expect(handle).toBeDisabled();
 

--- a/tests/e2e/domain-rules-search.spec.ts
+++ b/tests/e2e/domain-rules-search.spec.ts
@@ -146,7 +146,8 @@ test.describe('[US-DR-SEARCH-03] Highlight matching text in domain rule cards', 
 
     await page.getByPlaceholder('Search rules...').fill('GitHub');
 
-    // A <mark> element should wrap the matching part of the label
+    // A <mark> element should wrap the matching part of the label.
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'GitHub' }).first()).toBeVisible();
     await page.close();
   });
@@ -163,7 +164,8 @@ test.describe('[US-DR-SEARCH-03] Highlight matching text in domain rule cards', 
 
     await page.getByPlaceholder('Search rules...').fill('vercel');
 
-    // A <mark> element should wrap the matching part of the domain filter text
+    // A <mark> element should wrap the matching part of the domain filter text.
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'vercel' }).first()).toBeVisible();
     await page.close();
   });
@@ -178,12 +180,13 @@ test.describe('[US-DR-SEARCH-03] Highlight matching text in domain rule cards', 
     const page = await extensionContext.newPage();
     await goToDomainRulesSection(page, extensionId);
 
-    // No search term → no <mark> elements
+    // No search term so no <mark> elements.
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark')).toHaveCount(0);
     await page.close();
   });
 
-  test('highlight is case-insensitive — lowercase query matches mixed-case label', async ({
+  test('highlight is case-insensitive: lowercase query matches mixed-case label', async ({
     extensionContext,
     extensionId,
     helpers,
@@ -195,6 +198,7 @@ test.describe('[US-DR-SEARCH-03] Highlight matching text in domain rule cards', 
 
     await page.getByPlaceholder('Search rules...').fill('confluence');
 
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: /confluence/i }).first()).toBeVisible();
     await page.close();
   });

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -10,6 +10,7 @@
 import { test, expect } from './fixtures';
 import { goToDomainRulesSection } from './helpers/navigation';
 import { auditPage } from './helpers/a11y';
+import { RuleWizardPage } from '../../e2e-shared/pages/index.js';
 
 test.beforeEach(async ({ helpers }) => {
   await helpers.clearDomainRules();
@@ -103,7 +104,8 @@ test.describe('Edit rule via dropdown', () => {
     await page.getByRole('listitem', { name: /Slack/i }).getByLabel('More actions').click();
     await page.getByRole('menuitem', { name: /edit/i }).click();
 
-    await expect(page.getByRole('dialog')).toBeVisible();
+    const wizard = new RuleWizardPage(page);
+    await wizard.expectVisible();
     await expect(page.getByText('Edit Rule')).toBeVisible();
     await page.close();
   });

--- a/tests/e2e/helpers/navigation.ts
+++ b/tests/e2e/helpers/navigation.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import { DialogPage } from '../../../e2e-shared/pages/index.js';
 
 /** Navigate to the extension options page. */
 export async function goToOptionsPage(page: Page, extensionId: string): Promise<void> {
@@ -40,9 +41,8 @@ export async function goToSessionsSectionWithSnapshot(page: Page, extensionId: s
   await page.goto(`chrome-extension://${extensionId}/options.html#sessions?action=snapshot`);
   await page.waitForLoadState('domcontentloaded');
   // Wait for the wizard dialog (opened by the deep link action)
-  await page
-    .getByRole('dialog')
-    .waitFor({ state: 'visible', timeout: 10_000 });
+  const dialog = new DialogPage(page);
+  await dialog.expectVisible({ timeout: 10_000 });
 }
 
 /**

--- a/tests/e2e/import-export-shortcuts.spec.ts
+++ b/tests/e2e/import-export-shortcuts.spec.ts
@@ -6,6 +6,7 @@
  */
 import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
+import { DialogPage } from '../../e2e-shared/pages/index.js';
 
 async function goToImportExportSection(page: Page, extensionId: string): Promise<void> {
   await page.goto(`chrome-extension://${extensionId}/options.html`);
@@ -23,6 +24,8 @@ async function goToImportExportSection(page: Page, extensionId: string): Promise
 }
 
 async function focusBody(page: Page): Promise<void> {
+  // allow-inline-dom: focusing the page body to dispatch the next keydown
+  // outside any inner input is a generic UI gesture, not a wizard locator.
   await page.locator('body').click({ position: { x: 5, y: 5 } });
 }
 
@@ -35,7 +38,8 @@ test.describe('[issue-275] Import/Export sequence shortcuts', () => {
     await page.keyboard.press('i');
     await page.keyboard.press('r');
 
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    const dialog = new DialogPage(page);
+    await dialog.expectVisible({ timeout: 5000 });
     await page.close();
   });
 
@@ -47,7 +51,8 @@ test.describe('[issue-275] Import/Export sequence shortcuts', () => {
     await page.keyboard.press('i');
     await page.keyboard.press('s');
 
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    const dialog = new DialogPage(page);
+    await dialog.expectVisible({ timeout: 5000 });
     await page.close();
   });
 
@@ -59,7 +64,8 @@ test.describe('[issue-275] Import/Export sequence shortcuts', () => {
     await page.keyboard.press('i');
     await page.keyboard.press('w');
 
-    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
+    const dialog = new DialogPage(page);
+    await dialog.expectVisible({ timeout: 5000 });
     await page.close();
   });
 
@@ -78,7 +84,8 @@ test.describe('[issue-275] Import/Export sequence shortcuts', () => {
     await expect(indicator).toBeHidden({ timeout: 3000 });
     // r alone is not a binding in this scope, so no dialog opens.
     await page.keyboard.press('r');
-    await expect(page.getByRole('dialog')).toBeHidden();
+    const dialog = new DialogPage(page);
+    await dialog.expectHidden();
     await page.close();
   });
 
@@ -94,7 +101,8 @@ test.describe('[issue-275] Import/Export sequence shortcuts', () => {
     await expect(indicator).toBeHidden({ timeout: 1000 });
     // r alone is not a binding in this scope, so no dialog opens.
     await page.keyboard.press('r');
-    await expect(page.getByRole('dialog')).toBeHidden();
+    const dialog = new DialogPage(page);
+    await dialog.expectHidden();
     await page.close();
   });
 });

--- a/tests/e2e/import-export.spec.ts
+++ b/tests/e2e/import-export.spec.ts
@@ -20,7 +20,7 @@ import type { BrowserContext, Page } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { auditPage } from './helpers/a11y';
 import { goToImportExportSection } from './helpers/navigation';
-import { ImportWizardPage } from '../../e2e-shared/pages/index.js';
+import { DialogPage, ImportWizardPage } from '../../e2e-shared/pages/index.js';
 import { openRulesImportWizard, openRulesExportWizard } from '../../e2e-shared/actions/index.js';
 
 // ─── Local fixtures ─────────────────────────────────────────────────────────
@@ -526,11 +526,12 @@ test.describe('Import / Export', () => {
       await page.waitForLoadState('domcontentloaded');
 
       await openWizard();
-      await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      const dialog = new DialogPage(page);
+      await dialog.expectVisible({ timeout: 10_000 });
       await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(hash);
 
       await page.keyboard.press('Escape');
-      await expect(page.getByRole('dialog')).toBeHidden();
+      await dialog.expectHidden();
       await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(hash);
     }
 
@@ -590,13 +591,14 @@ test.describe('Import / Export', () => {
     }) => {
       await extensionPage.goto(`chrome-extension://${extensionId}/options.html#importexport`);
       await extensionPage.waitForLoadState('domcontentloaded');
+      const dialog = new DialogPage(extensionPage);
       await expect(extensionPage.getByTestId('page-import-export')).toBeVisible();
-      await expect(extensionPage.getByRole('dialog')).toBeHidden();
+      await dialog.expectHidden();
 
       await extensionPage.reload();
       await extensionPage.waitForLoadState('domcontentloaded');
       await expect(extensionPage.getByTestId('page-import-export')).toBeVisible();
-      await expect(extensionPage.getByRole('dialog')).toBeHidden();
+      await dialog.expectHidden();
     });
   });
 
@@ -610,11 +612,12 @@ test.describe('Import / Export', () => {
       await extensionPage.goto(`chrome-extension://${extensionId}/options.html#rules?action=import`);
       await extensionPage.waitForLoadState('domcontentloaded');
 
+      const dialog = new DialogPage(extensionPage);
       await expect(extensionPage.getByTestId('page-rules')).toBeVisible({ timeout: 10_000 });
-      await expect(extensionPage.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+      await dialog.expectVisible({ timeout: 10_000 });
 
       await extensionPage.keyboard.press('Escape');
-      await expect(extensionPage.getByRole('dialog')).toBeHidden();
+      await dialog.expectHidden();
       await expect(extensionPage.getByTestId('page-rules')).toBeVisible();
     });
   });

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -50,6 +50,7 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
 
     // Only the 2 popup-relevant groups must be displayed (Popup, Session
     // card). Global, Options and Lists groups are hidden in the popup drawer.
+    // allow-inline-dom: scopes to a testid-keyed content surface, not a dialog/wizard.
     await expect(
       page.locator('[data-testid="shortcuts-content"] [data-group-id]'),
     ).toHaveCount(2);
@@ -107,6 +108,7 @@ test.describe('[US-KB-popup] Popup shortcuts', () => {
       timeout: 5000,
     });
 
+    // allow-inline-dom: body.click() is a generic UI gesture to refocus, not a wizard surface.
     await page.locator('body').click();
     const [newPage] = await Promise.all([
       extensionContext.waitForEvent('page'),
@@ -134,6 +136,7 @@ test.describe('[US-KB-options] Options shortcuts', () => {
 
     // Click the top-left corner so a fresh-install Home (empty rules ->
     // HeroOnboarding) does not intercept the click on its CTA button.
+    // allow-inline-dom: body.click() is a generic UI gesture to refocus, not a wizard surface.
     await page.locator('body').click({ position: { x: 5, y: 5 } });
     // Sequence shortcut: `m` opens the navigation prefix, `s` selects Sessions.
     await page.keyboard.press('m');
@@ -156,6 +159,7 @@ test.describe('[US-KB-options] Options shortcuts', () => {
     const page = await extensionContext.newPage();
     await goToOptionsPage(page, extensionId);
 
+    // allow-inline-dom: body.click() is a generic UI gesture to refocus, not a wizard surface.
     await page.locator('body').click({ position: { x: 5, y: 5 } });
     await page.keyboard.press('Shift+Slash');
 
@@ -231,6 +235,7 @@ test.describe('[US-KB-panel] Shortcuts panel keyboard navigation', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
+    // allow-inline-dom: body.click() is a generic UI gesture to refocus, not a wizard surface.
     await page.locator('body').click();
     await page.keyboard.press('Shift+Slash');
 

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -367,8 +367,8 @@ test.describe('Edit mode — Summary View', () => {
 
     await wizard.clickModifySection(1);
 
-    const dialogs = page.locator('[role="dialog"]');
-    await expect(dialogs).toHaveCount(2);
+    await wizard.expectVisible();
+    await expect(page.getByTestId('modal-edit-config')).toBeVisible();
     await page.close();
   });
 

--- a/tests/e2e/session-editor.spec.ts
+++ b/tests/e2e/session-editor.spec.ts
@@ -6,6 +6,7 @@ import { test, expect } from './fixtures';
 import { goToSessionsSection } from './helpers/navigation';
 import { seedSessions, clearSessions, getSessionsFromStorage, createTestSession } from './helpers/seed';
 import { auditPage } from './helpers/a11y';
+import { SessionEditorPage } from '../../e2e-shared/pages/index.js';
 
 test.beforeEach(async ({ extensionContext }) => {
   await clearSessions(extensionContext);
@@ -25,10 +26,8 @@ test.describe('[US-E01] Opening', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
-
-    await expect(page.getByTestId('dialog-session-edit')).toBeVisible();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
     await expect(page.getByText('Edit Session')).toBeVisible();
     await auditPage(page, 'session-editor-dialog-open', { include: '[role="dialog"]' });
     await page.close();
@@ -41,11 +40,10 @@ test.describe('[US-E01] Opening', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const nameInput = page.getByTestId('dialog-session-edit-field-name');
-    await expect(nameInput).toHaveValue('My Special Session');
+    await expect(editor.nameInput()).toHaveValue('My Special Session');
     await page.close();
   });
 
@@ -57,13 +55,11 @@ test.describe('[US-E01] Opening', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    // Scope to dialog to avoid matching the same count on the session card
-    const dialog = page.getByRole('dialog');
-    await expect(dialog.getByText(/3 tab/i)).toBeVisible();
-    await expect(dialog.getByText(/1 group/i)).toBeVisible();
+    await editor.expectCounterVisible(/3 tab/i);
+    await editor.expectCounterVisible(/1 group/i);
     await page.close();
   });
 });
@@ -82,15 +78,13 @@ test.describe('[US-E01] Name editing', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const nameInput = page.getByTestId('dialog-session-edit-field-name');
-    await nameInput.fill('After Edit');
+    await editor.fillName('After Edit');
+    await editor.clickSave();
 
-    await page.getByTestId('dialog-session-edit-btn-save').click();
-
-    await expect(page.getByTestId('dialog-session-edit')).toBeHidden();
+    await editor.expectHidden();
     await expect(page.getByText('After Edit')).toBeVisible();
 
     const sessions = await getSessionsFromStorage(extensionContext);
@@ -113,12 +107,11 @@ test.describe('[US-E01] Cancel and unsaved changes', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    await page.getByTestId('dialog-session-edit-btn-cancel').click();
-
-    await expect(page.getByTestId('dialog-session-edit')).toBeHidden();
+    await editor.clickCancel();
+    await editor.expectHidden();
     await page.close();
   });
 
@@ -129,18 +122,13 @@ test.describe('[US-E01] Cancel and unsaved changes', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    // Make a change
-    const nameInput = page.getByTestId('dialog-session-edit-field-name');
-    await nameInput.fill('Modified Name');
+    await editor.fillName('Modified Name');
+    await editor.clickCancel();
 
-    await page.getByTestId('dialog-session-edit-btn-cancel').click();
-
-    // AlertDialog should appear asking about unsaved changes ("unsaved" appears in both title and body)
-    await expect(page.getByRole('alertdialog')).toBeVisible();
-    await expect(page.getByRole('alertdialog').getByText(/unsaved/i).first()).toBeVisible();
+    await editor.expectUnsavedAlertVisible();
     await page.close();
   });
 
@@ -154,18 +142,14 @@ test.describe('[US-E01] Cancel and unsaved changes', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const nameInput = page.getByTestId('dialog-session-edit-field-name');
-    await nameInput.fill('Will Not Save');
+    await editor.fillName('Will Not Save');
+    await editor.clickCancel();
+    await editor.confirmLeaveUnsaved();
 
-    await page.getByRole('button', { name: /cancel/i }).click();
-    await page.getByRole('button', { name: /leave/i }).click();
-
-    // Both dialogs should be closed
-    await expect(page.getByRole('dialog')).toBeHidden();
-    // The session name should be unchanged
+    await editor.expectHidden();
     await expect(page.getByText('Original')).toBeVisible();
     await expect(page.getByText('Will Not Save')).toBeHidden();
     await page.close();
@@ -183,13 +167,12 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    // Scope to dialog; use exact:true since 'Example' also appears in 'example.com'
-    const dialog = page.getByRole('dialog');
-    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('GitHub', { exact: true })).toBeVisible();
+    // Use exact:true since 'Example' also appears in 'example.com'
+    await editor.expectTextVisible('Example', { exact: true });
+    await editor.expectTextVisible('GitHub', { exact: true });
     await page.close();
   });
 
@@ -200,20 +183,18 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Scope to the GitHub listitem to avoid strict-mode violations (3 rows have 'Delete tab')
-    const githubRow = dialog.getByRole('listitem').filter({ hasText: 'GitHub' });
-    // Hover the right edge of the row (not just the title text) to verify the full row width is hoverable
+    // Scope to the GitHub listitem to avoid strict-mode violations (3 rows have 'Delete tab').
+    // Hover the right edge of the row (not just the title text) to verify the full row width is hoverable.
+    const githubRow = editor.rowByText('GitHub');
     const box = await githubRow.boundingBox();
     expect(box).not.toBeNull();
     await page.mouse.move(box!.x + box!.width - 8, box!.y + box!.height / 2);
     await githubRow.getByRole('button', { name: 'Delete tab' }).click();
 
-    // GitHub tab should be gone
-    await expect(dialog.getByText('GitHub', { exact: true })).toBeHidden();
+    await editor.expectTextHidden('GitHub', { exact: true });
     await page.close();
   });
 
@@ -224,26 +205,15 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Scope to the GitHub listitem to avoid strict-mode violations
-    const githubRow = dialog.getByRole('listitem').filter({ hasText: 'GitHub' });
-    await githubRow.hover();
-    await githubRow.getByRole('button', { name: 'Edit tab' }).click();
+    await editor.editTab('GitHub');
+    await editor.fillTabUrlAndCommit('https://modified.example.com');
 
-    // Replace the URL
-    const urlInput = dialog.getByRole('textbox', { name: /url/i });
-    await urlInput.clear();
-    await urlInput.fill('https://modified.example.com');
-    await urlInput.press('Enter');
+    await editor.clickSave();
+    await editor.expectHidden();
 
-    // Save the session
-    await page.getByTestId('dialog-session-edit-btn-save').click();
-    await expect(page.getByRole('dialog')).toBeHidden();
-
-    // Verify storage updated
     const sessions = await getSessionsFromStorage(extensionContext);
     const allUrls = [
       ...sessions[0].ungroupedTabs.map(t => t.url),
@@ -260,22 +230,14 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Hover the group row and click Edit group
-    await dialog.getByRole('listitem').filter({ hasText: 'Work' }).first().hover();
-    await dialog.getByRole('button', { name: 'Edit group' }).click();
+    await editor.editGroup('Work');
+    await editor.fillGroupNameAndCommit('Renamed Group');
 
-    // Rename in the inline text field
-    const nameInput = dialog.getByRole('textbox', { name: /group name/i });
-    await nameInput.clear();
-    await nameInput.fill('Renamed Group');
-    await nameInput.press('Enter');
-
-    await expect(dialog.getByText('Renamed Group', { exact: true })).toBeVisible();
-    await expect(dialog.getByText('Work', { exact: true })).toBeHidden();
+    await editor.expectTextVisible('Renamed Group', { exact: true });
+    await editor.expectTextHidden('Work', { exact: true });
     await page.close();
   });
 
@@ -296,20 +258,15 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Hover Example tab (in Work group) and open Move dropdown
-    const exampleRow = dialog.getByRole('listitem').filter({ hasText: 'Example' });
-    await exampleRow.hover();
-    await exampleRow.getByRole('button', { name: 'Move tab to group' }).click();
-    // Choose Personal as target
-    await page.getByRole('menuitem', { name: 'Personal' }).click();
+    await editor.openMoveTabDropdown('Example');
+    await editor.selectMoveTarget('Personal');
 
     // The Work group should have lost one tab (Google remains, Example moved)
     // Work group now shows count (1)
-    const workRow = dialog.getByRole('listitem').filter({ hasText: 'Work' }).first();
+    const workRow = editor.rowByText('Work').first();
     await expect(workRow.getByText('(1)')).toBeVisible();
     await page.close();
   });
@@ -325,20 +282,14 @@ test.describe('[US-E01] Tab tree', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Verify initial count
-    await expect(dialog.getByText(/3 tab/i)).toBeVisible();
+    await editor.expectCounterVisible(/3 tab/i);
 
-    // Delete the ungrouped GitHub tab
-    const githubRow = dialog.getByRole('listitem').filter({ hasText: 'GitHub' });
-    await githubRow.hover();
-    await githubRow.getByRole('button', { name: 'Delete tab' }).click();
+    await editor.deleteTab('GitHub');
 
-    // Counter should update to 2 tabs
-    await expect(dialog.getByText(/2 tab/i)).toBeVisible();
+    await editor.expectCounterVisible(/2 tab/i);
     await page.close();
   });
 });
@@ -357,13 +308,11 @@ test.describe('[US-E02] Delete group', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Hover the group row to reveal the action buttons
-    await dialog.getByRole('listitem').filter({ hasText: 'Work' }).first().hover();
-    await expect(dialog.getByRole('button', { name: 'Delete group' })).toBeVisible();
+    await editor.rowByText('Work').first().hover();
+    await expect(editor.dialog().getByRole('button', { name: 'Delete group' })).toBeVisible();
     await page.close();
   });
 
@@ -377,15 +326,11 @@ test.describe('[US-E02] Delete group', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('listitem').filter({ hasText: 'Work' }).first().hover();
-    await dialog.getByRole('button', { name: 'Delete group' }).click();
-
-    // AlertDialog for group deletion should appear
-    await expect(page.getByRole('alertdialog')).toBeVisible();
+    await editor.openDeleteGroupAlert('Work');
+    await editor.expectDeleteGroupAlertVisible();
     await page.close();
   });
 
@@ -399,18 +344,13 @@ test.describe('[US-E02] Delete group', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('listitem').filter({ hasText: 'Work' }).first().hover();
-    await dialog.getByRole('button', { name: 'Delete group' }).click();
+    await editor.openDeleteGroupAlert('Work');
+    await editor.confirmDeleteGroupAndTabs();
 
-    // Click the destructive "Delete group and N tab(s)" button
-    await page.getByRole('button', { name: /delete group and/i }).click();
-
-    // Group 'Work' should no longer appear in the editor
-    await expect(dialog.getByText('Work', { exact: true })).toBeHidden();
+    await editor.expectTextHidden('Work', { exact: true });
     await page.close();
   });
 
@@ -424,19 +364,14 @@ test.describe('[US-E02] Delete group', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.getByRole('listitem').filter({ hasText: 'Work' }).first().hover();
-    await dialog.getByRole('button', { name: 'Delete group' }).click();
+    await editor.openDeleteGroupAlert('Work');
+    await editor.confirmUngroupTabs();
 
-    // Choose to ungroup tabs rather than delete them
-    await page.getByRole('button', { name: /ungroup/i }).click();
-
-    // Group 'Work' is gone, but its tabs remain (now ungrouped)
-    await expect(dialog.getByText('Work', { exact: true })).toBeHidden();
-    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
+    await editor.expectTextHidden('Work', { exact: true });
+    await editor.expectTextVisible('Example', { exact: true });
     await page.close();
   });
 });
@@ -456,15 +391,12 @@ test.describe('[US-S018] Collapsed group state in editor', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Group header should be visible
-    await expect(dialog.getByText('Work', { exact: true })).toBeVisible();
-    // Tabs inside the collapsed group should NOT be visible
-    await expect(dialog.getByText('Example', { exact: true })).toBeHidden();
-    await expect(dialog.getByText('Google', { exact: true })).toBeHidden();
+    await editor.expectTextVisible('Work', { exact: true });
+    await editor.expectTextHidden('Example', { exact: true });
+    await editor.expectTextHidden('Google', { exact: true });
     await page.close();
   });
 
@@ -479,13 +411,11 @@ test.describe('[US-S018] Collapsed group state in editor', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await expect(dialog.getByText('Work', { exact: true })).toBeVisible();
-    // Tabs inside the expanded group should be visible
-    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
+    await editor.expectTextVisible('Work', { exact: true });
+    await editor.expectTextVisible('Example', { exact: true });
     await page.close();
   });
 
@@ -499,24 +429,18 @@ test.describe('[US-S018] Collapsed group state in editor', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
-    await page.getByRole('menuitem', { name: /edit/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    // Tabs should be visible (group starts expanded)
-    await expect(dialog.getByText('Example', { exact: true })).toBeVisible();
+    await editor.expectTextVisible('Example', { exact: true });
 
-    // Click the expand/collapse toggle on the group row
-    await dialog.getByRole('button', { name: /collapse group/i }).click();
+    await editor.toggleCollapseGroup();
 
-    // Tabs should now be hidden
-    await expect(dialog.getByText('Example', { exact: true })).toBeHidden();
+    await editor.expectTextHidden('Example', { exact: true });
 
-    // Save
-    await page.getByTestId('dialog-session-edit-btn-save').click();
-    await expect(dialog).toBeHidden();
+    await editor.clickSave();
+    await editor.expectHidden();
 
-    // Verify storage
     const sessions = await getSessionsFromStorage(extensionContext);
     expect(sessions[0].groups[0].collapsed).toBe(true);
     await page.close();

--- a/tests/e2e/session-notes.spec.ts
+++ b/tests/e2e/session-notes.spec.ts
@@ -16,6 +16,7 @@ import {
   getSessionsFromStorage,
 } from './helpers/seed';
 import type { TestSession } from './helpers/seed';
+import { SessionEditorPage } from '../../e2e-shared/pages/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -212,7 +213,8 @@ test.describe('[US-S-NOTE-04] Search matches note', () => {
 
     // Session appears (note matched)
     await expect(page.getByText('Generic Name ABC', { exact: true })).toBeVisible();
-    // Note text is visible (card opened) — use first() since AccessibleHighlight may split text
+    // Note text is visible (card opened); use first() since AccessibleHighlight may split text.
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'only-in-note-xyz' }).first()).toBeVisible();
     await page.close();
   });
@@ -235,7 +237,8 @@ test.describe('[US-S-NOTE-05] Note text is highlighted in search', () => {
 
     await page.getByPlaceholder('Search sessions...').fill('TypeScript');
 
-    // Card auto-opens; note visible with highlighted text
+    // Card auto-opens; note visible with highlighted text.
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'TypeScript' }).first()).toBeVisible();
     await page.close();
   });
@@ -250,8 +253,9 @@ test.describe('[US-S-NOTE-05] Note text is highlighted in search', () => {
     // No search — expand the card
     await page.getByText(/1 tab/i).click();
 
-    // Note visible but no <mark> elements
+    // Note visible but no <mark> elements.
     await expect(page.getByText('Some note content')).toBeVisible();
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark')).toHaveCount(0);
     await page.close();
   });
@@ -269,15 +273,10 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    // Open the "..." menu and click Edit
-    await page.getByRole('button', { name: /more actions/i }).click();
-    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible' });
-
-    // The note textarea should be present in the dialog
-    await expect(dialog.locator('textarea')).toBeVisible();
+    await expect(editor.noteTextarea()).toBeVisible();
     await page.close();
   });
 
@@ -291,13 +290,10 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /more actions/i }).click();
-    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible' });
-
-    await expect(dialog.locator('textarea')).toHaveValue('Pre-existing note content');
+    await expect(editor.noteTextarea()).toHaveValue('Pre-existing note content');
     await page.close();
   });
 
@@ -308,18 +304,12 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /more actions/i }).click();
-    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible' });
-
-    // Type a note
-    await dialog.locator('textarea').fill('My new note for this session');
-
-    // Save
-    await dialog.getByRole('button', { name: /save/i }).click();
-    await dialog.waitFor({ state: 'hidden' });
+    await editor.fillNote('My new note for this session');
+    await editor.clickSave();
+    await editor.expectHidden();
 
     // Verify persisted in storage
     const stored = await getSessionsFromStorage(extensionContext);
@@ -338,17 +328,12 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /more actions/i }).click();
-    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible' });
-
-    // Clear the note
-    await dialog.locator('textarea').fill('');
-
-    await dialog.getByRole('button', { name: /save/i }).click();
-    await dialog.waitFor({ state: 'hidden' });
+    await editor.fillNote('');
+    await editor.clickSave();
+    await editor.expectHidden();
 
     const stored = await getSessionsFromStorage(extensionContext);
     const saved = stored.find(s => s.name === 'Session To Clear Note');
@@ -356,7 +341,7 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     await page.close();
   });
 
-  test('note change makes dialog dirty — confirmation appears on cancel', async ({
+  test('note change makes dialog dirty, confirmation appears on cancel', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -366,20 +351,13 @@ test.describe('[US-S-NOTE-02] Edit note via SessionEditDialog', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: /more actions/i }).click();
-    await page.getByRole('menuitem', { name: /^edit$/i }).click();
+    const editor = new SessionEditorPage(page);
+    await editor.openFromFirstSessionMenu();
 
-    const dialog = page.getByRole('dialog');
-    await dialog.waitFor({ state: 'visible' });
+    await editor.fillNote('Unsaved note');
+    await editor.clickCancel();
 
-    // Type in the note to make dialog dirty
-    await dialog.locator('textarea').fill('Unsaved note');
-
-    // Click Cancel
-    await dialog.getByRole('button', { name: /cancel/i }).click();
-
-    // Unsaved changes alert dialog should appear
-    await expect(page.getByRole('alertdialog')).toBeVisible();
+    await editor.expectUnsavedAlertVisible();
     await page.close();
   });
 });

--- a/tests/e2e/session-search.spec.ts
+++ b/tests/e2e/session-search.spec.ts
@@ -330,6 +330,7 @@ test.describe('[US-S-SEARCH-06] Highlight matching text in session cards', () =>
     await page.getByPlaceholder('Search sessions...').fill('React');
 
     // A <mark> element wrapping the matched portion of the session name
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'React' }).first()).toBeVisible();
     await page.close();
   });
@@ -347,6 +348,7 @@ test.describe('[US-S-SEARCH-06] Highlight matching text in session cards', () =>
     await page.getByPlaceholder('Search sessions...').fill('TypeScript');
 
     // Preview is auto-opened; the matched part of the tab title should be in a <mark>
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'TypeScript' }).first()).toBeVisible();
     await page.close();
   });
@@ -364,6 +366,7 @@ test.describe('[US-S-SEARCH-06] Highlight matching text in session cards', () =>
     await page.getByPlaceholder('Search sessions...').fill('my-unique-domain');
 
     // The domain extracted from the URL should appear highlighted
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'my-unique-domain' }).first()).toBeVisible();
     await page.close();
   });
@@ -381,6 +384,7 @@ test.describe('[US-S-SEARCH-06] Highlight matching text in session cards', () =>
     await page.getByPlaceholder('Search sessions...').fill('Backend');
 
     // Preview auto-opens; the matched part of the group title should be in a <mark>
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark').filter({ hasText: 'Backend' }).first()).toBeVisible();
     await page.close();
   });
@@ -396,6 +400,7 @@ test.describe('[US-S-SEARCH-06] Highlight matching text in session cards', () =>
     await goToSessionsSection(page, extensionId);
 
     // No search term → no <mark> elements in the session list
+    // allow-inline-dom: `<mark>` is the search highlight atom, not a dialog/wizard surface.
     await expect(page.locator('mark')).toHaveCount(0);
     await page.close();
   });

--- a/tests/e2e/sessions-keyboard-dnd.spec.ts
+++ b/tests/e2e/sessions-keyboard-dnd.spec.ts
@@ -27,6 +27,7 @@ test.describe('[KBD-DND] Sessions keyboard drag-and-drop', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
+    // allow-inline-dom: drag-handle is a DnD atom selector, not a dialog/wizard surface.
     const handle = page.locator('[data-testid$="-drag-handle"]').first();
     await expect(handle).toBeVisible();
 

--- a/tests/e2e/workspaces-search.spec.ts
+++ b/tests/e2e/workspaces-search.spec.ts
@@ -18,6 +18,7 @@ async function createWorkspace(page: Page, name: string) {
   await page.getByTestId('workspace-form-name').fill(name);
   await page.getByTestId('workspace-form-btn-submit').click();
   await expect(page.getByTestId('workspace-form-dialog')).toBeHidden();
+  // allow-inline-dom: testid-prefix scoping to a list row, not a dialog/wizard.
   await expect(page.locator('[data-testid^="workspace-row-"]', { hasText: name })).toBeVisible();
 }
 


### PR DESCRIPTION
Lot 7 closes the last gap of epic #303: every spec that still reached for
`page.getByRole('dialog')` or `page.locator(...)` directly now consumes a
Page Object, and a CI grep guard prevents regressions.

- new `SessionEditorPage` Page Object (16 occurrences in
  `session-editor.spec.ts`), reused by `session-notes.spec.ts`
- `DialogPage` is now directly instantiable for the rare "any dialog is
  open" assertion (keyboard-sequence specs that fan out to several
  wizards)
- migrated specs: `session-editor`, `session-notes`,
  `import-export-shortcuts`, residual `import-export`, `domain-rules`,
  `rule-wizard`
- `tests/e2e/helpers/navigation.ts` + `e2e-doc-scenarios/helpers/ui-actions.ts`
  use `DialogPage` instead of inline `getByRole('dialog')`
- `ConfigEditModal` now exposes a `modal-edit-config` testid (matches
  `modal-edit-identity` / `modal-edit-options`)
- inline `// allow-inline-dom` markers tag legitimate local selectors
  (<mark> highlights, drag-handle attribute selectors, body.click()
  gestures, scoped testid queries)
- `dialog-initial-focus.spec.ts` exempted via the file-level allow-list
  (its subject IS the raw dialog element)
- `.github/scripts/e2e-no-inline-dom.sh` runs in the `Lint` job and
  fails the build if a new inline DOM violation appears
- `tests/e2e/README.md` documents the contract and the procedure to
  add to the allow-list

https://claude.ai/code/session_01AGVTLri42ExTa3Lkss4dKy