### PR TITLE
feat(rules): export from BulkActionsBar with preselection (#311)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -138,6 +138,7 @@
   "enableSelected": { "message": "Enable Selected" },
   "disableSelected": { "message": "Disable Selected" },
   "deleteSelected": { "message": "Delete Selected" },
+  "exportSelected": { "message": "Export Selected" },
   "confirmDeleteSelected": { "message": "Delete the selected rules?" },
   "confirmDeleteSelectedDescription": { "message": "This will permanently delete the selected rules. This action cannot be undone." },
   "searchRules": { "message": "Search rules..." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -138,6 +138,7 @@
   "enableSelected": { "message": "Activar Seleccionados" },
   "disableSelected": { "message": "Desactivar Seleccionados" },
   "deleteSelected": { "message": "Eliminar Seleccionados" },
+  "exportSelected": { "message": "Exportar Seleccionados" },
   "confirmDeleteSelected": { "message": "¿Eliminar las reglas seleccionadas?" },
   "confirmDeleteSelectedDescription": { "message": "Las reglas seleccionadas se eliminarán permanentemente. Esta acción no se puede deshacer." },
   "searchRules": { "message": "Buscar reglas..." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -138,6 +138,7 @@
   "enableSelected": { "message": "Activer Sélectionnés" },
   "disableSelected": { "message": "Désactiver Sélectionnés" },
   "deleteSelected": { "message": "Supprimer Sélectionnés" },
+  "exportSelected": { "message": "Exporter Sélectionnés" },
   "confirmDeleteSelected": { "message": "Supprimer les règles sélectionnées ?" },
   "confirmDeleteSelectedDescription": { "message": "Les règles sélectionnées seront définitivement supprimées. Cette action est irréversible." },
   "searchRules": { "message": "Rechercher des règles..." },

--- a/src/components/UI/ImportExportWizards/ExportWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizard.tsx
@@ -11,12 +11,14 @@ interface ExportWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   rules: DomainRuleSetting[];
+  initialSelectedIds?: string[];
 }
 
-export function ExportWizard({ open, onOpenChange, rules }: ExportWizardProps) {
+export function ExportWizard({ open, onOpenChange, rules, initialSelectedIds }: ExportWizardProps) {
   const state = useExportWizardState<DomainRuleSetting>({
     open,
     items: rules,
+    initialSelectedIds,
     payloadKey: 'domainRules',
     filename: 'smarttab_organizer_rules.json',
     notifyTitleKey: 'exportNotificationTitle',

--- a/src/components/UI/ImportExportWizards/useExportWizardState.ts
+++ b/src/components/UI/ImportExportWizards/useExportWizardState.ts
@@ -8,6 +8,12 @@ interface UseExportWizardStateOptions<TItem extends { id: string }> {
   items?: TItem[];
   /** Async loader called when the dialog opens (e.g. `loadSessions`). */
   loadItems?: () => Promise<TItem[]>;
+  /**
+   * Optional pre-selection applied on dialog open (sync `items` source only).
+   * Invalid ids (not in `items`) are filtered out. When omitted or empty,
+   * all items are selected (historical default).
+   */
+  initialSelectedIds?: string[];
   /** JSON top-level key wrapping the selected items (e.g. "domainRules", "sessions"). */
   payloadKey: string;
   filename: string;
@@ -40,6 +46,7 @@ export function useExportWizardState<TItem extends { id: string }>({
   open,
   items: providedItems,
   loadItems,
+  initialSelectedIds,
   payloadKey,
   filename,
   notifyTitleKey,
@@ -59,7 +66,16 @@ export function useExportWizardState<TItem extends { id: string }>({
         selection.setAll(loaded.map((item) => item.id));
       });
     } else if (providedItems) {
-      selection.setAll(providedItems.map((item) => item.id));
+      if (initialSelectedIds && initialSelectedIds.length > 0) {
+        const validIds = initialSelectedIds.filter((id) =>
+          providedItems.some((item) => item.id === id),
+        );
+        selection.setAll(
+          validIds.length > 0 ? validIds : providedItems.map((item) => item.id),
+        );
+      } else {
+        selection.setAll(providedItems.map((item) => item.id));
+      }
     }
   });
 

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Button, Text, Flex, Box, Checkbox, Separator } from '@radix-ui/themes';
-import { Plus, Eye, EyeOff, Shield, AlertCircle, Upload, Trash2 } from 'lucide-react';
+import { Plus, Eye, EyeOff, Shield, AlertCircle, Upload, Trash2, FileDown } from 'lucide-react';
 import { DragDropProvider, type DragEndEvent, type DragOverEvent } from '@dnd-kit/react';
 import { move } from '@dnd-kit/helpers';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { EmptyState } from '@/components/UI/EmptyState';
 import { RuleWizardModal } from '@/components/Core/DomainRule/RuleWizardModal';
+import { ExportWizard } from '@/components/UI/ImportExportWizards/ExportWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { ListToolbar } from '@/components/UI/ListToolbar';
 import { getMessage } from '@/utils/i18n';
@@ -67,11 +68,12 @@ interface BulkActionsBarProps {
   onSelectAll: (checked: boolean) => void;
   onBulkToggle: (ids: string[], enabled: boolean) => void;
   onBulkDeleteRequest: (ids: string[]) => void;
+  onBulkExportRequest: (ids: string[]) => void;
 }
 
 function BulkActionsBar({
   selectedIds, filteredRules: _filteredRules, isAllSelected, isIndeterminate,
-  onSelectAll, onBulkToggle, onBulkDeleteRequest,
+  onSelectAll, onBulkToggle, onBulkDeleteRequest, onBulkExportRequest,
 }: BulkActionsBarProps) {
   return (
     <Flex data-testid="page-rules-bulk-bar" align="center" gap="3" p="2" mb="4"
@@ -96,6 +98,15 @@ function BulkActionsBar({
         <Button size="1" variant="soft" onClick={() => onBulkToggle(Array.from(selectedIds), false)}>
           <EyeOff size={14} />
           {getMessage('disableSelected')}
+        </Button>
+        <Button
+          size="1"
+          variant="soft"
+          data-testid="page-rules-bulk-btn-export"
+          onClick={() => onBulkExportRequest(Array.from(selectedIds))}
+        >
+          <FileDown size={14} />
+          {getMessage('exportSelected')}
         </Button>
         <Button size="1" variant="soft" color="red"
           onClick={() => onBulkDeleteRequest(Array.from(selectedIds))}>
@@ -168,6 +179,7 @@ export function DomainRulesPage({
   }, [syncSettings.domainRules, updateRules]);
 
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const [bulkExportIds, setBulkExportIds] = useState<string[] | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
@@ -378,6 +390,7 @@ export function DomainRulesPage({
                 onSelectAll={handleSelectAll}
                 onBulkToggle={handleBulkToggle}
                 onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', ruleIds: ids })}
+                onBulkExportRequest={(ids) => setBulkExportIds(ids)}
               />
             )}
 
@@ -452,6 +465,13 @@ export function DomainRulesPage({
             : getMessage('confirmDeleteRule')
         }
         description={confirmDeleteDescription(deleteTarget, syncSettings.domainRules)}
+      />
+
+      <ExportWizard
+        open={bulkExportIds != null}
+        onOpenChange={(open) => { if (!open) setBulkExportIds(null); }}
+        rules={syncSettings.domainRules}
+        initialSelectedIds={bulkExportIds ?? undefined}
       />
 
     </>


### PR DESCRIPTION
Adds an Export button to the domain-rules BulkActionsBar. It opens
ExportWizard pre-seeded with only the rules currently ticked in the
list, while leaving the row checkboxes untouched on close so the user
can iterate on the bulk selection. The wizard still receives the full
rule list, so Select All / Deselect All keep working.

Threads an optional `initialSelectedIds` through ExportWizard and
`useExportWizardState`: when provided (sync items source), the
dialog-reset callback seeds the selection from those ids (filtered
against current items) instead of selecting everything. Invalid or
empty inputs fall back to the historical select-all behavior, so the
existing global Export Rules flow is unchanged.

Adds the `exportSelected` i18n key in EN/FR/ES alongside the sibling
bulk-action labels.