### PR TITLE
ci: enable pnpm store cache across all workflows

### DIFF
--- a/.github/workflows/doc-scenarios.yml
+++ b/.github/workflows/doc-scenarios.yml
@@ -68,6 +68,12 @@ jobs:
             exit 1
           fi
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
 

--- a/.github/workflows/doc-scenarios.yml
+++ b/.github/workflows/doc-scenarios.yml
@@ -39,13 +39,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - name: Install xvfb
         run: sudo apt-get install -y xvfb

--- a/.github/workflows/doc-scenarios.yml
+++ b/.github/workflows/doc-scenarios.yml
@@ -69,10 +69,17 @@ jobs:
           fi
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Report Playwright cache status
+        run: |
+          STATUS="${{ steps.playwright-cache.outputs.cache-hit }}"
+          echo "Playwright cache hit: ${STATUS:-false}"
+          echo "Playwright cache hit: ${STATUS:-false}" >> "$GITHUB_STEP_SUMMARY"
 
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build

--- a/.github/workflows/duplication.yml
+++ b/.github/workflows/duplication.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
 
       - name: Run jscpd
         run: npx --yes jscpd@4.0.9

--- a/.github/workflows/duplication.yml
+++ b/.github/workflows/duplication.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Run jscpd
         run: npx --yes jscpd@4.0.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,6 +212,12 @@ jobs:
         run: sudo apt-get install -y xvfb
 
       - run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
 
@@ -253,6 +259,12 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Storybook accessibility tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,10 +213,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Report Playwright cache status
+        run: |
+          STATUS="${{ steps.playwright-cache.outputs.cache-hit }}"
+          echo "Playwright cache hit: ${STATUS:-false}"
+          echo "Playwright cache hit: ${STATUS:-false}" >> "$GITHUB_STEP_SUMMARY"
 
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
@@ -260,10 +267,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Report Playwright cache status
+        run: |
+          STATUS="${{ steps.playwright-cache.outputs.cache-hit }}"
+          echo "Playwright cache hit: ${STATUS:-false}"
+          echo "Playwright cache hit: ${STATUS:-false}" >> "$GITHUB_STEP_SUMMARY"
 
       - run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,13 +36,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -117,13 +118,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -197,13 +199,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - name: Install xvfb
         run: sudo apt-get install -y xvfb
@@ -240,13 +243,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
@@ -439,13 +443,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - uses: pnpm/action-setup@v4
         with:
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install docs dependencies
         working-directory: docs


### PR DESCRIPTION
Activate setup-node@v4 native pnpm cache on every job that runs
`pnpm install`, plus npm cache on the npx-only jscpd job. Reorders
pnpm/action-setup before setup-node (required for `cache: 'pnpm'` to
locate the pnpm binary on PATH).

- tests.yml: unit-tests, lint, e2e-tests (x3 shards), a11y-storybook,
  docs-build. docs-build pins cache-dependency-path to docs/pnpm-lock.yaml.
- doc-scenarios.yml: capture job.
- duplication.yml: jscpd job uses `cache: 'npm'` to speed up npx --yes.