### PR TITLE
Add bulk selection and actions to Sessions page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 storybook-static
 playwright-report/
 .playwright-mcp/
+.preview-shots/
 .screenshots/
 test-results/
 e2e-doc-scenarios/output/

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -371,6 +371,8 @@
   "confirmDeleteSelectedSessions": { "message": "Delete the selected sessions?" },
   "confirmDeleteSelectedSessionsDescription": { "message": "This will permanently delete {count} session(s). This action cannot be undone." },
   "sessionSelectAriaLabel": { "message": "Select session" },
+  "pinSelected": { "message": "Pin Selected" },
+  "unpinSelected": { "message": "Unpin Selected" },
 
   "snapshotTitle": { "message": "Save Session Snapshot" },
   "snapshotDescription": { "message": "Choose which tabs to save in this session." },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -368,6 +368,9 @@
   "sessionNamePlaceholder": { "message": "e.g., Work tabs - Monday" },
   "sessionSaveError": { "message": "Failed to save session. Please try again." },
   "confirmDeleteSession": { "message": "Are you sure you want to delete the session \"{name}\"? This action cannot be undone." },
+  "confirmDeleteSelectedSessions": { "message": "Delete the selected sessions?" },
+  "confirmDeleteSelectedSessionsDescription": { "message": "This will permanently delete {count} session(s). This action cannot be undone." },
+  "sessionSelectAriaLabel": { "message": "Select session" },
 
   "snapshotTitle": { "message": "Save Session Snapshot" },
   "snapshotDescription": { "message": "Choose which tabs to save in this session." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -371,6 +371,8 @@
   "confirmDeleteSelectedSessions": { "message": "¿Eliminar las sesiones seleccionadas?" },
   "confirmDeleteSelectedSessionsDescription": { "message": "Esta acción eliminará definitivamente {count} sesión(es). No se puede deshacer." },
   "sessionSelectAriaLabel": { "message": "Seleccionar sesión" },
+  "pinSelected": { "message": "Anclar selección" },
+  "unpinSelected": { "message": "Desanclar selección" },
 
   "snapshotTitle": { "message": "Guardar instantánea de sesión" },
   "snapshotDescription": { "message": "Elige qué pestañas incluir en esta sesión." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -368,6 +368,9 @@
   "sessionNamePlaceholder": { "message": "ej. Pestañas de trabajo - Lunes" },
   "sessionSaveError": { "message": "Error al guardar la sesión. Por favor, inténtalo de nuevo." },
   "confirmDeleteSession": { "message": "¿Estás seguro de que quieres eliminar la sesión \"{name}\"? Esta acción no se puede deshacer." },
+  "confirmDeleteSelectedSessions": { "message": "¿Eliminar las sesiones seleccionadas?" },
+  "confirmDeleteSelectedSessionsDescription": { "message": "Esta acción eliminará definitivamente {count} sesión(es). No se puede deshacer." },
+  "sessionSelectAriaLabel": { "message": "Seleccionar sesión" },
 
   "snapshotTitle": { "message": "Guardar instantánea de sesión" },
   "snapshotDescription": { "message": "Elige qué pestañas incluir en esta sesión." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -371,6 +371,8 @@
   "confirmDeleteSelectedSessions": { "message": "Supprimer les sessions sélectionnées ?" },
   "confirmDeleteSelectedSessionsDescription": { "message": "Cette action supprimera définitivement {count} session(s). Elle est irréversible." },
   "sessionSelectAriaLabel": { "message": "Sélectionner la session" },
+  "pinSelected": { "message": "Épingler la sélection" },
+  "unpinSelected": { "message": "Désépingler la sélection" },
 
   "snapshotTitle": { "message": "Sauvegarder un instantané" },
   "snapshotDescription": { "message": "Choisissez les onglets à inclure dans cette session." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -368,6 +368,9 @@
   "sessionNamePlaceholder": { "message": "ex. Onglets travail - Lundi" },
   "sessionSaveError": { "message": "Échec de la sauvegarde. Veuillez réessayer." },
   "confirmDeleteSession": { "message": "Êtes-vous sûr de vouloir supprimer la session « {name} » ? Cette action est irréversible." },
+  "confirmDeleteSelectedSessions": { "message": "Supprimer les sessions sélectionnées ?" },
+  "confirmDeleteSelectedSessionsDescription": { "message": "Cette action supprimera définitivement {count} session(s). Elle est irréversible." },
+  "sessionSelectAriaLabel": { "message": "Sélectionner la session" },
 
   "snapshotTitle": { "message": "Sauvegarder un instantané" },
   "snapshotDescription": { "message": "Choisissez les onglets à inclure dans cette session." },

--- a/src/components/Core/Session/SessionCard.stories.tsx
+++ b/src/components/Core/Session/SessionCard.stories.tsx
@@ -87,6 +87,17 @@ export const SessionCardPinned: Story = {
 };
 
 // ---------------------------------------------------------------------------
+// Bulk selection: checkbox visible & checked.
+// ---------------------------------------------------------------------------
+export const SessionCardSelected: Story = {
+  args: {
+    ...SessionCardDefault.args,
+    isSelected: true,
+    onSelect: noop,
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Relative dates: cards staggered across multiple time ranges to validate
 // the "updated X ago" / "created Y ago" rendering on the right of the
 // counters line, and the wrap behavior on narrow widths.

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -3,7 +3,7 @@ import * as Collapsible from '@radix-ui/react-collapsible';
 import { useSortable } from '@dnd-kit/react/sortable';
 import {
   Card, Flex, Text, IconButton, TextField,
-  DropdownMenu, HoverCard, Tooltip, Badge, Box,
+  DropdownMenu, HoverCard, Tooltip, Badge, Box, Checkbox,
 } from '@radix-ui/themes';
 import {
   MoreHorizontal, Pencil, Trash2, Check, X,
@@ -39,6 +39,10 @@ interface SessionCardProps extends SessionRestoreCallbacks {
   leading?: React.ReactNode;
   /** Trailing slot in summary mode (e.g. status Badge, DiffPopover). */
   trailing?: React.ReactNode;
+  /** Whether the card is currently selected (full mode bulk selection). */
+  isSelected?: boolean;
+  /** Bulk selection toggle (full mode only). Showing the checkbox is conditioned on this. */
+  onSelect?: (id: string, checked: boolean) => void;
   existingSessions?: Session[];
   onRename?: (id: string, newName: string) => Promise<void>;
   onEdit?: (session: Session) => void;
@@ -298,6 +302,8 @@ interface SessionCardFullHeaderProps extends SessionRestoreCallbacks {
   searchQuery: string | undefined;
   category: ReturnType<typeof getRuleCategory>;
   hoverCardContent: React.ReactNode;
+  isSelected?: boolean;
+  onSelect?: (id: string, checked: boolean) => void;
   onPin?: (session: Session) => void;
   onUnpin?: (session: Session) => void;
   onEdit?: (session: Session) => void;
@@ -312,6 +318,7 @@ function SessionCardFullHeader({
   renameError, setRenameError, renameInputRef,
   handleRenameSubmit, handleRenameCancel, handleKeyDown,
   searchQuery, category, hoverCardContent,
+  isSelected, onSelect,
   onPin, onUnpin, onRestore, onRestoreCurrentWindow, onRestoreNewWindow, onReplaceCurrentWindow,
   onEdit, onDelete, onMoveToFirst, onMoveLast,
 }: SessionCardFullHeaderProps) {
@@ -334,6 +341,16 @@ function SessionCardFullHeader({
         >
           <GripVertical size={16} />
         </IconButton>
+      )}
+
+      {/* Bulk selection checkbox (after drag handle, like DomainRuleCard). */}
+      {!isRenaming && onSelect && (
+        <Checkbox
+          checked={isSelected ?? false}
+          onCheckedChange={(checked) => onSelect(session.id, checked as boolean)}
+          aria-label={getMessage('sessionSelectAriaLabel')}
+          data-testid={`session-card-${session.id}-checkbox`}
+        />
       )}
 
       {/* Pin / Unpin button */}
@@ -446,6 +463,8 @@ export function SessionCard({
   status = 'default',
   leading,
   trailing,
+  isSelected,
+  onSelect,
   existingSessions = [],
   onRestore,
   onRestoreCurrentWindow,
@@ -559,6 +578,8 @@ export function SessionCard({
               searchQuery={searchQuery}
               category={category}
               hoverCardContent={hoverCardContent}
+              isSelected={isSelected}
+              onSelect={onSelect}
               onPin={onPin}
               onUnpin={onUnpin}
               onRestore={onRestore}

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Theme, Button, Box } from '@radix-ui/themes';
+import { Eye, EyeOff, FileDown, Trash2 } from 'lucide-react';
+import { BulkActionsBar } from './BulkActionsBar';
+
+const meta = {
+  title: 'Components/UI/BulkActionsBar/BulkActionsBar',
+  component: BulkActionsBar,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <Theme accentColor="indigo">
+        <Box style={{ maxWidth: 720 }}>
+          <Story />
+        </Box>
+      </Theme>
+    ),
+  ],
+} satisfies Meta<typeof BulkActionsBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function rulesActions() {
+  return (
+    <>
+      <Button size="1" variant="solid">
+        <Eye size={14} />
+        Enable Selected
+      </Button>
+      <Button size="1" variant="soft">
+        <EyeOff size={14} />
+        Disable Selected
+      </Button>
+      <Button size="1" variant="soft">
+        <FileDown size={14} />
+        Export Selected
+      </Button>
+      <Button size="1" variant="soft" color="red">
+        <Trash2 size={14} />
+        Delete Selected
+      </Button>
+    </>
+  );
+}
+
+function sessionsActions() {
+  return (
+    <>
+      <Button size="1" variant="soft">
+        <FileDown size={14} />
+        Export Selected
+      </Button>
+      <Button size="1" variant="soft" color="red">
+        <Trash2 size={14} />
+        Delete Selected
+      </Button>
+    </>
+  );
+}
+
+function ControlledBulkBar(props: React.ComponentProps<typeof BulkActionsBar>) {
+  const [allSelected, setAllSelected] = useState(props.isAllSelected);
+  return (
+    <BulkActionsBar
+      {...props}
+      isAllSelected={allSelected}
+      onSelectAll={(checked) => setAllSelected(checked)}
+    />
+  );
+}
+
+export const BulkActionsBarDefault: Story = {
+  args: {
+    testId: 'demo-bulk-bar',
+    selectedCount: 3,
+    isAllSelected: false,
+    isIndeterminate: true,
+    onSelectAll: () => {},
+    children: rulesActions(),
+  },
+  render: (args) => <ControlledBulkBar {...args} />,
+};
+
+export const BulkActionsBarSessions: Story = {
+  args: {
+    testId: 'page-sessions-bulk-bar-unpinned',
+    selectedCount: 2,
+    isAllSelected: false,
+    isIndeterminate: true,
+    onSelectAll: () => {},
+    children: sessionsActions(),
+  },
+  render: (args) => <ControlledBulkBar {...args} />,
+};
+
+export const BulkActionsBarAllSelected: Story = {
+  args: {
+    testId: 'demo-bulk-bar',
+    selectedCount: 5,
+    isAllSelected: true,
+    isIndeterminate: false,
+    onSelectAll: () => {},
+    children: rulesActions(),
+  },
+  render: (args) => <ControlledBulkBar {...args} />,
+};
+
+export const BulkActionsBarSingleSelected: Story = {
+  args: {
+    testId: 'demo-bulk-bar',
+    selectedCount: 1,
+    isAllSelected: false,
+    isIndeterminate: true,
+    onSelectAll: () => {},
+    children: sessionsActions(),
+  },
+  render: (args) => <ControlledBulkBar {...args} />,
+};

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
@@ -40,7 +40,7 @@ function rulesActions() {
         <FileDown size={14} />
         Export Selected
       </Button>
-      <Button size="1" variant="solid" color="red" highContrast>
+      <Button size="1" variant="soft" color="red" highContrast>
         <Trash2 size={14} />
         Delete Selected
       </Button>
@@ -59,7 +59,7 @@ function sessionsUnpinnedActions() {
         <FileDown size={14} />
         Export Selected
       </Button>
-      <Button size="1" variant="solid" color="red" highContrast>
+      <Button size="1" variant="soft" color="red" highContrast>
         <Trash2 size={14} />
         Delete Selected
       </Button>
@@ -78,7 +78,7 @@ function sessionsPinnedActions() {
         <FileDown size={14} />
         Export Selected
       </Button>
-      <Button size="1" variant="solid" color="red" highContrast>
+      <Button size="1" variant="soft" color="red" highContrast>
         <Trash2 size={14} />
         Delete Selected
       </Button>

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
@@ -40,7 +40,7 @@ function rulesActions() {
         <FileDown size={14} />
         Export Selected
       </Button>
-      <Button size="1" variant="soft" color="red">
+      <Button size="1" variant="solid" color="red" highContrast>
         <Trash2 size={14} />
         Delete Selected
       </Button>
@@ -55,7 +55,7 @@ function sessionsActions() {
         <FileDown size={14} />
         Export Selected
       </Button>
-      <Button size="1" variant="soft" color="red">
+      <Button size="1" variant="solid" color="red" highContrast>
         <Trash2 size={14} />
         Delete Selected
       </Button>

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Theme, Button, Box } from '@radix-ui/themes';
-import { Eye, EyeOff, FileDown, Trash2 } from 'lucide-react';
+import { Eye, EyeOff, FileDown, Pin, PinOff, Trash2 } from 'lucide-react';
 import { BulkActionsBar } from './BulkActionsBar';
 
 const meta = {
@@ -48,9 +48,32 @@ function rulesActions() {
   );
 }
 
-function sessionsActions() {
+function sessionsUnpinnedActions() {
   return (
     <>
+      <Button size="1" variant="soft">
+        <Pin size={14} />
+        Pin Selected
+      </Button>
+      <Button size="1" variant="soft">
+        <FileDown size={14} />
+        Export Selected
+      </Button>
+      <Button size="1" variant="solid" color="red" highContrast>
+        <Trash2 size={14} />
+        Delete Selected
+      </Button>
+    </>
+  );
+}
+
+function sessionsPinnedActions() {
+  return (
+    <>
+      <Button size="1" variant="soft">
+        <PinOff size={14} />
+        Unpin Selected
+      </Button>
       <Button size="1" variant="soft">
         <FileDown size={14} />
         Export Selected
@@ -93,7 +116,19 @@ export const BulkActionsBarSessions: Story = {
     isAllSelected: false,
     isIndeterminate: true,
     onSelectAll: () => {},
-    children: sessionsActions(),
+    children: sessionsUnpinnedActions(),
+  },
+  render: (args) => <ControlledBulkBar {...args} />,
+};
+
+export const BulkActionsBarSessionsPinned: Story = {
+  args: {
+    testId: 'page-sessions-bulk-bar-pinned',
+    selectedCount: 1,
+    isAllSelected: false,
+    isIndeterminate: true,
+    onSelectAll: () => {},
+    children: sessionsPinnedActions(),
   },
   render: (args) => <ControlledBulkBar {...args} />,
 };
@@ -117,7 +152,7 @@ export const BulkActionsBarSingleSelected: Story = {
     isAllSelected: false,
     isIndeterminate: true,
     onSelectAll: () => {},
-    children: sessionsActions(),
+    children: sessionsUnpinnedActions(),
   },
   render: (args) => <ControlledBulkBar {...args} />,
 };

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Flex, Text, Checkbox, Separator } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+
+interface BulkActionsBarProps {
+  /** Test id appliqué au conteneur (chaque appelant fournit le sien). */
+  testId?: string;
+  /** Nombre d'éléments actuellement sélectionnés (drive le libellé). */
+  selectedCount: number;
+  /** True ssi tous les éléments visibles sont sélectionnés. */
+  isAllSelected: boolean;
+  /** True si au moins un mais pas tous sont sélectionnés. */
+  isIndeterminate: boolean;
+  /** Master checkbox handler. */
+  onSelectAll: (checked: boolean) => void;
+  /** Slot des boutons d'action (Export, Delete, ...). Affiché après le séparateur. */
+  children: React.ReactNode;
+}
+
+export function BulkActionsBar({
+  testId,
+  selectedCount,
+  isAllSelected,
+  isIndeterminate,
+  onSelectAll,
+  children,
+}: BulkActionsBarProps) {
+  return (
+    <Flex
+      data-testid={testId}
+      align="center"
+      gap="3"
+      p="2"
+      mb="4"
+      style={{ backgroundColor: 'var(--accent-a3)', borderRadius: 'var(--radius-2)' }}
+    >
+      <Checkbox
+        checked={isAllSelected}
+        onCheckedChange={(checked) => onSelectAll(checked as boolean)}
+        {...(isIndeterminate && { 'data-indeterminate': true })}
+      />
+      <Text size="2" weight="medium">
+        {selectedCount === 1
+          ? getMessage('dataTableSelectedCountSingular')
+          : getMessage('dataTableSelectedCountPlural').replace('{count}', selectedCount.toString())}
+      </Text>
+      <Separator orientation="vertical" />
+      <Flex gap="2">{children}</Flex>
+    </Flex>
+  );
+}

--- a/src/components/UI/BulkActionsBar/BulkActionsBar.tsx
+++ b/src/components/UI/BulkActionsBar/BulkActionsBar.tsx
@@ -37,6 +37,7 @@ export function BulkActionsBar({
       <Checkbox
         checked={isAllSelected}
         onCheckedChange={(checked) => onSelectAll(checked as boolean)}
+        aria-label={getMessage('selectAll')}
         {...(isIndeterminate && { 'data-indeterminate': true })}
       />
       <Text size="2" weight="medium">

--- a/src/components/UI/BulkActionsBar/index.ts
+++ b/src/components/UI/BulkActionsBar/index.ts
@@ -1,0 +1,1 @@
+export { BulkActionsBar } from './BulkActionsBar';

--- a/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
+++ b/src/components/UI/ImportExportWizards/ExportSessionsWizard.tsx
@@ -12,12 +12,15 @@ import { SessionExportGroupSection } from './Export';
 interface ExportSessionsWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Optional pre-selection (typically passed by a bulk action call site). */
+  initialSelectedIds?: string[];
 }
 
-export function ExportSessionsWizard({ open, onOpenChange }: ExportSessionsWizardProps) {
+export function ExportSessionsWizard({ open, onOpenChange, initialSelectedIds }: ExportSessionsWizardProps) {
   const state = useExportWizardState<Session>({
     open,
     loadItems: loadSessions,
+    initialSelectedIds,
     payloadKey: 'sessions',
     filename: 'smarttab_organizer_sessions.json',
     notifyTitleKey: 'exportSessionsNotificationTitle',

--- a/src/components/UI/ImportExportWizards/useExportWizardState.ts
+++ b/src/components/UI/ImportExportWizards/useExportWizardState.ts
@@ -9,9 +9,9 @@ interface UseExportWizardStateOptions<TItem extends { id: string }> {
   /** Async loader called when the dialog opens (e.g. `loadSessions`). */
   loadItems?: () => Promise<TItem[]>;
   /**
-   * Optional pre-selection applied on dialog open (sync `items` source only).
-   * Invalid ids (not in `items`) are filtered out. When omitted or empty,
-   * all items are selected (historical default).
+   * Optional pre-selection applied on dialog open. Invalid ids (not in
+   * the resolved items) are filtered out. When omitted or empty, all
+   * items are selected (historical default).
    */
   initialSelectedIds?: string[];
   /** JSON top-level key wrapping the selected items (e.g. "domainRules", "sessions"). */
@@ -58,24 +58,28 @@ export function useExportWizardState<TItem extends { id: string }>({
   const selection = useToggleSet<string>();
   const [exportNote, setExportNote] = useState('');
 
+  const applySelection = useCallback((resolved: TItem[]) => {
+    if (initialSelectedIds && initialSelectedIds.length > 0) {
+      const validIds = initialSelectedIds.filter((id) =>
+        resolved.some((item) => item.id === id),
+      );
+      selection.setAll(
+        validIds.length > 0 ? validIds : resolved.map((item) => item.id),
+      );
+    } else {
+      selection.setAll(resolved.map((item) => item.id));
+    }
+  }, [initialSelectedIds, selection]);
+
   useDialogReset(open, () => {
     setExportNote('');
     if (loadItems) {
       loadItems().then((loaded) => {
         setLoadedItems(loaded);
-        selection.setAll(loaded.map((item) => item.id));
+        applySelection(loaded);
       });
     } else if (providedItems) {
-      if (initialSelectedIds && initialSelectedIds.length > 0) {
-        const validIds = initialSelectedIds.filter((id) =>
-          providedItems.some((item) => item.id === id),
-        );
-        selection.setAll(
-          validIds.length > 0 ? validIds : providedItems.map((item) => item.id),
-        );
-      } else {
-        selection.setAll(providedItems.map((item) => item.id));
-      }
+      applySelection(providedItems);
     }
   });
 

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Button, Text, Flex, Box, Checkbox, Separator } from '@radix-ui/themes';
+import { Button, Flex, Box } from '@radix-ui/themes';
 import { Plus, Eye, EyeOff, Shield, AlertCircle, Upload, Trash2, FileDown } from 'lucide-react';
 import { DragDropProvider, type DragEndEvent, type DragOverEvent } from '@dnd-kit/react';
 import { move } from '@dnd-kit/helpers';
@@ -10,6 +10,7 @@ import { RuleWizardModal } from '@/components/Core/DomainRule/RuleWizardModal';
 import { ExportWizard } from '@/components/UI/ImportExportWizards/ExportWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { ListToolbar } from '@/components/UI/ListToolbar';
+import { BulkActionsBar } from '@/components/UI/BulkActionsBar';
 import { getMessage } from '@/utils/i18n';
 import { foldAccents } from '@/utils/stringUtils';
 import { generateUUID } from '@/utils/utils';
@@ -56,66 +57,6 @@ interface DomainRulesPageProps {
   pendingAction?: RulesPendingAction | null;
   /** Called once the pending action has been consumed so the parent can clear it. */
   onPendingActionConsumed?: () => void;
-}
-
-/* ─── Local presentation components ──────────────────────────────────────── */
-
-interface BulkActionsBarProps {
-  selectedIds: Set<string>;
-  filteredRules: DomainRuleSetting[];
-  isAllSelected: boolean;
-  isIndeterminate: boolean;
-  onSelectAll: (checked: boolean) => void;
-  onBulkToggle: (ids: string[], enabled: boolean) => void;
-  onBulkDeleteRequest: (ids: string[]) => void;
-  onBulkExportRequest: (ids: string[]) => void;
-}
-
-function BulkActionsBar({
-  selectedIds, filteredRules: _filteredRules, isAllSelected, isIndeterminate,
-  onSelectAll, onBulkToggle, onBulkDeleteRequest, onBulkExportRequest,
-}: BulkActionsBarProps) {
-  return (
-    <Flex data-testid="page-rules-bulk-bar" align="center" gap="3" p="2" mb="4"
-      style={{ backgroundColor: 'var(--accent-a3)', borderRadius: 'var(--radius-2)' }}>
-      <Checkbox
-        checked={isAllSelected}
-        onCheckedChange={(checked) => onSelectAll(checked as boolean)}
-        {...(isIndeterminate && { 'data-indeterminate': true })}
-      />
-      <Text size="2" weight="medium">
-        {selectedIds.size === 1
-          ? getMessage('dataTableSelectedCountSingular')
-          : getMessage('dataTableSelectedCountPlural').replace('{count}', selectedIds.size.toString())
-        }
-      </Text>
-      <Separator orientation="vertical" />
-      <Flex gap="2">
-        <Button size="1" variant="solid" onClick={() => onBulkToggle(Array.from(selectedIds), true)}>
-          <Eye size={14} />
-          {getMessage('enableSelected')}
-        </Button>
-        <Button size="1" variant="soft" onClick={() => onBulkToggle(Array.from(selectedIds), false)}>
-          <EyeOff size={14} />
-          {getMessage('disableSelected')}
-        </Button>
-        <Button
-          size="1"
-          variant="soft"
-          data-testid="page-rules-bulk-btn-export"
-          onClick={() => onBulkExportRequest(Array.from(selectedIds))}
-        >
-          <FileDown size={14} />
-          {getMessage('exportSelected')}
-        </Button>
-        <Button size="1" variant="soft" color="red"
-          onClick={() => onBulkDeleteRequest(Array.from(selectedIds))}>
-          <Trash2 size={14} />
-          {getMessage('deleteSelected')}
-        </Button>
-      </Flex>
-    </Flex>
-  );
 }
 
 /* ─── Page component ──────────────────────────────────────────────────────── */
@@ -383,15 +324,39 @@ export function DomainRulesPage({
 
             {selectedIds.size > 0 && (
               <BulkActionsBar
-                selectedIds={selectedIds}
-                filteredRules={filteredRules}
+                testId="page-rules-bulk-bar"
+                selectedCount={selectedIds.size}
                 isAllSelected={isAllSelected}
                 isIndeterminate={isIndeterminate}
                 onSelectAll={handleSelectAll}
-                onBulkToggle={handleBulkToggle}
-                onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', ruleIds: ids })}
-                onBulkExportRequest={(ids) => setBulkExportIds(ids)}
-              />
+              >
+                <Button size="1" variant="solid" onClick={() => handleBulkToggle(Array.from(selectedIds), true)}>
+                  <Eye size={14} />
+                  {getMessage('enableSelected')}
+                </Button>
+                <Button size="1" variant="soft" onClick={() => handleBulkToggle(Array.from(selectedIds), false)}>
+                  <EyeOff size={14} />
+                  {getMessage('disableSelected')}
+                </Button>
+                <Button
+                  size="1"
+                  variant="soft"
+                  data-testid="page-rules-bulk-btn-export"
+                  onClick={() => setBulkExportIds(Array.from(selectedIds))}
+                >
+                  <FileDown size={14} />
+                  {getMessage('exportSelected')}
+                </Button>
+                <Button
+                  size="1"
+                  variant="soft"
+                  color="red"
+                  onClick={() => setDeleteTarget({ type: 'bulk', ruleIds: Array.from(selectedIds) })}
+                >
+                  <Trash2 size={14} />
+                  {getMessage('deleteSelected')}
+                </Button>
+              </BulkActionsBar>
             )}
 
             {filteredRules.length === 0 && syncSettings.domainRules.length === 0 && !searchTerm && (

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -349,8 +349,9 @@ export function DomainRulesPage({
                 </Button>
                 <Button
                   size="1"
-                  variant="soft"
+                  variant="solid"
                   color="red"
+                  highContrast
                   onClick={() => setDeleteTarget({ type: 'bulk', ruleIds: Array.from(selectedIds) })}
                 >
                   <Trash2 size={14} />

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -349,7 +349,7 @@ export function DomainRulesPage({
                 </Button>
                 <Button
                   size="1"
-                  variant="solid"
+                  variant="soft"
                   color="red"
                   highContrast
                   onClick={() => setDeleteTarget({ type: 'bulk', ruleIds: Array.from(selectedIds) })}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -226,8 +226,9 @@ function SessionSection({
             </Button>
             <Button
               size="1"
-              variant="soft"
+              variant="solid"
               color="red"
+              highContrast
               data-testid={`page-sessions-bulk-btn-delete-${testIdSuffix}`}
               onClick={() => onBulkDeleteRequest(Array.from(selectedIds))}
             >

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -36,6 +36,20 @@ type DeleteTarget =
   | { type: 'single'; session: Session }
   | { type: 'bulk'; scope: BulkScope; ids: string[] };
 
+/** Returns `prev` unchanged when every id is still visible, otherwise a new
+ * Set restricted to ids present in `visible`. Used to keep section-local
+ * selections in sync after delete / pin / search filtering. */
+function pruneSelection(prev: Set<string>, visible: readonly { id: string }[]): Set<string> {
+  const visibleIds = new Set(visible.map(s => s.id));
+  let changed = false;
+  const next = new Set<string>();
+  for (const id of prev) {
+    if (visibleIds.has(id)) next.add(id);
+    else changed = true;
+  }
+  return changed ? next : prev;
+}
+
 interface SessionsPageProps {
   syncSettings: AppSettings;
   /** Controlled by options.tsx: true when a deep-link requests the snapshot wizard. */
@@ -440,29 +454,11 @@ export function SessionsPage({
   // pinned/unpinned, or filtered out by the search). This keeps the master
   // checkbox count in sync with what the user actually sees.
   useEffect(() => {
-    const visibleIds = new Set(pinnedSessions.map(s => s.id));
-    setSelectedPinnedIds(prev => {
-      let changed = false;
-      const next = new Set<string>();
-      for (const id of prev) {
-        if (visibleIds.has(id)) next.add(id);
-        else changed = true;
-      }
-      return changed ? next : prev;
-    });
+    setSelectedPinnedIds(prev => pruneSelection(prev, pinnedSessions));
   }, [pinnedSessions]);
 
   useEffect(() => {
-    const visibleIds = new Set(unpinnedSessions.map(s => s.id));
-    setSelectedUnpinnedIds(prev => {
-      let changed = false;
-      const next = new Set<string>();
-      for (const id of prev) {
-        if (visibleIds.has(id)) next.add(id);
-        else changed = true;
-      }
-      return changed ? next : prev;
-    });
+    setSelectedUnpinnedIds(prev => pruneSelection(prev, unpinnedSessions));
   }, [unpinnedSessions]);
 
   const handleSaveSession = useCallback(

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, Flex, Button, Text, Callout, Separator, Badge } from '@radix-ui/themes';
-import { Camera, Archive, CheckCircle, Pin, Upload, Trash2, FileDown, type LucideIcon } from 'lucide-react';
+import { Camera, Archive, CheckCircle, Pin, PinOff, Upload, Trash2, FileDown, type LucideIcon } from 'lucide-react';
 import { DragDropProvider, type DragOverEvent, type DragEndEvent } from '@dnd-kit/react';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { move } from '@dnd-kit/helpers';
@@ -111,6 +111,8 @@ interface SessionSectionProps {
   onSelectionChange: (next: Set<string>) => void;
   onBulkDeleteRequest: (ids: string[]) => void;
   onBulkExportRequest: (ids: string[]) => void;
+  /** Bulk pin (in unpinned section) / unpin (in pinned section). */
+  onBulkPinToggle: (ids: string[]) => void;
   /** Suffix appended to bulk testIds (e.g. 'pinned' / 'unpinned'). */
   testIdSuffix: BulkScope;
 }
@@ -139,6 +141,7 @@ function SessionSection({
   onSelectionChange,
   onBulkDeleteRequest,
   onBulkExportRequest,
+  onBulkPinToggle,
   testIdSuffix,
 }: SessionSectionProps) {
   const [dragItems, setDragItems] = useState<Session[] | null>(null);
@@ -215,6 +218,15 @@ function SessionSection({
             isIndeterminate={isIndeterminate}
             onSelectAll={handleSelectAll}
           >
+            <Button
+              size="1"
+              variant="soft"
+              data-testid={`page-sessions-bulk-btn-${isPinned ? 'unpin' : 'pin'}-${testIdSuffix}`}
+              onClick={() => onBulkPinToggle(Array.from(selectedIds))}
+            >
+              {isPinned ? <PinOff size={14} /> : <Pin size={14} />}
+              {getMessage(isPinned ? 'unpinSelected' : 'pinSelected')}
+            </Button>
             <Button
               size="1"
               variant="soft"
@@ -484,6 +496,13 @@ export function SessionsPage({
     [reload],
   );
 
+  const handleBulkPinToggle = useCallback(async (ids: string[], makePinned: boolean) => {
+    for (const id of ids) {
+      await updateSession(id, { isPinned: makePinned });
+    }
+    await reload();
+  }, [reload]);
+
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;
     if (deleteTarget.type === 'single') {
@@ -631,6 +650,7 @@ export function SessionsPage({
                 onSelectionChange={setSelectedPinnedIds}
                 onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', scope: 'pinned', ids })}
                 onBulkExportRequest={(ids) => setBulkExportIds(ids)}
+                onBulkPinToggle={(ids) => handleBulkPinToggle(ids, false)}
                 testIdSuffix="pinned"
                 {...sharedSectionProps}
               />
@@ -648,6 +668,7 @@ export function SessionsPage({
                 onSelectionChange={setSelectedUnpinnedIds}
                 onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', scope: 'unpinned', ids })}
                 onBulkExportRequest={(ids) => setBulkExportIds(ids)}
+                onBulkPinToggle={(ids) => handleBulkPinToggle(ids, true)}
                 testIdSuffix="unpinned"
                 {...sharedSectionProps}
               />

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -238,7 +238,7 @@ function SessionSection({
             </Button>
             <Button
               size="1"
-              variant="solid"
+              variant="soft"
               color="red"
               highContrast
               data-testid={`page-sessions-bulk-btn-delete-${testIdSuffix}`}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, Flex, Button, Text, Callout, Separator, Badge } from '@radix-ui/themes';
-import { Camera, Archive, CheckCircle, Pin, Upload, type LucideIcon } from 'lucide-react';
+import { Camera, Archive, CheckCircle, Pin, Upload, Trash2, FileDown, type LucideIcon } from 'lucide-react';
 import { DragDropProvider, type DragOverEvent, type DragEndEvent } from '@dnd-kit/react';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { move } from '@dnd-kit/helpers';
@@ -12,6 +12,8 @@ import { SnapshotWizard } from '@/components/UI/SessionWizards/SnapshotWizard';
 import { RestoreWizard } from '@/components/UI/SessionWizards/RestoreWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { ListToolbar } from '@/components/UI/ListToolbar';
+import { BulkActionsBar } from '@/components/UI/BulkActionsBar';
+import { ExportSessionsWizard } from '@/components/UI/ImportExportWizards/ExportSessionsWizard';
 import { getMessage } from '@/utils/i18n';
 import { foldAccents } from '@/utils/stringUtils';
 import { matchSessionSearch, splitByPinned, getFocusedSessionFromDOM } from '@/utils/sessionUtils';
@@ -27,6 +29,12 @@ import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
 import type { AppSettings } from '@/types/syncSettings';
+
+type BulkScope = 'pinned' | 'unpinned';
+
+type DeleteTarget =
+  | { type: 'single'; session: Session }
+  | { type: 'bulk'; scope: BulkScope; ids: string[] };
 
 interface SessionsPageProps {
   syncSettings: AppSettings;
@@ -84,6 +92,13 @@ interface SessionSectionProps {
   /** Pin/unpin handlers shared with the page-level widget shortcuts. */
   onPin: (session: Session) => void;
   onUnpin: (session: Session) => void;
+  /** Section-local bulk selection (independent between pinned and unpinned). */
+  selectedIds: Set<string>;
+  onSelectionChange: (next: Set<string>) => void;
+  onBulkDeleteRequest: (ids: string[]) => void;
+  onBulkExportRequest: (ids: string[]) => void;
+  /** Suffix appended to bulk testIds (e.g. 'pinned' / 'unpinned'). */
+  testIdSuffix: BulkScope;
 }
 
 function SessionSection({
@@ -106,6 +121,11 @@ function SessionSection({
   onReplaceCurrentWindow,
   onPin,
   onUnpin,
+  selectedIds,
+  onSelectionChange,
+  onBulkDeleteRequest,
+  onBulkExportRequest,
+  testIdSuffix,
 }: SessionSectionProps) {
   const [dragItems, setDragItems] = useState<Session[] | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -153,11 +173,56 @@ function SessionSection({
     void updateOrder(moveSessionToLastInGroup(allSessions, session.id));
   }, [allSessions, updateOrder]);
 
+  const handleCardSelect = useCallback((id: string, checked: boolean) => {
+    const next = new Set(selectedIds);
+    if (checked) next.add(id);
+    else next.delete(id);
+    onSelectionChange(next);
+  }, [selectedIds, onSelectionChange]);
+
+  const handleSelectAll = useCallback((checked: boolean) => {
+    onSelectionChange(checked ? new Set(sessions.map(s => s.id)) : new Set());
+  }, [sessions, onSelectionChange]);
+
+  const isAllSelected = sessions.length > 0 && selectedIds.size === sessions.length;
+  const isIndeterminate = selectedIds.size > 0 && selectedIds.size < sessions.length;
+
   // When a search is active, hide the whole section if it matched nothing.
   if (sessions.length === 0 && searchQuery) return null;
   return (
     <Box>
       <SectionHeader icon={icon} titleKey={titleKey} count={sessions.length} />
+      {selectedIds.size > 0 && (
+        <Box mt="3">
+          <BulkActionsBar
+            testId={`page-sessions-bulk-bar-${testIdSuffix}`}
+            selectedCount={selectedIds.size}
+            isAllSelected={isAllSelected}
+            isIndeterminate={isIndeterminate}
+            onSelectAll={handleSelectAll}
+          >
+            <Button
+              size="1"
+              variant="soft"
+              data-testid={`page-sessions-bulk-btn-export-${testIdSuffix}`}
+              onClick={() => onBulkExportRequest(Array.from(selectedIds))}
+            >
+              <FileDown size={14} />
+              {getMessage('exportSelected')}
+            </Button>
+            <Button
+              size="1"
+              variant="soft"
+              color="red"
+              data-testid={`page-sessions-bulk-btn-delete-${testIdSuffix}`}
+              onClick={() => onBulkDeleteRequest(Array.from(selectedIds))}
+            >
+              <Trash2 size={14} />
+              {getMessage('deleteSelected')}
+            </Button>
+          </BulkActionsBar>
+        </Box>
+      )}
       {sessions.length === 0 ? (
         <EmptyState
           icon={icon}
@@ -180,6 +245,8 @@ function SessionSection({
                   key={session.id}
                   session={session}
                   existingSessions={allSessions}
+                  isSelected={selectedIds.has(session.id)}
+                  onSelect={handleCardSelect}
                   onRestore={onOpenRestoreWizard}
                   onRestoreCurrentWindow={onRestoreCurrentWindow}
                   onRestoreNewWindow={onRestoreNewWindow}
@@ -235,7 +302,10 @@ export function SessionsPage({
 
   const [restoreSession, setRestoreSession] = useState<Session | null>(null);
   const [editTarget, setEditTarget] = useState<Session | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<Session | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const [bulkExportIds, setBulkExportIds] = useState<string[] | null>(null);
+  const [selectedPinnedIds, setSelectedPinnedIds] = useState<Set<string>>(new Set());
+  const [selectedUnpinnedIds, setSelectedUnpinnedIds] = useState<Set<string>>(new Set());
   const [quickRestoreMessage, setQuickRestoreMessage] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -318,7 +388,7 @@ export function SessionsPage({
       },
       'sessionCard.delete': () => {
         const focused = getFocusedSession();
-        if (focused) setDeleteTarget(focused);
+        if (focused) setDeleteTarget({ type: 'single', session: focused });
       },
       'sessionCard.pin': () => {
         const focused = getFocusedSession();
@@ -366,6 +436,35 @@ export function SessionsPage({
     [displayedSessions],
   );
 
+  // Cleanup: drop selected ids that are no longer in their section (deleted,
+  // pinned/unpinned, or filtered out by the search). This keeps the master
+  // checkbox count in sync with what the user actually sees.
+  useEffect(() => {
+    const visibleIds = new Set(pinnedSessions.map(s => s.id));
+    setSelectedPinnedIds(prev => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (visibleIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [pinnedSessions]);
+
+  useEffect(() => {
+    const visibleIds = new Set(unpinnedSessions.map(s => s.id));
+    setSelectedUnpinnedIds(prev => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (visibleIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [unpinnedSessions]);
+
   const handleSaveSession = useCallback(
     async (session: Session) => {
       await createSession(session);
@@ -390,9 +489,21 @@ export function SessionsPage({
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!deleteTarget) return;
-    await removeSession(deleteTarget.id);
+    if (deleteTarget.type === 'single') {
+      await removeSession(deleteTarget.session.id);
+    } else {
+      for (const id of deleteTarget.ids) {
+        await removeSession(id);
+      }
+      if (deleteTarget.scope === 'pinned') setSelectedPinnedIds(new Set());
+      else setSelectedUnpinnedIds(new Set());
+    }
     setDeleteTarget(null);
   }, [deleteTarget, removeSession]);
+
+  const handleOpenSingleDelete = useCallback((session: Session) => {
+    setDeleteTarget({ type: 'single', session });
+  }, []);
 
   const sharedSectionProps: Pick<
     SessionSectionProps,
@@ -417,13 +528,24 @@ export function SessionsPage({
     renameSession,
     onOpenRestoreWizard: setRestoreSession,
     onOpenEditDialog: setEditTarget,
-    onOpenDeleteDialog: setDeleteTarget,
+    onOpenDeleteDialog: handleOpenSingleDelete,
     onRestoreCurrentWindow: handleRestoreCurrentWindow,
     onRestoreNewWindow: handleRestoreNewWindow,
     onReplaceCurrentWindow: handleReplaceCurrentWindow,
     onPin: handlePin,
     onUnpin: handleUnpin,
   };
+
+  const deleteDialogTitle = deleteTarget?.type === 'bulk'
+    ? getMessage('confirmDeleteSelectedSessions')
+    : getMessage('confirmDelete');
+  const singleDeleteName = deleteTarget?.type === 'single' ? deleteTarget.session.name : '';
+  const deleteDialogDescription = deleteTarget?.type === 'bulk'
+    ? getMessage('confirmDeleteSelectedSessionsDescription').replace(
+      '{count}',
+      String(deleteTarget.ids.length),
+    )
+    : getMessage('confirmDeleteSession').replace('{name}', singleDeleteName);
 
   return (
     <PageLayout
@@ -508,6 +630,11 @@ export function SessionsPage({
                 emptyDescriptionKey="pinnedSessionsEmptyDescription"
                 isPinned={true}
                 sessions={pinnedSessions}
+                selectedIds={selectedPinnedIds}
+                onSelectionChange={setSelectedPinnedIds}
+                onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', scope: 'pinned', ids })}
+                onBulkExportRequest={(ids) => setBulkExportIds(ids)}
+                testIdSuffix="pinned"
                 {...sharedSectionProps}
               />
 
@@ -520,6 +647,11 @@ export function SessionsPage({
                 emptyDescriptionKey="unpinnedSessionsEmptyDescription"
                 isPinned={false}
                 sessions={unpinnedSessions}
+                selectedIds={selectedUnpinnedIds}
+                onSelectionChange={setSelectedUnpinnedIds}
+                onBulkDeleteRequest={(ids) => setDeleteTarget({ type: 'bulk', scope: 'unpinned', ids })}
+                onBulkExportRequest={(ids) => setBulkExportIds(ids)}
+                testIdSuffix="unpinned"
                 {...sharedSectionProps}
               />
             </Flex>
@@ -563,13 +695,16 @@ export function SessionsPage({
               if (!isOpen) setDeleteTarget(null);
             }}
             onConfirm={handleDeleteConfirm}
-            title={getMessage('confirmDelete')}
-            description={getMessage('confirmDeleteSession').replace(
-              '{name}',
-              deleteTarget?.name ?? '',
-            )}
+            title={deleteDialogTitle}
+            description={deleteDialogDescription}
             confirmLabel={getMessage('delete')}
             color="red"
+          />
+
+          <ExportSessionsWizard
+            open={bulkExportIds != null}
+            onOpenChange={(open) => { if (!open) setBulkExportIds(null); }}
+            initialSelectedIds={bulkExportIds ?? undefined}
           />
         </Box>
       )}


### PR DESCRIPTION
## Summary
Implements bulk selection and bulk actions (export, delete) for sessions on the SessionsPage, mirroring the existing bulk actions pattern from DomainRulesPage. Extracts the reusable `BulkActionsBar` component into a shared UI component.

## Key Changes

- **New `BulkActionsBar` component** (`src/components/UI/BulkActionsBar/`):
  - Extracted from DomainRulesPage's inline implementation
  - Reusable across pages with configurable action buttons via `children` slot
  - Displays selection count, master checkbox, and action buttons
  - Includes Storybook stories for documentation

- **SessionsPage bulk selection**:
  - Added independent selection state for pinned and unpinned sections (`selectedPinnedIds`, `selectedUnpinnedIds`)
  - Selection state automatically cleaned up when sessions are deleted, pinned/unpinned, or filtered by search
  - SessionCard now displays checkbox when in bulk selection mode (`isSelected`, `onSelect` props)
  - BulkActionsBar shown per section with Export and Delete buttons

- **Bulk delete support**:
  - Extended `DeleteTarget` type to support both single and bulk deletes
  - Bulk delete dialog displays appropriate title and description based on target type
  - Bulk delete clears selection state after completion

- **Bulk export support**:
  - `ExportSessionsWizard` now accepts `initialSelectedIds` prop for pre-selection
  - Bulk export triggered from BulkActionsBar passes selected session IDs

- **DomainRulesPage refactoring**:
  - Replaced inline `BulkActionsBar` with shared component
  - Action buttons now passed as children to the component
  - Maintains existing bulk toggle (enable/disable) functionality

- **Localization**:
  - Added new i18n keys: `confirmDeleteSelectedSessions`, `confirmDeleteSelectedSessionsDescription`
  - Updated EN, FR, ES message files

- **Export wizard improvements**:
  - Refactored `useExportWizardState` to extract `applySelection` logic
  - Handles pre-selection consistently for both sync and async item loading

## Implementation Details

- Selection state is section-scoped (pinned vs unpinned) to avoid cross-section interference
- Cleanup effects ensure selected IDs remain valid when underlying data changes
- BulkActionsBar is presentation-only; callers handle selection logic and action callbacks
- SessionCard checkbox only renders when `onSelect` callback is provided (opt-in)
- Bulk delete confirmation dialog dynamically updates title/description based on delete target type

https://claude.ai/code/session_01GD3aSsSPX8QpHTqnfpiHnU