### PR TITLE
Auto-derive identity label from domain

### DIFF
--- a/e2e-shared/pages/RuleWizardPage.ts
+++ b/e2e-shared/pages/RuleWizardPage.ts
@@ -94,15 +94,11 @@ export class RuleWizardPage extends DialogPage {
   }
 
   /**
-   * Category picker trigger button (the colored swatch shown next to the
-   * label input). Opens a Radix Popover containing the category radios.
+   * Category radiogroup container, rendered inline as its own row in step 1.
+   * Anchored by data-testid so it stays locale-agnostic.
    */
-  categoryPicker(): Locator {
-    // The CategoryPicker is rendered next to the label input; its trigger is
-    // a `<button type="button">` with an `aria-label` matching the currently
-    // selected category. The only stable anchor across locales is the
-    // sibling structure of TextFieldWithCategory.
-    return this.step1Identity().locator('button[type="button"]').first();
+  categoryField(): Locator {
+    return this.step1Identity().getByTestId('wizard-rule-field-category');
   }
 
   // ─── Locators: config & options ──────────────────────────────────────────
@@ -178,14 +174,12 @@ export class RuleWizardPage extends DialogPage {
   }
 
   /**
-   * Open the category picker popover and select a category by its
-   * accessible label. Pass `null` to clear the selection.
+   * Pick a category by its accessible label in the inline radiogroup of
+   * step 1. Pass `null` to select the "None" swatch.
    */
   async selectCategory(label: string | null): Promise<void> {
-    await this.categoryPicker().click();
-    const popover = this.page.locator('[role="radiogroup"]').last();
     const target = label === null ? /no category|none/i : new RegExp(label, 'i');
-    await popover.getByRole('radio', { name: target }).click();
+    await this.categoryField().getByRole('radio', { name: target }).click();
   }
 
   // ─── Atomic actions: configuration (step 2) ──────────────────────────────

--- a/src/components/Core/DomainRule/CategoryPicker.tsx
+++ b/src/components/Core/DomainRule/CategoryPicker.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
-import { Popover, Tooltip } from '@radix-ui/themes';
+import { useState } from 'react';
+import { Popover } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
-import { useSettings } from '@/hooks/useSettings';
+import { CategoryRadioGroup } from './CategoryRadioGroup';
 import styles from './CategoryPicker.module.css';
 
 export interface CategoryPickerProps {
@@ -12,10 +12,10 @@ export interface CategoryPickerProps {
 
 export function CategoryPicker({ value, onChange }: CategoryPickerProps) {
   const [open, setOpen] = useState(false);
-  const { settings } = useSettings();
-  const categories = settings?.categories ?? [];
   const selectedCategory = getRuleCategory(value);
-  const selectedLabel = selectedCategory ? getCategoryLabel(selectedCategory) : getMessage('categoryNone');
+  const selectedLabel = selectedCategory
+    ? getCategoryLabel(selectedCategory)
+    : getMessage('categoryNone');
 
   function handleSelect(id: string | null) {
     onChange(id);
@@ -34,43 +34,8 @@ export function CategoryPicker({ value, onChange }: CategoryPickerProps) {
           {selectedCategory ? selectedCategory.emoji : null}
         </button>
       </Popover.Trigger>
-      <Popover.Content side="bottom" align="start" style={{ padding: 'var(--space-3)' }}>
-        <div
-          className={styles.grid}
-          role="radiogroup"
-          aria-label={getMessage('categoryPickerLabel')}
-        >
-          {/* None option */}
-          <Tooltip content={getMessage('categoryNone')}>
-            <button
-              type="button"
-              role="radio"
-              aria-checked={!value}
-              aria-label={getMessage('categoryNone')}
-              className={`${styles.swatch} ${styles.swatchNone} ${!value ? styles.swatchActive : ''}`}
-              onClick={() => handleSelect(null)}
-            />
-          </Tooltip>
-
-          {/* Category options */}
-          {categories.map((category) => {
-            const label = getCategoryLabel(category);
-            return (
-              <Tooltip key={category.id} content={label}>
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={value === category.id}
-                  aria-label={label}
-                  className={`${styles.swatch} ${value === category.id ? styles.swatchActive : ''}`}
-                  onClick={() => handleSelect(category.id)}
-                >
-                  {category.emoji}
-                </button>
-              </Tooltip>
-            );
-          })}
-        </div>
+      <Popover.Content side="bottom" align="start" style={{ padding: 'var(--space-3)', width: 176 }}>
+        <CategoryRadioGroup value={value} onChange={handleSelect} selectOnFocus={false} />
       </Popover.Content>
     </Popover.Root>
   );

--- a/src/components/Core/DomainRule/CategoryRadioGroup.stories.tsx
+++ b/src/components/Core/DomainRule/CategoryRadioGroup.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Box } from '@radix-ui/themes';
+import { CategoryRadioGroup } from './CategoryRadioGroup';
+
+const meta: Meta<typeof CategoryRadioGroup> = {
+  title: 'Components/Core/DomainRule/CategoryRadioGroup',
+  component: CategoryRadioGroup,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <Box style={{ width: 480, padding: 'var(--space-3)' }}>
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledExample({ initial }: { initial: string | null }) {
+  const [value, setValue] = useState<string | null>(initial);
+  return <CategoryRadioGroup value={value} onChange={setValue} />;
+}
+
+export const CategoryRadioGroupDefault: Story = {
+  render: () => <ControlledExample initial={null} />,
+};
+
+export const CategoryRadioGroupSelected: Story = {
+  render: () => <ControlledExample initial="development" />,
+};
+
+export const CategoryRadioGroupNoneSelected: Story = {
+  render: () => <ControlledExample initial={null} />,
+};
+
+export const CategoryRadioGroupNarrowContainer: Story = {
+  decorators: [
+    (Story) => (
+      <Box style={{ width: 320, padding: 'var(--space-3)' }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  render: () => <ControlledExample initial="productivity" />,
+};

--- a/src/components/Core/DomainRule/CategoryRadioGroup.tsx
+++ b/src/components/Core/DomainRule/CategoryRadioGroup.tsx
@@ -1,0 +1,89 @@
+import { useRef } from 'react';
+import { Flex, Tooltip } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+import { getCategoryLabel } from '@/utils/categoriesStore';
+import { useSettings } from '@/hooks/useSettings';
+import { useListNavigation } from '@/hooks/useListNavigation';
+import styles from './CategoryPicker.module.css';
+
+export interface CategoryRadioGroupProps {
+  value: string | null | undefined;
+  onChange: (value: string | null) => void;
+  'aria-label'?: string;
+  'data-testid'?: string;
+  swatchTestIdPrefix?: string;
+  /**
+   * When true (default), focusing a swatch via arrow keys also commits the
+   * selection (ARIA "automatic activation" pattern, recommended for an
+   * inline radiogroup). Set to false in contexts where selection must be
+   * explicit, e.g. inside a popover that closes on selection.
+   */
+  selectOnFocus?: boolean;
+}
+
+export function CategoryRadioGroup({
+  value,
+  onChange,
+  'aria-label': ariaLabel,
+  'data-testid': dataTestId,
+  swatchTestIdPrefix,
+  selectOnFocus = true,
+}: CategoryRadioGroupProps) {
+  const { settings } = useSettings();
+  const categories = settings?.categories ?? [];
+  const listRef = useRef<HTMLDivElement>(null);
+  const { handleNavigationKey } = useListNavigation(listRef, '[role="radio"]', {
+    axis: 'both',
+    rovingTabIndex: true,
+  });
+
+  const noneLabel = getMessage('categoryNone');
+  const groupLabel = ariaLabel ?? getMessage('categoryPickerLabel');
+
+  // Build a flat list of options to keep indices aligned with the DOM order
+  // expected by useListNavigation.
+  const options: Array<{ id: string | null; label: string; emoji: string | null }> = [
+    { id: null, label: noneLabel, emoji: null },
+    ...categories.map((c) => ({ id: c.id, label: getCategoryLabel(c), emoji: c.emoji })),
+  ];
+
+  const swatchTestId = (id: string | null) => {
+    if (!swatchTestIdPrefix) return undefined;
+    return `${swatchTestIdPrefix}-${id ?? 'none'}`;
+  };
+
+  return (
+    <Flex
+      ref={listRef}
+      align="center"
+      gap="2"
+      wrap="wrap"
+      role="radiogroup"
+      aria-label={groupLabel}
+      data-testid={dataTestId}
+    >
+      {options.map((option, index) => {
+        const isSelected = (option.id ?? null) === (value ?? null);
+        const isNone = option.id === null;
+        return (
+          <Tooltip key={option.id ?? '__none__'} content={option.label}>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={option.label}
+              data-testid={swatchTestId(option.id)}
+              tabIndex={isSelected ? 0 : -1}
+              className={`${styles.swatch} ${isNone ? styles.swatchNone : ''} ${isSelected ? styles.swatchActive : ''}`}
+              onClick={() => onChange(option.id)}
+              onFocus={selectOnFocus ? () => onChange(option.id) : undefined}
+              onKeyDown={(e) => handleNavigationKey(e, index)}
+            >
+              {option.emoji}
+            </button>
+          </Tooltip>
+        );
+      })}
+    </Flex>
+  );
+}

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -1,5 +1,5 @@
 import { Flex, TextField } from '@radix-ui/themes';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { EditModalShell } from './EditModalShell';
@@ -7,6 +7,7 @@ import { FormField } from '@/components/Form/FormFields';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
 import { createDomainFilterValidator } from '@/schemas/common';
+import { deriveLabelFromDomain } from '@/utils/labelFromDomain';
 import type { ChromeGroupColor } from '@/types/tabTree';
 import type { DomainRule } from '@/schemas/domainRule';
 
@@ -65,14 +66,31 @@ export function IdentityEditModal({
   const [color, setColor] = useState<ChromeGroupColor>(initial.color);
   const [domainFilter, setDomainFilter] = useState(initial.domainFilter);
 
+  // The label is considered "owned by the user" as soon as it's non-empty.
+  // Clearing the label re-arms the autofill on the next domainFilter change.
+  const labelOwnedRef = useRef<boolean>(initial.label.trim().length > 0);
+
   useEffect(() => {
     if (isOpen) {
       setLabel(initial.label);
       setCategoryId(initial.categoryId);
       setColor(initial.color);
       setDomainFilter(initial.domainFilter);
+      labelOwnedRef.current = initial.label.trim().length > 0;
     }
   }, [isOpen, initial]);
+
+  const handleLabelChange = (value: string) => {
+    labelOwnedRef.current = value.trim().length > 0;
+    setLabel(value);
+  };
+
+  const handleDomainFilterChange = (value: string) => {
+    setDomainFilter(value);
+    if (!labelOwnedRef.current) {
+      setLabel(deriveLabelFromDomain(value));
+    }
+  };
 
   const existingLabels = useMemo(
     () => existingRules
@@ -103,6 +121,20 @@ export function IdentityEditModal({
       data-testid="modal-edit-identity"
     >
       <Flex direction="column" gap="4" mt="4">
+        <FormField label={getMessage('domainFilter')} required error={domainError}>
+          {(fieldId) => (
+            <TextField.Root
+              id={fieldId}
+              name="domainFilter"
+              data-testid="modal-edit-identity-field-domain"
+              value={domainFilter}
+              onChange={(e) => handleDomainFilterChange(e.target.value)}
+              placeholder={getMessage('domainFilterPlaceholder')}
+              style={{ marginTop: '4px' }}
+            />
+          )}
+        </FormField>
+
         <FormField label={getMessage('labelLabel')} required error={labelError}>
           {(fieldId) => (
             <div style={{ marginTop: '4px' }}>
@@ -110,7 +142,7 @@ export function IdentityEditModal({
                 id={fieldId}
                 name="label"
                 value={label}
-                onChange={setLabel}
+                onChange={handleLabelChange}
                 data-testid="modal-edit-identity-field-label"
                 placeholder={getMessage('labelPlaceholder')}
                 categoryId={categoryId}
@@ -125,20 +157,6 @@ export function IdentityEditModal({
             <div style={{ marginTop: '4px' }}>
               <ChromeColorPicker value={color} onChange={setColor} />
             </div>
-          )}
-        </FormField>
-
-        <FormField label={getMessage('domainFilter')} required error={domainError}>
-          {(fieldId) => (
-            <TextField.Root
-              id={fieldId}
-              name="domainFilter"
-              data-testid="modal-edit-identity-field-domain"
-              value={domainFilter}
-              onChange={(e) => setDomainFilter(e.target.value)}
-              placeholder={getMessage('domainFilterPlaceholder')}
-              style={{ marginTop: '4px' }}
-            />
           )}
         </FormField>
       </Flex>

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -4,7 +4,7 @@ import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { EditModalShell } from './EditModalShell';
 import { FormField } from '@/components/Form/FormFields';
-import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
+import { CategoryRadioGroup } from '@/components/Core/DomainRule/CategoryRadioGroup';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
 import { createDomainFilterValidator } from '@/schemas/common';
 import { deriveLabelFromDomain } from '@/utils/labelFromDomain';
@@ -137,16 +137,26 @@ export function IdentityEditModal({
 
         <FormField label={getMessage('labelLabel')} required error={labelError}>
           {(fieldId) => (
+            <TextField.Root
+              id={fieldId}
+              name="label"
+              data-testid="modal-edit-identity-field-label"
+              value={label}
+              onChange={(e) => handleLabelChange(e.target.value)}
+              placeholder={getMessage('labelPlaceholder')}
+              style={{ marginTop: '4px' }}
+            />
+          )}
+        </FormField>
+
+        <FormField label={getMessage('categoryPickerLabel')}>
+          {() => (
             <div style={{ marginTop: '4px' }}>
-              <TextFieldWithCategory
-                id={fieldId}
-                name="label"
-                value={label}
-                onChange={handleLabelChange}
-                data-testid="modal-edit-identity-field-label"
-                placeholder={getMessage('labelPlaceholder')}
-                categoryId={categoryId}
-                onCategoryChange={setCategoryId}
+              <CategoryRadioGroup
+                value={categoryId}
+                onChange={setCategoryId}
+                data-testid="modal-edit-identity-field-category"
+                swatchTestIdPrefix="modal-edit-identity-category"
               />
             </div>
           )}

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -460,7 +460,7 @@ export function RuleWizardModal({
       fillHeight={!isEditing && step === 1}
       onOpenAutoFocus={(e) => {
         e.preventDefault();
-        const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[name="label"]');
+        const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[name="domainFilter"]');
         input?.focus();
       }}
     >
@@ -507,7 +507,7 @@ export function RuleWizardModal({
               <>
                 {step === 0 && (
                   <Box data-testid="wizard-rule-step-1">
-                    <WizardStep1Identity control={control} errors={errors} />
+                    <WizardStep1Identity control={control} errors={errors} setValue={setValue} />
                   </Box>
                 )}
                 {step === 1 && (

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -1,20 +1,66 @@
+import { useEffect } from 'react';
 import { Flex, TextField } from '@radix-ui/themes';
-import { Controller, type Control, type FieldErrors } from 'react-hook-form';
+import {
+  Controller,
+  useFormState,
+  useWatch,
+  type Control,
+  type FieldErrors,
+  type UseFormSetValue,
+} from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { FormField } from '@/components/Form/FormFields';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
+import { deriveLabelFromDomain } from '@/utils/labelFromDomain';
 import type { DomainRule } from '@/schemas/domainRule';
 import type { ChromeGroupColor } from '@/types/tabTree';
 
 interface WizardStep1IdentityProps {
   control: Control<DomainRule>;
   errors: FieldErrors<DomainRule>;
+  setValue: UseFormSetValue<DomainRule>;
 }
 
-export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProps) {
+export function WizardStep1Identity({ control, errors, setValue }: WizardStep1IdentityProps) {
+  const domainFilter = useWatch({ control, name: 'domainFilter' }) ?? '';
+  const { dirtyFields } = useFormState({ control, name: 'label' });
+
+  // Auto-derive the label from the domain as long as the user hasn't
+  // edited the label manually. shouldDirty is false so that further URL
+  // changes keep triggering the autofill until the user takes ownership.
+  useEffect(() => {
+    if (dirtyFields.label) return;
+    const derived = deriveLabelFromDomain(domainFilter);
+    setValue('label', derived, { shouldDirty: false, shouldValidate: true });
+  }, [domainFilter, dirtyFields.label, setValue]);
+
   return (
     <Flex direction="column" gap="4">
+      {/* Domain Filter */}
+      <FormField
+        label={getMessage('domainFilter')}
+        required={true}
+        error={errors.domainFilter}
+      >
+        {(fieldId) => (
+          <Controller
+            name="domainFilter"
+            control={control}
+            render={({ field }) => (
+              <TextField.Root
+                {...field}
+                id={fieldId}
+                data-testid="wizard-rule-field-domain"
+                name="domainFilter"
+                placeholder={getMessage('domainFilterPlaceholder')}
+                style={{ marginTop: '4px' }}
+              />
+            )}
+          />
+        )}
+      </FormField>
+
       {/* Label + Category */}
       <FormField
         label={getMessage('labelLabel')}
@@ -66,30 +112,6 @@ export function WizardStep1Identity({ control, errors }: WizardStep1IdentityProp
               )}
             />
           </div>
-        )}
-      </FormField>
-
-      {/* Domain Filter */}
-      <FormField
-        label={getMessage('domainFilter')}
-        required={true}
-        error={errors.domainFilter}
-      >
-        {(fieldId) => (
-          <Controller
-            name="domainFilter"
-            control={control}
-            render={({ field }) => (
-              <TextField.Root
-                {...field}
-                id={fieldId}
-                data-testid="wizard-rule-field-domain"
-                name="domainFilter"
-                placeholder={getMessage('domainFilterPlaceholder')}
-                style={{ marginTop: '4px' }}
-              />
-            )}
-          />
         )}
       </FormField>
     </Flex>

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { FormField } from '@/components/Form/FormFields';
-import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
+import { CategoryRadioGroup } from '@/components/Core/DomainRule/CategoryRadioGroup';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
 import { deriveLabelFromDomain } from '@/utils/labelFromDomain';
 import type { DomainRule } from '@/schemas/domainRule';
@@ -61,35 +61,44 @@ export function WizardStep1Identity({ control, errors, setValue }: WizardStep1Id
         )}
       </FormField>
 
-      {/* Label + Category */}
+      {/* Label */}
       <FormField
         label={getMessage('labelLabel')}
         required={true}
         error={errors.label}
       >
         {(fieldId) => (
+          <Controller
+            name="label"
+            control={control}
+            render={({ field }) => (
+              <TextField.Root
+                {...field}
+                value={field.value ?? ''}
+                id={fieldId}
+                data-testid="wizard-rule-field-label"
+                name="label"
+                placeholder={getMessage('labelPlaceholder')}
+                style={{ marginTop: '4px' }}
+              />
+            )}
+          />
+        )}
+      </FormField>
+
+      {/* Category */}
+      <FormField label={getMessage('categoryPickerLabel')} error={errors.categoryId}>
+        {() => (
           <div style={{ marginTop: '4px' }}>
             <Controller
-              name="label"
+              name="categoryId"
               control={control}
-              render={({ field: labelField }) => (
-                <Controller
-                  name="categoryId"
-                  control={control}
-                  render={({ field: catField }) => (
-                    <TextFieldWithCategory
-                      id={fieldId}
-                      ref={labelField.ref}
-                      name={labelField.name}
-                      value={labelField.value ?? ''}
-                      onChange={labelField.onChange}
-                      onBlur={labelField.onBlur}
-                      data-testid="wizard-rule-field-label"
-                      placeholder={getMessage('labelPlaceholder')}
-                      categoryId={catField.value as string | null | undefined}
-                      onCategoryChange={catField.onChange}
-                    />
-                  )}
+              render={({ field }) => (
+                <CategoryRadioGroup
+                  value={field.value as string | null | undefined}
+                  onChange={field.onChange}
+                  data-testid="wizard-rule-field-category"
+                  swatchTestIdPrefix="wizard-rule-category"
                 />
               )}
             />

--- a/src/components/Core/TabTree/ChromeColorPicker.tsx
+++ b/src/components/Core/TabTree/ChromeColorPicker.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import { useRef } from 'react';
 import { Flex, Tooltip } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { chromeGroupColors } from '@/utils/tabTreeUtils';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import type { ChromeGroupColor } from '@/types/tabTree';
 import styles from './ChromeColorPicker.module.css';
 
@@ -23,27 +24,40 @@ export interface ChromeColorPickerProps {
 }
 
 export function ChromeColorPicker({ value, onChange }: ChromeColorPickerProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const { handleNavigationKey } = useListNavigation(listRef, '[role="radio"]', {
+    axis: 'horizontal',
+    rovingTabIndex: true,
+  });
+
   return (
     <Flex
+      ref={listRef}
       align="center"
       gap="1"
       role="radiogroup"
       aria-label={getMessage('colorPickerLabel')}
       style={{ flexShrink: 0 }}
     >
-      {CHROME_COLORS.map((color) => (
-        <Tooltip key={color} content={getMessage(`color_${color}`)}>
-          <button
-            type="button"
-            role="radio"
-            aria-checked={value === color}
-            aria-label={getMessage(`color_${color}`)}
-            onClick={() => onChange(color)}
-            className={`${styles.swatch} ${value === color ? styles.swatchActive : ''}`}
-            style={{ backgroundColor: chromeGroupColors[color] }}
-          />
-        </Tooltip>
-      ))}
+      {CHROME_COLORS.map((color, index) => {
+        const isSelected = value === color;
+        return (
+          <Tooltip key={color} content={getMessage(`color_${color}`)}>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={getMessage(`color_${color}`)}
+              tabIndex={isSelected ? 0 : -1}
+              onClick={() => onChange(color)}
+              onFocus={() => onChange(color)}
+              onKeyDown={(e) => handleNavigationKey(e, index)}
+              className={`${styles.swatch} ${isSelected ? styles.swatchActive : ''}`}
+              style={{ backgroundColor: chromeGroupColors[color] }}
+            />
+          </Tooltip>
+        );
+      })}
     </Flex>
   );
 }

--- a/src/utils/labelFromDomain.ts
+++ b/src/utils/labelFromDomain.ts
@@ -1,0 +1,31 @@
+const COMMON_SUBDOMAINS = new Set(['www', 'mail', 'app', 'm', 'web', 'api', 'static', 'cdn']);
+
+const SECOND_LEVEL_PUBLIC_SUFFIXES = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac']);
+
+const REGEX_SPECIAL_CHARS = /[*+?^${}()|[\]\\]/;
+
+export function deriveLabelFromDomain(domain: string): string {
+  const trimmed = domain.trim();
+  if (!trimmed) return '';
+  if (trimmed.toLowerCase() === 'localhost') return 'Localhost';
+  if (REGEX_SPECIAL_CHARS.test(trimmed)) return '';
+
+  const parts = trimmed.toLowerCase().split('.').filter(Boolean);
+  if (parts.length === 0) return '';
+
+  while (parts.length > 2 && COMMON_SUBDOMAINS.has(parts[0])) {
+    parts.shift();
+  }
+
+  let sld: string;
+  if (parts.length >= 3 && SECOND_LEVEL_PUBLIC_SUFFIXES.has(parts[parts.length - 2])) {
+    sld = parts[parts.length - 3];
+  } else if (parts.length >= 2) {
+    sld = parts[parts.length - 2];
+  } else {
+    sld = parts[0];
+  }
+
+  if (!sld) return '';
+  return sld.charAt(0).toUpperCase() + sld.slice(1);
+}

--- a/tests/e2e/dialog-initial-focus.spec.ts
+++ b/tests/e2e/dialog-initial-focus.spec.ts
@@ -34,7 +34,7 @@ test.describe('[US-A11Y001] Rule creation wizard', () => {
     await helpers.clearDomainRules();
   });
 
-  test('opening the wizard focuses the label input, not the close button', async ({
+  test('opening the wizard focuses the domain input, not the close button', async ({
     extensionContext,
     extensionId,
   }) => {
@@ -44,8 +44,8 @@ test.describe('[US-A11Y001] Rule creation wizard', () => {
     await page.getByTestId('page-rules-btn-add').click();
     await page.getByTestId('wizard-rule').waitFor({ state: 'visible' });
 
-    // Label input must have focus
-    await expect(page.getByTestId('wizard-rule-field-label')).toBeFocused();
+    // Domain filter input must have focus (label is auto-derived from it).
+    await expect(page.getByTestId('wizard-rule-field-domain')).toBeFocused();
     // Close button must NOT have focus
     expect(await isCloseFocused(page)).toBe(false);
 

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -83,6 +83,52 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     await page.close();
   });
 
+  test('step 1 — category radiogroup is visible and selection persists across steps', async ({
+    extensionContext, extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    const wizard = await openCreateWizard(page, extensionId);
+
+    await expect(wizard.categoryField()).toBeVisible();
+    await wizard.selectCategory('Development');
+    const developmentRadio = wizard.categoryField().getByTestId('wizard-rule-category-development');
+    await expect(developmentRadio).toHaveAttribute('aria-checked', 'true');
+
+    await wizard.fillLabel('Cat Rule');
+    await wizard.fillDomainFilter('catrule.com');
+    await wizard.clickNext();
+    await wizard.expectOnStep(2);
+
+    await wizard.clickBack();
+    await expect(wizard.categoryField().getByTestId('wizard-rule-category-development'))
+      .toHaveAttribute('aria-checked', 'true');
+    await page.close();
+  });
+
+  test('step 1 — category radiogroup supports arrow-key navigation', async ({
+    extensionContext, extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    const wizard = await openCreateWizard(page, extensionId);
+
+    const noneSwatch = wizard.categoryField().getByTestId('wizard-rule-category-none');
+    await noneSwatch.focus();
+    await expect(noneSwatch).toBeFocused();
+    await expect(noneSwatch).toHaveAttribute('aria-checked', 'true');
+
+    // Selection-follows-focus: ArrowRight selects the next swatch (the first
+    // built-in category by registry order).
+    await page.keyboard.press('ArrowRight');
+    const checkedAfterArrow = wizard.categoryField().getByRole('radio', { checked: true });
+    await expect(checkedAfterArrow).not.toHaveAttribute('data-testid', 'wizard-rule-category-none');
+
+    // Home key cycles back to the first swatch (None).
+    await page.keyboard.press('Home');
+    await expect(noneSwatch).toBeFocused();
+    await expect(noneSwatch).toHaveAttribute('aria-checked', 'true');
+    await page.close();
+  });
+
   test('step 1 — Next is blocked when domainFilter is invalid', async ({
     extensionContext, extensionId,
   }) => {

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -52,17 +52,34 @@ test.describe('Creation wizard — Step 1: Identity', () => {
     await page.close();
   });
 
-  test('step 1 — Next is blocked when label is empty', async ({
+  test('step 1 — Next is blocked when fields are empty', async ({
     extensionContext, extensionId,
   }) => {
     const page = await extensionContext.newPage();
     const wizard = await openCreateWizard(page, extensionId);
 
-    await wizard.fillDomainFilter('test.com');
+    // Click Next without filling anything: label is empty (and so is the
+    // auto-derived value from an empty domain), so validation must block.
     await wizard.clickNext();
 
     // Still on step 1.
     await expect(wizard.labelInput()).toBeVisible();
+    await page.close();
+  });
+
+  test('step 1 — label is auto-derived from the domain filter', async ({
+    extensionContext, extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    const wizard = await openCreateWizard(page, extensionId);
+
+    await wizard.fillDomainFilter('mail.google.com');
+    await expect(wizard.labelInput()).toHaveValue('Google');
+
+    // Once the user owns the label, further domain edits do not overwrite it.
+    await wizard.fillLabel('Custom Label');
+    await wizard.fillDomainFilter('atlassian.net');
+    await expect(wizard.labelInput()).toHaveValue('Custom Label');
     await page.close();
   });
 

--- a/tests/utils/labelFromDomain.test.ts
+++ b/tests/utils/labelFromDomain.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { deriveLabelFromDomain } from '../../src/utils/labelFromDomain';
+
+describe('deriveLabelFromDomain', () => {
+  it('returns empty string for empty input', () => {
+    expect(deriveLabelFromDomain('')).toBe('');
+    expect(deriveLabelFromDomain('   ')).toBe('');
+  });
+
+  it('handles localhost as a special case', () => {
+    expect(deriveLabelFromDomain('localhost')).toBe('Localhost');
+    expect(deriveLabelFromDomain('LOCALHOST')).toBe('Localhost');
+  });
+
+  it('extracts the SLD from a simple 2-part domain', () => {
+    expect(deriveLabelFromDomain('atlassian.net')).toBe('Atlassian');
+    expect(deriveLabelFromDomain('example.com')).toBe('Example');
+  });
+
+  it('strips common subdomains', () => {
+    expect(deriveLabelFromDomain('mail.google.com')).toBe('Google');
+    expect(deriveLabelFromDomain('www.example.com')).toBe('Example');
+    expect(deriveLabelFromDomain('app.figma.com')).toBe('Figma');
+    expect(deriveLabelFromDomain('api.github.com')).toBe('Github');
+  });
+
+  it('keeps custom subdomains and uses the next-to-last segment', () => {
+    expect(deriveLabelFromDomain('sub.atlassian.net')).toBe('Atlassian');
+    expect(deriveLabelFromDomain('news.ycombinator.com')).toBe('Ycombinator');
+  });
+
+  it('handles compound public suffixes', () => {
+    expect(deriveLabelFromDomain('example.co.uk')).toBe('Example');
+    expect(deriveLabelFromDomain('site.com.br')).toBe('Site');
+    expect(deriveLabelFromDomain('shop.example.co.uk')).toBe('Example');
+  });
+
+  it('returns empty string for filters that look like regexes', () => {
+    expect(deriveLabelFromDomain('*.foo.com')).toBe('');
+    expect(deriveLabelFromDomain('foo\\.bar\\.com')).toBe('');
+    expect(deriveLabelFromDomain('(foo|bar)\\.com')).toBe('');
+    expect(deriveLabelFromDomain('foo[1-9].com')).toBe('');
+  });
+
+  it('handles deeply nested subdomains', () => {
+    expect(deriveLabelFromDomain('a.b.c.d.com')).toBe('D');
+  });
+
+  it('falls back to the only segment when there is just one part', () => {
+    expect(deriveLabelFromDomain('intranet')).toBe('Intranet');
+  });
+});


### PR DESCRIPTION
Add automatic label derivation from the domain filter and wire it into the identity modals. Introduces a new utility deriveLabelFromDomain (with unit tests) that extracts a friendly label from a domain string and guards against regex-like filters and common subdomains. IdentityEditModal: track whether the user has edited the label (so autofill stops once user owns it), move the domain field next to the label, and update handlers to autofill the label when appropriate. WizardStep1Identity: watch domainFilter and populate label via setValue unless the label was manually edited; simplify form layout. RuleWizardModal: focus the domainFilter input on open and pass setValue to the wizard step. Tests added for deriveLabelFromDomain to cover various domain forms and edge cases.