### PR TITLE
Shrink inline category swatches to match color picker scale

### DIFF
--- a/src/components/Core/DomainRule/CategoryPicker.module.css
+++ b/src/components/Core/DomainRule/CategoryPicker.module.css
@@ -38,8 +38,8 @@
 }
 
 .swatch {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   border: 2px solid transparent;
   background-color: var(--gray-a3);
@@ -49,7 +49,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
   transition: transform 0.1s ease, border-color 0.1s ease;
   position: relative;

--- a/src/components/Core/DomainRule/CategoryPicker.module.css
+++ b/src/components/Core/DomainRule/CategoryPicker.module.css
@@ -38,8 +38,8 @@
 }
 
 .swatch {
-  width: 32px;
-  height: 32px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   border: 2px solid transparent;
   background-color: var(--gray-a3);
@@ -49,7 +49,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1;
   transition: transform 0.1s ease, border-color 0.1s ease;
   position: relative;

--- a/src/components/Core/DomainRule/CategoryRadioGroup.stories.tsx
+++ b/src/components/Core/DomainRule/CategoryRadioGroup.stories.tsx
@@ -39,7 +39,7 @@ export const CategoryRadioGroupNoneSelected: Story = {
 export const CategoryRadioGroupNarrowContainer: Story = {
   decorators: [
     (Story) => (
-      <Box style={{ width: 320, padding: 'var(--space-3)' }}>
+      <Box style={{ width: 380, padding: 'var(--space-3)' }}>
         <Story />
       </Box>
     ),

--- a/src/components/Core/DomainRule/CategoryRadioGroup.tsx
+++ b/src/components/Core/DomainRule/CategoryRadioGroup.tsx
@@ -33,7 +33,7 @@ export function CategoryRadioGroup({
   const categories = settings?.categories ?? [];
   const listRef = useRef<HTMLDivElement>(null);
   const { handleNavigationKey } = useListNavigation(listRef, '[role="radio"]', {
-    axis: 'both',
+    axis: 'horizontal',
     rovingTabIndex: true,
   });
 
@@ -56,11 +56,11 @@ export function CategoryRadioGroup({
     <Flex
       ref={listRef}
       align="center"
-      gap="2"
-      wrap="wrap"
+      gap="1"
       role="radiogroup"
       aria-label={groupLabel}
       data-testid={dataTestId}
+      style={{ flexShrink: 0 }}
     >
       {options.map((option, index) => {
         const isSelected = (option.id ?? null) === (value ?? null);


### PR DESCRIPTION
The category radiogroup, recently promoted to an inline row in step 1
of the rule wizard and in the identity edit modal, used 32px swatches
with wrap. With 15 options this needed ~592px and forced wrapping in
narrow contexts. Resize to 20px swatches / 14px emoji, drop the wrap,
add flexShrink: 0 and switch arrow navigation to horizontal so the row
mirrors the ChromeColorPicker rendered just below.