### PR TITLE
Fix preset selection UX on RuleWizard step 2

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -196,6 +196,7 @@
   "errorSessionNameUnique": { "message": "Session name must be unique." },
   "loadingText": { "message": "Loading..." },
   "errorZodRequired": { "message": "This field is required" },
+  "errorPresetRequired": { "message": "Please select a preset to continue" },
   "errorZodMaxLength": { "message": "Must not exceed 100 characters" },
   "errorZodInvalid": { "message": "Invalid value" },
   "errorZodInvalidValue": { "message": "Invalid option selected" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -196,6 +196,7 @@
   "errorSessionNameUnique": { "message": "El nombre de la sesión debe ser único." },
   "loadingText": { "message": "Cargando..." },
   "errorZodRequired": { "message": "Este campo es requerido" },
+  "errorPresetRequired": { "message": "Por favor seleccione un preset para continuar" },
   "errorZodMaxLength": { "message": "No debe exceder 100 caracteres" },
   "errorZodInvalid": { "message": "Valor inválido" },
   "errorZodInvalidValue": { "message": "Opción seleccionada inválida" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -196,6 +196,7 @@
   "errorSessionNameUnique": { "message": "Le nom de la session doit être unique." },
   "loadingText": { "message": "Chargement..." },
   "errorZodRequired": { "message": "Ce champ est requis" },
+  "errorPresetRequired": { "message": "Veuillez choisir un preset pour continuer" },
   "errorZodMaxLength": { "message": "Ne doit pas dépasser 100 caractères" },
   "errorZodInvalid": { "message": "Valeur invalide" },
   "errorZodInvalidValue": { "message": "Option sélectionnée invalide" },

--- a/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
@@ -155,11 +155,15 @@ export const RuleWizardModalStep2: Story = {
 };
 
 // Reaches step 3 (options) by navigating through steps 1 and 2.
+// Switches to "ask" mode on step 2 to avoid the preset-required gating
+// (no preset list is loaded in jsdom, and ask mode has no further required fields).
 export const RuleWizardModalStep3: Story = {
   args: { isOpen: true, domainRule: undefined },
   play: async (context) => {
     await RuleWizardModalStep2.play?.(context);
     const body = within(context.canvasElement.ownerDocument.body);
+    const askRadio = body.getByTestId('config-mode-ask');
+    await userEvent.click(askRadio);
     const nextBtn = body.getByTestId('wizard-rule-btn-next');
     await userEvent.click(nextBtn);
   },
@@ -184,6 +188,21 @@ export const RuleWizardModalCreateComplete: Story = {
     const body = within(context.canvasElement.ownerDocument.body);
     const createBtn = body.getByTestId('wizard-rule-btn-create');
     await userEvent.click(createBtn);
+  },
+};
+
+// On step 2 in preset mode, the Next button is aria-disabled until a preset
+// is selected, and clicking it (e.g. via keyboard) does not advance the wizard.
+export const RuleWizardModalStep2PresetRequired: Story = {
+  args: { isOpen: true, domainRule: undefined },
+  play: async (context) => {
+    await RuleWizardModalStep2.play?.(context);
+    const body = within(context.canvasElement.ownerDocument.body);
+    const nextBtn = body.getByTestId('wizard-rule-btn-next');
+    await expect(nextBtn).toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(nextBtn);
+    // Still on step 2 — the gating short-circuited handleNext.
+    await expect(body.getByTestId('wizard-rule-step-2')).toBeInTheDocument();
   },
 };
 

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { getMessage } from '@/utils/i18n';
 import { WizardModal } from '@/components/UI/WizardModal';
 import { WizardStepper } from '@/components/UI/WizardStepper/WizardStepper';
+import { AriaButton } from '@/components/UI/AriaButton/AriaButton';
 import { WizardStep1Identity } from './WizardStep1Identity';
 import { WizardStep2Config } from './WizardStep2Config';
 import { WizardStep3Options } from './WizardStep3Options';
@@ -338,8 +339,15 @@ export function RuleWizardModal({
     return [];
   };
 
+  const isPresetSelectionMissing =
+    step === 1 && configMode === 'preset' && !watchedPresetId;
+
   const handleNext = async () => {
     setStepError(null);
+    if (isPresetSelectionMissing) {
+      setStepError(getMessage('errorPresetRequired'));
+      return;
+    }
     const fieldsToValidate = computeFieldsToValidate();
     const valid = fieldsToValidate.length === 0 || await trigger(fieldsToValidate);
     if (!valid) return;
@@ -579,7 +587,15 @@ export function RuleWizardModal({
                 </Button>
               )}
               {step < 3 && (
-                <Button data-testid="wizard-rule-btn-next" type="button" onClick={handleNext}>{getMessage('next')}</Button>
+                <AriaButton
+                  data-testid="wizard-rule-btn-next"
+                  type="button"
+                  onClick={handleNext}
+                  ariaDisabled={isPresetSelectionMissing}
+                  disabledReason={isPresetSelectionMissing ? getMessage('errorPresetRequired') : undefined}
+                >
+                  {getMessage('next')}
+                </AriaButton>
               )}
               {step === 3 && (
                 <Button data-testid="wizard-rule-btn-create" type="submit">{getMessage('create')}</Button>

--- a/src/components/Form/FormFields/SearchableInlineList.tsx
+++ b/src/components/Form/FormFields/SearchableInlineList.tsx
@@ -42,6 +42,7 @@ export function SearchableInlineList({
   'aria-labelledby': ariaLabelledBy,
 }: SearchableInlineListProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const listboxId = useId();
 
   // cmdk's Command.Input overrides the `id` prop with its internal useId,
@@ -56,6 +57,18 @@ export function SearchableInlineList({
     return () => clearTimeout(t);
   }, [autoFocus]);
 
+  // Center the pre-selected item on mount so the user does not have to scroll
+  // to find it (e.g. edit-mode dialogs reopening on a saved value).
+  useEffect(() => {
+    if (!value) return;
+    const t = setTimeout(() => {
+      const selected = containerRef.current?.querySelector<HTMLElement>('.ss-item--selected');
+      selected?.scrollIntoView({ block: 'center', behavior: 'auto' });
+    }, 0);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const renderItem = (option: SearchableSelectOption) => (
     <SearchableSelectItem
       key={option.value}
@@ -67,6 +80,7 @@ export function SearchableInlineList({
 
   return (
     <div
+      ref={containerRef}
       className={['ss-inline', className].filter(Boolean).join(' ')}
       aria-label={ariaLabelledBy ? undefined : ariaLabel}
       aria-labelledby={ariaLabelledBy}

--- a/src/components/Form/FormFields/SearchableSelect.css
+++ b/src/components/Form/FormFields/SearchableSelect.css
@@ -176,13 +176,14 @@
 }
 
 .ss-item--selected {
-  background: var(--accent-a3);
+  background: var(--accent-a5);
   color: var(--accent-11);
   font-weight: 500;
+  box-shadow: inset 3px 0 0 var(--accent-9);
 }
 
 .ss-item--selected[aria-selected='true'] {
-  background: var(--accent-a4);
+  background: var(--accent-a6);
 }
 
 .ss-item--disabled {

--- a/tests/components/RuleWizardModal.stories.test.tsx
+++ b/tests/components/RuleWizardModal.stories.test.tsx
@@ -10,6 +10,7 @@ const {
   RuleWizardModalEditDeduplicationDisabled,
   RuleWizardModalClosed,
   RuleWizardModalStep2,
+  RuleWizardModalStep2PresetRequired,
   RuleWizardModalStep3,
   RuleWizardModalStep4,
   RuleWizardModalCreateComplete,
@@ -61,6 +62,13 @@ describe('RuleWizardModal — step navigation', () => {
     await RuleWizardModalStep3.run();
 
     expect(screen.getByTestId('wizard-rule-step-3')).toBeInTheDocument();
+  });
+
+  it('blocks step 2 → step 3 in preset mode until a preset is selected', async () => {
+    await RuleWizardModalStep2PresetRequired.run();
+
+    expect(screen.getByTestId('wizard-rule-step-2')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-rule-btn-next')).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('reaches step 4 (summary) after navigating through all previous steps', async () => {

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -252,6 +252,8 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
 test.describe('Creation wizard — Step 3: Options', () => {
   async function advanceToStep3(wizard: RuleWizardPage): Promise<void> {
     await advanceToStep2(wizard);
+    // Switch to Ask mode so step 2 does not require a preset selection.
+    await wizard.selectConfigMode('ask');
     await wizard.clickNext();
     await wizard.deduplicationSwitch().waitFor({ state: 'visible' });
   }
@@ -312,6 +314,8 @@ test.describe('Creation wizard — Step 3: Options', () => {
 test.describe('Creation wizard — Step 4: Summary', () => {
   async function advanceToStep4(wizard: RuleWizardPage): Promise<void> {
     await advanceToStep2(wizard);
+    // Switch to Ask mode so step 2 does not require a preset selection.
+    await wizard.selectConfigMode('ask');
     await wizard.clickNext(); // step 3
     await wizard.deduplicationSwitch().waitFor({ state: 'visible' });
     await wizard.clickNext(); // step 4


### PR DESCRIPTION
- Block Next button (aria-disabled + tooltip + handleNext guard) when
  preset mode has no preset selected; the schema declared presetId as
  nullable so validation silently passed before.
- Strengthen the selected-item highlight in SearchableInlineList with a
  stronger accent background and a 3px inset shadow on the leading edge.
- Auto-scroll the pre-selected item into view on SearchableInlineList
  mount so edit-mode users do not have to scroll to find the active
  preset.
- Add errorPresetRequired key (en/fr/es) and a story covering the
  preset-required gating.

https://claude.ai/code/session_013KPjupZ8UrTghgDmsC8J5h