### PR TITLE
Preload lazy pages on sidebar hover/focus

### DIFF
--- a/src/components/UI/Sidebar/Sidebar.tsx
+++ b/src/components/UI/Sidebar/Sidebar.tsx
@@ -29,6 +29,7 @@ interface SidebarProps {
   onToggleCollapse?: () => void;
   activeItem?: string;
   onItemClick?: (itemId: string) => void;
+  onItemPreload?: (itemId: string) => void;
   sections: SidebarSection[];
   showFooter?: boolean;
   footerContent?: React.ReactNode;
@@ -50,6 +51,7 @@ export function Sidebar({
   onToggleCollapse,
   activeItem,
   onItemClick,
+  onItemPreload,
   sections,
   showFooter = false,
   footerContent,
@@ -111,6 +113,7 @@ export function Sidebar({
           isCollapsed={isCollapsed}
           activeItem={activeItem}
           onItemClick={onItemClick}
+          onItemPreload={onItemPreload}
           sections={sections}
         />
         

--- a/src/components/UI/Sidebar/SidebarContent.tsx
+++ b/src/components/UI/Sidebar/SidebarContent.tsx
@@ -6,6 +6,7 @@ interface SidebarContentProps {
   isCollapsed?: boolean;
   activeItem?: string;
   onItemClick?: (itemId: string) => void;
+  onItemPreload?: (itemId: string) => void;
   sections: SidebarSection[];
 }
 
@@ -13,6 +14,7 @@ export function SidebarContent({
   isCollapsed = false,
   activeItem,
   onItemClick,
+  onItemPreload,
   sections
 }: SidebarContentProps) {
   return (
@@ -26,6 +28,7 @@ export function SidebarContent({
           isCollapsed={isCollapsed}
           activeItem={activeItem}
           onItemClick={onItemClick}
+          onItemPreload={onItemPreload}
           sections={sections}
         />
       </Box>

--- a/src/components/UI/Sidebar/SidebarItems.tsx
+++ b/src/components/UI/Sidebar/SidebarItems.tsx
@@ -10,6 +10,7 @@ interface SidebarItemsProps {
   isCollapsed?: boolean;
   activeItem?: string;
   onItemClick?: (itemId: string) => void;
+  onItemPreload?: (itemId: string) => void;
   sections: SidebarSection[];
 }
 
@@ -144,6 +145,7 @@ export function SidebarItems({
   isCollapsed = false,
   activeItem,
   onItemClick,
+  onItemPreload,
   sections
 }: SidebarItemsProps) {
   const listRef = useRef<HTMLDivElement>(null);
@@ -217,7 +219,11 @@ export function SidebarItems({
                     variant="ghost"
                     size="3"
                     onClick={() => handleItemClick(item.id, item.onClick)}
-                    onFocus={() => setFocusIndex(itemIndex)}
+                    onMouseEnter={() => onItemPreload?.(item.id)}
+                    onFocus={() => {
+                      setFocusIndex(itemIndex);
+                      onItemPreload?.(item.id);
+                    }}
                     onKeyDown={(e) => handleNavigationKey(e, itemIndex)}
                     tabIndex={itemIndex === focusIndex ? 0 : -1}
                     aria-label={isCollapsed ? item.label : undefined}

--- a/src/contexts/ImportExportWizardsContext.tsx
+++ b/src/contexts/ImportExportWizardsContext.tsx
@@ -1,30 +1,31 @@
-import React, { createContext, lazy, Suspense, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, Suspense, useCallback, useContext, useMemo, useState } from 'react';
 import { useSettings } from '@/hooks/useSettings.js';
+import { lazyWithTiming } from '@/utils/lazyWithTiming.js';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 import type { SourceMode } from '@/components/UI/ImportExportWizards/Source';
 
-const ImportWizard = lazy(() =>
+const ImportWizard = lazyWithTiming('ImportWizard', () =>
   import('@/components/UI/ImportExportWizards/ImportWizard').then((m) => ({ default: m.ImportWizard })),
 );
-const ExportWizard = lazy(() =>
+const ExportWizard = lazyWithTiming('ExportWizard', () =>
   import('@/components/UI/ImportExportWizards/ExportWizard').then((m) => ({ default: m.ExportWizard })),
 );
-const ImportSessionsWizard = lazy(() =>
+const ImportSessionsWizard = lazyWithTiming('ImportSessionsWizard', () =>
   import('@/components/UI/ImportExportWizards/ImportSessionsWizard').then((m) => ({
     default: m.ImportSessionsWizard,
   })),
 );
-const ExportSessionsWizard = lazy(() =>
+const ExportSessionsWizard = lazyWithTiming('ExportSessionsWizard', () =>
   import('@/components/UI/ImportExportWizards/ExportSessionsWizard').then((m) => ({
     default: m.ExportSessionsWizard,
   })),
 );
-const ImportWorkspaceDialog = lazy(() =>
+const ImportWorkspaceDialog = lazyWithTiming('ImportWorkspaceDialog', () =>
   import('@/components/UI/Workspace/ImportWorkspaceDialog').then((m) => ({
     default: m.ImportWorkspaceDialog,
   })),
 );
-const ExportWorkspaceDialog = lazy(() =>
+const ExportWorkspaceDialog = lazyWithTiming('ExportWorkspaceDialog', () =>
   import('@/components/UI/Workspace/ExportWorkspaceDialog').then((m) => ({
     default: m.ExportWorkspaceDialog,
   })),

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -1,5 +1,5 @@
 // options/options.ts
-import React, { lazy, Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Flex, Spinner, Text, Theme } from '@radix-ui/themes';
@@ -28,23 +28,25 @@ import { HomePage } from './HomePage';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { Home, Shield, FileText, BarChart3, Settings, Archive, Layers } from 'lucide-react';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
+import { lazyWithTiming } from '@/utils/lazyWithTiming.js';
+import { preloadPage } from './pagePreloaders.js';
 
-const DomainRulesPage = lazy(() =>
+const DomainRulesPage = lazyWithTiming('DomainRulesPage', () =>
     import('./DomainRulesPage').then((m) => ({ default: m.DomainRulesPage })),
 );
-const SessionsPage = lazy(() =>
+const SessionsPage = lazyWithTiming('SessionsPage', () =>
     import('./SessionsPage').then((m) => ({ default: m.SessionsPage })),
 );
-const ImportExportPage = lazy(() =>
+const ImportExportPage = lazyWithTiming('ImportExportPage', () =>
     import('./ImportExportPage').then((m) => ({ default: m.ImportExportPage })),
 );
-const StatisticsPage = lazy(() =>
+const StatisticsPage = lazyWithTiming('StatisticsPage', () =>
     import('./StatisticsPage').then((m) => ({ default: m.StatisticsPage })),
 );
-const SettingsPage = lazy(() =>
+const SettingsPage = lazyWithTiming('SettingsPage', () =>
     import('@/components/UI/SettingsPage/SettingsPage').then((m) => ({ default: m.SettingsPage })),
 );
-const WorkspacesPage = lazy(() =>
+const WorkspacesPage = lazyWithTiming('WorkspacesPage', () =>
     import('./WorkspacesPage').then((m) => ({ default: m.WorkspacesPage })),
 );
 import type { Session } from '@/types/session';
@@ -188,6 +190,7 @@ export function OptionsContent() {
                 onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
                 activeItem={currentTab}
                 onItemClick={handleTabChange}
+                onItemPreload={preloadPage}
                 sections={sidebarSections}
                 headerContent={<OptionsHeader />}
                 headerCollapsedContent={<OptionsHeaderCollapsed />}

--- a/src/pages/pagePreloaders.ts
+++ b/src/pages/pagePreloaders.ts
@@ -1,0 +1,29 @@
+import { logger } from '@/utils/logger.js';
+
+type PagePreloader = () => Promise<unknown>;
+
+export const pagePreloaders: Record<string, PagePreloader> = {
+  rules: () => import('./DomainRulesPage'),
+  sessions: () => import('./SessionsPage'),
+  importexport: () => import('./ImportExportPage'),
+  stats: () => import('./StatisticsPage'),
+  settings: () => import('@/components/UI/SettingsPage/SettingsPage'),
+  workspaces: () => import('./WorkspacesPage'),
+};
+
+const triggered = new Set<string>();
+
+export function preloadPage(id: string): void {
+  if (triggered.has(id)) return;
+  const loader = pagePreloaders[id];
+  if (!loader) return;
+  triggered.add(id);
+  const t0 = performance.now();
+  loader().then(
+    () => logger.debug(`[PRELOAD] ${id} fetched in ${Math.round(performance.now() - t0)}ms`),
+    (err) => {
+      triggered.delete(id);
+      logger.warn(`[PRELOAD] ${id} failed`, err);
+    },
+  );
+}

--- a/src/utils/lazyWithTiming.ts
+++ b/src/utils/lazyWithTiming.ts
@@ -1,0 +1,21 @@
+import { lazy, type ComponentType } from 'react';
+import { logger } from './logger.js';
+
+// Mirrors React's own `lazy` signature, which uses `any` to allow any
+// component shape to flow through unchanged.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = ComponentType<any>;
+
+export function lazyWithTiming<T extends AnyComponent>(
+  name: string,
+  factory: () => Promise<{ default: T }>,
+) {
+  return lazy(() => {
+    const t0 = performance.now();
+    return factory().then((mod) => {
+      const ms = Math.round(performance.now() - t0);
+      logger.debug(`[LAZY] ${name} loaded in ${ms}ms`);
+      return mod;
+    });
+  });
+}


### PR DESCRIPTION
The 1-2s delay on first sidebar click was the cost of fetching, parsing
and evaluating the lazy page chunk (DomainRulesPage 89kB, SessionsPage
+ SessionCard + shared HoverCard chunk reach ~300kB cumulatively).

Trigger the dynamic import on mouseenter and focus so the chunk is
warming up during the typical hover-to-click window. Add a lightweight
lazyWithTiming helper that logs fetch+parse duration via logger.debug
(no-op in production) so future regressions are easy to spot.