### PR TITLE
Add Refresh button to update saved sessions in place

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -351,6 +351,7 @@
   "sessionGroupOne": { "message": "1 group" },
   "sessionGroupCount": { "message": "$1 groups" },
   "sessionRestore": { "message": "Restore" },
+  "sessionRefresh": { "message": "Refresh" },
   "sessionRename": { "message": "Rename" },
   "sessionRenameLabel": { "message": "Session name" },
   "sessionConfirmRename": { "message": "Confirm rename" },
@@ -386,6 +387,12 @@
   "snapshotDefaultName": { "message": "Snapshot" },
   "snapshotSaveButton": { "message": "Save Session" },
   "snapshotActiveGroupCallout": { "message": "Selection limited to the active group. You can extend it before saving." },
+
+  "refreshTitle": { "message": "Refresh Session" },
+  "refreshDescription": { "message": "Capture the current tabs and overwrite this saved session. Title, note and category are preserved." },
+  "refreshSaveButton": { "message": "Update Session" },
+  "refreshNotificationTitle": { "message": "Session Updated" },
+  "refreshNotificationMessage": { "message": "\"$1\" has been updated" },
 
   "restoreTitle": { "message": "Restore \"$1\"" },
   "restoreStepSelectionDescription": { "message": "Select the tabs to restore and their destination." },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -351,6 +351,7 @@
   "sessionGroupOne": { "message": "1 grupo" },
   "sessionGroupCount": { "message": "$1 grupos" },
   "sessionRestore": { "message": "Restaurar" },
+  "sessionRefresh": { "message": "Actualizar" },
   "sessionRename": { "message": "Renombrar" },
   "sessionRenameLabel": { "message": "Nombre de la sesión" },
   "sessionConfirmRename": { "message": "Confirmar cambio de nombre" },
@@ -386,6 +387,12 @@
   "snapshotDefaultName": { "message": "Instantánea" },
   "snapshotSaveButton": { "message": "Guardar sesión" },
   "snapshotActiveGroupCallout": { "message": "Selección limitada al grupo activo. Puedes ampliarla antes de guardar." },
+
+  "refreshTitle": { "message": "Actualizar sesión" },
+  "refreshDescription": { "message": "Captura las pestañas actuales y sobrescribe la sesión guardada. El título, la nota y la categoría se conservan." },
+  "refreshSaveButton": { "message": "Actualizar sesión" },
+  "refreshNotificationTitle": { "message": "Sesión actualizada" },
+  "refreshNotificationMessage": { "message": "\"$1\" ha sido actualizada" },
 
   "restoreTitle": { "message": "Restaurar \"$1\"" },
   "restoreStepSelectionDescription": { "message": "Seleccione las pestañas a restaurar y su destino." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -351,6 +351,7 @@
   "sessionGroupOne": { "message": "1 groupe" },
   "sessionGroupCount": { "message": "$1 groupes" },
   "sessionRestore": { "message": "Restaurer" },
+  "sessionRefresh": { "message": "Rafraîchir" },
   "sessionRename": { "message": "Renommer" },
   "sessionRenameLabel": { "message": "Nom de la session" },
   "sessionConfirmRename": { "message": "Confirmer le renommage" },
@@ -386,6 +387,12 @@
   "snapshotDefaultName": { "message": "Instantané" },
   "snapshotSaveButton": { "message": "Sauvegarder la session" },
   "snapshotActiveGroupCallout": { "message": "Sélection restreinte au groupe actif. Vous pouvez l'étendre avant de sauvegarder." },
+
+  "refreshTitle": { "message": "Mettre à jour la session" },
+  "refreshDescription": { "message": "Capture les onglets actuels et écrase la session sauvegardée. Le titre, la note et la catégorie sont conservés." },
+  "refreshSaveButton": { "message": "Mettre à jour" },
+  "refreshNotificationTitle": { "message": "Session mise à jour" },
+  "refreshNotificationMessage": { "message": "« $1 » a été mis à jour" },
 
   "restoreTitle": { "message": "Restaurer « $1 »" },
   "restoreStepSelectionDescription": { "message": "Sélectionnez les onglets à restaurer et leur destination." },

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -81,6 +81,7 @@ interface SessionRestoreCallbacks {
   onRestoreCurrentWindow?: (session: Session) => void;
   onRestoreNewWindow?: (session: Session) => void;
   onReplaceCurrentWindow?: (session: Session) => void;
+  onRefresh?: (session: Session) => void;
 }
 
 /* SessionMoreMenu */
@@ -319,7 +320,7 @@ function SessionCardFullHeader({
   handleRenameSubmit, handleRenameCancel, handleKeyDown,
   searchQuery, category, hoverCardContent,
   isSelected, onSelect,
-  onPin, onUnpin, onRestore, onRestoreCurrentWindow, onRestoreNewWindow, onReplaceCurrentWindow,
+  onPin, onUnpin, onRestore, onRestoreCurrentWindow, onRestoreNewWindow, onReplaceCurrentWindow, onRefresh,
   onEdit, onDelete, onMoveToFirst, onMoveLast,
 }: SessionCardFullHeaderProps) {
   return (
@@ -436,6 +437,7 @@ function SessionCardFullHeader({
           onRestoreNewWindow={onRestoreNewWindow}
           onReplaceCurrentWindow={onReplaceCurrentWindow}
           onCustomize={onRestore}
+          onRefresh={onRefresh}
           data-testid={`session-card-${session.id}-btn-restore`}
         />
       )}
@@ -470,6 +472,7 @@ export function SessionCard({
   onRestoreCurrentWindow,
   onRestoreNewWindow,
   onReplaceCurrentWindow,
+  onRefresh,
   onRename,
   onEdit,
   onDelete,
@@ -586,6 +589,7 @@ export function SessionCard({
               onRestoreCurrentWindow={onRestoreCurrentWindow}
               onRestoreNewWindow={onRestoreNewWindow}
               onReplaceCurrentWindow={onReplaceCurrentWindow}
+              onRefresh={onRefresh}
               onEdit={onEdit}
               onDelete={onDelete}
               onMoveToFirst={onMoveToFirst}

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.stories.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.stories.tsx
@@ -66,3 +66,19 @@ export const SessionRestoreButtonTile: Story = {
     size: '2',
   },
 };
+
+export const SessionRestoreButtonWithRefresh: Story = {
+  args: {
+    ...SessionRestoreButtonDefault.args,
+    onRefresh: noop,
+  },
+};
+
+export const SessionRestoreButtonTileWithRefresh: Story = {
+  args: {
+    ...SessionRestoreButtonDefault.args,
+    presentation: 'tile',
+    size: '2',
+    onRefresh: noop,
+  },
+};

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Flex } from '@radix-ui/themes';
-import { Monitor, Play, Replace, RotateCcw, Square, Wrench } from 'lucide-react';
+import { Flex, IconButton, Tooltip } from '@radix-ui/themes';
+import { Monitor, Play, Replace, RotateCcw, RotateCw, Square, Wrench } from 'lucide-react';
 import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
 import { getMessage } from '@/utils/i18n';
 import type { Session } from '@/types/session';
@@ -11,6 +11,8 @@ export interface SessionRestoreButtonProps {
   onRestoreNewWindow: (session: Session) => void;
   onReplaceCurrentWindow: (session: Session) => void;
   onCustomize: (session: Session) => void;
+  /** Optional: when provided, renders a Refresh icon button to the left of the restore split button. */
+  onRefresh?: (session: Session) => void;
   size?: '1' | '2' | '3';
   variant?: 'solid' | 'soft' | 'outline';
   presentation?: 'default' | 'tile';
@@ -23,6 +25,7 @@ export function SessionRestoreButton({
   onRestoreNewWindow,
   onReplaceCurrentWindow,
   onCustomize,
+  onRefresh,
   size = '1',
   variant = 'soft',
   presentation = 'default',
@@ -38,7 +41,7 @@ export function SessionRestoreButton({
     <Play size={12} fill="currentColor" />
   );
 
-  return (
+  const splitButton = (
     <SplitButton
       data-testid={testId}
       label={label}
@@ -78,5 +81,25 @@ export function SessionRestoreButton({
         },
       ]}
     />
+  );
+
+  if (!onRefresh) return splitButton;
+
+  return (
+    <Flex align="center" gap="1">
+      <Tooltip content={getMessage('sessionRefresh')}>
+        <IconButton
+          size={size}
+          variant={variant}
+          color="gray"
+          onClick={() => onRefresh(session)}
+          aria-label={getMessage('sessionRefresh')}
+          data-testid={testId ? `${testId}-refresh` : undefined}
+        >
+          <RotateCw size={isTile ? 14 : 12} aria-hidden="true" />
+        </IconButton>
+      </Tooltip>
+      {splitButton}
+    </Flex>
   );
 }

--- a/src/components/HomePage/PinnedSessionTile.tsx
+++ b/src/components/HomePage/PinnedSessionTile.tsx
@@ -57,6 +57,7 @@ export function PinnedSessionTile({
             onRestoreNewWindow={(s) => onRestore(s, 'new')}
             onReplaceCurrentWindow={(s) => onRestore(s, 'replace')}
             onCustomize={(s) => onRestore(s, 'custom')}
+            onRefresh={(s) => onRestore(s, 'refresh')}
             presentation="tile"
             size="2"
             data-testid={`home-pinned-tile-restore-${session.id}`}

--- a/src/components/HomePage/types.ts
+++ b/src/components/HomePage/types.ts
@@ -1,1 +1,1 @@
-export type HomeRestoreTarget = 'current' | 'new' | 'replace' | 'custom';
+export type HomeRestoreTarget = 'current' | 'new' | 'replace' | 'custom' | 'refresh';

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -8,6 +8,7 @@ import { getMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
 import { getFocusedSessionFromDOM } from '@/utils/sessionUtils';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
+import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { showSuccessNotification } from '@/utils/notifications';
 import { getRuleCategory } from '@/utils/categoriesStore';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
@@ -74,6 +75,14 @@ async function openSessionsPage(hashSuffix = '') {
 
 async function openCustomizeRestore(session: Session) {
   await openSessionsPage(`?action=restore&sessionId=${encodeURIComponent(session.id)}`);
+}
+
+async function openRefreshFromPopup(session: Session) {
+  const groupId = await getActiveTabGroupId();
+  const suffix = groupId !== null
+    ? `?action=refresh&sessionId=${encodeURIComponent(session.id)}&groupId=${groupId}`
+    : `?action=refresh&sessionId=${encodeURIComponent(session.id)}`;
+  await openSessionsPage(suffix);
 }
 
 export function PopupProfilesList() {
@@ -269,6 +278,7 @@ export function PopupProfilesList() {
                 onRestoreNewWindow={(s) => handleRestore(s, 'new')}
                 onReplaceCurrentWindow={(s) => handleRestore(s, 'replace')}
                 onCustomize={(s) => { void openCustomizeRestore(s); }}
+                onRefresh={(s) => { void openRefreshFromPopup(s); }}
                 data-testid={`popup-profile-btn-restore-${session.id}`}
               />
             </Flex>

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -4,7 +4,7 @@ import { browser } from 'wxt/browser';
 import { Camera, RotateCcw, Wand2 } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { loadSessions } from '@/utils/sessionStorage';
-import { hasCapturableTabs } from '@/utils/tabCapture';
+import { getActiveTabGroupId, hasCapturableTabs } from '@/utils/tabCapture';
 import { openOptionsWithHash } from '@/utils/openOptions';
 import { useSettings } from '@/hooks/useSettings';
 import styles from './PopupToolbar.module.css';
@@ -52,10 +52,7 @@ export function PopupToolbar(props: PopupToolbarProps = {}) {
       browser.tabs.query({ currentWindow: true }).then((tabs) => setTabCount(tabs.length));
     }
     if (props.activeTabGroupId === undefined) {
-      browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
-        const groupId = (tabs[0] as { groupId?: number } | undefined)?.groupId;
-        setActiveTabGroupId(typeof groupId === 'number' && groupId >= 0 ? groupId : null);
-      });
+      getActiveTabGroupId().then(setActiveTabGroupId);
     }
   }, [props.tabCount, props.hasSessions, props.canSave, props.activeTabGroupId]);
 

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -3,7 +3,7 @@ import {
   Dialog, Flex, Button, Text,
   TextArea, Callout,
 } from '@radix-ui/themes';
-import { Camera, AlertCircle, Info } from 'lucide-react';
+import { Camera, AlertCircle, Info, RotateCw } from 'lucide-react';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
 import { WizardModal } from '@/components/UI/WizardModal';
@@ -21,9 +21,18 @@ interface SnapshotWizardProps {
   existingSessions: Session[];
   /** Chrome numeric groupId: if set, pre-select only that group's tabs and use the group title as default name. */
   initialGroupId?: number;
+  /**
+   * When set, switches the wizard to "refresh mode": pre-fills name/note/category from this
+   * session, the uniqueness check excludes its id, and `onRefresh` is called instead of `onSave`
+   * with an updated Session object preserving id/createdAt/isPinned/position.
+   */
+  refreshSession?: Session;
+  /** Called on save in refresh mode. Receives the updated Session payload to persist via updateSession. */
+  onRefresh?: (session: Session) => Promise<void>;
 }
 
-export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, initialGroupId }: SnapshotWizardProps) {
+export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, initialGroupId, refreshSession, onRefresh }: SnapshotWizardProps) {
+  const isRefresh = refreshSession !== undefined;
   const [sessionName, setSessionName] = useState('');
   const [treeData, setTreeData] = useState<TabTreeData | null>(null);
   const [ungroupedTabs, setUngroupedTabs] = useState<SavedTab[]>([]);
@@ -43,14 +52,16 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
   useEffect(() => {
     if (!open) return;
     setSessionName(
-      `${getMessage('snapshotDefaultName')} ${formatSessionDate(new Date().toISOString())}`,
+      refreshSession
+        ? refreshSession.name
+        : `${getMessage('snapshotDefaultName')} ${formatSessionDate(new Date().toISOString())}`,
     );
     setTreeData(null);
     setSelectedTabIds(new Set());
     setSaveError(null);
     setIsCapturing(true);
-    setCategoryId(null);
-    setNote('');
+    setCategoryId(refreshSession?.categoryId ?? null);
+    setNote(refreshSession?.note ?? '');
     setCameFromActiveGroup(false);
 
     captureCurrentTabs()
@@ -70,7 +81,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
               if (groupTabUuids.has(uuid)) preSelected.add(numId);
             }
             setSelectedTabIds(preSelected);
-            if (targetGroup.title) {
+            if (!refreshSession && targetGroup.title) {
               setSessionName(targetGroup.title);
             }
             setCameFromActiveGroup(true);
@@ -86,7 +97,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
       .catch(() => {
         setIsCapturing(false);
       });
-  }, [open, initialGroupId]);
+  }, [open, initialGroupId, refreshSession]);
 
   const showGroupCallout =
     cameFromActiveGroup && selectedTabIds.size < numericIdToSavedTabId.size;
@@ -101,7 +112,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
     const trimmed = sessionName.trim();
     if (!trimmed) return;
     const isDuplicate = existingSessions.some(
-      s => s.name.toLowerCase() === trimmed.toLowerCase(),
+      s => s.id !== refreshSession?.id && s.name.toLowerCase() === trimmed.toLowerCase(),
     );
     if (isDuplicate) {
       setSaveError(getMessage('errorSessionNameUnique'));
@@ -117,27 +128,49 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
         trimmed,
         { categoryId: categoryId ?? null, note: note || undefined },
       );
-      await onSave(session);
-      onOpenChange(false);
-      showSuccessToast(
-        getMessage('snapshotNotificationTitle'),
-        getMessage('sessionNotificationMessage', [trimmed]),
-      );
+      if (isRefresh && refreshSession && onRefresh) {
+        const updated: Session = {
+          ...session,
+          id: refreshSession.id,
+          createdAt: refreshSession.createdAt,
+          isPinned: refreshSession.isPinned,
+          position: refreshSession.position,
+        };
+        await onRefresh(updated);
+        onOpenChange(false);
+        showSuccessToast(
+          getMessage('refreshNotificationTitle'),
+          getMessage('refreshNotificationMessage', [trimmed]),
+        );
+      } else {
+        await onSave(session);
+        onOpenChange(false);
+        showSuccessToast(
+          getMessage('snapshotNotificationTitle'),
+          getMessage('sessionNotificationMessage', [trimmed]),
+        );
+      }
     } catch {
       setSaveError(getMessage('sessionSaveError'));
     } finally {
       setIsSaving(false);
     }
-  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, note, onSave, onOpenChange, existingSessions]);
+  }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, note, onSave, onOpenChange, existingSessions, isRefresh, refreshSession, onRefresh]);
+
+  const wizardIcon = isRefresh ? RotateCw : Camera;
+  const wizardTitle = isRefresh ? getMessage('refreshTitle') : getMessage('snapshotTitle');
+  const wizardDescription = isRefresh ? getMessage('refreshDescription') : getMessage('snapshotDescription');
+  const saveLabel = isRefresh ? getMessage('refreshSaveButton') : getMessage('snapshotSaveButton');
+  const testIdPrefix = isRefresh ? 'wizard-refresh' : 'wizard-snapshot';
 
   return (
     <WizardModal
       open={open}
       onOpenChange={onOpenChange}
-      data-testid="wizard-snapshot"
-      icon={Camera}
-      title={getMessage('snapshotTitle')}
-      description={getMessage('snapshotDescription')}
+      data-testid={testIdPrefix}
+      icon={wizardIcon}
+      title={wizardTitle}
+      description={wizardDescription}
       onOpenAutoFocus={(e) => {
         e.preventDefault();
         const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[aria-label]');
@@ -151,7 +184,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
               color="blue"
               variant="soft"
               highContrast
-              data-testid="wizard-snapshot-group-callout"
+              data-testid={`${testIdPrefix}-group-callout`}
             >
               <Callout.Icon>
                 <Info size={16} />
@@ -164,7 +197,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
               {getMessage('sessionNameLabel')}
             </Text>
             <TextFieldWithCategory
-              data-testid="wizard-snapshot-field-name"
+              data-testid={`${testIdPrefix}-field-name`}
               value={sessionName}
               onChange={setSessionName}
               placeholder={getMessage('sessionNamePlaceholder')}
@@ -197,7 +230,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
               {getMessage('sessionNoteLabel')}
             </Text>
             <TextArea
-              data-testid="wizard-snapshot-field-notes"
+              data-testid={`${testIdPrefix}-field-notes`}
               value={note}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setNote(e.target.value)}
               placeholder={getMessage('sessionNotePlaceholder')}
@@ -219,17 +252,17 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
 
       <WizardModal.Footer>
         <Dialog.Close>
-          <Button data-testid="wizard-snapshot-btn-cancel" variant="soft" color="gray" disabled={isSaving}>
+          <Button data-testid={`${testIdPrefix}-btn-cancel`} variant="soft" color="gray" disabled={isSaving}>
             {getMessage('cancel')}
           </Button>
         </Dialog.Close>
         <Button
-          data-testid="wizard-snapshot-btn-save"
+          data-testid={`${testIdPrefix}-btn-save`}
           onClick={handleSave}
           disabled={!sessionName.trim() || selectedTabIds.size === 0 || isCapturing || isSaving}
         >
-          <Camera size={14} />
-          {getMessage('snapshotSaveButton')}
+          {isRefresh ? <RotateCw size={14} /> : <Camera size={14} />}
+          {saveLabel}
         </Button>
       </WizardModal.Footer>
     </WizardModal>

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -10,6 +10,7 @@ interface DeepLinkState {
   rulesPendingAction: RulesPendingAction | null;
   snapshotGroupId: number | null;
   restoreSessionId: string | null;
+  refreshSessionId: string | null;
 }
 
 const VALID_SECTIONS = ['home', 'rules', 'importexport', 'sessions', 'stats', 'settings', 'workspaces'] as const;
@@ -38,12 +39,14 @@ export function useDeepLinking(): DeepLinkState & {
   setRulesPendingAction: (action: RulesPendingAction | null) => void;
   setSnapshotGroupId: (id: number | null) => void;
   setRestoreSessionId: (id: string | null) => void;
+  setRefreshSessionId: (id: string | null) => void;
 } {
   const [currentTab, setCurrentTab] = useState<string>('home');
   const [openSnapshotWizard, setOpenSnapshotWizard] = useState(false);
   const [rulesPendingAction, setRulesPendingAction] = useState<RulesPendingAction | null>(null);
   const [snapshotGroupId, setSnapshotGroupId] = useState<number | null>(null);
   const [restoreSessionId, setRestoreSessionId] = useState<string | null>(null);
+  const [refreshSessionId, setRefreshSessionId] = useState<string | null>(null);
 
   useEffect(() => {
     function applySessionsAction(params: URLSearchParams) {
@@ -55,6 +58,11 @@ export function useDeepLinking(): DeepLinkState & {
       } else if (action === 'restore') {
         const sid = params.get('sessionId');
         if (sid) setRestoreSessionId(sid);
+      } else if (action === 'refresh') {
+        const sid = params.get('sessionId');
+        if (sid) setRefreshSessionId(sid);
+        const groupIdParam = params.get('groupId');
+        setSnapshotGroupId(groupIdParam ? parseInt(groupIdParam, 10) : null);
       }
     }
 
@@ -91,5 +99,7 @@ export function useDeepLinking(): DeepLinkState & {
     setSnapshotGroupId,
     restoreSessionId,
     setRestoreSessionId,
+    refreshSessionId,
+    setRefreshSessionId,
   };
 }

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -25,6 +25,7 @@ import { useImportExportWizards } from '@/contexts/ImportExportWizardsContext';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { updateSession } from '@/utils/sessionStorage';
 import { showSuccessNotification } from '@/utils/notifications';
+import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
@@ -64,6 +65,10 @@ interface SessionsPageProps {
   restoreSessionId?: string | null;
   /** Called to clear the restore deep-link once consumed. */
   onRestoreSessionIdChange?: (id: string | null) => void;
+  /** Session id for which a deep-link requests the refresh wizard to open. */
+  refreshSessionId?: string | null;
+  /** Called to clear the refresh deep-link once consumed. */
+  onRefreshSessionIdChange?: (id: string | null) => void;
 }
 
 function SectionHeader({ icon: Icon, titleKey, count }: { icon: LucideIcon; titleKey: string; count: number }) {
@@ -103,6 +108,8 @@ interface SessionSectionProps {
   onRestoreCurrentWindow: (session: Session) => void;
   onRestoreNewWindow: (session: Session) => void;
   onReplaceCurrentWindow: (session: Session) => void;
+  /** Open the refresh wizard for the session (captures current window state). */
+  onRefresh: (session: Session) => void;
   /** Pin/unpin handlers shared with the page-level widget shortcuts. */
   onPin: (session: Session) => void;
   onUnpin: (session: Session) => void;
@@ -312,6 +319,8 @@ export function SessionsPage({
   onSnapshotGroupIdChange,
   restoreSessionId,
   onRestoreSessionIdChange,
+  refreshSessionId,
+  onRefreshSessionIdChange,
 }: SessionsPageProps) {
   const { openImportSessions } = useImportExportWizards();
   const { sessions, isLoaded, createSession, renameSession, removeSession, reload, updateOrder } = useSessions();
@@ -331,6 +340,8 @@ export function SessionsPage({
   }, [onSnapshotWizardOpenChange]);
 
   const [restoreSession, setRestoreSession] = useState<Session | null>(null);
+  const [refreshTarget, setRefreshTarget] = useState<Session | null>(null);
+  const [refreshGroupId, setRefreshGroupId] = useState<number | null>(null);
   const [editTarget, setEditTarget] = useState<Session | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const [bulkExportIds, setBulkExportIds] = useState<string[] | null>(null);
@@ -340,6 +351,45 @@ export function SessionsPage({
   const [searchQuery, setSearchQuery] = useState('');
 
   const handleOpenSnapshotWizard = useCallback(() => setSnapshotOpen(true), []);
+
+  const handleOpenRefreshWizard = useCallback(async (session: Session) => {
+    const groupId = await getActiveTabGroupId();
+    setRefreshGroupId(groupId);
+    setRefreshTarget(session);
+  }, []);
+
+  const handleRefreshTrigger = useCallback(
+    (session: Session) => { void handleOpenRefreshWizard(session); },
+    [handleOpenRefreshWizard],
+  );
+
+  const handleRefreshSession = useCallback(
+    async (updatedSession: Session) => {
+      await updateSession(updatedSession.id, {
+        name: updatedSession.name,
+        note: updatedSession.note,
+        categoryId: updatedSession.categoryId,
+        groups: updatedSession.groups,
+        ungroupedTabs: updatedSession.ungroupedTabs,
+      });
+      await reload();
+    },
+    [reload],
+  );
+
+  // Deep-link: open the refresh wizard when a sessionId has been provided via
+  // URL hash (e.g. from the popup's refresh action). The optional groupId is
+  // consumed from snapshotGroupId (parsed by useDeepLinking).
+  useEffect(() => {
+    if (!refreshSessionId || !isLoaded) return;
+    const found = sessions.find((s) => s.id === refreshSessionId);
+    if (found) {
+      setRefreshGroupId(snapshotGroupId ?? null);
+      setRefreshTarget(found);
+      onRefreshSessionIdChange?.(null);
+      onSnapshotGroupIdChange?.(null);
+    }
+  }, [refreshSessionId, isLoaded, sessions, snapshotGroupId, onRefreshSessionIdChange, onSnapshotGroupIdChange]);
 
   // Quick-restore (no conflict-resolution wizard) handlers shared by the
   // SessionCard split button, the dropdown menu, and the widget-scope
@@ -537,6 +587,7 @@ export function SessionsPage({
     | 'onRestoreCurrentWindow'
     | 'onRestoreNewWindow'
     | 'onReplaceCurrentWindow'
+    | 'onRefresh'
     | 'onPin'
     | 'onUnpin'
   > = {
@@ -551,6 +602,7 @@ export function SessionsPage({
     onRestoreCurrentWindow: handleRestoreCurrentWindow,
     onRestoreNewWindow: handleRestoreNewWindow,
     onReplaceCurrentWindow: handleReplaceCurrentWindow,
+    onRefresh: handleRefreshTrigger,
     onPin: handlePin,
     onUnpin: handleUnpin,
   };
@@ -702,6 +754,21 @@ export function SessionsPage({
             onSave={handleSaveSession}
             existingSessions={sessions}
             initialGroupId={snapshotGroupId ?? undefined}
+          />
+
+          <SnapshotWizard
+            open={refreshTarget !== null}
+            onOpenChange={(open) => {
+              if (!open) {
+                setRefreshTarget(null);
+                setRefreshGroupId(null);
+              }
+            }}
+            onSave={async () => { /* unused in refresh mode */ }}
+            onRefresh={handleRefreshSession}
+            refreshSession={refreshTarget ?? undefined}
+            initialGroupId={refreshGroupId ?? undefined}
+            existingSessions={sessions}
           />
 
           <SessionEditDialog

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -28,6 +28,7 @@ import { HomePage } from './HomePage';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
 import { Home, Shield, FileText, BarChart3, Settings, Archive, Layers } from 'lucide-react';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
+import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { lazyWithTiming } from '@/utils/lazyWithTiming.js';
 import { preloadPage } from './pagePreloaders.js';
 
@@ -65,6 +66,7 @@ export function OptionsContent() {
         rulesPendingAction, setRulesPendingAction,
         snapshotGroupId, setSnapshotGroupId,
         restoreSessionId, setRestoreSessionId,
+        refreshSessionId, setRefreshSessionId,
     } = useDeepLinking();
 
     const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
@@ -99,8 +101,15 @@ export function OptionsContent() {
             handleTabChange('sessions');
             return;
         }
+        if (target === 'refresh') {
+            const groupId = await getActiveTabGroupId();
+            setSnapshotGroupId(groupId);
+            setRefreshSessionId(session.id);
+            handleTabChange('sessions');
+            return;
+        }
         await restoreSessionTabs(session, target as RestoreTarget);
-    }, [setRestoreSessionId, handleTabChange]);
+    }, [setRestoreSessionId, setRefreshSessionId, setSnapshotGroupId, handleTabChange]);
 
     const sidebarSections: SidebarSection[] = useMemo(() => [
         {
@@ -244,6 +253,8 @@ export function OptionsContent() {
                                     onSnapshotGroupIdChange={setSnapshotGroupId}
                                     restoreSessionId={restoreSessionId}
                                     onRestoreSessionIdChange={setRestoreSessionId}
+                                    refreshSessionId={refreshSessionId}
+                                    onRefreshSessionIdChange={setRefreshSessionId}
                                 />
                             )}
                             {currentTab === 'stats' && (

--- a/src/utils/tabCapture.ts
+++ b/src/utils/tabCapture.ts
@@ -43,6 +43,16 @@ export async function hasCapturableTabs(): Promise<boolean> {
   return tabs.some(tab => !isSystemUrl(tab.url));
 }
 
+/**
+ * Returns the Chrome groupId of the active tab in the current window,
+ * or null if the active tab is not in a group (or no active tab).
+ */
+export async function getActiveTabGroupId(): Promise<number | null> {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const groupId = (tabs[0] as { groupId?: number } | undefined)?.groupId;
+  return typeof groupId === 'number' && groupId >= 0 ? groupId : null;
+}
+
 interface GroupEntry {
   savedGroup: SavedTabGroup;
   treeGroup: TabGroupItem;

--- a/tests/components/SessionRestoreButton.test.tsx
+++ b/tests/components/SessionRestoreButton.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../../src/utils/i18n', () => ({
   getMessage: vi.fn((key: string) => {
     const messages: Record<string, string> = {
       sessionRestore: 'Restore',
+      sessionRefresh: 'Refresh',
       sessionRestoreCurrentWindow: 'Restore in current window',
       sessionRestoreNewWindow: 'Restore in new window',
       sessionRestoreReplaceCurrentWindow: 'Replace tabs in current window',
@@ -86,6 +87,45 @@ describe('SessionRestoreButton', () => {
     );
 
     expect(screen.getByRole('button', { name: /Restore options/i })).toBeInTheDocument();
+  });
+
+  it('does not render a Refresh button when onRefresh is omitted', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onReplaceCurrentWindow={onReplaceCurrentWindow}
+          onCustomize={onCustomize}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.queryByRole('button', { name: /Refresh/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a Refresh button when onRefresh is provided and calls it on click', () => {
+    const onRefresh = vi.fn();
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onReplaceCurrentWindow={onReplaceCurrentWindow}
+          onCustomize={onCustomize}
+          onRefresh={onRefresh}
+          data-testid="restore-btn"
+        />
+      </TestWrapper>,
+    );
+
+    const refreshBtn = screen.getByTestId('restore-btn-refresh');
+    fireEvent.click(refreshBtn);
+
+    expect(onRefresh).toHaveBeenCalledWith(session);
+    expect(onRestoreCurrentWindow).not.toHaveBeenCalled();
   });
 
   it('tile presentation renders the textual "Restore" label on the primary button', () => {


### PR DESCRIPTION
Adds a Refresh icon button to the left of the Restore split button
(SessionCard, PinnedSessionTile, PopupProfilesList). Clicking it opens
the SnapshotWizard in a new "refresh mode" pre-filled with the existing
session's name, note and category, captures the current window's tabs
(with the active tab's group pre-selected like the save flow), and
overwrites the existing session on submit (preserves id, createdAt,
isPinned, position).

https://claude.ai/code/session_016t4sJSXQBRViRHdafz5wgv