### PR TITLE
feat(shortcuts): bind U to session refresh on focused session card

### DIFF
--- a/docs/src/content/docs/annexes/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/annexes/raccourcis-clavier.mdx
@@ -24,6 +24,7 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 | `Shift + R` | Ajouter la session à la fenêtre courante |
 | `Alt + R` | Remplacer les onglets de la fenêtre |
 | `Alt + Shift + R` | Ouvrir la session dans une nouvelle fenêtre |
+| `U` | Rafraîchir la session avec les onglets de la fenêtre |
 
 ## Liste des règles
 
@@ -56,6 +57,7 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 | `Shift + R` | Ajouter la session à la fenêtre courante |
 | `Alt + R` | Remplacer les onglets de la fenêtre |
 | `Alt + Shift + R` | Ouvrir la session dans une nouvelle fenêtre |
+| `U` | Rafraîchir la session avec les onglets de la fenêtre |
 
 ## Import / Export
 

--- a/docs/src/content/docs/en/annexes/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/en/annexes/raccourcis-clavier.mdx
@@ -24,6 +24,7 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 | `Shift + R` | Add session to current window |
 | `Alt + R` | Replace current window tabs |
 | `Alt + Shift + R` | Open session in a new window |
+| `U` | Refresh session from current window tabs |
 
 ## Rules list
 
@@ -56,6 +57,7 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 | `Shift + R` | Add session to current window |
 | `Alt + R` | Replace current window tabs |
 | `Alt + Shift + R` | Open session in a new window |
+| `U` | Refresh session from current window tabs |
 
 ## Import / Export
 

--- a/docs/src/content/docs/es/annexes/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/es/annexes/raccourcis-clavier.mdx
@@ -24,6 +24,7 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 | `Shift + R` | Añadir la sesión a la ventana actual |
 | `Alt + R` | Reemplazar las pestañas de la ventana |
 | `Alt + Shift + R` | Abrir la sesión en una nueva ventana |
+| `U` | Actualizar la sesión con las pestañas de la ventana |
 
 ## Lista de reglas
 
@@ -56,6 +57,7 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 | `Shift + R` | Añadir la sesión a la ventana actual |
 | `Alt + R` | Reemplazar las pestañas de la ventana |
 | `Alt + Shift + R` | Abrir la sesión en una nueva ventana |
+| `U` | Actualizar la sesión con las pestañas de la ventana |
 
 ## Importar / Exportar
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -640,6 +640,7 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Add session to current window" },
   "shortcutDescSessionReplaceCurrent": { "message": "Replace current window tabs" },
   "shortcutDescSessionRestoreNew": { "message": "Open session in a new window" },
+  "shortcutDescSessionRefresh": { "message": "Refresh session from current window tabs" },
   "shortcutDescHomeFirstLast": { "message": "Move focus to first or last item" },
   "shortcutDescHomeNextSection": { "message": "Move focus to the next section" },
   "shortcutDescHomeActivate": { "message": "Activate the focused item" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -641,6 +641,7 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Añadir la sesión a la ventana actual" },
   "shortcutDescSessionReplaceCurrent": { "message": "Reemplazar las pestañas de la ventana" },
   "shortcutDescSessionRestoreNew": { "message": "Abrir la sesión en una nueva ventana" },
+  "shortcutDescSessionRefresh": { "message": "Actualizar la sesión con las pestañas de la ventana" },
   "shortcutDescHomeFirstLast": { "message": "Mover el foco al primer o último elemento" },
   "shortcutDescHomeNextSection": { "message": "Mover el foco a la sección siguiente" },
   "shortcutDescHomeActivate": { "message": "Activar el elemento con foco" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -641,6 +641,7 @@
   "shortcutDescSessionRestoreCurrent": { "message": "Ajouter la session à la fenêtre courante" },
   "shortcutDescSessionReplaceCurrent": { "message": "Remplacer les onglets de la fenêtre" },
   "shortcutDescSessionRestoreNew": { "message": "Ouvrir la session dans une nouvelle fenêtre" },
+  "shortcutDescSessionRefresh": { "message": "Rafraîchir la session avec les onglets de la fenêtre" },
   "shortcutDescHomeFirstLast": { "message": "Aller au premier ou au dernier élément" },
   "shortcutDescHomeNextSection": { "message": "Aller à la section suivante" },
   "shortcutDescHomeActivate": { "message": "Activer l'élément focus" },

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, IconButton, Tooltip } from '@radix-ui/themes';
+import { Flex, IconButton, Kbd, Tooltip } from '@radix-ui/themes';
 import { Camera, Monitor, Replace, RotateCcw, Square, Wrench } from 'lucide-react';
 import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
 import { getMessage } from '@/utils/i18n';
@@ -87,13 +87,21 @@ export function SessionRestoreButton({
 
   return (
     <Flex align="center" gap="1">
-      <Tooltip content={getMessage('sessionRefresh')}>
+      <Tooltip
+        content={
+          <Flex align="center" gap="2">
+            {getMessage('sessionRefresh')}
+            <Kbd>U</Kbd>
+          </Flex>
+        }
+      >
         <IconButton
           size={size}
           variant={variant}
           color="gray"
           onClick={() => onRefresh(session)}
           aria-label={getMessage('sessionRefresh')}
+          aria-keyshortcuts="U"
           data-testid={testId ? `${testId}-refresh` : undefined}
         >
           <Camera size={isTile ? 14 : 12} aria-hidden="true" />

--- a/src/components/HomePage/PinnedSessionsSection.tsx
+++ b/src/components/HomePage/PinnedSessionsSection.tsx
@@ -36,6 +36,11 @@ export function PinnedSessionsSection({ sessions, onSeeAll, onRestore }: PinnedS
         else if (e.altKey) onRestore(session, 'replace');
         else if (e.shiftKey) onRestore(session, 'current');
         else onRestore(session, 'custom');
+        return;
+      }
+      if (e.key.toLowerCase() === 'u' && !e.altKey && !e.shiftKey) {
+        e.preventDefault();
+        onRestore(session, 'refresh');
       }
     },
     [handleNavigationKey, onRestore],

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -152,6 +152,10 @@ export function PopupProfilesList() {
         const focused = getFocusedSession();
         if (focused) handleRestore(focused, 'new');
       },
+      'sessionCard.refresh': () => {
+        const focused = getFocusedSession();
+        if (focused) void openRefreshFromPopup(focused);
+      },
     },
     { scope: 'widget:session-card' },
   );

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -545,6 +545,10 @@ export function SessionsPage({
         const focused = getFocusedSession();
         if (focused) handleRestoreNewWindow(focused);
       },
+      'sessionCard.refresh': () => {
+        const focused = getFocusedSession();
+        if (focused) handleRefreshTrigger(focused);
+      },
       'sessionCard.edit': () => {
         const focused = getFocusedSession();
         if (focused) setEditTarget(focused);

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -326,6 +326,13 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     group: 'session-card',
     scope: 'widget:session-card',
   },
+  'sessionCard.refresh': {
+    id: 'sessionCard.refresh',
+    defaultBindings: ['u'],
+    descriptionKey: 'shortcutDescSessionRefresh',
+    group: 'session-card',
+    scope: 'widget:session-card',
+  },
 
   // Page: Import/Export. Mnemonic two-key sequences (i/e prefix + target
   // initial). The `i` and `e` letters are reserved as sequence prefixes in

--- a/tests/shortcuts/registry.test.ts
+++ b/tests/shortcuts/registry.test.ts
@@ -116,7 +116,7 @@ describe('SHORTCUTS_REGISTRY', () => {
     expect(getShortcutsByGroup('list-sessions')).toHaveLength(6);
     expect(getShortcutsByGroup('list-workspaces')).toHaveLength(1);
     expect(getShortcutsByGroup('list-home')).toHaveLength(4);
-    expect(getShortcutsByGroup('session-card')).toHaveLength(4);
+    expect(getShortcutsByGroup('session-card')).toHaveLength(5);
     expect(getShortcutsByGroup('importexport')).toHaveLength(6);
   });
 
@@ -160,7 +160,7 @@ describe('registry helpers', () => {
     expect(popupEntries.length).toBe(5);
 
     const cardEntries = getShortcutsByScope('widget:session-card');
-    expect(cardEntries.length).toBe(7);
+    expect(cardEntries.length).toBe(8);
 
     const ruleCardEntries = getShortcutsByScope('widget:rule-card');
     expect(ruleCardEntries.length).toBe(4);


### PR DESCRIPTION
Adds sessionCard.refresh (key U, scope widget:session-card) so the
refresh button on every session card (sessions page, popup pinned
list, home page tiles) can be triggered without leaving the keyboard.
The IconButton also advertises the shortcut via tooltip Kbd and
aria-keyshortcuts. Locales, registry tests and the Starlight reference
page are kept in sync.