### PR TITLE
refactor(dedupe): extract useSessionBucketLoader from session bucket hooks

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,8 +4,8 @@
     "jscpd": {
       "source": "kucherenko/jscpd",
       "sourceType": "github",
-      "skillPath": "SKILL.md",
-      "computedHash": "80b4c74864717ca5cfaf64a75a0cfd47736c9ebdcab388ee058395365f34f387"
+      "skillPath": "skills/jscpd/SKILL.md",
+      "computedHash": "4af10645dac7065babc570b9c6b3f293060d4f8e1d656d22c1c86007d78a17dc"
     }
   }
 }

--- a/src/hooks/useActiveSessions.ts
+++ b/src/hooks/useActiveSessions.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
 import { loadActiveSessions } from '@/utils/sessionStorage';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import type { Session } from '@/types/session';
+import { useSessionBucketLoader } from './useSessionBucketLoader';
 
 export interface UseActiveSessionsReturn {
   activeSessions: Session[];
@@ -15,25 +15,9 @@ export interface UseActiveSessionsReturn {
  */
 export function useActiveSessions(): UseActiveSessionsReturn {
   const { scopedItems } = useActiveWorkspaceContext();
-  const item = scopedItems.sessionsItem;
-  const [activeSessions, setActiveSessions] = useState<Session[]>([]);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const reload = useCallback(async () => {
-    const data = await loadActiveSessions();
-    setActiveSessions(data);
-    setIsLoaded(true);
-  }, []);
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
-
-  useEffect(() => {
-    return item.watch(() => {
-      reload();
-    });
-  }, [item, reload]);
-
-  return { activeSessions, isLoaded, reload };
+  const { sessions, isLoaded, reload } = useSessionBucketLoader({
+    item: scopedItems.sessionsItem,
+    loader: loadActiveSessions,
+  });
+  return { activeSessions: sessions, isLoaded, reload };
 }

--- a/src/hooks/useArchivedSessions.ts
+++ b/src/hooks/useArchivedSessions.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
 import { loadArchivedSessions } from '@/utils/sessionStorage';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import type { Session } from '@/types/session';
+import { useSessionBucketLoader } from './useSessionBucketLoader';
 
 export interface UseArchivedSessionsOptions {
   /**
@@ -25,28 +25,10 @@ export interface UseArchivedSessionsReturn {
  */
 export function useArchivedSessions({ enabled }: UseArchivedSessionsOptions): UseArchivedSessionsReturn {
   const { scopedItems } = useActiveWorkspaceContext();
-  const item = scopedItems.archivedSessionsItem;
-  const [archivedSessions, setArchivedSessions] = useState<Session[]>([]);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const reload = useCallback(async () => {
-    if (!enabled) return;
-    const data = await loadArchivedSessions();
-    setArchivedSessions(data);
-    setIsLoaded(true);
-  }, [enabled]);
-
-  useEffect(() => {
-    if (!enabled) return;
-    reload();
-  }, [enabled, reload]);
-
-  useEffect(() => {
-    if (!enabled) return;
-    return item.watch(() => {
-      reload();
-    });
-  }, [enabled, item, reload]);
-
-  return { archivedSessions, isLoaded, reload };
+  const { sessions, isLoaded, reload } = useSessionBucketLoader({
+    item: scopedItems.archivedSessionsItem,
+    loader: loadArchivedSessions,
+    enabled,
+  });
+  return { archivedSessions: sessions, isLoaded, reload };
 }

--- a/src/hooks/usePinnedSessions.ts
+++ b/src/hooks/usePinnedSessions.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
 import { loadPinnedSessions } from '@/utils/sessionStorage';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import type { Session } from '@/types/session';
+import { useSessionBucketLoader } from './useSessionBucketLoader';
 
 export interface UsePinnedSessionsReturn {
   pinnedSessions: Session[];
@@ -16,25 +16,9 @@ export interface UsePinnedSessionsReturn {
  */
 export function usePinnedSessions(): UsePinnedSessionsReturn {
   const { scopedItems } = useActiveWorkspaceContext();
-  const item = scopedItems.pinnedSessionsItem;
-  const [pinnedSessions, setPinnedSessions] = useState<Session[]>([]);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const reload = useCallback(async () => {
-    const data = await loadPinnedSessions();
-    setPinnedSessions(data);
-    setIsLoaded(true);
-  }, []);
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
-
-  useEffect(() => {
-    return item.watch(() => {
-      reload();
-    });
-  }, [item, reload]);
-
-  return { pinnedSessions, isLoaded, reload };
+  const { sessions, isLoaded, reload } = useSessionBucketLoader({
+    item: scopedItems.pinnedSessionsItem,
+    loader: loadPinnedSessions,
+  });
+  return { pinnedSessions: sessions, isLoaded, reload };
 }

--- a/src/hooks/useSessionBucketLoader.ts
+++ b/src/hooks/useSessionBucketLoader.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { WxtStorageItem } from 'wxt/utils/storage';
+import type { Session } from '@/types/session';
+
+export interface UseSessionBucketLoaderOptions {
+  /**
+   * The WXT storage item to watch for changes. When the item is updated the
+   * hook re-runs `loader` automatically.
+   */
+  item: WxtStorageItem<Session[], Record<string, unknown>>;
+  /**
+   * Async function that returns the current sessions for the bucket. Injected
+   * so each per-bucket hook can call its own dedicated loader without coupling
+   * this hook to a concrete storage key.
+   */
+  loader: () => Promise<Session[]>;
+  /**
+   * When `false` the hook stays completely inert: it does not load on mount
+   * and does not set up a storage watcher. Defaults to `true`.
+   * Useful for the archived bucket, which should only be loaded on demand.
+   */
+  enabled?: boolean;
+}
+
+export interface UseSessionBucketLoaderReturn {
+  sessions: Session[];
+  isLoaded: boolean;
+  reload: () => Promise<void>;
+}
+
+/**
+ * Generic hook that loads a session bucket on mount, watches its storage item
+ * for external changes and exposes a manual `reload` function.
+ *
+ * Extracted from `useActiveSessions`, `usePinnedSessions` and
+ * `useArchivedSessions`, which all share this load-and-watch pattern.
+ */
+export function useSessionBucketLoader({
+  item,
+  loader,
+  enabled = true,
+}: UseSessionBucketLoaderOptions): UseSessionBucketLoaderReturn {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const reload = useCallback(async () => {
+    if (!enabled) return;
+    const data = await loader();
+    setSessions(data);
+    setIsLoaded(true);
+  }, [enabled, loader]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    reload();
+  }, [enabled, reload]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    return item.watch(() => {
+      reload();
+    });
+  }, [enabled, item, reload]);
+
+  return { sessions, isLoaded, reload };
+}


### PR DESCRIPTION
All three per-bucket hooks (useActiveSessions, usePinnedSessions,
useArchivedSessions) shared an identical load-and-watch pattern: a
reload useCallback backed by the bucket's loader function, a useEffect
to trigger it on mount, and a second useEffect to watch the WXT storage
item for external changes. The only variation was the storage item, the
loader, and the optional enabled flag for the archived bucket.

Extracted the shared logic into src/hooks/useSessionBucketLoader.ts.
Each per-bucket hook is now a thin wrapper that supplies the concrete
item, loader, and (when relevant) enabled flag, and re-maps the generic
`sessions` field to the bucket-specific name for callers.

Files created:
- src/hooks/useSessionBucketLoader.ts

Files updated (call sites unchanged, public API preserved):
- src/hooks/useActiveSessions.ts
- src/hooks/usePinnedSessions.ts
- src/hooks/useArchivedSessions.ts

Originating painpoint: jscpd clone useActiveSessions.ts:24-38 ~
usePinnedSessions.ts:25-39 (extends to useArchivedSessions.ts as well).

https://claude.ai/code/session_01B5BvjFWViULi6zfagw2ZQT