### PR TITLE
fix(domain-rules): focus first field on edit dialogs open

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -170,6 +170,7 @@ export function ConfigEditModal({
       >
         <DomainRuleConfigForm
           idPrefix="edit"
+          autoFocusFirstField
           configMode={configMode}
           onConfigModeChange={handleConfigModeChange}
           presetId={presetId}

--- a/src/components/Core/DomainRule/ConfigModeSelector.tsx
+++ b/src/components/Core/DomainRule/ConfigModeSelector.tsx
@@ -27,6 +27,8 @@ export const MODE_HELP_LABELS: Record<ConfigMode, Parameters<typeof getMessage>[
 interface ConfigModeSelectorProps {
   value: ConfigMode;
   onValueChange: (mode: ConfigMode) => void;
+  /** Marks the currently selected radio item with [data-autofocus] so DialogShell focuses it on open. */
+  autoFocusFirstField?: boolean;
 }
 
 /**
@@ -34,7 +36,7 @@ interface ConfigModeSelectorProps {
  * The active mode's full description is rendered by the parent (right column).
  * Shared between ConfigEditModal and WizardStep2Config.
  */
-export function ConfigModeSelector({ value, onValueChange }: ConfigModeSelectorProps) {
+export function ConfigModeSelector({ value, onValueChange, autoFocusFirstField = false }: ConfigModeSelectorProps) {
   const labelId = useId();
   return (
     <Flex direction="column" gap="2">
@@ -69,6 +71,7 @@ export function ConfigModeSelector({ value, onValueChange }: ConfigModeSelectorP
                   <RadioGroup.Item
                     value={mode}
                     data-testid={`config-mode-${mode}`}
+                    data-autofocus={autoFocusFirstField && isSelected ? 'true' : undefined}
                     style={{ marginTop: '2px' }}
                   />
                   <Flex direction="column" gap="1">

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
@@ -46,6 +46,8 @@ export interface DomainRuleConfigFormProps {
   urlQueryParamNameError?: FieldError;
   /** Optional prefix for field IDs to avoid collisions when multiple instances coexist. */
   idPrefix?: string;
+  /** Forwards [data-autofocus] to the first interactive control (the active config mode radio). */
+  autoFocusFirstField?: boolean;
 }
 
 /**
@@ -73,6 +75,7 @@ export function DomainRuleConfigForm({
   onUrlQueryParamNameChange,
   urlQueryParamNameError,
   idPrefix,
+  autoFocusFirstField = false,
 }: DomainRuleConfigFormProps) {
   const prefix = idPrefix ? `${idPrefix}-` : '';
   const presetInputId = `${prefix}presetId`;
@@ -97,7 +100,11 @@ export function DomainRuleConfigForm({
       <Flex gap="4" style={{ flex: 1, minHeight: 0, overflow: 'hidden' }} align="stretch">
         {/* Left column: vertical radio list */}
         <Box style={{ width: 240, flexShrink: 0 }}>
-          <ConfigModeSelector value={configMode} onValueChange={onConfigModeChange} />
+          <ConfigModeSelector
+            value={configMode}
+            onValueChange={onConfigModeChange}
+            autoFocusFirstField={autoFocusFirstField}
+          />
         </Box>
 
         {/* Right column: active-mode description heading + mode-specific content */}

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -127,6 +127,7 @@ export function IdentityEditModal({
               id={fieldId}
               name="domainFilter"
               data-testid="modal-edit-identity-field-domain"
+              data-autofocus="true"
               value={domainFilter}
               onChange={(e) => handleDomainFilterChange(e.target.value)}
               placeholder={getMessage('domainFilterPlaceholder')}

--- a/src/components/Core/DomainRule/OptionsEditModal.tsx
+++ b/src/components/Core/DomainRule/OptionsEditModal.tsx
@@ -76,6 +76,7 @@ export function OptionsEditModal({ isOpen, onClose, onApply, initial }: OptionsE
           control={control}
           deduplicationEnabled={deduplicationEnabled}
           errors={errors}
+          autoFocusFirstField
         />
       </Flex>
     </EditModalShell>

--- a/src/components/Core/DomainRule/WizardStep3Options.tsx
+++ b/src/components/Core/DomainRule/WizardStep3Options.tsx
@@ -9,11 +9,18 @@ interface WizardStep3OptionsProps {
   control: Control<DomainRule>;
   deduplicationEnabled: boolean;
   errors?: FieldErrors<DomainRule>;
+  /** Marks the deduplication Switch with [data-autofocus] so DialogShell focuses it on open. */
+  autoFocusFirstField?: boolean;
 }
 
 const IGNORED_PARAM_PATTERN = /^[A-Za-z0-9_\-.*]+$/;
 
-export function WizardStep3Options({ control, deduplicationEnabled, errors }: WizardStep3OptionsProps) {
+export function WizardStep3Options({
+  control,
+  deduplicationEnabled,
+  errors,
+  autoFocusFirstField = false,
+}: WizardStep3OptionsProps) {
   const matchMode = useWatch({ control, name: 'deduplicationMatchMode' });
   const showIgnoredParams = deduplicationEnabled && matchMode === 'exact_ignore_params';
 
@@ -32,6 +39,7 @@ export function WizardStep3Options({ control, deduplicationEnabled, errors }: Wi
                   aria-label={getMessage('enableDeduplication')}
                   checked={field.value}
                   onCheckedChange={field.onChange}
+                  data-autofocus={autoFocusFirstField ? 'true' : undefined}
                 />
               )}
             />


### PR DESCRIPTION
The three pencil edit dialogs (Identity, Configuration, Options) on a
domain rule card were leaving the initial focus on the close button,
so pressing Enter dismissed the dialog instead of interacting with a
field.

Each modal now marks its first interactive control with
[data-autofocus], which DialogShell's defaultOnOpenAutoFocus picks up:

- IdentityEditModal: domain filter TextField
- ConfigEditModal: active config-mode radio item
- OptionsEditModal: deduplication Switch

The new autoFocusFirstField prop on the shared DomainRuleConfigForm,
ConfigModeSelector and WizardStep3Options components defaults to false,
so the wizard flow (RuleWizardModal) is untouched.

https://claude.ai/code/session_01DgisQsHbAkDUfT7hhrNLrt