### PR TITLE
fix(wizard): bump modal max height from 80vh to 85vh

### DIFF
--- a/src/components/UI/WizardModal/WizardModal.tsx
+++ b/src/components/UI/WizardModal/WizardModal.tsx
@@ -59,8 +59,8 @@ function WizardModalRoot({
       onOpenAutoFocus={onOpenAutoFocus}
       preventOutsideClose
       maxWidth={maxWidth}
-      minHeight={fillHeight ? undefined : 'min(480px, 80vh)'}
-      maxHeight={fillHeight ? undefined : '80vh'}
+      minHeight={fillHeight ? undefined : 'min(520px, 85vh)'}
+      maxHeight={fillHeight ? undefined : '85vh'}
       contentStyle={contentStyle}
     >
       {children}


### PR DESCRIPTION
Step 1 of the domain rule wizard now packs four rows (Domain Filter,
Label, Category swatches, Color picker) and overflows the previous
80vh cap on laptop-sized viewports, triggering a vertical scrollbar
that appears off by just a few pixels.

Relax the shared WizardModal bounds to min(520px, 85vh) / 85vh so the
content breathes without affecting wizards that have less content
(the min() form keeps short wizards at their natural height).