### PR TITLE
feat(grouping): join existing same-title same-color group instead of creating a duplicate

### DIFF
--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -6,6 +6,7 @@ import { promptForGroupName } from './messaging.js';
 import { showNotification, type UndoAction } from '@/utils/notifications.js';
 import { getMessage } from '@/utils/i18n.js';
 import type { DomainRuleSetting, AppSettings } from '@/types/syncSettings.js';
+import type { ChromeTabGroupsExtended } from '@/types/chromeApi.js';
 import { getRuleCategory } from '@/utils/categoriesStore.js';
 import { logger } from '@/utils/logger.js';
 
@@ -235,6 +236,29 @@ export async function addToExistingGroup(
     await browser.tabGroups.update(groupId, updatePayload);
 }
 
+// Looks up a tab group in `windowId` whose title matches `groupName`.
+// When the rule provides a `groupColor`, the group's color must match too;
+// when `groupColor` is null the rule has no color preference, so any color
+// is accepted.
+export async function findMatchingExistingGroup(
+    windowId: number | undefined,
+    groupName: string,
+    groupColor: string | null
+): Promise<number | null> {
+    if (windowId === undefined) return null;
+    try {
+        const groups = await (browser.tabGroups as unknown as ChromeTabGroupsExtended).query({ windowId });
+        const match = groups.find(g =>
+            g.title === groupName &&
+            (groupColor === null || g.color === groupColor)
+        );
+        return match?.id ?? null;
+    } catch (e) {
+        logger.warn('[GROUPING_DEBUG] findMatchingExistingGroup: tabGroups.query failed.', describeError(e));
+        return null;
+    }
+}
+
 export async function handleManualGroupNaming(
     rule: DomainRuleSetting,
     targetGroupId: number,
@@ -260,7 +284,7 @@ export async function handleManualGroupNaming(
     }
 }
 
-export async function performGroupingOperation(context: GroupingContext): Promise<{targetGroupId: number, groupedTabIds: number[]}> {
+export async function performGroupingOperation(context: GroupingContext): Promise<{targetGroupId: number, groupedTabIds: number[], joinedExisting: boolean}> {
     const openerTabId = context.openerTab.id;
     const newTabId = context.newTab.id;
     if (openerTabId === undefined || newTabId === undefined) {
@@ -275,12 +299,28 @@ export async function performGroupingOperation(context: GroupingContext): Promis
 
     let targetGroupId: number;
     let groupedTabIds: number[];
+    let joinedExisting = false;
 
     if (openerGroupId === browser.tabs.TAB_ID_NONE || typeof openerGroupId !== 'number' || openerGroupId <= 0) {
-        logger.debug(`[GROUPING_DEBUG] Opener tab ${currentOpenerTabId} is not in a group. Creating new group.`);
-        const tabsToGroup = [currentOpenerTabId, newTabId];
-        groupedTabIds = tabsToGroup.slice();
-        targetGroupId = await createNewGroup(tabsToGroup, context.groupName, context.groupColor, context.rule.id);
+        const matchingGroupId = await findMatchingExistingGroup(
+            currentOpenerTab.windowId,
+            context.groupName,
+            context.groupColor
+        );
+
+        if (matchingGroupId !== null) {
+            logger.debug(`[GROUPING_DEBUG] Opener tab ${currentOpenerTabId} is not grouped; joining existing group ${matchingGroupId} matching name "${context.groupName}" and color "${context.groupColor ?? '(any)'}".`);
+            targetGroupId = matchingGroupId;
+            groupedTabIds = [currentOpenerTabId, newTabId];
+            await browser.tabs.group({ groupId: matchingGroupId, tabIds: [currentOpenerTabId, newTabId] });
+            await browser.tabGroups.update(matchingGroupId, { collapsed: false });
+            joinedExisting = true;
+        } else {
+            logger.debug(`[GROUPING_DEBUG] Opener tab ${currentOpenerTabId} is not in a group and no matching existing group found. Creating new group.`);
+            const tabsToGroup = [currentOpenerTabId, newTabId];
+            groupedTabIds = tabsToGroup.slice();
+            targetGroupId = await createNewGroup(tabsToGroup, context.groupName, context.groupColor, context.rule.id);
+        }
     } else {
         logger.debug(`[GROUPING_DEBUG] Opener tab ${currentOpenerTabId} already in group ${openerGroupId}.`);
         targetGroupId = openerGroupId;
@@ -288,7 +328,7 @@ export async function performGroupingOperation(context: GroupingContext): Promis
         await addToExistingGroup(openerGroupId, newTabId);
     }
 
-    return { targetGroupId, groupedTabIds };
+    return { targetGroupId, groupedTabIds, joinedExisting };
 }
 
 export async function processGroupingForNewTab(openerTab: Browser.tabs.Tab, newTab: Browser.tabs.Tab): Promise<void> {
@@ -321,14 +361,16 @@ export async function processGroupingForNewTab(openerTab: Browser.tabs.Tab, newT
     logger.debug(`[GROUPING_DEBUG] Rule found: "${rule.label}", groupName: "${context.groupName}"`);
 
     try {
-        const { targetGroupId, groupedTabIds } = await performGroupingOperation(context);
+        const { targetGroupId, groupedTabIds, joinedExisting } = await performGroupingOperation(context);
         logger.debug(`[GROUPING_DEBUG] Grouping completed for new tab ${newTab.id}. Color: ${context.groupColor || 'Chrome default'}.`);
 
         // For smart_manual: only prompt when extraction failed (user story: "extracts name OR falls back to manual prompt").
         // For plain manual: always prompt.
+        // Skip manual naming when we joined an existing group: its name is already settled.
         const needsManualNaming =
-            rule.groupNameSource === 'manual' ||
-            (rule.groupNameSource === 'smart_manual' && !tryExtractGroupNameFromPresetOrFallback(rule, openerTab));
+            !joinedExisting &&
+            (rule.groupNameSource === 'manual' ||
+                (rule.groupNameSource === 'smart_manual' && !tryExtractGroupNameFromPresetOrFallback(rule, openerTab)));
         if (needsManualNaming && openerTab.id !== undefined) {
             await handleManualGroupNaming(rule, targetGroupId, context.groupName, groupedTabIds, openerTab.id);
         }

--- a/tests/background/grouping-async.test.ts
+++ b/tests/background/grouping-async.test.ts
@@ -60,6 +60,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockedBrowser.tabs.group.mockResolvedValue(99);
   mockedBrowser.tabGroups.update.mockResolvedValue(undefined);
+  mockedBrowser.tabGroups.query.mockResolvedValue([]);
   mockedBrowser.tabs.ungroup.mockResolvedValue(undefined);
   mockedBrowser.windows.get.mockResolvedValue({ id: 1, type: 'normal' });
   mockedIncrementStat.mockResolvedValue(undefined);
@@ -213,6 +214,76 @@ describe('performGroupingOperation', () => {
     expect(targetGroupId).toBe(55);
     expect(groupedTabIds).toEqual([2]);
     expect(mockedBrowser.tabs.group).toHaveBeenCalledWith({ groupId: 55, tabIds: [2] });
+  });
+
+  it('joins an existing group in the same window when title and color match', async () => {
+    mockedBrowser.tabs.get.mockResolvedValue(tab(1, { groupId: -1, windowId: 7 }));
+    mockedBrowser.tabGroups.query.mockResolvedValue([
+      { id: 42, title: 'My Group', color: 'blue', windowId: 7 },
+    ]);
+
+    const { targetGroupId, groupedTabIds, joinedExisting } = await performGroupingOperation(makeContext());
+
+    expect(targetGroupId).toBe(42);
+    expect(groupedTabIds).toEqual([1, 2]);
+    expect(joinedExisting).toBe(true);
+    expect(mockedBrowser.tabGroups.query).toHaveBeenCalledWith({ windowId: 7 });
+    expect(mockedBrowser.tabs.group).toHaveBeenCalledWith({ groupId: 42, tabIds: [1, 2] });
+    // No "create a new group" call (i.e. tabs.group({ tabIds }) without groupId)
+    expect(mockedBrowser.tabs.group).not.toHaveBeenCalledWith({ tabIds: [1, 2] });
+    expect(mockedBrowser.tabGroups.update).toHaveBeenCalledWith(42, { collapsed: false });
+    // No title/color update on the joined group
+    expect(mockedBrowser.tabGroups.update).not.toHaveBeenCalledWith(42, expect.objectContaining({ title: expect.anything() }));
+    expect(mockedIncrementStat).not.toHaveBeenCalled();
+  });
+
+  it('creates a new group when an existing group has the same title but a different color', async () => {
+    mockedBrowser.tabs.get.mockResolvedValue(tab(1, { groupId: -1, windowId: 7 }));
+    mockedBrowser.tabGroups.query.mockResolvedValue([
+      { id: 42, title: 'My Group', color: 'red', windowId: 7 },
+    ]);
+
+    const { targetGroupId, groupedTabIds, joinedExisting } = await performGroupingOperation(makeContext());
+
+    expect(joinedExisting).toBe(false);
+    expect(targetGroupId).toBe(99);
+    expect(groupedTabIds).toEqual([1, 2]);
+    expect(mockedBrowser.tabs.group).toHaveBeenCalledWith({ tabIds: [1, 2] });
+  });
+
+  it('joins on title only when the rule has no color preference', async () => {
+    mockedBrowser.tabs.get.mockResolvedValue(tab(1, { groupId: -1, windowId: 7 }));
+    mockedBrowser.tabGroups.query.mockResolvedValue([
+      { id: 42, title: 'My Group', color: 'red', windowId: 7 },
+    ]);
+
+    const { joinedExisting, targetGroupId } = await performGroupingOperation(
+      makeContext({ groupColor: null }),
+    );
+
+    expect(joinedExisting).toBe(true);
+    expect(targetGroupId).toBe(42);
+    expect(mockedBrowser.tabs.group).toHaveBeenCalledWith({ groupId: 42, tabIds: [1, 2] });
+  });
+
+  it('creates a new group when no existing group matches', async () => {
+    mockedBrowser.tabs.get.mockResolvedValue(tab(1, { groupId: -1, windowId: 7 }));
+    mockedBrowser.tabGroups.query.mockResolvedValue([
+      { id: 42, title: 'Other Group', color: 'blue', windowId: 7 },
+    ]);
+
+    const { joinedExisting } = await performGroupingOperation(makeContext());
+
+    expect(joinedExisting).toBe(false);
+    expect(mockedBrowser.tabs.group).toHaveBeenCalledWith({ tabIds: [1, 2] });
+  });
+
+  it('does not query for existing groups when the opener is already grouped', async () => {
+    mockedBrowser.tabs.get.mockResolvedValue(tab(1, { groupId: 55 }));
+
+    await performGroupingOperation(makeContext());
+
+    expect(mockedBrowser.tabGroups.query).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/e2e/grouping.spec.ts
+++ b/tests/e2e/grouping.spec.ts
@@ -391,7 +391,7 @@ test.describe('Tab Grouping', () => {
       expect(stats.tabGroupsCreatedCount).toBe(1); // Only one group was ever created
     });
 
-    test('creates a new group each time a fresh opener opens a child [US-G005]', async ({ helpers }) => {
+    test('joins the existing same-title same-color group when a fresh opener opens a child [US-G005]', async ({ helpers }) => {
       await helpers.addDomainRule({
         label: 'New Group Test',
         domainFilter: 'example.com',
@@ -410,9 +410,12 @@ test.describe('Tab Grouping', () => {
       await helpers.createTabFromOpener(opener2, 'https://example.com/child2');
       await helpers.waitForGrouping();
 
+      const groups = await helpers.getTabGroups();
       const stats = await helpers.getStatistics();
-      // Two separate openers → two separate groups
-      expect(stats.tabGroupsCreatedCount).toBe(2);
+      // The second fresh opener joins the existing group instead of creating
+      // a duplicate, since the rule produces the same name and color.
+      expect(groups).toHaveLength(1);
+      expect(stats.tabGroupsCreatedCount).toBe(1);
     });
   });
 

--- a/user-stories/US-G-grouping.md
+++ b/user-stories/US-G-grouping.md
@@ -72,7 +72,8 @@
 - [ ] A first child tab creates a new group; the `tabGroupsCreatedCount` counter goes to 1.
 - [ ] A second child tab opened from the **same** parent tab is added to the existing group without creating a new one.
 - [ ] The number of tabs in the group increases with each added child.
-- [ ] A new (distinct) parent tab creates a **new** separate group; `tabGroupsCreatedCount` increments.
+- [ ] A child opened from a new (distinct) parent tab joins an existing group in the same window when that group's title and color match what the rule would produce; the counter does **not** increment in that case.
+- [ ] When no existing group matches (different title, or different color when the rule specifies one), a **new** separate group is created and `tabGroupsCreatedCount` increments.
 
 ---
 


### PR DESCRIPTION
When the opener tab is not in a group, the new-tab grouping flow now
looks for an existing group in the same window whose title matches
the rule-computed name and whose color matches the rule color (or any
color when the rule has none). Both the opener and the new tab are
added to that group, preserving its color. Falls back to the previous
"create new group" path when no match exists.

https://claude.ai/code/session_01A4o3jEc7imhhMj8eS3N5FL