### PR TITLE
feat(sessions): allow choosing the default action of the Restore button (US-S022)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -85,6 +85,8 @@
   "deduplicationKeepStrategyNewLabel": { "message": "The newly opened tab" },
   "deduplicationKeepStrategyGroupedLabel": { "message": "Grouped tab wins, otherwise keep existing" },
   "deduplicationKeepStrategyGroupedOrNewLabel": { "message": "Grouped tab wins, otherwise keep the new one" },
+  "defaultRestoreActionLabel": { "message": "Default action" },
+  "defaultRestoreActionDescription": { "message": "Chooses which action the main Restore button triggers when clicked. The dropdown menu remains available with all four options." },
   "notificationGroupingTitle": { "message": "📁 Tabs Grouped" },
   "notificationGroupingMessage": { "message": "Tabs grouped into \"{groupName}\"" },
   "notificationDeduplicationTitle": { "message": "✂️ Duplicate Closed" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -85,6 +85,8 @@
   "deduplicationKeepStrategyNewLabel": { "message": "La pestaña recién abierta" },
   "deduplicationKeepStrategyGroupedLabel": { "message": "Gana la pestaña agrupada, si no mantener la existente" },
   "deduplicationKeepStrategyGroupedOrNewLabel": { "message": "Gana la pestaña agrupada, si no mantener la nueva" },
+  "defaultRestoreActionLabel": { "message": "Acción por defecto" },
+  "defaultRestoreActionDescription": { "message": "Elige qué acción dispara el botón principal Restaurar al hacer clic. El menú desplegable sigue disponible con las cuatro opciones." },
   "notificationGroupingTitle": { "message": "📁 Pestañas Agrupadas" },
   "notificationGroupingMessage": { "message": "Pestañas agrupadas en \"{groupName}\"" },
   "notificationDeduplicationTitle": { "message": "✂️ Duplicado Cerrado" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -85,6 +85,8 @@
   "deduplicationKeepStrategyNewLabel": { "message": "Le nouvel onglet ouvert" },
   "deduplicationKeepStrategyGroupedLabel": { "message": "L'onglet groupé gagne, sinon conserver l'existant" },
   "deduplicationKeepStrategyGroupedOrNewLabel": { "message": "L'onglet groupé gagne, sinon conserver le nouveau" },
+  "defaultRestoreActionLabel": { "message": "Action par défaut" },
+  "defaultRestoreActionDescription": { "message": "Choisit l'action déclenchée par le bouton principal Restaurer lors d'un clic. Le menu déroulant reste disponible avec les quatre options." },
   "notificationGroupingTitle": { "message": "📁 Onglets Regroupés" },
   "notificationGroupingMessage": { "message": "Onglets regroupés dans \"{groupName}\"" },
   "notificationDeduplicationTitle": { "message": "✂️ Doublon Fermé" },

--- a/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
@@ -10,6 +10,7 @@ const mockAppSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  defaultRestoreAction: 'current',
   categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -21,6 +21,7 @@ import { getStatusStyle } from '@/utils/statusStyle';
 import { SessionPreviewTree } from './SessionPreviewTree';
 import { SessionRestoreButton } from './SessionRestoreButton/SessionRestoreButton';
 import type { Session } from '@/types/session';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 
 interface SessionCardProps extends SessionRestoreCallbacks {
   session: Session;
@@ -84,6 +85,10 @@ interface SessionRestoreCallbacks {
   onRestoreNewWindow?: (session: Session) => void;
   onReplaceCurrentWindow?: (session: Session) => void;
   onRefresh?: (session: Session) => void;
+  /** Action triggered by the primary Restore button click. Defaults to 'current'. */
+  defaultRestoreAction?: DefaultRestoreActionValue;
+  /** Persists a new default action when the user picks it from the dropdown radio group. */
+  onDefaultRestoreActionChange?: (value: DefaultRestoreActionValue) => void;
 }
 
 /* SessionMoreMenu */
@@ -352,6 +357,7 @@ function SessionCardFullHeader({
   isSelected, onSelect,
   onPin, onUnpin, onArchive, onUnarchive,
   onRestore, onRestoreCurrentWindow, onRestoreNewWindow, onReplaceCurrentWindow, onRefresh,
+  defaultRestoreAction, onDefaultRestoreActionChange,
   onEdit, onDelete, onMoveToFirst, onMoveLast,
 }: SessionCardFullHeaderProps) {
   const isArchived = session.isArchived === true;
@@ -470,6 +476,8 @@ function SessionCardFullHeader({
           onReplaceCurrentWindow={onReplaceCurrentWindow}
           onCustomize={onRestore}
           onRefresh={onRefresh}
+          defaultRestoreAction={defaultRestoreAction}
+          onDefaultRestoreActionChange={onDefaultRestoreActionChange}
           data-testid={`session-card-${session.id}-btn-restore`}
         />
       )}
@@ -507,6 +515,8 @@ export function SessionCard({
   onRestoreNewWindow,
   onReplaceCurrentWindow,
   onRefresh,
+  defaultRestoreAction,
+  onDefaultRestoreActionChange,
   onRename,
   onEdit,
   onDelete,
@@ -628,6 +638,8 @@ export function SessionCard({
               onRestoreNewWindow={onRestoreNewWindow}
               onReplaceCurrentWindow={onReplaceCurrentWindow}
               onRefresh={onRefresh}
+              defaultRestoreAction={defaultRestoreAction}
+              onDefaultRestoreActionChange={onDefaultRestoreActionChange}
               onEdit={onEdit}
               onDelete={onDelete}
               onMoveToFirst={onMoveToFirst}

--- a/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
+++ b/src/components/Core/Session/SessionRestoreButton/SessionRestoreButton.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Flex, IconButton, Kbd, Tooltip } from '@radix-ui/themes';
 import { Camera, Monitor, Replace, RotateCcw, Square, Wrench } from 'lucide-react';
-import { SplitButton } from '@/components/UI/SplitButton/SplitButton';
+import { SplitButton, type SplitButtonRadioGroupConfig } from '@/components/UI/SplitButton/SplitButton';
 import { getMessage } from '@/utils/i18n';
 import type { Session } from '@/types/session';
+import { defaultRestoreActionOptions, type DefaultRestoreActionValue } from '@/schemas/enums';
 
 export interface SessionRestoreButtonProps {
   session: Session;
@@ -13,6 +14,10 @@ export interface SessionRestoreButtonProps {
   onCustomize: (session: Session) => void;
   /** Optional: when provided, renders a Refresh icon button to the left of the restore split button. */
   onRefresh?: (session: Session) => void;
+  /** Action triggered by the primary button click. Defaults to 'current' for backwards compatibility. */
+  defaultRestoreAction?: DefaultRestoreActionValue;
+  /** Called when the user picks a new default action from the dropdown radio group. */
+  onDefaultRestoreActionChange?: (value: DefaultRestoreActionValue) => void;
   size?: '1' | '2' | '3';
   variant?: 'solid' | 'soft' | 'outline';
   presentation?: 'default' | 'tile';
@@ -26,6 +31,8 @@ export function SessionRestoreButton({
   onReplaceCurrentWindow,
   onCustomize,
   onRefresh,
+  defaultRestoreAction = 'current',
+  onDefaultRestoreActionChange,
   size = '1',
   variant = 'soft',
   presentation = 'default',
@@ -41,14 +48,38 @@ export function SessionRestoreButton({
     <RotateCcw size={12} aria-hidden="true" />
   );
 
+  const primaryHandlers: Record<DefaultRestoreActionValue, (s: Session) => void> = {
+    current: onRestoreCurrentWindow,
+    new: onRestoreNewWindow,
+    replace: onReplaceCurrentWindow,
+    customize: onCustomize,
+  };
+  const currentOption = defaultRestoreActionOptions.find((o) => o.value === defaultRestoreAction)
+    ?? defaultRestoreActionOptions[0];
+  const primaryAriaLabel = getMessage(currentOption.keyLabel);
+
+  const radioGroup: SplitButtonRadioGroupConfig | undefined = onDefaultRestoreActionChange
+    ? {
+        label: getMessage('defaultRestoreActionLabel'),
+        value: defaultRestoreAction,
+        onValueChange: (v) => onDefaultRestoreActionChange(v as DefaultRestoreActionValue),
+        options: defaultRestoreActionOptions.map((option) => ({
+          value: option.value,
+          label: getMessage(option.keyLabel),
+          'data-testid': `session-restore-default-${option.value}`,
+        })),
+      }
+    : undefined;
+
   const splitButton = (
     <SplitButton
       data-testid={testId}
       label={label}
-      primaryAriaLabel={getMessage('sessionRestoreCurrentWindow')}
-      onClick={() => onRestoreCurrentWindow(session)}
+      primaryAriaLabel={primaryAriaLabel}
+      onClick={() => primaryHandlers[defaultRestoreAction](session)}
       size={size}
       variant={variant}
+      radioGroup={radioGroup}
       menuItems={[
         {
           label: getMessage('sessionRestoreCurrentWindow'),

--- a/src/components/HomePage/PinnedSessionTile.tsx
+++ b/src/components/HomePage/PinnedSessionTile.tsx
@@ -4,16 +4,22 @@ import { Pin } from 'lucide-react';
 import type { Session } from '@/types/session';
 import { SessionRestoreButton } from '@/components/Core/Session/SessionRestoreButton/SessionRestoreButton';
 import { getMessage } from '@/utils/i18n';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 import type { HomeRestoreTarget } from './types';
 import styles from './PinnedSessionsSection.module.css';
 
 export interface PinnedSessionTileProps {
   session: Session;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
+  /** Action triggered by the primary Restore button click. */
+  defaultRestoreAction?: DefaultRestoreActionValue;
+  /** Persists a new default action when the user picks it from the dropdown radio group. */
+  onDefaultRestoreActionChange?: (value: DefaultRestoreActionValue) => void;
   tabIndex?: number;
   onKeyDown?: (e: KeyboardEvent<HTMLElement>) => void;
   onFocus?: () => void;
 }
+
 
 function getCounts(session: Session): { groups: number; tabs: number } {
   const groups = session.groups.length;
@@ -24,6 +30,8 @@ function getCounts(session: Session): { groups: number; tabs: number } {
 export function PinnedSessionTile({
   session,
   onRestore,
+  defaultRestoreAction = 'current',
+  onDefaultRestoreActionChange,
   tabIndex = 0,
   onKeyDown,
   onFocus,
@@ -58,6 +66,8 @@ export function PinnedSessionTile({
             onReplaceCurrentWindow={(s) => onRestore(s, 'replace')}
             onCustomize={(s) => onRestore(s, 'custom')}
             onRefresh={(s) => onRestore(s, 'refresh')}
+            defaultRestoreAction={defaultRestoreAction}
+            onDefaultRestoreActionChange={onDefaultRestoreActionChange}
             presentation="tile"
             size="2"
             data-testid={`home-pinned-tile-restore-${session.id}`}

--- a/src/components/HomePage/PinnedSessionsSection.tsx
+++ b/src/components/HomePage/PinnedSessionsSection.tsx
@@ -5,6 +5,7 @@ import type { Session } from '@/types/session';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
 import { useListNavigation } from '@/hooks/useListNavigation';
 import { getMessage } from '@/utils/i18n';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 import { PinnedSessionTile } from './PinnedSessionTile';
 import type { HomeRestoreTarget } from './types';
 
@@ -12,11 +13,21 @@ export interface PinnedSessionsSectionProps {
   sessions: Session[];
   onSeeAll: () => void;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
+  /** Action triggered by the primary Restore button click on each tile. */
+  defaultRestoreAction?: DefaultRestoreActionValue;
+  /** Persists a new default action when the user picks it from a tile's dropdown radio group. */
+  onDefaultRestoreActionChange?: (value: DefaultRestoreActionValue) => void;
 }
 
 const MAX_TILES = 6;
 
-export function PinnedSessionsSection({ sessions, onSeeAll, onRestore }: PinnedSessionsSectionProps) {
+export function PinnedSessionsSection({
+  sessions,
+  onSeeAll,
+  onRestore,
+  defaultRestoreAction,
+  onDefaultRestoreActionChange,
+}: PinnedSessionsSectionProps) {
   const visible = sessions.slice(0, MAX_TILES);
   const gridRef = useRef<HTMLDivElement>(null);
   const [focusIndex, setFocusIndex] = useState(0);
@@ -71,6 +82,8 @@ export function PinnedSessionsSection({ sessions, onSeeAll, onRestore }: PinnedS
                 key={s.id}
                 session={s}
                 onRestore={onRestore}
+                defaultRestoreAction={defaultRestoreAction}
+                onDefaultRestoreActionChange={onDefaultRestoreActionChange}
                 tabIndex={i === focusIndex ? 0 : -1}
                 onFocus={() => setFocusIndex(i)}
                 onKeyDown={(e) => handleTileKeyDown(e, i, s)}

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -13,8 +13,11 @@ import { showSuccessNotification } from '@/utils/notifications';
 import { getRuleCategory } from '@/utils/categoriesStore';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import { useListNavigation } from '@/hooks/useListNavigation';
+import { useSettings } from '@/hooks/useSettings';
 import { useShortcuts } from '@/hooks/useShortcuts';
 import type { Session } from '@/types/session';
+import { defaultAppSettings } from '@/types/syncSettings';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 import styles from './PopupProfilesList.module.css';
 
 function getCategoryIcon(categoryId: string | null | undefined): React.ReactNode {
@@ -118,6 +121,16 @@ export function PopupProfilesList() {
       })
       .catch(() => {});
   }, []);
+
+  const { settings, setDefaultRestoreAction } = useSettings();
+  const defaultRestoreAction: DefaultRestoreActionValue =
+    settings?.defaultRestoreAction ?? defaultAppSettings.defaultRestoreAction;
+  const handleDefaultRestoreActionChange = useCallback(
+    (value: DefaultRestoreActionValue) => {
+      void setDefaultRestoreAction(value);
+    },
+    [setDefaultRestoreAction],
+  );
 
   const { handleNavigationKey } = useListNavigation(listRef, '[data-popup-pinned-card]');
 
@@ -283,6 +296,8 @@ export function PopupProfilesList() {
                 onReplaceCurrentWindow={(s) => handleRestore(s, 'replace')}
                 onCustomize={(s) => { void openCustomizeRestore(s); }}
                 onRefresh={(s) => { void openRefreshFromPopup(s); }}
+                defaultRestoreAction={defaultRestoreAction}
+                onDefaultRestoreActionChange={handleDefaultRestoreActionChange}
                 data-testid={`popup-profile-btn-restore-${session.id}`}
               />
             </Flex>

--- a/src/components/UI/SettingsPage/SettingsPage.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.tsx
@@ -1,11 +1,13 @@
 import { Box, Flex, Text, Switch, Card, RadioGroup } from '@radix-ui/themes';
-import { Bell, Copy } from 'lucide-react';
+import { Bell, Copy, RotateCcw } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { getMessage } from '@/utils/i18n';
 import type { AppSettings } from '@/types/syncSettings';
 import {
   deduplicationKeepStrategyOptions,
+  defaultRestoreActionOptions,
   type DeduplicationKeepStrategyValue,
+  type DefaultRestoreActionValue,
 } from '@/schemas/enums';
 
 interface SettingsPageProps {
@@ -60,6 +62,47 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                       onCheckedChange={(checked) => updateSettings({ notifyOnOrganize: checked })}
                     />
                   </Flex>
+                </Flex>
+              </Box>
+            </Card>
+
+            <Card>
+              <Box p="4">
+                <Flex align="center" gap="2" mb="4">
+                  <RotateCcw size={20} style={{ color: 'var(--accent-9)' }} />
+                  <Text size="3" weight="bold">{getMessage('sessionRestore')}</Text>
+                </Flex>
+
+                <Flex direction="column" gap="2">
+                  <Text size="2" id="page-settings-default-restore-action-label">
+                    {getMessage('defaultRestoreActionLabel')}
+                  </Text>
+                  <RadioGroup.Root
+                    id="page-settings-default-restore-action"
+                    data-testid="page-settings-default-restore-action"
+                    aria-labelledby="page-settings-default-restore-action-label"
+                    value={syncSettings.defaultRestoreAction}
+                    onValueChange={(value) =>
+                      updateSettings({ defaultRestoreAction: value as DefaultRestoreActionValue })
+                    }
+                  >
+                    <Flex direction="column" gap="2">
+                      {defaultRestoreActionOptions.map((option) => (
+                        <Text as="label" size="2" key={option.value}>
+                          <Flex gap="2" align="center">
+                            <RadioGroup.Item
+                              value={option.value}
+                              data-testid={`page-settings-default-restore-action-${option.value}`}
+                            />
+                            {getMessage(option.keyLabel)}
+                          </Flex>
+                        </Text>
+                      ))}
+                    </Flex>
+                  </RadioGroup.Root>
+                  <Text size="1" color="gray">
+                    {getMessage('defaultRestoreActionDescription')}
+                  </Text>
                 </Flex>
               </Box>
             </Card>

--- a/src/components/UI/SplitButton/SplitButton.stories.tsx
+++ b/src/components/UI/SplitButton/SplitButton.stories.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Theme } from '@radix-ui/themes';
+import { Monitor, Replace, Square, Wrench } from 'lucide-react';
+import { SplitButton, type SplitButtonRadioGroupConfig } from './SplitButton';
+
+const noop = () => {};
+
+const baseMenuItems = [
+  { label: 'Restore in current window', icon: <Monitor size={14} />, onClick: noop, shortcut: 'Shift+R', 'data-testid': 'split-menu-current' },
+  { label: 'Restore in new window', icon: <Square size={14} />, onClick: noop, shortcut: 'Alt+Shift+R', 'data-testid': 'split-menu-new' },
+  { label: 'Replace tabs in current window', icon: <Replace size={14} />, onClick: noop, shortcut: 'Alt+R', 'data-testid': 'split-menu-replace' },
+  { label: 'Customized restoration...', icon: <Wrench size={14} />, onClick: noop, shortcut: 'R', 'data-testid': 'split-menu-customize' },
+];
+
+function RadioGroupSplitButton({ initialValue = 'current' }: { initialValue?: string }) {
+  const [value, setValue] = useState(initialValue);
+  const radioGroup: SplitButtonRadioGroupConfig = {
+    label: 'Default action',
+    value,
+    onValueChange: setValue,
+    options: [
+      { value: 'current', label: 'Restore in current window', 'data-testid': 'split-default-current' },
+      { value: 'new', label: 'Restore in new window', 'data-testid': 'split-default-new' },
+      { value: 'replace', label: 'Replace tabs in current window', 'data-testid': 'split-default-replace' },
+      { value: 'customize', label: 'Customized restoration...', 'data-testid': 'split-default-customize' },
+    ],
+  };
+  return (
+    <SplitButton
+      label="Restore"
+      primaryAriaLabel="Restore"
+      onClick={noop}
+      menuItems={baseMenuItems}
+      radioGroup={radioGroup}
+      variant="soft"
+    />
+  );
+}
+
+const meta: Meta<typeof SplitButton> = {
+  title: 'Components/UI/SplitButton',
+  component: SplitButton,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <Theme>
+        <Box style={{ padding: 16 }}>
+          <Story />
+        </Box>
+      </Theme>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SplitButtonDefault: Story = {
+  args: {
+    label: 'Export',
+    onClick: noop,
+    menuItems: [
+      { label: 'Download file', onClick: noop, 'data-testid': 'split-export-file' },
+      { label: 'Copy to clipboard', onClick: noop, 'data-testid': 'split-export-clipboard' },
+    ],
+    variant: 'soft',
+  },
+};
+
+export const SplitButtonDisabled: Story = {
+  args: {
+    ...SplitButtonDefault.args,
+    disabled: true,
+    disabledReason: 'Nothing to export',
+  },
+};
+
+export const SplitButtonWithRadioGroup: Story = {
+  render: () => <RadioGroupSplitButton initialValue="current" />,
+};
+
+export const SplitButtonWithRadioGroupNew: Story = {
+  render: () => <RadioGroupSplitButton initialValue="new" />,
+};
+
+export const SplitButtonWithRadioGroupReplace: Story = {
+  render: () => <RadioGroupSplitButton initialValue="replace" />,
+};
+
+export const SplitButtonWithRadioGroupCustomize: Story = {
+  render: () => <RadioGroupSplitButton initialValue="customize" />,
+};

--- a/src/components/UI/SplitButton/SplitButton.tsx
+++ b/src/components/UI/SplitButton/SplitButton.tsx
@@ -17,6 +17,23 @@ export interface SplitButtonMenuItem {
   'data-testid'?: string;
 }
 
+export interface SplitButtonRadioGroupOption {
+  value: string;
+  label: string;
+  'data-testid'?: string;
+}
+
+export interface SplitButtonRadioGroupConfig {
+  /** Visible label rendered above the radio group inside the dropdown. */
+  label: string;
+  /** Currently selected option value. */
+  value: string;
+  /** Available options. */
+  options: SplitButtonRadioGroupOption[];
+  /** Called when the user picks a new option. Selecting an option must not trigger any other action. */
+  onValueChange: (value: string) => void;
+}
+
 export interface SplitButtonProps {
   /** Label of the primary button. Accepts text or any ReactNode (e.g. icon) */
   label: React.ReactNode;
@@ -24,6 +41,12 @@ export interface SplitButtonProps {
   onClick: () => void;
   /** Dropdown menu items */
   menuItems: SplitButtonMenuItem[];
+  /**
+   * Optional radio group rendered at the bottom of the dropdown menu, below
+   * the action items. Selecting a radio item only emits `onValueChange`; it
+   * never triggers any of the action items.
+   */
+  radioGroup?: SplitButtonRadioGroupConfig;
   /** Radix variant */
   variant?: 'solid' | 'soft' | 'outline';
   /** Radix size */
@@ -44,6 +67,7 @@ export function SplitButton({
   label,
   onClick,
   menuItems,
+  radioGroup,
   variant = 'solid',
   size = '2',
   disabled = false,
@@ -118,6 +142,27 @@ export function SplitButton({
                 </DropdownMenu.Item>
               </React.Fragment>
             ))}
+            {radioGroup && (
+              <>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Label>{radioGroup.label}</DropdownMenu.Label>
+                <DropdownMenu.RadioGroup
+                  value={radioGroup.value}
+                  onValueChange={radioGroup.onValueChange}
+                >
+                  {radioGroup.options.map((option) => (
+                    <DropdownMenu.RadioItem
+                      key={option.value}
+                      value={option.value}
+                      data-testid={option['data-testid']}
+                      onSelect={(event) => event.preventDefault()}
+                    >
+                      {option.label}
+                    </DropdownMenu.RadioItem>
+                  ))}
+                </DropdownMenu.RadioGroup>
+              </>
+            )}
           </DropdownMenu.Content>
         </DropdownMenu.Root>
       )}

--- a/src/components/UI/Workspace/ExportWorkspaceDialog.tsx
+++ b/src/components/UI/Workspace/ExportWorkspaceDialog.tsx
@@ -25,6 +25,7 @@ const EMPTY_PAYLOAD: WorkspaceExportPayload = {
     globalDeduplicationEnabled: true,
     deduplicateUnmatchedDomains: false,
     deduplicationKeepStrategy: 'keep-grouped-or-new',
+    defaultRestoreAction: 'current',
     notifyOnGrouping: true,
     notifyOnDeduplication: true,
     notifyOnOrganize: true,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { storage } from 'wxt/utils/storage';
 import type { AppSettings, DomainRuleSettings } from '@/types/syncSettings.js';
-import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import type { DeduplicationKeepStrategyValue, DefaultRestoreActionValue } from '@/schemas/enums.js';
 import type { RuleCategory } from '@/schemas/category.js';
 import type { ScopedItems } from '@/utils/workspaceStorage.js';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext.js';
@@ -15,6 +15,7 @@ export interface UseSettingsReturn {
   setGlobalDeduplicationEnabled: (value: boolean) => Promise<void>;
   setDeduplicateUnmatchedDomains: (value: boolean) => Promise<void>;
   setDeduplicationKeepStrategy: (value: DeduplicationKeepStrategyValue) => Promise<void>;
+  setDefaultRestoreAction: (value: DefaultRestoreActionValue) => Promise<void>;
   setDomainRules: (value: DomainRuleSettings) => Promise<void>;
   setCategories: (value: RuleCategory[]) => Promise<void>;
 
@@ -23,6 +24,9 @@ export interface UseSettingsReturn {
   onDeduplicateUnmatchedDomainsChange: (callback: (value: boolean) => void) => () => void;
   onDeduplicationKeepStrategyChange: (
     callback: (value: DeduplicationKeepStrategyValue) => void,
+  ) => () => void;
+  onDefaultRestoreActionChange: (
+    callback: (value: DefaultRestoreActionValue) => void,
   ) => () => void;
   onDomainRulesChange: (callback: (value: DomainRuleSettings) => void) => () => void;
   onCategoriesChange: (callback: (value: RuleCategory[]) => void) => () => void;
@@ -41,6 +45,7 @@ function buildSettingsItemMap(items: ScopedItems): SettingsItemMap {
     globalDeduplicationEnabled: items.globalDeduplicationEnabledItem,
     deduplicateUnmatchedDomains: items.deduplicateUnmatchedDomainsItem,
     deduplicationKeepStrategy: items.deduplicationKeepStrategyItem,
+    defaultRestoreAction: items.defaultRestoreActionItem,
     domainRules: items.domainRulesItem,
     categories: items.categoriesItem,
     notifyOnGrouping: items.notifyOnGroupingItem,
@@ -55,6 +60,7 @@ async function loadSettingsFromStorage(items: ScopedItems): Promise<AppSettings>
     items.globalDeduplicationEnabledItem,
     items.deduplicateUnmatchedDomainsItem,
     items.deduplicationKeepStrategyItem,
+    items.defaultRestoreActionItem,
     items.domainRulesItem,
     items.categoriesItem,
     items.notifyOnGroupingItem,
@@ -62,7 +68,7 @@ async function loadSettingsFromStorage(items: ScopedItems): Promise<AppSettings>
     items.notifyOnOrganizeItem,
   ]);
 
-  const rawRules = results[4].value as DomainRuleSettings;
+  const rawRules = results[5].value as DomainRuleSettings;
   // Migrate legacy wildcard syntax: *.example.com -> example.com
   const hasWildcards = rawRules?.some(r => r.domainFilter?.startsWith('*.'));
   const domainRules = hasWildcards
@@ -80,11 +86,12 @@ async function loadSettingsFromStorage(items: ScopedItems): Promise<AppSettings>
     globalDeduplicationEnabled: results[1].value as boolean,
     deduplicateUnmatchedDomains: results[2].value as boolean,
     deduplicationKeepStrategy: results[3].value as DeduplicationKeepStrategyValue,
+    defaultRestoreAction: results[4].value as DefaultRestoreActionValue,
     domainRules,
-    categories: results[5].value as RuleCategory[],
-    notifyOnGrouping: results[6].value as boolean,
-    notifyOnDeduplication: results[7].value as boolean,
-    notifyOnOrganize: results[8].value as boolean,
+    categories: results[6].value as RuleCategory[],
+    notifyOnGrouping: results[7].value as boolean,
+    notifyOnDeduplication: results[8].value as boolean,
+    notifyOnOrganize: results[9].value as boolean,
   };
 }
 
@@ -133,6 +140,7 @@ export function useSettings(): UseSettingsReturn {
     setGlobalDeduplicationEnabled: (v) => update({ globalDeduplicationEnabled: v }),
     setDeduplicateUnmatchedDomains: (v) => update({ deduplicateUnmatchedDomains: v }),
     setDeduplicationKeepStrategy: (v) => update({ deduplicationKeepStrategy: v }),
+    setDefaultRestoreAction: (v) => update({ defaultRestoreAction: v }),
     setDomainRules: (v) => update({ domainRules: v }),
     setCategories: (v) => update({ categories: v }),
 
@@ -140,6 +148,7 @@ export function useSettings(): UseSettingsReturn {
     onGlobalDeduplicationEnabledChange: (cb) => onFieldChange('globalDeduplicationEnabled', cb),
     onDeduplicateUnmatchedDomainsChange: (cb) => onFieldChange('deduplicateUnmatchedDomains', cb),
     onDeduplicationKeepStrategyChange: (cb) => onFieldChange('deduplicationKeepStrategy', cb),
+    onDefaultRestoreActionChange: (cb) => onFieldChange('defaultRestoreAction', cb),
     onDomainRulesChange: (cb) => onFieldChange('domainRules', cb),
     onCategoriesChange: (cb) => onFieldChange('categories', cb),
 

--- a/src/pages/DomainRulesPage.stories.tsx
+++ b/src/pages/DomainRulesPage.stories.tsx
@@ -41,6 +41,7 @@ const mockSyncSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  defaultRestoreAction: 'current',
   categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,

--- a/src/pages/HomePage.stories.tsx
+++ b/src/pages/HomePage.stories.tsx
@@ -56,6 +56,7 @@ const baseSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: false,
   deduplicationKeepStrategy: 'keep-grouped-or-new',
+  defaultRestoreAction: 'current',
   categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
@@ -110,6 +111,7 @@ const meta: Meta<typeof HomePage> = {
     onOpenRuleWizard: () => {},
     onOpenShortcutsAside: () => {},
     onRestore: () => {},
+    onDefaultRestoreActionChange: () => {},
   },
 };
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -18,6 +18,7 @@ import {
 import { HomePageSkeleton } from '@/components/HomePage/HomePageSkeleton';
 import type { QuickActionId } from '@/components/HomePage/data';
 import type { HomeRestoreTarget } from '@/components/HomePage/types';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 
 export interface HomePageProps {
   syncSettings: AppSettings;
@@ -27,6 +28,8 @@ export interface HomePageProps {
   onOpenRuleWizard: () => void;
   onOpenShortcutsAside: () => void;
   onRestore: (session: Session, target: HomeRestoreTarget) => void;
+  /** Persists a new default restore action when the user picks it from a pinned tile dropdown. */
+  onDefaultRestoreActionChange: (value: DefaultRestoreActionValue) => void;
   /** Locale used by mini-stats for thousand-separator formatting. */
   locale?: string;
 }
@@ -47,6 +50,7 @@ export function HomePage({
   onOpenRuleWizard,
   onOpenShortcutsAside,
   onRestore,
+  onDefaultRestoreActionChange,
   locale,
 }: HomePageProps) {
   const { openImportRules } = useImportExportWizards();
@@ -132,6 +136,8 @@ export function HomePage({
                 sessions={pinnedSessions}
                 onSeeAll={handleSeeAllSessions}
                 onRestore={onRestore}
+                defaultRestoreAction={syncSettings.defaultRestoreAction}
+                onDefaultRestoreActionChange={onDefaultRestoreActionChange}
               />
 
               <QuickActionsSection count={QUICK_COUNT_DEFAULT} onAction={handleQuickAction} />

--- a/src/pages/SessionsPage.stories.tsx
+++ b/src/pages/SessionsPage.stories.tsx
@@ -25,6 +25,7 @@ const mockSyncSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: true,
   deduplicationKeepStrategy: 'keep-old',
+  defaultRestoreAction: 'current',
   categories: [],
   notifyOnGrouping: true,
   notifyOnDeduplication: true,
@@ -45,6 +46,7 @@ const meta: Meta<typeof SessionsPage> = {
   ],
   args: {
     syncSettings: mockSyncSettings,
+    updateSettings: () => {},
   },
 };
 

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -31,6 +31,7 @@ import { browser } from 'wxt/browser';
 import type { Session } from '@/types/session';
 import type { SessionSearchMatch } from '@/utils/sessionUtils';
 import type { AppSettings } from '@/types/syncSettings';
+import type { DefaultRestoreActionValue } from '@/schemas/enums';
 
 type BulkScope = 'pinned' | 'unpinned' | 'archived';
 
@@ -54,6 +55,8 @@ function pruneSelection(prev: Set<string>, visible: readonly { id: string }[]): 
 
 interface SessionsPageProps {
   syncSettings: AppSettings;
+  /** Persist a partial settings update (for example the default restore action). */
+  updateSettings: (updates: Partial<AppSettings>) => void;
   /** Controlled by options.tsx: true when a deep-link requests the snapshot wizard. */
   snapshotWizardOpen?: boolean;
   /** Called by SessionsPage to let options.tsx know the wizard closed (or page unmounted). */
@@ -115,6 +118,10 @@ interface SessionSectionProps {
   onReplaceCurrentWindow: (session: Session) => void;
   /** Open the refresh wizard for the session (captures current window state). */
   onRefresh: (session: Session) => void;
+  /** Action triggered by the primary Restore button click. */
+  defaultRestoreAction: DefaultRestoreActionValue;
+  /** Persists a new default restore action when the user picks it from the dropdown radio group. */
+  onDefaultRestoreActionChange: (value: DefaultRestoreActionValue) => void;
   /** Pin/unpin handlers shared with the page-level widget shortcuts. */
   onPin: (session: Session) => void;
   onUnpin: (session: Session) => void;
@@ -161,6 +168,8 @@ function SessionSection({
   onRestoreNewWindow,
   onReplaceCurrentWindow,
   onRefresh,
+  defaultRestoreAction,
+  onDefaultRestoreActionChange,
   onPin,
   onUnpin,
   onArchive,
@@ -314,6 +323,8 @@ function SessionSection({
                   onRestoreNewWindow={onRestoreNewWindow}
                   onReplaceCurrentWindow={onReplaceCurrentWindow}
                   onRefresh={onRefresh}
+                  defaultRestoreAction={defaultRestoreAction}
+                  onDefaultRestoreActionChange={onDefaultRestoreActionChange}
                   onRename={renameSession}
                   onEdit={onOpenEditDialog}
                   onDelete={onOpenDeleteDialog}
@@ -342,6 +353,7 @@ function SessionSection({
 
 export function SessionsPage({
   syncSettings,
+  updateSettings,
   snapshotWizardOpen = false,
   onSnapshotWizardOpenChange,
   snapshotGroupId,
@@ -699,6 +711,8 @@ export function SessionsPage({
     | 'onRestoreNewWindow'
     | 'onReplaceCurrentWindow'
     | 'onRefresh'
+    | 'defaultRestoreAction'
+    | 'onDefaultRestoreActionChange'
     | 'onPin'
     | 'onUnpin'
     | 'onArchive'
@@ -716,6 +730,8 @@ export function SessionsPage({
     onRestoreNewWindow: handleRestoreNewWindow,
     onReplaceCurrentWindow: handleReplaceCurrentWindow,
     onRefresh: handleRefreshTrigger,
+    defaultRestoreAction: syncSettings.defaultRestoreAction,
+    onDefaultRestoreActionChange: (value) => updateSettings({ defaultRestoreAction: value }),
     onPin: handlePin,
     onUnpin: handleUnpin,
     onArchive: handleArchive,

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -231,6 +231,7 @@ export function OptionsContent() {
                                     onOpenRuleWizard={handleOpenRuleWizardFromHome}
                                     onOpenShortcutsAside={openShortcuts}
                                     onRestore={handleRestoreFromHome}
+                                    onDefaultRestoreActionChange={(value) => updateSettings({ defaultRestoreAction: value })}
                                 />
                             )}
                             {currentTab === 'rules' && (
@@ -250,6 +251,7 @@ export function OptionsContent() {
                             {currentTab === 'sessions' && (
                                 <SessionsPage
                                     syncSettings={settings}
+                                    updateSettings={updateSettings}
                                     snapshotWizardOpen={openSnapshotWizard}
                                     onSnapshotWizardOpenChange={setOpenSnapshotWizard}
                                     snapshotGroupId={snapshotGroupId}

--- a/src/schemas/enums.ts
+++ b/src/schemas/enums.ts
@@ -40,6 +40,13 @@ export const deduplicationKeepStrategyOptions = [
   { value: 'keep-grouped-or-new', keyLabel: 'deduplicationKeepStrategyGroupedOrNewLabel' }
 ] as const;
 
+export const defaultRestoreActionOptions = [
+  { value: 'current', keyLabel: 'sessionRestoreCurrentWindow' },
+  { value: 'new', keyLabel: 'sessionRestoreNewWindow' },
+  { value: 'replace', keyLabel: 'sessionRestoreReplaceCurrentWindow' },
+  { value: 'customize', keyLabel: 'sessionRestoreCustomize' }
+] as const;
+
 export const badgeOptions = [
   { value: 'NEW', color: 'green', keyLabel: 'badge_new' },
   { value: 'WARNING', color: 'orange', keyLabel: 'badge_warning' },
@@ -51,5 +58,6 @@ export type ColorValue = typeof colorOptions[number]['value'];
 export type GroupNameSourceValue = typeof groupNameSourceOptions[number]['value'];
 export type DeduplicationMatchModeValue = typeof deduplicationMatchModeOptions[number]['value'];
 export type DeduplicationKeepStrategyValue = typeof deduplicationKeepStrategyOptions[number]['value'];
+export type DefaultRestoreActionValue = typeof defaultRestoreActionOptions[number]['value'];
 export type BadgeType = typeof badgeOptions[number]['value'];
 export type UrlExtractionModeValue = typeof urlExtractionModeOptions[number]['value'];

--- a/src/schemas/importExport.ts
+++ b/src/schemas/importExport.ts
@@ -4,10 +4,12 @@ import {
   deduplicationMatchModeOptions,
   colorOptions,
   deduplicationKeepStrategyOptions,
+  defaultRestoreActionOptions,
   type GroupNameSourceValue,
   type DeduplicationMatchModeValue,
   type ColorValue,
-  type DeduplicationKeepStrategyValue
+  type DeduplicationKeepStrategyValue,
+  type DefaultRestoreActionValue
 } from './enums.js';
 import { sessionSchema } from './session.js';
 import { ruleCategorySchema } from './category.js';
@@ -71,6 +73,9 @@ const importWorkspaceSettingsSchema = z.object({
   deduplicationKeepStrategy: z.enum(
     deduplicationKeepStrategyOptions.map(opt => opt.value) as [DeduplicationKeepStrategyValue, ...DeduplicationKeepStrategyValue[]],
   ),
+  defaultRestoreAction: z.enum(
+    defaultRestoreActionOptions.map(opt => opt.value) as [DefaultRestoreActionValue, ...DefaultRestoreActionValue[]],
+  ).optional(),
   notifyOnGrouping: z.boolean(),
   notifyOnDeduplication: z.boolean(),
   notifyOnOrganize: z.boolean().optional(),

--- a/src/types/syncSettings.ts
+++ b/src/types/syncSettings.ts
@@ -1,5 +1,9 @@
 import type { DomainRule } from '@/schemas/domainRule.js';
-import { type BadgeType, type DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import {
+  type BadgeType,
+  type DeduplicationKeepStrategyValue,
+  type DefaultRestoreActionValue
+} from '@/schemas/enums.js';
 import type { RuleCategory } from '@/schemas/category.js';
 
 // Settings types that extend the Zod-inferred types.
@@ -17,6 +21,7 @@ export interface AppSettings {
   globalDeduplicationEnabled: boolean;
   deduplicateUnmatchedDomains: boolean;
   deduplicationKeepStrategy: DeduplicationKeepStrategyValue;
+  defaultRestoreAction: DefaultRestoreActionValue;
   domainRules: DomainRuleSettings;
   categories: RuleCategory[];
   // Notification settings
@@ -31,6 +36,7 @@ export const defaultAppSettings: AppSettings = {
   globalDeduplicationEnabled: true,
   deduplicateUnmatchedDomains: false,
   deduplicationKeepStrategy: 'keep-grouped-or-new',
+  defaultRestoreAction: 'current',
   domainRules: [],
   categories: [],
   notifyOnGrouping: true,

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -21,6 +21,7 @@ export async function getSettings(): Promise<AppSettings> {
       items.globalDeduplicationEnabledItem,
       items.deduplicateUnmatchedDomainsItem,
       items.deduplicationKeepStrategyItem,
+      items.defaultRestoreActionItem,
       items.domainRulesItem,
       items.categoriesItem,
       items.notifyOnGroupingItem,
@@ -32,11 +33,12 @@ export async function getSettings(): Promise<AppSettings> {
       globalDeduplicationEnabled: results[1].value as boolean,
       deduplicateUnmatchedDomains: results[2].value as boolean,
       deduplicationKeepStrategy: results[3].value as AppSettings['deduplicationKeepStrategy'],
-      domainRules: results[4].value as AppSettings['domainRules'],
-      categories: results[5].value as AppSettings['categories'],
-      notifyOnGrouping: results[6].value as boolean,
-      notifyOnDeduplication: results[7].value as boolean,
-      notifyOnOrganize: results[8].value as boolean,
+      defaultRestoreAction: results[4].value as AppSettings['defaultRestoreAction'],
+      domainRules: results[5].value as AppSettings['domainRules'],
+      categories: results[6].value as AppSettings['categories'],
+      notifyOnGrouping: results[7].value as boolean,
+      notifyOnDeduplication: results[8].value as boolean,
+      notifyOnOrganize: results[9].value as boolean,
     };
   } catch (error) {
     logger.error('Error getting settings:', error);
@@ -52,6 +54,7 @@ export async function setSettings(settings: AppSettings): Promise<void> {
       { item: items.globalDeduplicationEnabledItem, value: settings.globalDeduplicationEnabled },
       { item: items.deduplicateUnmatchedDomainsItem, value: settings.deduplicateUnmatchedDomains },
       { item: items.deduplicationKeepStrategyItem, value: settings.deduplicationKeepStrategy },
+      { item: items.defaultRestoreActionItem, value: settings.defaultRestoreAction },
       { item: items.domainRulesItem, value: settings.domainRules },
       { item: items.categoriesItem, value: settings.categories },
       { item: items.notifyOnGroupingItem, value: settings.notifyOnGrouping },
@@ -75,6 +78,8 @@ export async function updateSettings(updates: Partial<AppSettings>): Promise<voi
       writes.push({ item: items.deduplicateUnmatchedDomainsItem, value: updates.deduplicateUnmatchedDomains! });
     if ('deduplicationKeepStrategy' in updates)
       writes.push({ item: items.deduplicationKeepStrategyItem, value: updates.deduplicationKeepStrategy! });
+    if ('defaultRestoreAction' in updates)
+      writes.push({ item: items.defaultRestoreActionItem, value: updates.defaultRestoreAction! });
     if ('domainRules' in updates)
       writes.push({ item: items.domainRulesItem, value: updates.domainRules! });
     if ('categories' in updates)
@@ -104,6 +109,7 @@ export function watchSettings(
     items.globalDeduplicationEnabledItem.watch(() => getSettings().then(callback)),
     items.deduplicateUnmatchedDomainsItem.watch(() => getSettings().then(callback)),
     items.deduplicationKeepStrategyItem.watch(() => getSettings().then(callback)),
+    items.defaultRestoreActionItem.watch(() => getSettings().then(callback)),
     items.domainRulesItem.watch(() => getSettings().then(callback)),
     items.categoriesItem.watch(() => getSettings().then(callback)),
     items.notifyOnGroupingItem.watch(() => getSettings().then(callback)),
@@ -123,6 +129,7 @@ export function watchSettingsField<K extends keyof AppSettings>(
     globalDeduplicationEnabled: items.globalDeduplicationEnabledItem,
     deduplicateUnmatchedDomains: items.deduplicateUnmatchedDomainsItem,
     deduplicationKeepStrategy: items.deduplicationKeepStrategyItem,
+    defaultRestoreAction: items.defaultRestoreActionItem,
     domainRules: items.domainRulesItem,
     categories: items.categoriesItem,
     notifyOnGrouping: items.notifyOnGroupingItem,

--- a/src/utils/workspaceImportExport.ts
+++ b/src/utils/workspaceImportExport.ts
@@ -30,6 +30,7 @@ export interface WorkspaceExportPayload {
     | 'globalDeduplicationEnabled'
     | 'deduplicateUnmatchedDomains'
     | 'deduplicationKeepStrategy'
+    | 'defaultRestoreAction'
     | 'notifyOnGrouping'
     | 'notifyOnDeduplication'
     | 'notifyOnOrganize'
@@ -52,6 +53,7 @@ async function readScopedSnapshot(items: ScopedItems): Promise<{
     items.globalDeduplicationEnabledItem,
     items.deduplicateUnmatchedDomainsItem,
     items.deduplicationKeepStrategyItem,
+    items.defaultRestoreActionItem,
     items.notifyOnGroupingItem,
     items.notifyOnDeduplicationItem,
     items.notifyOnOrganizeItem,
@@ -63,9 +65,9 @@ async function readScopedSnapshot(items: ScopedItems): Promise<{
     items.archivedSessionsItem,
   ]);
 
-  const activeSessions = (results[9].value as Session[]) ?? [];
-  const pinnedSessions = (results[11].value as Session[]) ?? [];
-  const archivedSessions = (results[12].value as Session[]) ?? [];
+  const activeSessions = (results[10].value as Session[]) ?? [];
+  const pinnedSessions = (results[12].value as Session[]) ?? [];
+  const archivedSessions = (results[13].value as Session[]) ?? [];
 
   return {
     settings: {
@@ -73,14 +75,15 @@ async function readScopedSnapshot(items: ScopedItems): Promise<{
       globalDeduplicationEnabled: results[1].value as boolean,
       deduplicateUnmatchedDomains: results[2].value as boolean,
       deduplicationKeepStrategy: results[3].value as AppSettings['deduplicationKeepStrategy'],
-      notifyOnGrouping: results[4].value as boolean,
-      notifyOnDeduplication: results[5].value as boolean,
-      notifyOnOrganize: results[6].value as boolean,
+      defaultRestoreAction: results[4].value as AppSettings['defaultRestoreAction'],
+      notifyOnGrouping: results[5].value as boolean,
+      notifyOnDeduplication: results[6].value as boolean,
+      notifyOnOrganize: results[7].value as boolean,
     },
-    domainRules: (results[7].value as AppSettings['domainRules']) ?? [],
-    categories: (results[8].value as RuleCategory[]) ?? [],
+    domainRules: (results[8].value as AppSettings['domainRules']) ?? [],
+    categories: (results[9].value as RuleCategory[]) ?? [],
     sessions: [...pinnedSessions, ...activeSessions, ...archivedSessions],
-    statistics: results[10].value as Statistics,
+    statistics: results[11].value as Statistics,
   };
 }
 
@@ -130,6 +133,7 @@ async function writeScopedSnapshot(
     { item: items.globalDeduplicationEnabledItem, value: payload.settings.globalDeduplicationEnabled },
     { item: items.deduplicateUnmatchedDomainsItem, value: payload.settings.deduplicateUnmatchedDomains },
     { item: items.deduplicationKeepStrategyItem, value: payload.settings.deduplicationKeepStrategy },
+    { item: items.defaultRestoreActionItem, value: payload.settings.defaultRestoreAction ?? defaultAppSettings.defaultRestoreAction },
     { item: items.notifyOnGroupingItem, value: payload.settings.notifyOnGrouping },
     { item: items.notifyOnDeduplicationItem, value: payload.settings.notifyOnDeduplication },
     { item: items.notifyOnOrganizeItem, value: payload.settings.notifyOnOrganize ?? defaultAppSettings.notifyOnOrganize },

--- a/src/utils/workspaceStorage.ts
+++ b/src/utils/workspaceStorage.ts
@@ -1,7 +1,7 @@
 import { storage, type WxtStorageItem, type StorageItemKey } from 'wxt/utils/storage';
 import type { DomainRuleSettings } from '@/types/syncSettings.js';
 import { defaultAppSettings } from '@/types/syncSettings.js';
-import type { DeduplicationKeepStrategyValue } from '@/schemas/enums.js';
+import type { DeduplicationKeepStrategyValue, DefaultRestoreActionValue } from '@/schemas/enums.js';
 import type { RuleCategory } from '@/schemas/category.js';
 import type { Statistics } from '@/types/statistics.js';
 import { defaultStatistics } from '@/types/statistics.js';
@@ -21,6 +21,7 @@ export const WORKSPACE_SCOPED_KEYS = [
   'globalDeduplicationEnabled',
   'deduplicateUnmatchedDomains',
   'deduplicationKeepStrategy',
+  'defaultRestoreAction',
   'domainRules',
   'categories',
   'categoriesSeeded',
@@ -55,6 +56,7 @@ export interface ScopedItems {
   globalDeduplicationEnabledItem: WxtStorageItem<boolean, Record<string, unknown>>;
   deduplicateUnmatchedDomainsItem: WxtStorageItem<boolean, Record<string, unknown>>;
   deduplicationKeepStrategyItem: WxtStorageItem<DeduplicationKeepStrategyValue, Record<string, unknown>>;
+  defaultRestoreActionItem: WxtStorageItem<DefaultRestoreActionValue, Record<string, unknown>>;
   domainRulesItem: WxtStorageItem<DomainRuleSettings, Record<string, unknown>>;
   categoriesItem: WxtStorageItem<RuleCategory[], Record<string, unknown>>;
   categoriesSeededItem: WxtStorageItem<boolean, Record<string, unknown>>;
@@ -95,6 +97,10 @@ export function defineWorkspaceItems(wsId: string): ScopedItems {
     deduplicationKeepStrategyItem: storage.defineItem<DeduplicationKeepStrategyValue>(
       workspaceStorageKey(wsId, 'deduplicationKeepStrategy'),
       { defaultValue: defaultAppSettings.deduplicationKeepStrategy },
+    ),
+    defaultRestoreActionItem: storage.defineItem<DefaultRestoreActionValue>(
+      workspaceStorageKey(wsId, 'defaultRestoreAction'),
+      { defaultValue: defaultAppSettings.defaultRestoreAction },
     ),
     domainRulesItem: storage.defineItem<DomainRuleSettings>(
       workspaceStorageKey(wsId, 'domainRules'),

--- a/tests/components/PopupProfilesList.test.tsx
+++ b/tests/components/PopupProfilesList.test.tsx
@@ -40,6 +40,17 @@ vi.mock('../../src/utils/sessionStorage', () => ({
   loadActiveSessions: vi.fn(),
 }));
 
+// Mock useSettings to avoid hitting real workspace storage for the new
+// defaultRestoreAction wiring exercised by SessionRestoreButton.
+vi.mock('../../src/hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: { defaultRestoreAction: 'current' },
+    isLoaded: true,
+    setDefaultRestoreAction: vi.fn(async () => {}),
+    updateSettings: vi.fn(async () => {}),
+  }),
+}));
+
 // Mock tabRestore
 vi.mock('../../src/utils/tabRestore', () => ({
   restoreSessionTabs: vi.fn().mockResolvedValue(undefined),

--- a/tests/components/SessionRestoreButton.test.tsx
+++ b/tests/components/SessionRestoreButton.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../src/utils/i18n', () => ({
       sessionRestoreReplaceCurrentWindow: 'Replace tabs in current window',
       sessionRestoreCustomize: 'Customized restoration',
       sessionRestoreOptions: 'Restore options',
+      defaultRestoreActionLabel: 'Default action',
     };
     return messages[key] || key;
   }),
@@ -147,5 +148,67 @@ describe('SessionRestoreButton', () => {
     expect(primary).toHaveTextContent('Restore');
     fireEvent.click(primary);
     expect(onRestoreCurrentWindow).toHaveBeenCalledWith(session);
+  });
+
+  it('primary click routes to onRestoreNewWindow when defaultRestoreAction is "new"', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onReplaceCurrentWindow={onReplaceCurrentWindow}
+          onCustomize={onCustomize}
+          defaultRestoreAction="new"
+          data-testid="restore-btn"
+        />
+      </TestWrapper>,
+    );
+
+    const primary = screen.getByRole('button', { name: /Restore in new window/i });
+    fireEvent.click(primary);
+
+    expect(onRestoreNewWindow).toHaveBeenCalledWith(session);
+    expect(onRestoreCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it('primary click routes to onReplaceCurrentWindow when defaultRestoreAction is "replace"', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onReplaceCurrentWindow={onReplaceCurrentWindow}
+          onCustomize={onCustomize}
+          defaultRestoreAction="replace"
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Replace tabs in current window/i }));
+
+    expect(onReplaceCurrentWindow).toHaveBeenCalledWith(session);
+    expect(onRestoreCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it('primary click routes to onCustomize when defaultRestoreAction is "customize"', () => {
+    render(
+      <TestWrapper>
+        <SessionRestoreButton
+          session={session}
+          onRestoreCurrentWindow={onRestoreCurrentWindow}
+          onRestoreNewWindow={onRestoreNewWindow}
+          onReplaceCurrentWindow={onReplaceCurrentWindow}
+          onCustomize={onCustomize}
+          defaultRestoreAction="customize"
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Customized restoration/i }));
+
+    expect(onCustomize).toHaveBeenCalledWith(session);
+    expect(onRestoreCurrentWindow).not.toHaveBeenCalled();
   });
 });

--- a/tests/utils/settingsUtils.test.ts
+++ b/tests/utils/settingsUtils.test.ts
@@ -43,6 +43,11 @@ describe('settingsUtils', () => {
       expect(settings.deduplicationKeepStrategy).toBe('keep-grouped-or-new');
     });
 
+    it('defaults defaultRestoreAction to current when missing from storage', async () => {
+      const settings = await getSettings();
+      expect(settings.defaultRestoreAction).toBe('current');
+    });
+
     it('returns default values on error', async () => {
       vi.spyOn(fakeBrowser.storage.local, 'get').mockRejectedValueOnce(
         new Error('Local storage error'),
@@ -108,6 +113,12 @@ describe('settingsUtils', () => {
       await updateSettings({ deduplicationKeepStrategy: 'keep-old' });
       const settings = await getSettings();
       expect(settings.deduplicationKeepStrategy).toBe('keep-old');
+    });
+
+    it('updates defaultRestoreAction', async () => {
+      await updateSettings({ defaultRestoreAction: 'replace' });
+      const settings = await getSettings();
+      expect(settings.defaultRestoreAction).toBe('replace');
     });
 
     it('updates domainRules', async () => {

--- a/user-stories/US-S-sessions.md
+++ b/user-stories/US-S-sessions.md
@@ -232,3 +232,22 @@
 - [ ] A system notification (title "Session activated", message `Switched to session "{name}"`) confirms the switch after the restore.
 - [ ] Automatic deduplication is neutralized for the duration of the restore (cf. corresponding US-D): if a kept pinned tab shares a URL with a session tab, both tabs coexist.
 - [ ] From the popup, the popup automatically closes after triggering the replacement.
+
+## US-S022: Choice of the default action for the Restore button
+
+**As a** user,
+**I want** to choose which restore action is triggered by the primary Restore button (among: current window, new window, replace, customize),
+**so that** I can trigger the action I use most often in one click without going through the dropdown menu.
+
+### Acceptance criteria
+
+- [ ] A new `defaultRestoreAction` field is added to `AppSettings`, with possible values `current`, `new`, `replace`, `customize`. Default value is `current`, preserving prior behavior.
+- [ ] The setting is persisted in `browser.storage.local`, scoped per workspace, through the existing pipeline (`getSettings`, `setSettings`, `updateSettings`, `useSettings`, `getActiveScopedItems`, `WORKSPACE_SCOPED_KEYS`), and included in the workspace import/export payload.
+- [ ] Clicking the primary (left) part of the `SessionRestoreButton` triggers the action matching `defaultRestoreAction`. When the value is `customize`, the primary click opens the customized restore flow.
+- [ ] The `aria-label` of the primary part reflects the current action.
+- [ ] The dropdown menu keeps its 4 clickable actions (immediate execution) with their `data-testid` and shortcuts unchanged. Below them, a `Separator` and a `RadioGroup` titled "Default action" list the same 4 options; the radio matching `defaultRestoreAction` is announced as selected, and picking a radio updates the setting without triggering any restoration.
+- [ ] Each `RadioItem` of the menu carries a stable `data-testid` of the form `session-restore-default-{current|new|replace|customize}`.
+- [ ] The Settings page exposes a `RadioGroup` titled "Default action" with a localized label and description, allowing the user to change `defaultRestoreAction` outside any session card. Changes made there are reflected on all session cards (and vice versa) without manual reload.
+- [ ] The Sessions page, the popup (`PopupProfilesList`) and the HomePage pinned tiles all respect `defaultRestoreAction` for the primary click. The Sessions page, the popup and the pinned tiles also expose the `RadioGroup` in their dropdown so the default can be changed in place; the HomePage tiles map `customize` to the existing `custom` `HomeRestoreTarget` without introducing a new value.
+- [ ] All strings (group label, description) exist in `fr`, `en` and `es`. Existing keys (`sessionRestoreCurrentWindow`, etc.) are reused for the per-option labels.
+- [ ] The keyboard shortcuts of the 4 menu actions (Shift+R, Alt+Shift+R, Alt+R, R) remain attached to those entries and continue to trigger their specific action regardless of `defaultRestoreAction`.


### PR DESCRIPTION
Add a new workspace-scoped AppSettings field `defaultRestoreAction` that
controls which of the four restore actions is triggered by the primary
SessionRestoreButton click (current window, new window, replace,
customize). The setting is exposed both in the Settings page and as a
dropdown radio group inside the SessionRestoreButton menu, persists per
workspace, and is included in the workspace import/export payload.

The HomePage pinned tiles and the popup pinned session cards also
respect this setting and surface the inline radio group.