### PR TITLE
refactor(workspaces): drop redundant color label from workspace card

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -17,7 +17,6 @@
   "workspaceFormBtnCreate": { "message": "Create workspace" },
   "workspaceFormErrorDuplicate": { "message": "A workspace with this name already exists." },
   "workspaceColorPickerLabel": { "message": "Workspace accent color" },
-  "workspaceColorLabelInline": { "message": "Color: $1$", "placeholders": { "1": { "content": "$1", "example": "indigo" } } },
   "workspaceSwitchLabel": { "message": "Switch" },
   "workspaceEditLabel": { "message": "Edit" },
   "workspaceDeleteLabel": { "message": "Delete workspace" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -17,7 +17,6 @@
   "workspaceFormBtnCreate": { "message": "Crear espacio" },
   "workspaceFormErrorDuplicate": { "message": "Ya existe un espacio de trabajo con ese nombre." },
   "workspaceColorPickerLabel": { "message": "Color de acento del espacio" },
-  "workspaceColorLabelInline": { "message": "Color: $1$", "placeholders": { "1": { "content": "$1", "example": "indigo" } } },
   "workspaceSwitchLabel": { "message": "Activar" },
   "workspaceEditLabel": { "message": "Editar" },
   "workspaceDeleteLabel": { "message": "Eliminar espacio" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -17,7 +17,6 @@
   "workspaceFormBtnCreate": { "message": "Créer l'espace" },
   "workspaceFormErrorDuplicate": { "message": "Un espace de travail porte déjà ce nom." },
   "workspaceColorPickerLabel": { "message": "Couleur d'accentuation de l'espace" },
-  "workspaceColorLabelInline": { "message": "Couleur : $1$", "placeholders": { "1": { "content": "$1", "example": "indigo" } } },
   "workspaceSwitchLabel": { "message": "Activer" },
   "workspaceEditLabel": { "message": "Modifier" },
   "workspaceDeleteLabel": { "message": "Supprimer l'espace" },

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -70,9 +70,6 @@ function WorkspaceRow({ workspace, isActive, isDefault, isOnly, searchTerm, onSw
               </Text>
             ) : null}
           </Flex>
-          <Text size="1" color="gray">
-            {getMessage('workspaceColorLabelInline', [workspace.accentColor])}
-          </Text>
           <Text size="1" color="gray" data-testid={`workspace-row-${workspace.id}-relative-time`}>
             {relativePrefix}{' '}
             <time dateTime={relativeDate}>{relativeText}</time>


### PR DESCRIPTION
The avatar already conveys the accent color visually, so the inline
"Color: indigo" line was redundant and made the card heavy alongside
the recently added relative-time line.