### PR TITLE
feat(ui): replace Suspense spinner with per-page Radix skeletons

### DIFF
--- a/src/components/UI/ListToolbar/ListToolbarSkeleton.tsx
+++ b/src/components/UI/ListToolbar/ListToolbarSkeleton.tsx
@@ -1,0 +1,12 @@
+import { Box, Flex, Skeleton } from '@radix-ui/themes';
+
+export function ListToolbarSkeleton() {
+  return (
+    <Flex data-testid="list-toolbar-skeleton" gap="3" mb="4" align="center">
+      <Box style={{ flex: 1 }}>
+        <Skeleton height="32px" />
+      </Box>
+      <Skeleton width="120px" height="32px" />
+    </Flex>
+  );
+}

--- a/src/components/UI/ListToolbar/index.ts
+++ b/src/components/UI/ListToolbar/index.ts
@@ -1,1 +1,2 @@
 export { ListToolbar } from './ListToolbar';
+export { ListToolbarSkeleton } from './ListToolbarSkeleton';

--- a/src/components/UI/PageLayout/PageLayout.tsx
+++ b/src/components/UI/PageLayout/PageLayout.tsx
@@ -1,7 +1,6 @@
-import { Heading, Box, Text } from '@radix-ui/themes';
-import { getMessage } from '@/utils/i18n';
 import type { AppSettings } from '@/types/syncSettings.js';
 import { StatusBar } from '@/components/UI/StatusBar/StatusBar';
+import { PageLayoutFrame } from './PageLayoutFrame';
 
 interface PageLayoutProps {
   titleKey: string;
@@ -18,37 +17,13 @@ interface PageLayoutProps {
 
 export function PageLayout({ titleKey, descriptionKey, descriptionOverride, syncSettings, children }: PageLayoutProps) {
   return (
-    <Box style={{
-      width: '100%',
-      height: '100%',
-      display: 'flex',
-      flexDirection: 'column'
-    }}>
-      <Box
-        data-testid="page-layout-header"
-        pb="3"
-        style={{ borderBottom: '1px solid var(--gray-a4)' }}
-      >
-        <Heading size="5" weight="bold" as="h1" style={{ letterSpacing: '-0.02em' }}>
-          {getMessage(titleKey)}
-        </Heading>
-
-        <Box data-testid="page-layout-description" pt="2">
-          <Text size="2" color="gray" as="p" style={{ margin: 0 }}>
-            {descriptionOverride ?? getMessage(descriptionKey)}
-          </Text>
-        </Box>
-      </Box>
-
-      <Box
-        data-testid="page-layout-content"
-        pt="4"
-        style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
-      >
-        {children(syncSettings)}
-      </Box>
-
-      <StatusBar />
-    </Box>
+    <PageLayoutFrame
+      titleKey={titleKey}
+      descriptionKey={descriptionKey}
+      descriptionOverride={descriptionOverride}
+      footer={<StatusBar />}
+    >
+      {children(syncSettings)}
+    </PageLayoutFrame>
   );
 }

--- a/src/components/UI/PageLayout/PageLayoutFrame.tsx
+++ b/src/components/UI/PageLayout/PageLayoutFrame.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Heading, Box, Text } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+
+interface PageLayoutFrameProps {
+  titleKey: string;
+  descriptionKey: string;
+  descriptionOverride?: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  rootAriaBusy?: boolean;
+  rootTestId?: string;
+  contentTestId?: string;
+}
+
+export function PageLayoutFrame({
+  titleKey,
+  descriptionKey,
+  descriptionOverride,
+  children,
+  footer,
+  rootAriaBusy,
+  rootTestId,
+  contentTestId = 'page-layout-content',
+}: PageLayoutFrameProps) {
+  return (
+    <Box
+      data-testid={rootTestId}
+      aria-busy={rootAriaBusy || undefined}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box
+        data-testid="page-layout-header"
+        pb="3"
+        style={{ borderBottom: '1px solid var(--gray-a4)' }}
+      >
+        <Heading size="5" weight="bold" as="h1" style={{ letterSpacing: '-0.02em' }}>
+          {getMessage(titleKey)}
+        </Heading>
+
+        <Box data-testid="page-layout-description" pt="2">
+          <Text size="2" color="gray" as="p" style={{ margin: 0 }}>
+            {descriptionOverride ?? getMessage(descriptionKey)}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box
+        data-testid={contentTestId}
+        pt="4"
+        style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
+      >
+        {children}
+      </Box>
+
+      {footer}
+    </Box>
+  );
+}

--- a/src/components/UI/PageLayout/PageLayoutSkeleton.tsx
+++ b/src/components/UI/PageLayout/PageLayoutSkeleton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Heading, Box, Text } from '@radix-ui/themes';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { getMessage } from '@/utils/i18n';
+import { PageLayoutFrame } from './PageLayoutFrame';
 
 interface PageLayoutSkeletonProps {
   titleKey: string;
@@ -17,45 +17,20 @@ export function PageLayoutSkeleton({
   children,
 }: PageLayoutSkeletonProps) {
   return (
-    <Box
-      data-testid="page-layout-skeleton"
-      aria-busy="true"
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
+    <PageLayoutFrame
+      titleKey={titleKey}
+      descriptionKey={descriptionKey}
+      descriptionOverride={descriptionOverride}
+      rootAriaBusy
+      rootTestId="page-layout-skeleton"
+      contentTestId="page-layout-skeleton-content"
     >
       <VisuallyHidden>
         <div role="status" aria-live="polite" aria-atomic="true">
           {getMessage('loadingText')}
         </div>
       </VisuallyHidden>
-
-      <Box
-        data-testid="page-layout-header"
-        pb="3"
-        style={{ borderBottom: '1px solid var(--gray-a4)' }}
-      >
-        <Heading size="5" weight="bold" as="h1" style={{ letterSpacing: '-0.02em' }}>
-          {getMessage(titleKey)}
-        </Heading>
-
-        <Box data-testid="page-layout-description" pt="2">
-          <Text size="2" color="gray" as="p" style={{ margin: 0 }}>
-            {descriptionOverride ?? getMessage(descriptionKey)}
-          </Text>
-        </Box>
-      </Box>
-
-      <Box
-        data-testid="page-layout-skeleton-content"
-        pt="4"
-        style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
-      >
-        {children}
-      </Box>
-    </Box>
+      {children}
+    </PageLayoutFrame>
   );
 }

--- a/src/components/UI/PageLayout/PageLayoutSkeleton.tsx
+++ b/src/components/UI/PageLayout/PageLayoutSkeleton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Heading, Box, Text } from '@radix-ui/themes';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { getMessage } from '@/utils/i18n';
+
+interface PageLayoutSkeletonProps {
+  titleKey: string;
+  descriptionKey: string;
+  descriptionOverride?: string;
+  children: React.ReactNode;
+}
+
+export function PageLayoutSkeleton({
+  titleKey,
+  descriptionKey,
+  descriptionOverride,
+  children,
+}: PageLayoutSkeletonProps) {
+  return (
+    <Box
+      data-testid="page-layout-skeleton"
+      aria-busy="true"
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <VisuallyHidden>
+        <div role="status" aria-live="polite" aria-atomic="true">
+          {getMessage('loadingText')}
+        </div>
+      </VisuallyHidden>
+
+      <Box
+        data-testid="page-layout-header"
+        pb="3"
+        style={{ borderBottom: '1px solid var(--gray-a4)' }}
+      >
+        <Heading size="5" weight="bold" as="h1" style={{ letterSpacing: '-0.02em' }}>
+          {getMessage(titleKey)}
+        </Heading>
+
+        <Box data-testid="page-layout-description" pt="2">
+          <Text size="2" color="gray" as="p" style={{ margin: 0 }}>
+            {descriptionOverride ?? getMessage(descriptionKey)}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box
+        data-testid="page-layout-skeleton-content"
+        pt="4"
+        style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/UI/PageLayout/index.ts
+++ b/src/components/UI/PageLayout/index.ts
@@ -1,1 +1,2 @@
 export { PageLayout } from './PageLayout';
+export { PageLayoutSkeleton } from './PageLayoutSkeleton';

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -32,6 +32,12 @@ import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { lazyWithTiming } from '@/utils/lazyWithTiming.js';
 import { preloadPage } from './pagePreloaders.js';
+import { DomainRulesPageSkeleton } from './skeletons/DomainRulesPageSkeleton';
+import { SessionsPageSkeleton } from './skeletons/SessionsPageSkeleton';
+import { WorkspacesPageSkeleton } from './skeletons/WorkspacesPageSkeleton';
+import { ImportExportPageSkeleton } from './skeletons/ImportExportPageSkeleton';
+import { StatisticsPageSkeleton } from './skeletons/StatisticsPageSkeleton';
+import { SettingsPageSkeleton } from './skeletons/SettingsPageSkeleton';
 
 const DomainRulesPage = lazyWithTiming('DomainRulesPage', () =>
     import('./DomainRulesPage').then((m) => ({ default: m.DomainRulesPage })),
@@ -55,6 +61,25 @@ import type { Session } from '@/types/session';
 import type { HomeRestoreTarget } from '@/components/HomePage/types';
 import { Toaster } from '@/components/UI/Toaster/Toaster';
 import type { DomainRuleSettings } from '@/types/syncSettings';
+
+function renderLazyFallback(currentTab: string): React.ReactNode {
+    switch (currentTab) {
+        case 'rules':
+            return <DomainRulesPageSkeleton />;
+        case 'sessions':
+            return <SessionsPageSkeleton />;
+        case 'workspaces':
+            return <WorkspacesPageSkeleton />;
+        case 'importexport':
+            return <ImportExportPageSkeleton />;
+        case 'stats':
+            return <StatisticsPageSkeleton />;
+        case 'settings':
+            return <SettingsPageSkeleton />;
+        default:
+            return null;
+    }
+}
 
 export function OptionsContent() {
     const version = browser.runtime.getManifest().version;
@@ -214,14 +239,7 @@ export function OptionsContent() {
                 <OptionsTopbar pageTitle={activePageTitle} />
                 <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
                     <main data-testid="options-content" style={{ flex: 1, overflow: 'auto', padding: '20px 20px 0 20px', minWidth: 0 }}>
-                        <Suspense
-                            fallback={
-                                <Flex align="center" justify="center" gap="2" style={{ height: '100%' }}>
-                                    <Spinner size="3" />
-                                    <Text>{getMessage('loadingText')}</Text>
-                                </Flex>
-                            }
-                        >
+                        <Suspense fallback={renderLazyFallback(currentTab)}>
                             {currentTab === 'home' && (
                                 <HomePage
                                     syncSettings={settings}

--- a/src/pages/skeletons/DomainRulesPageSkeleton.tsx
+++ b/src/pages/skeletons/DomainRulesPageSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Box, Card, Flex, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
+
+const ROWS = [0, 1, 2];
+
+export function DomainRulesPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="domainRulesTab" descriptionKey="domainRulesPageDescription">
+      <Box data-testid="page-rules-skeleton">
+        <ListToolbarSkeleton />
+        <Flex direction="column" gap="3">
+          {ROWS.map((i) => (
+            <Card key={i} variant="surface" size="2">
+              <Flex align="center" justify="between" gap="4">
+                <Skeleton width="16px" height="20px" />
+                <Skeleton width="20px" height="20px" />
+                <Flex direction="column" gap="2" style={{ flex: 1 }}>
+                  <Skeleton width="140px" height="22px" />
+                  <Skeleton width="200px" height="16px" />
+                </Flex>
+                <Skeleton width="40px" height="22px" />
+                <Skeleton width="28px" height="28px" />
+              </Flex>
+            </Card>
+          ))}
+        </Flex>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/ImportExportPageSkeleton.tsx
+++ b/src/pages/skeletons/ImportExportPageSkeleton.tsx
@@ -1,0 +1,28 @@
+import { Box, Card, Flex, Grid, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+
+const CARDS = [0, 1, 2, 3, 4, 5];
+
+export function ImportExportPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="importExportTab" descriptionKey="importExportPageDescription">
+      <Box data-testid="page-import-export-skeleton">
+        <Grid columns={{ initial: '1', sm: '2' }} gap="4">
+          {CARDS.map((i) => (
+            <Card key={i}>
+              <Flex direction="column" gap="3" p="3">
+                <Flex align="center" gap="2">
+                  <Skeleton width="20px" height="20px" />
+                  <Skeleton width="140px" height="20px" />
+                </Flex>
+                <Skeleton width="100%" height="14px" />
+                <Skeleton width="80%" height="14px" />
+                <Skeleton width="96px" height="32px" />
+              </Flex>
+            </Card>
+          ))}
+        </Grid>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/SessionsPageSkeleton.tsx
+++ b/src/pages/skeletons/SessionsPageSkeleton.tsx
@@ -1,0 +1,71 @@
+import { Box, Card, Flex, Separator, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
+
+const PINNED = [0, 1];
+const UNPINNED = [0, 1, 2];
+
+function SessionCardSkeleton() {
+  return (
+    <Card size="2">
+      <Flex direction="column" gap="2">
+        <Flex align="center" gap="2">
+          <Skeleton width="16px" height="20px" />
+          <Skeleton width="28px" height="28px" />
+          <Flex align="center" gap="2" style={{ flex: 1 }}>
+            <Skeleton width="180px" height="22px" />
+            <Skeleton width="32px" height="20px" />
+          </Flex>
+          <Skeleton width="96px" height="32px" />
+          <Skeleton width="32px" height="32px" />
+        </Flex>
+        <Box style={{ borderTop: '1px solid var(--gray-a4)' }} />
+        <Flex align="center" gap="2">
+          <Skeleton width="14px" height="14px" />
+          <Skeleton width="120px" height="14px" />
+          <Box style={{ flex: 1 }} />
+          <Skeleton width="80px" height="14px" />
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}
+
+function SectionHeaderSkeleton() {
+  return (
+    <Flex align="center" gap="2">
+      <Skeleton width="16px" height="16px" />
+      <Skeleton width="120px" height="20px" />
+      <Skeleton width="24px" height="20px" />
+    </Flex>
+  );
+}
+
+export function SessionsPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="sessionsTab" descriptionKey="sessionsPageDescription">
+      <Box data-testid="page-sessions-skeleton">
+        <ListToolbarSkeleton />
+        <Flex direction="column" gap="3">
+          <Box>
+            <SectionHeaderSkeleton />
+            <Flex direction="column" gap="3" pl="6" mt="3">
+              {PINNED.map((i) => (
+                <SessionCardSkeleton key={`pinned-${i}`} />
+              ))}
+            </Flex>
+          </Box>
+          <Separator size="4" />
+          <Box>
+            <SectionHeaderSkeleton />
+            <Flex direction="column" gap="3" pl="6" mt="3">
+              {UNPINNED.map((i) => (
+                <SessionCardSkeleton key={`unpinned-${i}`} />
+              ))}
+            </Flex>
+          </Box>
+        </Flex>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/SettingsPageSkeleton.tsx
+++ b/src/pages/skeletons/SettingsPageSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Box, Card, Flex, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+
+const SECTIONS = [
+  { rows: 3 },
+  { rows: 2 },
+  { rows: 3 },
+];
+
+export function SettingsPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="settingsTab" descriptionKey="settingsPageDescription">
+      <Box data-testid="page-settings-skeleton">
+        <Flex direction="column" gap="4">
+          {SECTIONS.map((section, i) => (
+            <Card key={i}>
+              <Box p="4">
+                <Flex align="center" gap="2" mb="4">
+                  <Skeleton width="20px" height="20px" />
+                  <Skeleton width="160px" height="20px" />
+                </Flex>
+                <Flex direction="column" gap="4">
+                  {Array.from({ length: section.rows }).map((_, j) => (
+                    <Flex key={j} align="center" justify="between">
+                      <Skeleton width="200px" height="18px" />
+                      <Skeleton width="44px" height="24px" />
+                    </Flex>
+                  ))}
+                </Flex>
+              </Box>
+            </Card>
+          ))}
+        </Flex>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/StatisticsPageSkeleton.tsx
+++ b/src/pages/skeletons/StatisticsPageSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Box, Card, Flex, Grid, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+
+const CARDS: Array<{ heading: string; body: number }> = [
+  { heading: '160px', body: 120 },
+  { heading: '160px', body: 180 },
+  { heading: '140px', body: 100 },
+  { heading: '140px', body: 100 },
+  { heading: '120px', body: 150 },
+  { heading: '160px', body: 200 },
+];
+
+export function StatisticsPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="statisticsTab" descriptionKey="statisticsPageDescription">
+      <Box data-testid="page-stats-skeleton">
+        <Grid columns={{ initial: '1', md: '2' }} gap="4">
+          {CARDS.map((card, i) => (
+            <Card key={i}>
+              <Flex direction="column" gap="3" p="2">
+                <Skeleton width={card.heading} height="20px" />
+                <Skeleton height={`${card.body}px`} />
+              </Flex>
+            </Card>
+          ))}
+        </Grid>
+        <Box mt="4">
+          <Skeleton width="120px" height="32px" />
+        </Box>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/WorkspacesPageSkeleton.tsx
+++ b/src/pages/skeletons/WorkspacesPageSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Box, Card, Flex, Skeleton } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
+
+const ROWS = [0, 1];
+
+export function WorkspacesPageSkeleton() {
+  return (
+    <PageLayoutSkeleton titleKey="workspacesTab" descriptionKey="workspacesDescription">
+      <Box data-testid="page-workspaces-skeleton">
+        <ListToolbarSkeleton />
+        <Flex direction="column" gap="2">
+          {ROWS.map((i) => (
+            <Card key={i} variant="surface">
+              <Flex align="center" gap="3">
+                <Skeleton width="40px" height="40px" />
+                <Flex direction="column" gap="2" style={{ flex: 1 }}>
+                  <Skeleton width="200px" height="22px" />
+                  <Skeleton width="140px" height="14px" />
+                </Flex>
+                <Skeleton width="72px" height="32px" />
+                <Skeleton width="32px" height="32px" />
+                <Skeleton width="32px" height="32px" />
+              </Flex>
+            </Card>
+          ))}
+        </Flex>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}


### PR DESCRIPTION
Lazy-loaded pages were falling back to a generic Spinner that erased
the layout for ~2s on first open. Each page now ships a dedicated
skeleton that mirrors its silhouette (toolbar, sections, cards) so the
target page is visible immediately. Adds shared PageLayoutSkeleton and
ListToolbarSkeleton with aria-busy and a polite live-region announce
for screen readers.

https://claude.ai/code/session_018Arm7SiyVojWUvgLN4h3pz