### PR TITLE
feat(sessions): replace SegmentedControl with TabNav, switch to #sessions/archived sub-route

### DIFF
--- a/src/components/UI/OptionsLayout/OptionsTopbar.tsx
+++ b/src/components/UI/OptionsLayout/OptionsTopbar.tsx
@@ -1,4 +1,4 @@
-import { Flex, IconButton, Text, Tooltip } from '@radix-ui/themes';
+import { Flex, IconButton, Link, Text, Tooltip } from '@radix-ui/themes';
 import { HelpCircle } from 'lucide-react';
 import { ThemeToggle } from '@/components/UI/ThemeToggle/ThemeToggle';
 import { useShortcutsControl } from '@/contexts/ShortcutsControlContext';
@@ -6,10 +6,17 @@ import { getMessage } from '@/utils/i18n';
 
 interface OptionsTopbarProps {
   pageTitle: string;
+  /** When set, the topbar renders a second crumb after pageTitle. */
+  pageSubtitle?: string;
+  /** href to attach to the parent crumb (`pageTitle`) when a subtitle is shown.
+   *  Makes the parent crumb a clickable link back to the parent route. */
+  parentHref?: string;
 }
 
-export function OptionsTopbar({ pageTitle }: OptionsTopbarProps) {
+export function OptionsTopbar({ pageTitle, pageSubtitle, parentHref }: OptionsTopbarProps) {
   const { openShortcuts } = useShortcutsControl();
+  const parentCrumbStyle = { color: 'var(--gray-12)', letterSpacing: '-0.005em' };
+  const parentIsLink = Boolean(pageSubtitle && parentHref);
 
   return (
     <Flex
@@ -47,14 +54,41 @@ export function OptionsTopbar({ pageTitle }: OptionsTopbarProps) {
           <Text size="2" style={{ color: 'var(--gray-9)' }} aria-hidden="true">
             /
           </Text>
-          <Text
-            size="2"
-            weight="medium"
-            data-testid="topbar-page-title"
-            style={{ color: 'var(--gray-12)', letterSpacing: '-0.005em' }}
-          >
-            {pageTitle}
-          </Text>
+          {parentIsLink ? (
+            <Link
+              size="2"
+              weight="medium"
+              href={parentHref}
+              data-testid="topbar-page-title"
+              style={parentCrumbStyle}
+            >
+              {pageTitle}
+            </Link>
+          ) : (
+            <Text
+              size="2"
+              weight="medium"
+              data-testid="topbar-page-title"
+              style={parentCrumbStyle}
+            >
+              {pageTitle}
+            </Text>
+          )}
+          {pageSubtitle && (
+            <>
+              <Text size="2" style={{ color: 'var(--gray-9)' }} aria-hidden="true">
+                /
+              </Text>
+              <Text
+                size="2"
+                weight="medium"
+                data-testid="topbar-page-subtitle"
+                style={{ color: 'var(--gray-12)', letterSpacing: '-0.005em' }}
+              >
+                {pageSubtitle}
+              </Text>
+            </>
+          )}
         </Flex>
         <Flex align="center" gap="1">
           <ThemeToggle />

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -5,7 +5,6 @@ const VALID_RULES_ACTIONS = ['create', 'import'] as const;
 export type RulesPendingAction = typeof VALID_RULES_ACTIONS[number];
 
 export type SessionsSubTab = 'active' | 'archived';
-const VALID_SESSIONS_TABS: readonly SessionsSubTab[] = ['active', 'archived'] as const;
 
 interface DeepLinkState {
   currentTab: string;
@@ -21,16 +20,21 @@ const VALID_SECTIONS = ['home', 'rules', 'importexport', 'sessions', 'stats', 's
 
 interface ParsedHash {
   section: string;
+  /** Optional path segment after the section, e.g. "archived" in `#sessions/archived`. */
+  sub: string | null;
   params: URLSearchParams;
 }
 
 function parseHash(hash: string): ParsedHash | null {
   if (!hash.startsWith('#')) return null;
   const questionMark = hash.indexOf('?');
-  const section = questionMark === -1 ? hash.slice(1) : hash.slice(1, questionMark);
+  const pathPart = questionMark === -1 ? hash.slice(1) : hash.slice(1, questionMark);
+  const queryPart = questionMark === -1 ? '' : hash.slice(questionMark + 1);
+  const slashIndex = pathPart.indexOf('/');
+  const section = slashIndex === -1 ? pathPart : pathPart.slice(0, slashIndex);
+  const sub = slashIndex === -1 ? null : pathPart.slice(slashIndex + 1);
   if (!(VALID_SECTIONS as readonly string[]).includes(section)) return null;
-  const params = new URLSearchParams(questionMark === -1 ? '' : hash.slice(questionMark + 1));
-  return { section, params };
+  return { section, sub, params: new URLSearchParams(queryPart) };
 }
 
 /**
@@ -55,11 +59,12 @@ export function useDeepLinking(): DeepLinkState & {
   const [sessionsTab, setSessionsTab] = useState<SessionsSubTab>('active');
 
   useEffect(() => {
-    function applySessionsAction(params: URLSearchParams) {
-      const tab = params.get('tab');
-      if (tab && (VALID_SESSIONS_TABS as readonly string[]).includes(tab)) {
-        setSessionsTab(tab as SessionsSubTab);
-      }
+    function applySessionsAction(sub: string | null, params: URLSearchParams) {
+      // Sub-route drives the active/archived tab. Unknown or absent sub-route
+      // falls back to 'active' so navigating `#sessions/archived` -> `#sessions`
+      // resets the view as users expect.
+      const tab: SessionsSubTab = sub === 'archived' ? 'archived' : 'active';
+      setSessionsTab(tab);
       const action = params.get('action');
       if (action === 'snapshot') {
         setOpenSnapshotWizard(true);
@@ -89,7 +94,7 @@ export function useDeepLinking(): DeepLinkState & {
       const parsed = parseHash(window.location.hash);
       if (!parsed) return;
       setCurrentTab(parsed.section);
-      if (parsed.section === 'sessions') applySessionsAction(parsed.params);
+      if (parsed.section === 'sessions') applySessionsAction(parsed.sub, parsed.params);
       else if (parsed.section === 'rules') applyRulesAction(parsed.params);
     }
 

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import { Box, Flex, Button, Text, Callout, Separator, Badge, SegmentedControl } from '@radix-ui/themes';
+import { Box, Flex, Button, Text, Callout, Separator, Badge, TabNav } from '@radix-ui/themes';
 import { Camera, Archive, ArchiveRestore, CheckCircle, Pin, PinOff, Upload, Trash2, FileDown, Boxes, type LucideIcon } from 'lucide-react';
 import { DragDropProvider, type DragOverEvent, type DragEndEvent } from '@dnd-kit/react';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
@@ -411,12 +411,10 @@ export function SessionsPage({
   const [searchQuery, setSearchQuery] = useState('');
 
   const handleTabChange = useCallback(
-    (next: string) => {
-      if (next !== 'active' && next !== 'archived') return;
-      const tab = next as SessionsSubTab;
-      onSessionsTabChange?.(tab);
+    (next: SessionsSubTab) => {
+      onSessionsTabChange?.(next);
       // Keep the URL hash in sync so back/forward and shareable links work.
-      const nextHash = tab === 'archived' ? '#sessions?tab=archived' : '#sessions';
+      const nextHash = next === 'archived' ? '#sessions/archived' : '#sessions';
       if (window.location.hash !== nextHash) {
         window.location.hash = nextHash;
       }
@@ -773,19 +771,24 @@ export function SessionsPage({
           {/* Sub-tabs: Active vs Archived */}
           {isLoaded && hasAnyOverall && (
             <Box mb="3">
-              <SegmentedControl.Root
-                data-testid="page-sessions-tabs"
-                value={sessionsTab}
-                onValueChange={handleTabChange}
-                size="2"
-              >
-                <SegmentedControl.Item value="active" data-testid="page-sessions-tab-active">
+              <TabNav.Root data-testid="page-sessions-tabs">
+                <TabNav.Link
+                  href="#sessions"
+                  active={sessionsTab === 'active'}
+                  data-testid="page-sessions-tab-active"
+                  onClick={(e) => { e.preventDefault(); handleTabChange('active'); }}
+                >
                   {getMessage('activeSessionsTab')}
-                </SegmentedControl.Item>
-                <SegmentedControl.Item value="archived" data-testid="page-sessions-tab-archived">
+                </TabNav.Link>
+                <TabNav.Link
+                  href="#sessions/archived"
+                  active={sessionsTab === 'archived'}
+                  data-testid="page-sessions-tab-archived"
+                  onClick={(e) => { e.preventDefault(); handleTabChange('archived'); }}
+                >
                   {getMessage('archivedSessionsTab')}
-                </SegmentedControl.Item>
-              </SegmentedControl.Root>
+                </TabNav.Link>
+              </TabNav.Root>
             </Box>
           )}
 

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -175,6 +175,13 @@ export function OptionsContent() {
         return getMessage('homeTab');
     }, [sidebarSections, currentTab]);
 
+    const breadcrumb = useMemo<{ pageSubtitle?: string; parentHref?: string }>(() => {
+        if (currentTab === 'sessions' && sessionsTab === 'archived') {
+            return { pageSubtitle: getMessage('archivedSessionsTab'), parentHref: '#sessions' };
+        }
+        return {};
+    }, [currentTab, sessionsTab]);
+
 
     const focusActiveSearch = useCallback(() => {
         const node = document.querySelector<HTMLInputElement>(
@@ -236,7 +243,11 @@ export function OptionsContent() {
                 footerCollapsedContent={<WorkspaceFooterCollapsed onManage={() => handleTabChange('workspaces')} />}
             />
             <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                <OptionsTopbar pageTitle={activePageTitle} />
+                <OptionsTopbar
+                    pageTitle={activePageTitle}
+                    pageSubtitle={breadcrumb.pageSubtitle}
+                    parentHref={breadcrumb.parentHref}
+                />
                 <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
                     <main data-testid="options-content" style={{ flex: 1, overflow: 'auto', padding: '20px 20px 0 20px', minWidth: 0 }}>
                         <Suspense fallback={renderLazyFallback(currentTab)}>

--- a/tests/hooks/useDeepLinking.test.ts
+++ b/tests/hooks/useDeepLinking.test.ts
@@ -189,6 +189,52 @@ describe('useDeepLinking — restore deep link', () => {
   });
 });
 
+describe('useDeepLinking — sessions sub-route', () => {
+  it('defaults sessionsTab to "active" when no hash is set', () => {
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.sessionsTab).toBe('active');
+  });
+
+  it('parses #sessions as the active sub-tab', () => {
+    window.location.hash = '#sessions';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('sessions');
+    expect(result.current.sessionsTab).toBe('active');
+  });
+
+  it('parses #sessions/archived as the archived sub-tab', () => {
+    window.location.hash = '#sessions/archived';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('sessions');
+    expect(result.current.sessionsTab).toBe('archived');
+  });
+
+  it('combines the archived sub-route with the snapshot action', () => {
+    window.location.hash = '#sessions/archived?action=snapshot';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('sessions');
+    expect(result.current.sessionsTab).toBe('archived');
+    expect(result.current.openSnapshotWizard).toBe(true);
+  });
+
+  it('resets the sub-tab to "active" when navigating from archived back to #sessions', () => {
+    window.location.hash = '#sessions/archived';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.sessionsTab).toBe('archived');
+
+    act(() => setHash('#sessions'));
+
+    expect(result.current.sessionsTab).toBe('active');
+  });
+
+  it('falls back to "active" for an unknown sub-route', () => {
+    window.location.hash = '#sessions/foo';
+    const { result } = renderHook(() => useDeepLinking());
+    expect(result.current.currentTab).toBe('sessions');
+    expect(result.current.sessionsTab).toBe('active');
+  });
+});
+
 describe('useDeepLinking — setters', () => {
   it('exposes setCurrentTab to override the tab manually', () => {
     const { result } = renderHook(() => useDeepLinking());


### PR DESCRIPTION
Persist the Active vs Archived selection as a hash sub-route
(#sessions/archived) parsed by useDeepLinking instead of the legacy
?tab=archived query param. Render the switcher as Radix TabNav so users
can right-click / open-in-new-tab, and reflect the sub-route in the
OptionsTopbar breadcrumb with the parent "Sessions" crumb linkable back
to the active view.