### PR TITLE
refactor(ui): use Radix Kbd instead of native <kbd>

### DIFF
--- a/src/components/HomePage/QuickActionCard.tsx
+++ b/src/components/HomePage/QuickActionCard.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from 'react';
-import { Card, Flex, Heading, Text } from '@radix-ui/themes';
+import { Card, Flex, Heading, Kbd, Text } from '@radix-ui/themes';
 import { IconBox } from '@/components/UI/IconBox/IconBox';
 import { getMessage } from '@/utils/i18n';
 import type { QuickActionDef } from './data';
@@ -32,7 +32,8 @@ export function QuickActionCard({
       data-home-quick-action=""
     >
       {action.shortcutLetter && (
-        <kbd
+        <Kbd
+          size="1"
           className={styles.kbd}
           aria-label={getMessage('homepageQuickActionShortcutAriaLabel', [
             action.shortcutLetter.toUpperCase(),
@@ -40,7 +41,7 @@ export function QuickActionCard({
           data-testid={`home-quick-action-${action.id}-kbd`}
         >
           {action.shortcutLetter.toUpperCase()}
-        </kbd>
+        </Kbd>
       )}
       <Card className={styles.actionCard}>
         <Flex direction="column" gap="2">

--- a/src/components/HomePage/QuickActionsSection.module.css
+++ b/src/components/HomePage/QuickActionsSection.module.css
@@ -22,19 +22,6 @@
   top: 8px;
   right: 8px;
   z-index: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  padding: 1px 6px;
-  border-radius: var(--radius-1);
-  background: var(--gray-a3);
-  color: var(--gray-11);
   pointer-events: none;
 }
 

--- a/src/components/UI/PopupToolbar/PopupToolbar.module.css
+++ b/src/components/UI/PopupToolbar/PopupToolbar.module.css
@@ -69,16 +69,6 @@
 }
 
 .heroKbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 11px;
-  font-weight: 500;
-  padding: 1px 6px;
-  border-radius: var(--radius-1);
-  background: rgba(255, 255, 255, 0.15);
-  opacity: 0.85;
   flex-shrink: 0;
 }
 

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Tooltip } from '@radix-ui/themes';
+import { Kbd, Tooltip } from '@radix-ui/themes';
 import { browser } from 'wxt/browser';
 import { Camera, RotateCcw, Wand2 } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
@@ -132,9 +132,9 @@ export function PopupToolbar(props: PopupToolbarProps = {}) {
           <strong className={styles.heroTitle}>{heroTitle}</strong>
           <span className={styles.heroSubtitle}>{heroSubtitle}</span>
         </span>
-        <kbd className={styles.heroKbd} aria-label={getMessage('popupOrganizeShortcut')}>
+        <Kbd size="1" className={styles.heroKbd} aria-label={getMessage('popupOrganizeShortcut')}>
           O
-        </kbd>
+        </Kbd>
       </button>
 
       <div className={styles.metaRow}>


### PR DESCRIPTION
Replace the two remaining native <kbd> elements (QuickActionCard shortcut
badge, PopupToolbar hero "O") with the Radix Themes Kbd component for
consistency with the rest of the UI. Existing classNames are preserved so
the custom positioning and on-accent styling are untouched.