### PR TITLE
fix(workspaces): treat rule categories as global, not per-workspace

### DIFF
--- a/src/utils/workspaceStorage.ts
+++ b/src/utils/workspaceStorage.ts
@@ -15,6 +15,10 @@ export const DEFAULT_WORKSPACE_ID = 'default';
  * Each entry represents a key that lived at the root of `storage.local`
  * before workspaces were introduced and is now prefixed with
  * `local:ws:{wsId}:`.
+ *
+ * `categories` and `categoriesSeeded` are intentionally absent: rule
+ * categories are global constants (sourced from `src/data/categories.json`)
+ * and must resolve to the same value regardless of the active workspace.
  */
 export const WORKSPACE_SCOPED_KEYS = [
   'globalGroupingEnabled',
@@ -23,8 +27,6 @@ export const WORKSPACE_SCOPED_KEYS = [
   'deduplicationKeepStrategy',
   'defaultRestoreAction',
   'domainRules',
-  'categories',
-  'categoriesSeeded',
   'notifyOnGrouping',
   'notifyOnDeduplication',
   'notifyOnOrganize',
@@ -70,6 +72,21 @@ export interface ScopedItems {
   popupPinnedEmptyCollapsedItem: WxtStorageItem<boolean, Record<string, unknown>>;
 }
 
+/**
+ * Rule categories are global constants (not workspace-scoped). They live at
+ * the unprefixed legacy keys (`local:categories`, `local:categoriesSeeded`)
+ * and are reused as-is across all workspaces, so switching workspace does
+ * not require re-seeding or re-loading the cache.
+ */
+const globalCategoriesItem = storage.defineItem<RuleCategory[]>(
+  'local:categories',
+  { defaultValue: defaultAppSettings.categories },
+);
+const globalCategoriesSeededItem = storage.defineItem<boolean>(
+  'local:categoriesSeeded',
+  { defaultValue: false },
+);
+
 const scopedItemsCache = new Map<string, ScopedItems>();
 
 /**
@@ -106,14 +123,8 @@ export function defineWorkspaceItems(wsId: string): ScopedItems {
       workspaceStorageKey(wsId, 'domainRules'),
       { defaultValue: defaultAppSettings.domainRules },
     ),
-    categoriesItem: storage.defineItem<RuleCategory[]>(
-      workspaceStorageKey(wsId, 'categories'),
-      { defaultValue: defaultAppSettings.categories },
-    ),
-    categoriesSeededItem: storage.defineItem<boolean>(
-      workspaceStorageKey(wsId, 'categoriesSeeded'),
-      { defaultValue: false },
-    ),
+    categoriesItem: globalCategoriesItem,
+    categoriesSeededItem: globalCategoriesSeededItem,
     notifyOnGroupingItem: storage.defineItem<boolean>(
       workspaceStorageKey(wsId, 'notifyOnGrouping'),
       { defaultValue: defaultAppSettings.notifyOnGrouping },

--- a/tests/utils/workspaceStorage.test.ts
+++ b/tests/utils/workspaceStorage.test.ts
@@ -60,6 +60,28 @@ describe('defineWorkspaceItems', () => {
     expect(items.statisticsItem.key).toBe('local:ws:ws-other:statistics');
   });
 
+  it('categoriesItem and categoriesSeededItem are global (shared across workspaces)', () => {
+    const defaultItems = defineWorkspaceItems(DEFAULT_WORKSPACE_ID);
+    const otherItems = defineWorkspaceItems('ws-other');
+    expect(defaultItems.categoriesItem.key).toBe('local:categories');
+    expect(otherItems.categoriesItem.key).toBe('local:categories');
+    expect(otherItems.categoriesItem).toBe(defaultItems.categoriesItem);
+    expect(defaultItems.categoriesSeededItem.key).toBe('local:categoriesSeeded');
+    expect(otherItems.categoriesSeededItem.key).toBe('local:categoriesSeeded');
+    expect(otherItems.categoriesSeededItem).toBe(defaultItems.categoriesSeededItem);
+  });
+
+  it('categories written from a non-default workspace are visible from the default one', async () => {
+    const sample = [
+      { id: 'development', emoji: '💻', labelKey: 'category_development', builtIn: true },
+    ];
+    const otherItems = defineWorkspaceItems('ws-other');
+    await otherItems.categoriesItem.setValue(sample);
+
+    const defaultItems = defineWorkspaceItems(DEFAULT_WORKSPACE_ID);
+    expect(await defaultItems.categoriesItem.getValue()).toEqual(sample);
+  });
+
   it('writes to one workspace are isolated from another', async () => {
     const a = defineWorkspaceItems('ws-a');
     const b = defineWorkspaceItems('ws-b');


### PR DESCRIPTION
Categories were stored under `local:ws:{wsId}:categories` for non-default
workspaces, but `categoriesStore` only initialized once (against the
workspace active at boot). Switching to another workspace left the cache
watching a stale key, so its categories never loaded.

Categories are constants sourced from `src/data/categories.json` and must
be identical across workspaces. Drop `categories` and `categoriesSeeded`
from `WORKSPACE_SCOPED_KEYS` and make `defineWorkspaceItems` return
shared global items pointing at `local:categories` and
`local:categoriesSeeded` regardless of workspace ID.