### PR TITLE
docs: transformer la home Starlight en landing page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import icon from 'astro-icon';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
@@ -109,6 +110,7 @@ export default defineConfig({
         { icon: 'github', label: 'GitHub', href: 'https://github.com/EspritVorace/smart-tab-organizer' },
       ],
     }),
+    icon(),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'SmartTab Organizer',
+      favicon: '/favicon.svg',
       customCss: ['./src/styles/global.css'],
       defaultLocale: 'root',
       locales: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@astrojs/starlight": "^0.39.2",
     "@astrojs/starlight-tailwind": "^5.0.0",
+    "@iconify-json/flat-color-icons": "^1.2.3",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.3.8",
+    "astro-icon": "^1.1.5",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.2.2"
   }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -18,12 +18,18 @@ importers:
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
         version: 5.0.0(@astrojs/starlight@0.39.2(astro@6.3.8(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)))(tailwindcss@4.2.2)
+      '@iconify-json/flat-color-icons':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0))
       astro:
         specifier: ^6.3.8
         version: 6.3.8(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)
+      astro-icon:
+        specifier: ^1.1.5
+        version: 1.1.5
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -32,6 +38,12 @@ importers:
         version: 4.2.2
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@antfu/utils@8.1.1':
+    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
@@ -272,6 +284,18 @@ packages:
   '@expressive-code/plugin-text-markers@0.42.0':
     resolution: {integrity: sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ==}
 
+  '@iconify-json/flat-color-icons@1.2.3':
+    resolution: {integrity: sha512-KcmJ7CY0TKFv5GuBjiS4/v++jEcNXna1jfY+yq014tnw/MN/jMI2oYpoMHGuIpYtUqDu7eove+WySnOYO8nS3w==}
+
+  '@iconify/tools@4.2.0':
+    resolution: {integrity: sha512-WRxPva/ipxYkqZd1+CkEAQmd86dQmrwH0vwK89gmp2Kh2WyyVw57XbPng0NehP3x4V1LzLsXUneP1uMfTMZmUA==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@2.3.0':
+    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -424,6 +448,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -796,6 +824,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -836,6 +867,9 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
+  astro-icon@1.1.5:
+    resolution: {integrity: sha512-CJYS5nWOw9jz4RpGWmzNQY7D0y2ZZacH7atL2K9DeJXJVaz7/5WrxeyIxO8KASk1jCM96Q4LjRx/F3R+InjJrw==}
+
   astro@6.3.8:
     resolution: {integrity: sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -857,6 +891,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -872,9 +909,20 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -894,9 +942,19 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -917,6 +975,10 @@ packages:
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -992,6 +1054,12 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -1002,6 +1070,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-module-lexer@2.0.0:
@@ -1052,8 +1124,16 @@ packages:
   expressive-code@0.42.0:
     resolution: {integrity: sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==}
 
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
 
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
@@ -1063,6 +1143,9 @@ packages:
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1089,12 +1172,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1171,6 +1262,9 @@ packages:
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1181,6 +1275,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -1237,6 +1335,9 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1311,6 +1412,10 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -1388,6 +1493,9 @@ packages:
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -1500,6 +1608,17 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1541,6 +1660,9 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -1572,8 +1694,20 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -1588,6 +1722,12 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
@@ -1609,6 +1749,12 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -1703,6 +1849,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -1755,6 +1904,11 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  svgo@3.3.3:
+    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -1766,6 +1920,10 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -1802,6 +1960,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1964,16 +2126,35 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -1986,6 +2167,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.1
+
+  '@antfu/utils@8.1.1': {}
 
   '@astrojs/compiler@4.0.0': {}
 
@@ -2235,6 +2423,39 @@ snapshots:
     dependencies:
       '@expressive-code/core': 0.42.0
 
+  '@iconify-json/flat-color-icons@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/tools@4.2.0':
+    dependencies:
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+      cheerio: 1.2.0
+      domhandler: 5.0.3
+      extract-zip: 2.0.1
+      local-pkg: 1.2.1
+      pathe: 2.0.3
+      svgo: 3.3.3
+      tar: 7.5.15
+    transitivePeerDependencies:
+      - supports-color
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@2.3.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@antfu/utils': 8.1.1
+      '@iconify/types': 2.0.0
+      debug: 4.4.3
+      globals: 15.15.0
+      kolorist: 1.8.0
+      local-pkg: 1.2.1
+      mlly: 1.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -2330,6 +2551,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2636,6 +2861,11 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 24.12.2
+    optional: true
+
   '@ungap/structured-clone@1.3.0': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -2663,6 +2893,14 @@ snapshots:
     dependencies:
       astro: 6.3.8(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)
       rehype-expressive-code: 0.42.0
+
+  astro-icon@1.1.5:
+    dependencies:
+      '@iconify/tools': 4.2.0
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   astro@6.3.8(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1):
     dependencies:
@@ -2771,6 +3009,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  buffer-crc32@0.2.13: {}
+
   ccount@2.0.1: {}
 
   character-entities-html4@2.1.0: {}
@@ -2781,9 +3021,34 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.26.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -2795,7 +3060,13 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
   common-ancestor-path@2.0.0: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   cookie-es@1.2.3: {}
 
@@ -2818,6 +3089,11 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@2.3.1:
+    dependencies:
+      mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   css-tree@3.2.1:
@@ -2879,6 +3155,15 @@ snapshots:
 
   dset@3.1.4: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -2887,6 +3172,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -2979,7 +3266,19 @@ snapshots:
       '@expressive-code/plugin-shiki': 0.42.0
       '@expressive-code/plugin-text-markers': 0.42.0
 
+  exsolve@1.0.8: {}
+
   extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   fast-string-truncated-width@1.2.1: {}
 
@@ -2990,6 +3289,10 @@ snapshots:
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3008,11 +3311,17 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
+
+  globals@15.15.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3223,9 +3532,20 @@ snapshots:
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
 
   i18next@26.3.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   inline-style-parser@0.2.7: {}
 
@@ -3265,6 +3585,8 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   klona@2.0.6: {}
+
+  kolorist@1.8.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3314,6 +3636,12 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
 
   longest-streak@3.1.0: {}
 
@@ -3517,6 +3845,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.0.28: {}
+
+  mdn-data@2.0.30: {}
 
   mdn-data@2.27.1: {}
 
@@ -3794,6 +4124,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -3825,6 +4168,10 @@ snapshots:
       ufo: 1.6.3
 
   ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.1: {}
 
@@ -3876,9 +4223,22 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   piccolore@0.1.3: {}
 
@@ -3887,6 +4247,18 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
 
   postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
@@ -3907,6 +4279,13 @@ snapshots:
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  quansync@0.2.11: {}
 
   radix3@1.1.2: {}
 
@@ -4108,6 +4487,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  safer-buffer@2.1.2: {}
+
   sax@1.6.0: {}
 
   semver@7.7.4: {}
@@ -4186,6 +4567,16 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  svgo@3.3.3:
+    dependencies:
+      commander: 7.2.0
+      css-select: 5.2.2
+      css-tree: 2.3.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -4199,6 +4590,14 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tiny-inflate@1.0.3: {}
 
@@ -4225,6 +4624,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.26.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -4336,11 +4737,26 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   which-pm-runs@1.1.0: {}
+
+  wrappy@1.0.2: {}
 
   xxhash-wasm@1.1.0: {}
 
+  yallist@5.0.0: {}
+
   yargs-parser@22.0.0: {}
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@1.2.2: {}
 

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="128" y2="128" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#9B7AE8"/>
+      <stop offset="1" stop-color="#6B4FD8"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+  <rect x="24" y="26" width="80" height="16" rx="8" fill="#EDE4FF"/>
+  <rect x="24" y="56" width="64" height="16" rx="8" fill="#EDE4FF"/>
+  <rect x="24" y="86" width="48" height="16" rx="8" fill="#EDE4FF"/>
+  <circle cx="32" cy="34" r="5" fill="#D4C5FF"/>
+  <circle cx="32" cy="64" r="5" fill="#5EE3E3"/>
+  <circle cx="32" cy="94" r="5" fill="#FFB68A"/>
+</svg>

--- a/docs/src/components/landing/ClosingCTA.astro
+++ b/docs/src/components/landing/ClosingCTA.astro
@@ -1,0 +1,93 @@
+---
+import { getLocale, localizePath } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].cta;
+
+const installHref = localizePath(locale, t.installPath);
+const startHref = localizePath(locale, t.startPath);
+---
+
+<section class="closing-cta" aria-labelledby="cta-title">
+  <h2 id="cta-title">{t.title}</h2>
+  <p>{t.subtitle}</p>
+  <div class="cta-actions">
+    <a class="cta-button cta-primary" href={installHref}>{t.install}</a>
+    <a class="cta-button cta-secondary" href={startHref}>{t.start}</a>
+    <a class="cta-button cta-minimal" href={t.githubHref} rel="noopener" target="_blank">
+      {t.github}
+    </a>
+  </div>
+</section>
+
+<style>
+  .closing-cta {
+    margin-block: 4rem 1rem;
+    text-align: center;
+    padding: 3rem 1.5rem;
+    border: 1px solid var(--blog-border);
+    border-radius: 1.1rem;
+    background: var(--blog-muted);
+  }
+
+  .closing-cta h2 {
+    font-size: clamp(1.6rem, 1rem + 2.4vw, 2.4rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .closing-cta p {
+    margin: 0 auto 1.75rem;
+    max-width: 36rem;
+    color: var(--sl-color-gray-2);
+  }
+
+  .cta-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+
+  .cta-button {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.7rem 1.4rem;
+    border-radius: 0.6rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition:
+      transform 0.15s ease,
+      background 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .cta-button:hover {
+    transform: translateY(-2px);
+  }
+
+  .cta-primary {
+    background: var(--blog-accent);
+    color: var(--blog-background);
+  }
+
+  .cta-secondary {
+    background: transparent;
+    color: var(--blog-accent);
+    border-color: var(--blog-accent);
+  }
+
+  .cta-secondary:hover {
+    background: var(--sl-color-bg-sidebar);
+  }
+
+  .cta-minimal {
+    background: transparent;
+    color: var(--sl-color-text);
+  }
+
+  .cta-minimal:hover {
+    color: var(--blog-accent);
+  }
+</style>

--- a/docs/src/components/landing/ClosingCTA.astro
+++ b/docs/src/components/landing/ClosingCTA.astro
@@ -6,7 +6,6 @@ const locale = getLocale(Astro.url.pathname);
 const t = landing[locale].cta;
 
 const installHref = localizePath(locale, t.installPath);
-const startHref = localizePath(locale, t.startPath);
 ---
 
 <section class="closing-cta" aria-labelledby="cta-title">
@@ -14,7 +13,6 @@ const startHref = localizePath(locale, t.startPath);
   <p>{t.subtitle}</p>
   <div class="cta-actions">
     <a class="cta-button cta-primary" href={installHref}>{t.install}</a>
-    <a class="cta-button cta-secondary" href={startHref}>{t.start}</a>
     <a class="cta-button cta-minimal" href={t.githubHref} rel="noopener" target="_blank">
       {t.github}
     </a>
@@ -70,16 +68,6 @@ const startHref = localizePath(locale, t.startPath);
   .cta-primary {
     background: var(--blog-accent);
     color: var(--blog-background);
-  }
-
-  .cta-secondary {
-    background: transparent;
-    color: var(--blog-accent);
-    border-color: var(--blog-accent);
-  }
-
-  .cta-secondary:hover {
-    background: var(--sl-color-bg-sidebar);
   }
 
   .cta-minimal {

--- a/docs/src/components/landing/ComparisonTable.astro
+++ b/docs/src/components/landing/ComparisonTable.astro
@@ -1,0 +1,129 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getLocale } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].comparison;
+---
+
+<section class="comparison" aria-labelledby="comparison-title">
+  <div class="landing-section-head">
+    <h2 id="comparison-title">{t.title}</h2>
+    <p>{t.subtitle}</p>
+  </div>
+  <div class="comparison-scroll">
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th scope="col">{t.columnCriterion}</th>
+          <th scope="col" class="col-sto">{t.columnSto}</th>
+          <th scope="col">{t.columnOthers}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          t.rows.map((row) => (
+            <tr>
+              <th scope="row">{row.criterion}</th>
+              <td class="cell-sto">
+                <span class="cell">
+                  <span class="mark mark-ok" aria-hidden="true">
+                    <Icon name="flat-color-icons:ok" />
+                  </span>
+                  {row.sto.text}
+                </span>
+              </td>
+              <td>
+                <span class="cell">
+                  <span class="mark mark-no" aria-hidden="true">
+                    <Icon name="flat-color-icons:cancel" />
+                  </span>
+                  {row.others.text}
+                </span>
+              </td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<style>
+  .comparison {
+    margin-block: 4rem;
+  }
+
+  .landing-section-head {
+    text-align: center;
+    max-width: 48rem;
+    margin-inline: auto;
+    margin-block-end: 2.5rem;
+  }
+
+  .landing-section-head h2 {
+    font-size: clamp(1.6rem, 1rem + 2.4vw, 2.4rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .landing-section-head p {
+    color: var(--sl-color-gray-2);
+    margin: 0;
+  }
+
+  .comparison-scroll {
+    overflow-x: auto;
+  }
+
+  .comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 38rem;
+  }
+
+  .comparison-table th,
+  .comparison-table td {
+    text-align: left;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--blog-border);
+    vertical-align: middle;
+  }
+
+  .comparison-table thead th {
+    font-size: 0.95rem;
+    color: var(--sl-color-gray-2);
+    border-bottom: 2px solid var(--blog-border);
+  }
+
+  .comparison-table thead th.col-sto,
+  .comparison-table td.cell-sto {
+    background: var(--blog-muted);
+  }
+
+  .comparison-table thead th.col-sto {
+    color: var(--blog-accent);
+    font-weight: 700;
+  }
+
+  .comparison-table tbody th {
+    font-weight: 600;
+  }
+
+  .cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .mark {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  .mark :global(svg) {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+  }
+</style>

--- a/docs/src/components/landing/FeatureGrid.astro
+++ b/docs/src/components/landing/FeatureGrid.astro
@@ -1,0 +1,104 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getLocale } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].features;
+---
+
+<section class="landing-features" aria-labelledby="features-title">
+  <div class="landing-section-head">
+    <h2 id="features-title">{t.title}</h2>
+    <p>{t.subtitle}</p>
+  </div>
+  <ul class="feature-grid" role="list">
+    {
+      t.items.map((item) => (
+        <li class="feature-card">
+          <span class="feature-icon" aria-hidden="true">
+            <Icon name={item.icon} />
+          </span>
+          <h3>{item.title}</h3>
+          <p>{item.description}</p>
+        </li>
+      ))
+    }
+  </ul>
+</section>
+
+<style>
+  .landing-features {
+    margin-block: 4rem;
+  }
+
+  .landing-section-head {
+    text-align: center;
+    max-width: 48rem;
+    margin-inline: auto;
+    margin-block-end: 2.5rem;
+  }
+
+  .landing-section-head h2 {
+    font-size: clamp(1.6rem, 1rem + 2.4vw, 2.4rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .landing-section-head p {
+    color: var(--sl-color-gray-2);
+    font-size: 1.05rem;
+    margin: 0;
+  }
+
+  .feature-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1.25rem;
+  }
+
+  .feature-card {
+    background: var(--sl-color-bg-sidebar);
+    border: 1px solid var(--blog-border);
+    border-radius: 0.9rem;
+    padding: 1.5rem;
+    transition:
+      transform 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .feature-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--blog-accent);
+    box-shadow: 0 8px 24px -16px var(--blog-accent);
+  }
+
+  .feature-icon {
+    display: inline-flex;
+    padding: 0.6rem;
+    border-radius: 0.75rem;
+    background: var(--blog-muted);
+    margin-block-end: 0.9rem;
+  }
+
+  .feature-icon :global(svg) {
+    width: 2.25rem;
+    height: 2.25rem;
+    display: block;
+  }
+
+  .feature-card h3 {
+    font-size: 1.15rem;
+    margin: 0 0 0.4rem;
+  }
+
+  .feature-card p {
+    margin: 0;
+    color: var(--sl-color-gray-2);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+</style>

--- a/docs/src/components/landing/PrivacyBand.astro
+++ b/docs/src/components/landing/PrivacyBand.astro
@@ -1,0 +1,95 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getLocale } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].privacy;
+---
+
+<section class="privacy-band" aria-labelledby="privacy-title">
+  <div class="privacy-inner">
+    <div class="privacy-head">
+      <h2 id="privacy-title">{t.title}</h2>
+      <p>{t.subtitle}</p>
+    </div>
+    <ul class="privacy-points" role="list">
+      {
+        t.points.map((point) => (
+          <li>
+            <span class="privacy-icon" aria-hidden="true">
+              <Icon name={point.icon} />
+            </span>
+            <span>{point.label}</span>
+          </li>
+        ))
+      }
+    </ul>
+    <p class="privacy-note">{t.note}</p>
+  </div>
+</section>
+
+<style>
+  .privacy-band {
+    margin-block: 4rem;
+    background: var(--blog-muted);
+    border: 1px solid var(--blog-border);
+    border-radius: 1.1rem;
+    padding: 2.5rem 1.75rem;
+  }
+
+  .privacy-inner {
+    max-width: 52rem;
+    margin-inline: auto;
+  }
+
+  .privacy-head {
+    text-align: center;
+    margin-block-end: 2rem;
+  }
+
+  .privacy-head h2 {
+    font-size: clamp(1.5rem, 1rem + 2vw, 2.1rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .privacy-head p {
+    margin: 0;
+    color: var(--sl-color-gray-2);
+  }
+
+  .privacy-points {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 1rem 1.5rem;
+  }
+
+  .privacy-points li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+  }
+
+  .privacy-icon {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  .privacy-icon :global(svg) {
+    width: 1.75rem;
+    height: 1.75rem;
+    display: block;
+  }
+
+  .privacy-note {
+    margin-block-start: 2rem;
+    margin-block-end: 0;
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--sl-color-gray-3);
+  }
+</style>

--- a/docs/src/components/landing/ValuesBand.astro
+++ b/docs/src/components/landing/ValuesBand.astro
@@ -1,0 +1,94 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getLocale } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].values;
+---
+
+<section class="values" aria-labelledby="values-title">
+  <div class="landing-section-head">
+    <h2 id="values-title">{t.title}</h2>
+    <p>{t.subtitle}</p>
+  </div>
+  <ul class="values-grid" role="list">
+    {
+      t.items.map((item) => (
+        <li class="value-card">
+          <span class="value-icon" aria-hidden="true">
+            <Icon name={item.icon} />
+          </span>
+          <h3>{item.title}</h3>
+          <p>{item.description}</p>
+        </li>
+      ))
+    }
+  </ul>
+</section>
+
+<style>
+  .values {
+    margin-block: 4rem;
+  }
+
+  .landing-section-head {
+    text-align: center;
+    max-width: 48rem;
+    margin-inline: auto;
+    margin-block-end: 2.5rem;
+  }
+
+  .landing-section-head h2 {
+    font-size: clamp(1.6rem, 1rem + 2.4vw, 2.4rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .landing-section-head p {
+    color: var(--sl-color-gray-2);
+    margin: 0;
+  }
+
+  .values-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1.25rem;
+  }
+
+  .value-card {
+    text-align: center;
+    padding: 1.75rem 1.5rem;
+    border: 1px solid var(--blog-border);
+    border-radius: 0.9rem;
+    background: var(--sl-color-bg-sidebar);
+  }
+
+  .value-icon {
+    display: inline-flex;
+    padding: 0.75rem;
+    border-radius: 999px;
+    background: var(--blog-muted);
+    margin-block-end: 1rem;
+  }
+
+  .value-icon :global(svg) {
+    width: 2.75rem;
+    height: 2.75rem;
+    display: block;
+  }
+
+  .value-card h3 {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .value-card p {
+    margin: 0;
+    color: var(--sl-color-gray-2);
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+</style>

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -25,10 +25,6 @@ import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
 
-SmartTab Organizer is a Chrome and Firefox extension that automatically groups your tabs by domain, removes duplicates, and lets you save named work sessions to recall in a single click.
-
-Rules rely on regular expressions you write yourself or that come from built-in packs (49 packs ready to use). No remote AI, no telemetry, no network requests: everything lives in `browser.storage.local`.
-
 <FeatureGrid />
 <PrivacyBand />
 <ComparisonTable />

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -19,6 +19,18 @@ hero:
       variant: minimal
 ---
 
+import FeatureGrid from '../../../components/landing/FeatureGrid.astro';
+import PrivacyBand from '../../../components/landing/PrivacyBand.astro';
+import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
+import ValuesBand from '../../../components/landing/ValuesBand.astro';
+import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
+
 SmartTab Organizer is a Chrome and Firefox extension that automatically groups your tabs by domain, removes duplicates, and lets you save named work sessions to recall in a single click.
 
 Rules rely on regular expressions you write yourself or that come from built-in packs (49 packs ready to use). No remote AI, no telemetry, no network requests: everything lives in `browser.storage.local`.
+
+<FeatureGrid />
+<PrivacyBand />
+<ComparisonTable />
+<ValuesBand />
+<ClosingCTA />

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -25,10 +25,6 @@ import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
 
-SmartTab Organizer es una extensión para Chrome y Firefox que agrupa automáticamente tus pestañas por dominio, elimina los duplicados y te deja guardar sesiones de trabajo nombradas para recuperarlas con un solo clic.
-
-Las reglas se basan en expresiones regulares que escribes tú o que provienen de paquetes integrados (49 packs listos para usar). Sin IA remota, sin telemetría, sin solicitudes de red: todo vive en `browser.storage.local`.
-
 <FeatureGrid />
 <PrivacyBand />
 <ComparisonTable />

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -6,11 +6,11 @@ hero:
   tagline: Organiza tus pestañas de forma inteligente, sin enviar ni una sola URL a internet.
   actions:
     - text: Empezar
-      link: /decouverte/pourquoi/
+      link: /es/decouverte/pourquoi/
       icon: right-arrow
       variant: primary
     - text: Instalar
-      link: /decouverte/installation/
+      link: /es/decouverte/installation/
       icon: external
       variant: secondary
     - text: Ver en GitHub
@@ -19,6 +19,18 @@ hero:
       variant: minimal
 ---
 
+import FeatureGrid from '../../../components/landing/FeatureGrid.astro';
+import PrivacyBand from '../../../components/landing/PrivacyBand.astro';
+import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
+import ValuesBand from '../../../components/landing/ValuesBand.astro';
+import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
+
 SmartTab Organizer es una extensión para Chrome y Firefox que agrupa automáticamente tus pestañas por dominio, elimina los duplicados y te deja guardar sesiones de trabajo nombradas para recuperarlas con un solo clic.
 
 Las reglas se basan en expresiones regulares que escribes tú o que provienen de paquetes integrados (49 packs listos para usar). Sin IA remota, sin telemetría, sin solicitudes de red: todo vive en `browser.storage.local`.
+
+<FeatureGrid />
+<PrivacyBand />
+<ComparisonTable />
+<ValuesBand />
+<ClosingCTA />

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,6 +19,18 @@ hero:
       variant: minimal
 ---
 
+import FeatureGrid from '../../components/landing/FeatureGrid.astro';
+import PrivacyBand from '../../components/landing/PrivacyBand.astro';
+import ComparisonTable from '../../components/landing/ComparisonTable.astro';
+import ValuesBand from '../../components/landing/ValuesBand.astro';
+import ClosingCTA from '../../components/landing/ClosingCTA.astro';
+
 SmartTab Organizer est une extension Chrome et Firefox qui regroupe automatiquement vos onglets par domaine, élimine les doublons et vous permet de sauvegarder des sessions de travail nommées pour les retrouver d'un clic.
 
 Les règles s'appuient sur des expressions régulières que vous écrivez vous-même ou qui viennent de packs intégrés (49 packs prêts à l'emploi). Aucune IA distante, aucune télémétrie, aucune requête réseau : tout vit dans `browser.storage.local`.
+
+<FeatureGrid />
+<PrivacyBand />
+<ComparisonTable />
+<ValuesBand />
+<ClosingCTA />

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -25,10 +25,6 @@ import ComparisonTable from '../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../components/landing/ClosingCTA.astro';
 
-SmartTab Organizer est une extension Chrome et Firefox qui regroupe automatiquement vos onglets par domaine, élimine les doublons et vous permet de sauvegarder des sessions de travail nommées pour les retrouver d'un clic.
-
-Les règles s'appuient sur des expressions régulières que vous écrivez vous-même ou qui viennent de packs intégrés (49 packs prêts à l'emploi). Aucune IA distante, aucune télémétrie, aucune requête réseau : tout vit dans `browser.storage.local`.
-
 <FeatureGrid />
 <PrivacyBand />
 <ComparisonTable />

--- a/docs/src/i18n/landing.ts
+++ b/docs/src/i18n/landing.ts
@@ -64,8 +64,6 @@ export interface LandingCopy {
     subtitle: string;
     install: string;
     installPath: string;
-    start: string;
-    startPath: string;
     github: string;
     githubHref: string;
   };
@@ -204,8 +202,6 @@ export const landing: Record<Locale, LandingCopy> = {
       subtitle: 'Installation en quelques secondes, sans compte ni configuration obligatoire.',
       install: 'Installer',
       installPath: '/decouverte/installation',
-      start: 'Commencer',
-      startPath: '/decouverte/pourquoi',
       github: 'Voir sur GitHub',
       githubHref: GITHUB_URL,
     },
@@ -341,8 +337,6 @@ export const landing: Record<Locale, LandingCopy> = {
       subtitle: 'Install in seconds, with no account and no mandatory setup.',
       install: 'Install',
       installPath: '/decouverte/installation',
-      start: 'Get started',
-      startPath: '/decouverte/pourquoi',
       github: 'View on GitHub',
       githubHref: GITHUB_URL,
     },
@@ -478,8 +472,6 @@ export const landing: Record<Locale, LandingCopy> = {
       subtitle: 'Instalacion en segundos, sin cuenta ni configuracion obligatoria.',
       install: 'Instalar',
       installPath: '/decouverte/installation',
-      start: 'Empezar',
-      startPath: '/decouverte/pourquoi',
       github: 'Ver en GitHub',
       githubHref: GITHUB_URL,
     },

--- a/docs/src/i18n/landing.ts
+++ b/docs/src/i18n/landing.ts
@@ -1,0 +1,487 @@
+// Centralized copy for the landing page sections (FR root / EN / ES).
+// Components stay presentational and read landing[locale].
+// Writing rule: no em-dash or en-dash anywhere in the strings.
+
+import type { Locale } from './locale';
+
+export interface FeatureItem {
+  /** Iconify name from @iconify-json/flat-color-icons, e.g. "flat-color-icons:rules". */
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface PrivacyPoint {
+  icon: string;
+  label: string;
+}
+
+export interface ComparisonCell {
+  /** true => positive (green check), false => negative (red cross). */
+  ok: boolean;
+  text: string;
+}
+
+export interface ComparisonRow {
+  criterion: string;
+  sto: ComparisonCell;
+  others: ComparisonCell;
+}
+
+export interface ValueItem {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface LandingCopy {
+  features: {
+    title: string;
+    subtitle: string;
+    items: FeatureItem[];
+  };
+  privacy: {
+    title: string;
+    subtitle: string;
+    points: PrivacyPoint[];
+    note: string;
+  };
+  comparison: {
+    title: string;
+    subtitle: string;
+    columnCriterion: string;
+    columnSto: string;
+    columnOthers: string;
+    rows: ComparisonRow[];
+  };
+  values: {
+    title: string;
+    subtitle: string;
+    items: ValueItem[];
+  };
+  cta: {
+    title: string;
+    subtitle: string;
+    install: string;
+    installPath: string;
+    start: string;
+    startPath: string;
+    github: string;
+    githubHref: string;
+  };
+}
+
+const GITHUB_URL = 'https://github.com/EspritVorace/smart-tab-organizer';
+
+export const landing: Record<Locale, LandingCopy> = {
+  fr: {
+    features: {
+      title: 'Tout ce dont vos onglets ont besoin',
+      subtitle:
+        'Six fonctions complementaires pour transformer un navigateur surcharge en outil de travail organise.',
+      items: [
+        {
+          icon: 'flat-color-icons:tree-structure',
+          title: 'Groupement automatique',
+          description:
+            "Les onglets ouverts depuis un meme parent rejoignent un groupe colore, selon vos regles, sans intervention manuelle.",
+        },
+        {
+          icon: 'flat-color-icons:reuse',
+          title: 'Deduplication',
+          description:
+            'Trois modes de correspondance (URL exacte, sans parametres ignores, inclusion) ferment les doublons en gardant le bon onglet.',
+        },
+        {
+          icon: 'flat-color-icons:data-backup',
+          title: 'Sessions et profils',
+          description:
+            "Capturez l'etat du navigateur, epinglez les contextes recurrents, restaurez-les en un clic avec resolution des conflits.",
+        },
+        {
+          icon: 'flat-color-icons:rules',
+          title: 'Regles et packs regex',
+          description:
+            "Ecrivez vos expressions regulieres ou partez de 49 packs prets a l'emploi, classes par categorie.",
+        },
+        {
+          icon: 'flat-color-icons:data-configuration',
+          title: 'Import et export',
+          description:
+            'Sauvegardez et partagez vos regles et sessions en JSON valide, avec detection et resolution des conflits.',
+        },
+        {
+          icon: 'flat-color-icons:briefcase',
+          title: 'Espaces de travail',
+          description:
+            "Separez travail et perso via des espaces distincts, chacun avec sa couleur d'accent et son exclusivite de fenetre.",
+        },
+      ],
+    },
+    privacy: {
+      title: 'Tout est local, rien ne part en ligne',
+      subtitle:
+        "L'inverse exact des outils qui envoient vos URL a un service distant. Ici, vos donnees ne quittent jamais le navigateur.",
+      points: [
+        { icon: 'flat-color-icons:data-protection', label: 'Stockage dans browser.storage.local, sur votre machine.' },
+        { icon: 'flat-color-icons:broken-link', label: 'Zero requete reseau initiee par l\'extension.' },
+        { icon: 'flat-color-icons:privacy', label: 'Zero telemetrie, zero analytics, zero pistage.' },
+        { icon: 'flat-color-icons:lock', label: 'Zero compte, zero cloud, zero IA distante.' },
+      ],
+      note: 'Si vous synchronisez vos profils Chrome ou Firefox, les donnees suivent le profil, mais aucune communication reseau n\'est initiee par l\'extension elle-meme.',
+    },
+    comparison: {
+      title: 'Pourquoi pas une alternative ?',
+      subtitle:
+        'Comparaison avec les categories courantes : gestionnaires cloud, outils de nommage par IA, extensions a abonnement.',
+      columnCriterion: 'Critere',
+      columnSto: 'Smart Tab Organizer',
+      columnOthers: 'Alternatives courantes',
+      rows: [
+        {
+          criterion: 'Stockage des donnees',
+          sto: { ok: true, text: '100% local' },
+          others: { ok: false, text: 'Souvent dans le cloud' },
+        },
+        {
+          criterion: 'Prix',
+          sto: { ok: true, text: 'Gratuit, pour toujours' },
+          others: { ok: false, text: 'Freemium ou abonnement' },
+        },
+        {
+          criterion: 'Code source',
+          sto: { ok: true, text: 'Open source' },
+          others: { ok: false, text: 'Proprietaire' },
+        },
+        {
+          criterion: 'Compte utilisateur',
+          sto: { ok: true, text: 'Aucun compte' },
+          others: { ok: false, text: 'Compte souvent requis' },
+        },
+        {
+          criterion: 'Tracking et telemetrie',
+          sto: { ok: true, text: 'Aucun' },
+          others: { ok: false, text: 'Frequent' },
+        },
+        {
+          criterion: 'Nommage des groupes',
+          sto: { ok: true, text: 'Regles regex locales' },
+          others: { ok: false, text: 'IA distante (URL envoyees)' },
+        },
+        {
+          criterion: 'Accessibilite',
+          sto: { ok: true, text: 'Polices dys, audits axe-core' },
+          others: { ok: false, text: 'Variable' },
+        },
+      ],
+    },
+    values: {
+      title: 'Des valeurs, pas seulement des fonctions',
+      subtitle: 'Ce qui guide chaque decision de conception.',
+      items: [
+        {
+          icon: 'flat-color-icons:copyleft',
+          title: 'Open source',
+          description:
+            'Code ouvert, verifiable et contribuable. Vous savez exactement ce que fait l\'extension, ligne par ligne.',
+        },
+        {
+          icon: 'flat-color-icons:reading',
+          title: 'Accessibilite',
+          description:
+            'Polices adaptees aux troubles dys (Luciole, Atkinson Hyperlegible), focus visibles, audits axe-core en continu.',
+        },
+        {
+          icon: 'flat-color-icons:donate',
+          title: 'Gratuit pour toujours',
+          description:
+            'Pas de version payante, pas de palier premium, pas de fonction bridee. Tout, gratuitement, durablement.',
+        },
+      ],
+    },
+    cta: {
+      title: 'Reprenez le controle de vos onglets',
+      subtitle: 'Installation en quelques secondes, sans compte ni configuration obligatoire.',
+      install: 'Installer',
+      installPath: '/decouverte/installation',
+      start: 'Commencer',
+      startPath: '/decouverte/pourquoi',
+      github: 'Voir sur GitHub',
+      githubHref: GITHUB_URL,
+    },
+  },
+
+  en: {
+    features: {
+      title: 'Everything your tabs need',
+      subtitle:
+        'Six complementary features that turn an overloaded browser into an organized work tool.',
+      items: [
+        {
+          icon: 'flat-color-icons:tree-structure',
+          title: 'Automatic grouping',
+          description:
+            'Tabs opened from the same parent join a colored group, following your rules, with no manual work.',
+        },
+        {
+          icon: 'flat-color-icons:reuse',
+          title: 'Deduplication',
+          description:
+            'Three matching modes (exact URL, ignored params stripped, includes) close duplicates while keeping the right tab.',
+        },
+        {
+          icon: 'flat-color-icons:data-backup',
+          title: 'Sessions and profiles',
+          description:
+            'Capture the browser state, pin recurring contexts, restore them in one click with conflict resolution.',
+        },
+        {
+          icon: 'flat-color-icons:rules',
+          title: 'Rules and regex packs',
+          description:
+            'Write your own regular expressions or start from 49 ready-to-use packs, sorted by category.',
+        },
+        {
+          icon: 'flat-color-icons:data-configuration',
+          title: 'Import and export',
+          description:
+            'Back up and share your rules and sessions as validated JSON, with conflict detection and resolution.',
+        },
+        {
+          icon: 'flat-color-icons:briefcase',
+          title: 'Workspaces',
+          description:
+            'Separate work and personal life through distinct workspaces, each with its accent color and window exclusivity.',
+        },
+      ],
+    },
+    privacy: {
+      title: 'Everything is local, nothing goes online',
+      subtitle:
+        'The exact opposite of tools that send your URLs to a remote service. Here, your data never leaves the browser.',
+      points: [
+        { icon: 'flat-color-icons:data-protection', label: 'Stored in browser.storage.local, on your machine.' },
+        { icon: 'flat-color-icons:broken-link', label: 'Zero network request initiated by the extension.' },
+        { icon: 'flat-color-icons:privacy', label: 'Zero telemetry, zero analytics, zero tracking.' },
+        { icon: 'flat-color-icons:lock', label: 'Zero account, zero cloud, zero remote AI.' },
+      ],
+      note: 'If you sync your Chrome or Firefox profiles, data follows the profile, but the extension itself never initiates any network communication.',
+    },
+    comparison: {
+      title: 'Why not an alternative?',
+      subtitle:
+        'Compared with the usual categories: cloud managers, AI naming tools, subscription extensions.',
+      columnCriterion: 'Criterion',
+      columnSto: 'Smart Tab Organizer',
+      columnOthers: 'Common alternatives',
+      rows: [
+        {
+          criterion: 'Data storage',
+          sto: { ok: true, text: '100% local' },
+          others: { ok: false, text: 'Often in the cloud' },
+        },
+        {
+          criterion: 'Price',
+          sto: { ok: true, text: 'Free, forever' },
+          others: { ok: false, text: 'Freemium or subscription' },
+        },
+        {
+          criterion: 'Source code',
+          sto: { ok: true, text: 'Open source' },
+          others: { ok: false, text: 'Proprietary' },
+        },
+        {
+          criterion: 'User account',
+          sto: { ok: true, text: 'No account' },
+          others: { ok: false, text: 'Account often required' },
+        },
+        {
+          criterion: 'Tracking and telemetry',
+          sto: { ok: true, text: 'None' },
+          others: { ok: false, text: 'Frequent' },
+        },
+        {
+          criterion: 'Group naming',
+          sto: { ok: true, text: 'Local regex rules' },
+          others: { ok: false, text: 'Remote AI (URLs sent)' },
+        },
+        {
+          criterion: 'Accessibility',
+          sto: { ok: true, text: 'Dys fonts, axe-core audits' },
+          others: { ok: false, text: 'Varies' },
+        },
+      ],
+    },
+    values: {
+      title: 'Values, not just features',
+      subtitle: 'What guides every design decision.',
+      items: [
+        {
+          icon: 'flat-color-icons:copyleft',
+          title: 'Open source',
+          description:
+            'Open, auditable, contributable code. You know exactly what the extension does, line by line.',
+        },
+        {
+          icon: 'flat-color-icons:reading',
+          title: 'Accessibility',
+          description:
+            'Fonts designed for dyslexia (Luciole, Atkinson Hyperlegible), visible focus, continuous axe-core audits.',
+        },
+        {
+          icon: 'flat-color-icons:donate',
+          title: 'Free forever',
+          description:
+            'No paid version, no premium tier, no gated feature. Everything, for free, for good.',
+        },
+      ],
+    },
+    cta: {
+      title: 'Take back control of your tabs',
+      subtitle: 'Install in seconds, with no account and no mandatory setup.',
+      install: 'Install',
+      installPath: '/decouverte/installation',
+      start: 'Get started',
+      startPath: '/decouverte/pourquoi',
+      github: 'View on GitHub',
+      githubHref: GITHUB_URL,
+    },
+  },
+
+  es: {
+    features: {
+      title: 'Todo lo que tus pestanas necesitan',
+      subtitle:
+        'Seis funciones complementarias que convierten un navegador sobrecargado en una herramienta de trabajo organizada.',
+      items: [
+        {
+          icon: 'flat-color-icons:tree-structure',
+          title: 'Agrupacion automatica',
+          description:
+            'Las pestanas abiertas desde un mismo padre se unen a un grupo de color, segun tus reglas, sin intervencion manual.',
+        },
+        {
+          icon: 'flat-color-icons:reuse',
+          title: 'Deduplicacion',
+          description:
+            'Tres modos de coincidencia (URL exacta, sin parametros ignorados, inclusion) cierran los duplicados conservando la pestana correcta.',
+        },
+        {
+          icon: 'flat-color-icons:data-backup',
+          title: 'Sesiones y perfiles',
+          description:
+            'Captura el estado del navegador, fija los contextos recurrentes, restauralos con un clic y resolucion de conflictos.',
+        },
+        {
+          icon: 'flat-color-icons:rules',
+          title: 'Reglas y paquetes regex',
+          description:
+            'Escribe tus expresiones regulares o parte de 49 paquetes listos para usar, ordenados por categoria.',
+        },
+        {
+          icon: 'flat-color-icons:data-configuration',
+          title: 'Importar y exportar',
+          description:
+            'Guarda y comparte tus reglas y sesiones en JSON validado, con deteccion y resolucion de conflictos.',
+        },
+        {
+          icon: 'flat-color-icons:briefcase',
+          title: 'Espacios de trabajo',
+          description:
+            'Separa trabajo y vida personal con espacios distintos, cada uno con su color de acento y su exclusividad de ventana.',
+        },
+      ],
+    },
+    privacy: {
+      title: 'Todo es local, nada sale a internet',
+      subtitle:
+        'Lo contrario exacto de las herramientas que envian tus URL a un servicio remoto. Aqui, tus datos nunca salen del navegador.',
+      points: [
+        { icon: 'flat-color-icons:data-protection', label: 'Almacenamiento en browser.storage.local, en tu equipo.' },
+        { icon: 'flat-color-icons:broken-link', label: 'Cero solicitudes de red iniciadas por la extension.' },
+        { icon: 'flat-color-icons:privacy', label: 'Cero telemetria, cero analiticas, cero rastreo.' },
+        { icon: 'flat-color-icons:lock', label: 'Cero cuenta, cero nube, cero IA remota.' },
+      ],
+      note: 'Si sincronizas tus perfiles de Chrome o Firefox, los datos siguen al perfil, pero la extension nunca inicia ninguna comunicacion de red por si misma.',
+    },
+    comparison: {
+      title: 'Por que no una alternativa?',
+      subtitle:
+        'Comparacion con las categorias habituales: gestores en la nube, herramientas de nombrado por IA, extensiones de suscripcion.',
+      columnCriterion: 'Criterio',
+      columnSto: 'Smart Tab Organizer',
+      columnOthers: 'Alternativas habituales',
+      rows: [
+        {
+          criterion: 'Almacenamiento de datos',
+          sto: { ok: true, text: '100% local' },
+          others: { ok: false, text: 'A menudo en la nube' },
+        },
+        {
+          criterion: 'Precio',
+          sto: { ok: true, text: 'Gratis, para siempre' },
+          others: { ok: false, text: 'Freemium o suscripcion' },
+        },
+        {
+          criterion: 'Codigo fuente',
+          sto: { ok: true, text: 'Codigo abierto' },
+          others: { ok: false, text: 'Propietario' },
+        },
+        {
+          criterion: 'Cuenta de usuario',
+          sto: { ok: true, text: 'Sin cuenta' },
+          others: { ok: false, text: 'Cuenta a menudo requerida' },
+        },
+        {
+          criterion: 'Rastreo y telemetria',
+          sto: { ok: true, text: 'Ninguno' },
+          others: { ok: false, text: 'Frecuente' },
+        },
+        {
+          criterion: 'Nombrado de grupos',
+          sto: { ok: true, text: 'Reglas regex locales' },
+          others: { ok: false, text: 'IA remota (URL enviadas)' },
+        },
+        {
+          criterion: 'Accesibilidad',
+          sto: { ok: true, text: 'Fuentes dys, auditorias axe-core' },
+          others: { ok: false, text: 'Variable' },
+        },
+      ],
+    },
+    values: {
+      title: 'Valores, no solo funciones',
+      subtitle: 'Lo que guia cada decision de diseno.',
+      items: [
+        {
+          icon: 'flat-color-icons:copyleft',
+          title: 'Codigo abierto',
+          description:
+            'Codigo abierto, verificable y al que puedes contribuir. Sabes exactamente que hace la extension, linea por linea.',
+        },
+        {
+          icon: 'flat-color-icons:reading',
+          title: 'Accesibilidad',
+          description:
+            'Fuentes adaptadas a la dislexia (Luciole, Atkinson Hyperlegible), foco visible, auditorias axe-core continuas.',
+        },
+        {
+          icon: 'flat-color-icons:donate',
+          title: 'Gratis para siempre',
+          description:
+            'Sin version de pago, sin nivel premium, sin funciones bloqueadas. Todo, gratis, de forma duradera.',
+        },
+      ],
+    },
+    cta: {
+      title: 'Recupera el control de tus pestanas',
+      subtitle: 'Instalacion en segundos, sin cuenta ni configuracion obligatoria.',
+      install: 'Instalar',
+      installPath: '/decouverte/installation',
+      start: 'Empezar',
+      startPath: '/decouverte/pourquoi',
+      github: 'Ver en GitHub',
+      githubHref: GITHUB_URL,
+    },
+  },
+};

--- a/docs/src/i18n/locale.ts
+++ b/docs/src/i18n/locale.ts
@@ -1,0 +1,23 @@
+// Shared locale helpers for the Starlight docs (FR root / EN / ES).
+// Mirrors the detection used in components/ConditionsDeclenchement.astro
+// so locale handling stays consistent across the site.
+
+export type Locale = 'fr' | 'en' | 'es';
+
+/** Detect the active locale from an Astro URL pathname. */
+export function getLocale(pathname: string): Locale {
+  if (pathname.startsWith('/en/') || pathname === '/en') return 'en';
+  if (pathname.startsWith('/es/') || pathname === '/es') return 'es';
+  return 'fr';
+}
+
+/**
+ * Prefix an internal path with the current locale segment.
+ * French is the root locale and carries no prefix.
+ * `path` is expected to start with a slash, e.g. "/decouverte/installation".
+ */
+export function localizePath(locale: Locale, path: string): string {
+  const clean = path.startsWith('/') ? path : `/${path}`;
+  if (locale === 'fr') return clean;
+  return `/${locale}${clean}`;
+}

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -140,3 +140,27 @@ button:focus-visible,
 .sl-link-button.primary:hover {
   color: var(--blog-background);
 }
+
+/* ----- Landing hero: centered to match the sections below ----- */
+/* This site ships no hero image. Starlight's splash hero still reserves a
+   second (image) grid column (7fr 4fr), so the copy stays stranded on the
+   left with an empty right column. Force a single centered column so the
+   hero lines up with the centered landing sections rendered underneath. */
+.hero {
+  grid-template-columns: 1fr;
+  justify-items: center;
+}
+
+.hero .stack {
+  align-items: center;
+}
+
+.hero .copy {
+  align-items: center;
+  text-align: center;
+  max-width: 50rem;
+}
+
+.hero .actions {
+  justify-content: center;
+}


### PR DESCRIPTION
Remplace le hero minimal par une vraie landing page presentant les
features et valeurs de Smart Tab Organizer, en restant trilingue
(FR/EN/ES) et fidele au theme vert accessible.

- 5 sections sur mesure: FeatureGrid, PrivacyBand, ComparisonTable,
  ValuesBand, ClosingCTA
- Copie centralisee par locale dans src/i18n/landing.ts, helper de
  locale partage dans src/i18n/locale.ts
- Icones multicolores via astro-icon + @iconify-json/flat-color-icons
  (bundlees au build, zero requete reseau au runtime)
- Comparaison positionnee face a des categories generiques (cloud, IA,
  abonnement), sans nommer de produits
- Corrige les liens du hero ES (prefixe /es/ manquant)

https://claude.ai/code/session_018qLYymKAESzgD7Jg7dJxHM