### PR TITLE
docs: add schema.org JSON-LD structured data for GEO

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -50,6 +50,10 @@ export default defineConfig({
       title: 'SmartTab Organizer',
       favicon: '/favicon.svg',
       customCss: ['./src/styles/global.css'],
+      components: {
+        // Inject schema.org JSON-LD structured data (GEO) on every page.
+        Head: './src/components/Head.astro',
+      },
       defaultLocale: 'root',
       locales: {
         root: { label: 'Français', lang: 'fr' },

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,9 @@
+---
+// Override of Starlight's `<Head>`: keep the default tags (canonical,
+// OpenGraph, Twitter, ...) and append our schema.org JSON-LD for GEO.
+import Default from '@astrojs/starlight/components/Head.astro';
+import StructuredData from './StructuredData.astro';
+---
+
+<Default />
+<StructuredData />

--- a/docs/src/components/StructuredData.astro
+++ b/docs/src/components/StructuredData.astro
@@ -1,0 +1,158 @@
+---
+// Emits a single schema.org JSON-LD `@graph` for the current page.
+//
+// Every page reinforces the product entity (SoftwareApplication), the site
+// (WebSite) and its publisher (Organization). On top of that, the page type
+// adds a tailored node:
+//   - splash homepage -> WebPage
+//   - FAQ page         -> FAQPage (questions parsed from the markdown body)
+//   - any other page   -> TechArticle + BreadcrumbList
+//
+// Cross-references use stable `@id` anchors so the graph stays consistent.
+import {
+  APP_NAME,
+  appDescription,
+  featureList,
+  homeLabel,
+  parseFaq,
+  sectionLabels,
+  type DocLocale,
+} from '../lib/structured-data';
+
+const route = Astro.locals.starlightRoute;
+const { entry } = route;
+
+const site = (Astro.site?.href ?? 'https://docs.esprit-vorace.fr/').replace(/\/$/, '');
+const pathname = Astro.url.pathname;
+
+const locale: DocLocale =
+  pathname.startsWith('/en/') || pathname === '/en'
+    ? 'en'
+    : pathname.startsWith('/es/') || pathname === '/es'
+      ? 'es'
+      : 'fr';
+
+const pageUrl = new URL(pathname, `${site}/`).href;
+
+// Stable graph anchors for cross-references.
+const websiteId = `${site}/#website`;
+const orgId = `${site}/#organization`;
+const appId = `${site}/#software`;
+
+const GITHUB = 'https://github.com/EspritVorace/smart-tab-organizer';
+const ORG_URL = 'https://esprit-vorace.fr';
+
+const title = entry.data.title;
+const description = entry.data.description ?? appDescription[locale];
+
+const organization = {
+  '@type': 'Organization',
+  '@id': orgId,
+  name: 'Esprit Vorace',
+  url: ORG_URL,
+  sameAs: [GITHUB],
+};
+
+const website = {
+  '@type': 'WebSite',
+  '@id': websiteId,
+  name: APP_NAME,
+  url: `${site}/`,
+  inLanguage: locale,
+  publisher: { '@id': orgId },
+};
+
+const softwareApplication = {
+  '@type': 'SoftwareApplication',
+  '@id': appId,
+  name: APP_NAME,
+  applicationCategory: 'BrowserApplication',
+  operatingSystem: 'Chrome, Firefox, Edge',
+  description: appDescription[locale],
+  featureList: featureList[locale],
+  url: `${site}/`,
+  inLanguage: locale,
+  isAccessibleForFree: true,
+  softwareHelp: { '@type': 'CreativeWork', url: pageUrl },
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+  publisher: { '@id': orgId },
+  sameAs: [GITHUB],
+};
+
+const graph: Record<string, unknown>[] = [organization, website, softwareApplication];
+
+const isHome =
+  entry.data.template === 'splash' ||
+  pathname === '/' ||
+  pathname === '/en/' ||
+  pathname === '/es/';
+const isFaq = entry.id.replace(/^(en|es)\//, '') === 'faq';
+
+if (isHome) {
+  graph.push({
+    '@type': 'WebPage',
+    '@id': `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: title,
+    description,
+    inLanguage: locale,
+    isPartOf: { '@id': websiteId },
+    about: { '@id': appId },
+  });
+} else if (isFaq) {
+  const faqItems = parseFaq(entry.body ?? '');
+  graph.push({
+    '@type': 'FAQPage',
+    '@id': `${pageUrl}#faq`,
+    url: pageUrl,
+    name: title,
+    description,
+    inLanguage: locale,
+    isPartOf: { '@id': websiteId },
+    about: { '@id': appId },
+    mainEntity: faqItems.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  });
+} else {
+  // Breadcrumb: Home > [section] > current page (locale segment stripped).
+  const segments = pathname.replace(/^\/(en|es)\//, '/').split('/').filter(Boolean);
+  const crumbs: Record<string, unknown>[] = [
+    { '@type': 'ListItem', position: 1, name: homeLabel[locale], item: `${site}/` },
+  ];
+  let position = 2;
+  const sectionId = segments[0];
+  if (sectionId && sectionLabels[sectionId]) {
+    crumbs.push({ '@type': 'ListItem', position, name: sectionLabels[sectionId][locale] });
+    position += 1;
+  }
+  crumbs.push({ '@type': 'ListItem', position, name: title, item: pageUrl });
+
+  graph.push({
+    '@type': 'TechArticle',
+    '@id': `${pageUrl}#article`,
+    headline: title,
+    description,
+    inLanguage: locale,
+    url: pageUrl,
+    isPartOf: { '@id': websiteId },
+    about: { '@id': appId },
+    author: { '@id': orgId },
+    publisher: { '@id': orgId },
+  });
+  graph.push({
+    '@type': 'BreadcrumbList',
+    '@id': `${pageUrl}#breadcrumb`,
+    itemListElement: crumbs,
+  });
+}
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': graph,
+};
+---
+
+<script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />

--- a/docs/src/components/StructuredData.astro
+++ b/docs/src/components/StructuredData.astro
@@ -17,6 +17,7 @@ import {
   homeLabel,
   parseFaq,
   sectionLabels,
+  serializeJsonLd,
   type Crumb,
   type DocLocale,
 } from '../lib/structured-data';
@@ -164,4 +165,4 @@ const jsonLd = {
 };
 ---
 
-<script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />
+<script type="application/ld+json" is:inline set:html={serializeJsonLd(jsonLd)} />

--- a/docs/src/components/StructuredData.astro
+++ b/docs/src/components/StructuredData.astro
@@ -12,10 +12,12 @@
 import {
   APP_NAME,
   appDescription,
+  breadcrumbList,
   featureList,
   homeLabel,
   parseFaq,
   sectionLabels,
+  type Crumb,
   type DocLocale,
 } from '../lib/structured-data';
 
@@ -41,6 +43,13 @@ const appId = `${site}/#software`;
 
 const GITHUB = 'https://github.com/EspritVorace/smart-tab-organizer';
 const ORG_URL = 'https://esprit-vorace.fr';
+const CHROME_STORE =
+  'https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah';
+const FIREFOX_STORE = 'https://addons.mozilla.org/firefox/addon/smarttab-organizer/';
+
+// The product lives on three platforms: those listings are the same entity
+// as the docs, which strengthens entity resolution for search/LLM engines.
+const APP_SAME_AS = [GITHUB, CHROME_STORE, FIREFOX_STORE];
 
 const title = entry.data.title;
 const description = entry.data.description ?? appDescription[locale];
@@ -74,9 +83,10 @@ const softwareApplication = {
   inLanguage: locale,
   isAccessibleForFree: true,
   softwareHelp: { '@type': 'CreativeWork', url: pageUrl },
+  downloadUrl: CHROME_STORE,
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
   publisher: { '@id': orgId },
-  sameAs: [GITHUB],
+  sameAs: APP_SAME_AS,
 };
 
 const graph: Record<string, unknown>[] = [organization, website, softwareApplication];
@@ -116,19 +126,22 @@ if (isHome) {
       acceptedAnswer: { '@type': 'Answer', text: item.answer },
     })),
   });
+  // FAQ breadcrumb: Home > FAQ.
+  graph.push(
+    breadcrumbList(`${pageUrl}#breadcrumb`, [
+      { name: homeLabel[locale], item: `${site}/` },
+      { name: title, item: pageUrl },
+    ])
+  );
 } else {
   // Breadcrumb: Home > [section] > current page (locale segment stripped).
   const segments = pathname.replace(/^\/(en|es)\//, '/').split('/').filter(Boolean);
-  const crumbs: Record<string, unknown>[] = [
-    { '@type': 'ListItem', position: 1, name: homeLabel[locale], item: `${site}/` },
-  ];
-  let position = 2;
+  const crumbs: Crumb[] = [{ name: homeLabel[locale], item: `${site}/` }];
   const sectionId = segments[0];
   if (sectionId && sectionLabels[sectionId]) {
-    crumbs.push({ '@type': 'ListItem', position, name: sectionLabels[sectionId][locale] });
-    position += 1;
+    crumbs.push({ name: sectionLabels[sectionId][locale] });
   }
-  crumbs.push({ '@type': 'ListItem', position, name: title, item: pageUrl });
+  crumbs.push({ name: title, item: pageUrl });
 
   graph.push({
     '@type': 'TechArticle',
@@ -142,11 +155,7 @@ if (isHome) {
     author: { '@id': orgId },
     publisher: { '@id': orgId },
   });
-  graph.push({
-    '@type': 'BreadcrumbList',
-    '@id': `${pageUrl}#breadcrumb`,
-    itemListElement: crumbs,
-  });
+  graph.push(breadcrumbList(`${pageUrl}#breadcrumb`, crumbs));
 }
 
 const jsonLd = {

--- a/docs/src/lib/structured-data.ts
+++ b/docs/src/lib/structured-data.ts
@@ -74,6 +74,29 @@ export const sectionLabels: Record<string, Record<DocLocale, string>> = {
   faq: { fr: 'FAQ', en: 'FAQ', es: 'FAQ' },
 };
 
+/** A single breadcrumb entry. `item` (URL) is omitted for non-linked crumbs. */
+export interface Crumb {
+  name: string;
+  item?: string;
+}
+
+/** Build a schema.org BreadcrumbList node, numbering positions from 1. */
+export function breadcrumbList(id: string, crumbs: Crumb[]): Record<string, unknown> {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': id,
+    itemListElement: crumbs.map((crumb, index) => {
+      const node: Record<string, unknown> = {
+        '@type': 'ListItem',
+        position: index + 1,
+        name: crumb.name,
+      };
+      if (crumb.item) node.item = crumb.item;
+      return node;
+    }),
+  };
+}
+
 export interface FaqItem {
   question: string;
   answer: string;

--- a/docs/src/lib/structured-data.ts
+++ b/docs/src/lib/structured-data.ts
@@ -1,0 +1,129 @@
+// Helpers for the schema.org JSON-LD emitted by `components/Head.astro`.
+//
+// The structured data targets GEO (Generative Engine Optimization): it
+// describes the product entity (SoftwareApplication), reinforces the site
+// (WebSite / Organization) and exposes machine-readable Q&A (FAQPage) and
+// article (TechArticle) nodes so search engines and LLMs can ingest the
+// documentation reliably.
+//
+// All locale-sensitive copy lives here so the .astro component stays thin
+// and the markdown parser can be reasoned about in isolation.
+
+export type DocLocale = 'fr' | 'en' | 'es';
+
+/** Public product name, identical across locales. */
+export const APP_NAME = 'SmartTab Organizer';
+
+/** Concise product description used on the SoftwareApplication node. */
+export const appDescription: Record<DocLocale, string> = {
+  fr: "Extension de navigateur (Chrome et Firefox) qui groupe automatiquement les onglets par règles de domaine, supprime les doublons et sauvegarde vos sessions de travail. Tout reste local, aucune donnée n'est envoyée en ligne.",
+  en: 'Browser extension (Chrome and Firefox) that automatically groups tabs with domain rules, removes duplicates and saves your work sessions. Everything stays local, no data is sent online.',
+  es: 'Extensión de navegador (Chrome y Firefox) que agrupa automáticamente las pestañas mediante reglas de dominio, elimina los duplicados y guarda tus sesiones de trabajo. Todo permanece local, no se envía ningún dato en línea.',
+};
+
+/** Feature bullet points surfaced on the SoftwareApplication node. */
+export const featureList: Record<DocLocale, string[]> = {
+  fr: [
+    'Groupement automatique des onglets par règles de domaine',
+    'Déduplication des onglets en double',
+    'Sessions de travail et profils épinglés',
+    'Workspaces multiples',
+    'Import et export des règles et sessions (JSON)',
+    'Statistiques de groupement et de déduplication',
+    'Presets regex et packs de règles intégrés',
+    'Fonctionnement 100% local, sans requête réseau',
+  ],
+  en: [
+    'Automatic tab grouping with domain rules',
+    'Deduplication of duplicate tabs',
+    'Work sessions and pinned profiles',
+    'Multiple workspaces',
+    'Import and export of rules and sessions (JSON)',
+    'Grouping and deduplication statistics',
+    'Built-in regex presets and rule packs',
+    'Fully local, no network requests',
+  ],
+  es: [
+    'Agrupación automática de pestañas mediante reglas de dominio',
+    'Deduplicación de pestañas duplicadas',
+    'Sesiones de trabajo y perfiles fijados',
+    'Múltiples workspaces',
+    'Importación y exportación de reglas y sesiones (JSON)',
+    'Estadísticas de agrupación y deduplicación',
+    'Presets regex y packs de reglas integrados',
+    'Funcionamiento 100% local, sin peticiones de red',
+  ],
+};
+
+/** Label of the breadcrumb root ("Home") per locale. */
+export const homeLabel: Record<DocLocale, string> = {
+  fr: 'Accueil',
+  en: 'Home',
+  es: 'Inicio',
+};
+
+/**
+ * Localized names for the first path segment, mirroring the Starlight
+ * sidebar group labels. Used to build the intermediate breadcrumb crumb.
+ */
+export const sectionLabels: Record<string, Record<DocLocale, string>> = {
+  decouverte: { fr: 'Découverte', en: 'Discover', es: 'Descubrir' },
+  guides: { fr: 'Guides', en: 'Guides', es: 'Guías' },
+  reference: { fr: 'Référence', en: 'Reference', es: 'Referencia' },
+  contribuer: { fr: 'Contribuer', en: 'Contributing', es: 'Contribuir' },
+  faq: { fr: 'FAQ', en: 'FAQ', es: 'FAQ' },
+};
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+/** Strip inline markdown so a fragment becomes plain text for JSON-LD. */
+function stripMarkdown(md: string): string {
+  return (
+    md
+      // images: ![alt](url)
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+      // links: [text](url) -> text
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      // bold: **text** / __text__ -> text
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/__([^_]+)__/g, '$1')
+      // inline code: `text` -> text
+      .replace(/`([^`]+)`/g, '$1')
+      // leftover heading markers
+      .replace(/^#{1,6}\s+/gm, '')
+      // collapse all whitespace runs into single spaces
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * Parse the raw markdown body of an FAQ page into question/answer pairs.
+ *
+ * Each `## Heading` becomes a question and the prose below it (until the
+ * next `##`) becomes the answer. `import` statements and JSX/HTML tags are
+ * removed first, which collapses the trailing "next steps" card grid into
+ * an empty answer that is then skipped.
+ */
+export function parseFaq(body: string): FaqItem[] {
+  const cleaned = body
+    .replace(/^import[^\n]*$/gm, '') // ESM import lines
+    .replace(/<[^>]+>/g, ''); // JSX / HTML tags (single-line in these files)
+
+  const items: FaqItem[] = [];
+  const sections = cleaned.split(/^##\s+/m).slice(1); // drop pre-heading intro
+  for (const section of sections) {
+    const newline = section.indexOf('\n');
+    const rawQuestion = newline === -1 ? section : section.slice(0, newline);
+    const rawAnswer = newline === -1 ? '' : section.slice(newline + 1);
+    const question = stripMarkdown(rawQuestion);
+    const answer = stripMarkdown(rawAnswer);
+    // Skip navigation-only or empty sections (e.g. the card-grid footer).
+    if (!question || answer.length < 2) continue;
+    items.push({ question, answer });
+  }
+  return items;
+}

--- a/docs/src/lib/structured-data.ts
+++ b/docs/src/lib/structured-data.ts
@@ -97,6 +97,21 @@ export function breadcrumbList(id: string, crumbs: Crumb[]): Record<string, unkn
   };
 }
 
+/**
+ * Serialize a JSON-LD object for safe embedding inside a `<script>` element.
+ *
+ * `JSON.stringify` does not escape `<`, `>` or `&`, so a literal `</script>`
+ * (or `<!--`) in any string value could otherwise terminate the script tag
+ * and inject markup. Escaping these characters as `\uXXXX` keeps the JSON
+ * valid (parsers decode the escapes) while neutralizing any breakout.
+ */
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(
+    /[<>&\u2028\u2029]/g,
+    (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`
+  );
+}
+
 export interface FaqItem {
   question: string;
   answer: string;
@@ -132,9 +147,15 @@ function stripMarkdown(md: string): string {
  * an empty answer that is then skipped.
  */
 export function parseFaq(body: string): FaqItem[] {
-  const cleaned = body
-    .replace(/^import[^\n]*$/gm, '') // ESM import lines
-    .replace(/<[^>]+>/g, ''); // JSX / HTML tags (single-line in these files)
+  let cleaned = body.replace(/^import[^\n]*$/gm, ''); // ESM import lines
+  // Strip JSX / HTML tags. Repeat until the string is stable so that
+  // overlapping or nested angle-bracket sequences cannot survive a single
+  // pass (a one-shot replace is bypassable, e.g. `<<tag>tag>`).
+  let previous: string;
+  do {
+    previous = cleaned;
+    cleaned = cleaned.replace(/<[^>]*>/g, '');
+  } while (cleaned !== previous);
 
   const items: FaqItem[] = [];
   const sections = cleaned.split(/^##\s+/m).slice(1); // drop pre-heading intro


### PR DESCRIPTION
Inject a schema.org @graph on every Starlight page to improve GEO
(Generative Engine Optimization) and SEO:

- WebSite, Organization and SoftwareApplication entity on all pages
  (product name, browser category, free offer, localized feature list).
- FAQPage with question/answer pairs parsed from the FAQ markdown body
  (per locale: fr, en, es).
- TechArticle plus BreadcrumbList on content pages.
- WebPage node on the splash homepage.

Implemented via a Starlight Head override (src/components/Head.astro)
that keeps the default head tags and appends StructuredData.astro. The
locale-aware copy and the FAQ markdown parser live in
src/lib/structured-data.ts.