### PR TITLE
docs: align landing hero with the closing CTA card style

### DIFF
--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -141,14 +141,21 @@ button:focus-visible,
   color: var(--blog-background);
 }
 
-/* ----- Landing hero: centered to match the sections below ----- */
+/* ----- Landing hero: card treatment matching the closing CTA below ----- */
 /* This site ships no hero image. Starlight's splash hero still reserves a
    second (image) grid column (7fr 4fr), so the copy stays stranded on the
-   left with an empty right column. Force a single centered column so the
-   hero lines up with the centered landing sections rendered underneath. */
+   left with an empty right column. Force a single centered column, then wrap
+   the whole hero in the same bordered, muted card used by the closing CTA
+   (ClosingCTA.astro) so the top and bottom of the landing page share one
+   visual language. */
 .hero {
   grid-template-columns: 1fr;
   justify-items: center;
+  border: 1px solid var(--blog-border);
+  border-radius: 1.1rem;
+  background: var(--blog-muted);
+  padding: 3rem 1.5rem;
+  margin-block-start: 1rem;
 }
 
 .hero .stack {
@@ -163,4 +170,19 @@ button:focus-visible,
 
 .hero .actions {
   justify-content: center;
+}
+
+/* Hero action buttons share the closing CTA button shape (rounded rect,
+   lift on hover) instead of Starlight's default pill. */
+.hero .actions .sl-link-button {
+  border-radius: 0.6rem;
+  font-weight: 600;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.hero .actions .sl-link-button:hover {
+  transform: translateY(-2px);
 }


### PR DESCRIPTION
Wrap the splash hero in the same bordered, muted card used by
ClosingCTA.astro (border, border-radius, --blog-muted background,
padding) and reshape the hero action buttons to the closing CTA's
rounded-rect with hover lift, so the top and bottom of the landing
page share one visual language.

https://claude.ai/code/session_01YFFHXeQRU6uxZMcpzfp5TJ