### PR TITLE
docs: add robots.txt allowing AI crawlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,19 @@ pnpm doc:scenarios:audit                  # Audit routing manifests vs output / 
 pnpm doc:scenarios:sync                   # Re-route output to dest dirs (without re-running Playwright)
 ```
 
+> **The Starlight docs (`docs/`) are a separate pnpm project, NOT part of
+> the root workspace.** They have their own `package.json` and their own
+> `node_modules`, which the root `pnpm install` does not populate.
+>
+> - Build the docs with `pnpm docs:build` (the root `pnpm build` builds
+>   the WXT extension, not the docs). The `docs:*` scripts just delegate
+>   via `pnpm --dir docs ...`.
+> - Before the first docs build/dev in a fresh checkout, install the docs
+>   deps: `pnpm --dir docs install` (or `cd docs && pnpm install`).
+>   Symptom of a missing install: `sh: 1: astro: not found`.
+> - Build output is `docs/dist/`. Static files in `docs/public/` (e.g.
+>   `robots.txt`, `favicon.svg`, fonts) are served as-is at the site root.
+
 ## Architecture
 
 **Cross-browser extension** (WXT framework), Chrome MV3 / Firefox MV2.

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,36 @@
+# Autorise tout le monde, y compris les robots IA, a indexer la documentation.
+User-agent: *
+Allow: /
+
+# Robots IA explicitement autorises (listes a titre de clarte).
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://docs.esprit-vorace.fr/sitemap-index.xml


### PR DESCRIPTION
Add a static robots.txt served at the docs root that explicitly
allows all crawlers (including AI bots like GPTBot, ClaudeBot,
Google-Extended, PerplexityBot, CCBot) and declares the
Starlight-generated sitemap.

https://claude.ai/code/session_01LV1VeHYaLKmZ8mCGV1tYmH