### PR TITLE
docs: revue landing/docs orientee visiteur (visuels, FAQ, quick start, fixes)

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -57,7 +57,7 @@ Captura tus pestañas y grupos abiertos, ponles nombre, fija las que más usas. 
 ## Y además
 
 - **Espacios de trabajo** : reglas, sesiones y estadísticas separadas por contexto (trabajo, personal, side project)
-- **20+ packs de reglas** listos para importar para herramientas populares (GitHub, GitLab, Jira, AWS, asistentes de IA, Discord...)
+- **49 packs de reglas** listos para importar para herramientas populares (GitHub, GitLab, Jira, AWS, asistentes de IA, Discord...)
 - **Importar / exportar** con resolución de conflictos para reglas y sesiones
 - **Estadísticas locales** : ve cuántas agrupaciones y deduplicaciones te ahorran tiempo
 - **Atajos de teclado** con panel de ayuda integrado
@@ -83,7 +83,7 @@ pnpm storybook    # Explorador de componentes (puerto 6006)
 pnpm build        # Build de producción
 ```
 
-El stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) y las convenciones de código están documentadas en [`CLAUDE.md`](CLAUDE.md) y el [anexo stack técnico](docs/src/content/docs/annexes/stack-technique.mdx).
+El stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) y las convenciones de código están documentadas en [`CLAUDE.md`](CLAUDE.md) y el [anexo stack técnico](docs/src/content/docs/contribuer/stack.mdx).
 
 Por favor, abre una issue antes de enviar una pull request grande.
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -57,7 +57,7 @@ Capture tes onglets et tes groupes ouverts, nomme-les, épingle ceux dans lesque
 ## Et aussi
 
 - **Espaces de travail** : règles, sessions et stats séparés par contexte (pro, perso, projet annexe)
-- **20+ packs de règles** prêts à importer pour les outils courants (GitHub, GitLab, Jira, AWS, assistants IA, Discord...)
+- **49 packs de règles** prêts à importer pour les outils courants (GitHub, GitLab, Jira, AWS, assistants IA, Discord...)
 - **Import / export** avec résolution de conflits pour les règles comme pour les sessions
 - **Statistiques locales** : vois combien de regroupements et de déduplications te font gagner du temps
 - **Raccourcis clavier** avec panneau d'aide intégré
@@ -83,7 +83,7 @@ pnpm storybook    # Explorateur de composants (port 6006)
 pnpm build        # Build production
 ```
 
-La stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) et les conventions de code sont documentées dans [`CLAUDE.md`](CLAUDE.md) et l'[annexe stack technique](docs/src/content/docs/annexes/stack-technique.mdx).
+La stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) et les conventions de code sont documentées dans [`CLAUDE.md`](CLAUDE.md) et l'[annexe stack technique](docs/src/content/docs/contribuer/stack.mdx).
 
 Merci d'ouvrir une issue avant de soumettre une pull request importante.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Snapshot your open tabs and groups, name them, pin the ones you live in. Restore
 ## And there's more
 
 - **Workspaces** : keep separate rules, sessions and stats per context (work, personal, side project)
-- **20+ rule packs** for popular tools (GitHub, GitLab, Jira, AWS, AI assistants, Discord...) ready to import
+- **49 rule packs** for popular tools (GitHub, GitLab, Jira, AWS, AI assistants, Discord...) ready to import
 - **Import / export** with conflict resolution for both rules and sessions
 - **Local statistics** : see how much grouping and dedup actually saves you
 - **Keyboard shortcuts** with a built-in help panel
@@ -83,7 +83,7 @@ pnpm storybook    # Component explorer (port 6006)
 pnpm build        # Production build
 ```
 
-The stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) and code conventions are documented in [`CLAUDE.md`](CLAUDE.md) and the [stack technique annex](docs/src/content/docs/annexes/stack-technique.mdx).
+The stack (WXT, React 19, Radix UI, Zod, Vitest, Playwright, Storybook) and code conventions are documented in [`CLAUDE.md`](CLAUDE.md) and the [stack technique annex](docs/src/content/docs/contribuer/stack.mdx).
 
 Please open an issue before submitting a large pull request.
 

--- a/docs/src/components/landing/ClosingCTA.astro
+++ b/docs/src/components/landing/ClosingCTA.astro
@@ -12,7 +12,13 @@ const installHref = localizePath(locale, t.installPath);
   <h2 id="cta-title">{t.title}</h2>
   <p>{t.subtitle}</p>
   <div class="cta-actions">
-    <a class="cta-button cta-primary" href={installHref}>{t.install}</a>
+    <a class="cta-button cta-primary" href={t.chromeHref} rel="noopener" target="_blank">
+      {t.chrome}
+    </a>
+    <a class="cta-button cta-store" href={t.firefoxHref} rel="noopener" target="_blank">
+      {t.firefox}
+    </a>
+    <a class="cta-button cta-minimal" href={installHref}>{t.install}</a>
     <a class="cta-button cta-minimal" href={t.githubHref} rel="noopener" target="_blank">
       {t.github}
     </a>
@@ -68,6 +74,16 @@ const installHref = localizePath(locale, t.installPath);
   .cta-primary {
     background: var(--blog-accent);
     color: var(--blog-background);
+  }
+
+  .cta-store {
+    background: transparent;
+    color: var(--blog-accent);
+    border-color: var(--blog-accent);
+  }
+
+  .cta-store:hover {
+    background: var(--blog-muted);
   }
 
   .cta-minimal {

--- a/docs/src/components/landing/Showcase.astro
+++ b/docs/src/components/landing/Showcase.astro
@@ -1,0 +1,100 @@
+---
+import type { ImageMetadata } from 'astro';
+import ThemeImage from '../ThemeImage.astro';
+import { getLocale } from '../../i18n/locale';
+import { landing } from '../../i18n/landing';
+
+const locale = getLocale(Astro.url.pathname);
+const t = landing[locale].showcase;
+
+// Eagerly load every screenshot so we can pick the locale/theme variant by name.
+const screenshots = import.meta.glob<{ default: ImageMetadata }>(
+  '../../assets/screenshots/*.png',
+  { eager: true },
+);
+
+function variant(theme: 'light' | 'dark', screen: string): ImageMetadata {
+  const key = `../../assets/screenshots/${locale}-${theme}-${screen}.png`;
+  const mod = screenshots[key];
+  if (!mod) {
+    throw new Error(`Showcase: missing screenshot ${key}`);
+  }
+  return mod.default;
+}
+---
+
+<section class="showcase" aria-labelledby="showcase-title">
+  <div class="landing-section-head">
+    <h2 id="showcase-title">{t.title}</h2>
+    <p>{t.subtitle}</p>
+  </div>
+  <div class="showcase-grid">
+    {
+      t.items.map((item) => (
+        <figure class="showcase-card">
+          <ThemeImage
+            lightSrc={variant('light', item.screen)}
+            darkSrc={variant('dark', item.screen)}
+            alt={item.alt}
+          />
+          <figcaption>{item.caption}</figcaption>
+        </figure>
+      ))
+    }
+  </div>
+</section>
+
+<style>
+  .showcase {
+    margin-block: 4rem;
+  }
+
+  .landing-section-head {
+    text-align: center;
+    max-width: 48rem;
+    margin-inline: auto;
+    margin-block-end: 2.5rem;
+  }
+
+  .landing-section-head h2 {
+    font-size: clamp(1.6rem, 1rem + 2.4vw, 2.4rem);
+    margin-block-end: 0.5rem;
+  }
+
+  .landing-section-head p {
+    color: var(--sl-color-gray-2);
+    margin: 0;
+  }
+
+  .showcase-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .showcase-card {
+    margin: 0;
+    border: 1px solid var(--blog-border);
+    border-radius: 0.9rem;
+    overflow: hidden;
+    background: var(--sl-color-bg-sidebar);
+  }
+
+  .showcase-card :global(.theme-image) {
+    display: block;
+  }
+
+  .showcase-card :global(img) {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .showcase-card figcaption {
+    padding: 0.85rem 1rem;
+    font-size: 0.95rem;
+    color: var(--sl-color-gray-2);
+    border-top: 1px solid var(--blog-border);
+  }
+</style>

--- a/docs/src/content/docs/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/decouverte/pourquoi.mdx
@@ -3,7 +3,15 @@ title: Pourquoi cette extension ?
 description: Le problème que résout SmartTab Organizer, ses trois piliers (grouper, dédupliquer, sauvegarder) et son positionnement face aux outils basés sur l'IA en ligne.
 ---
 
-import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Démarrage rapide">
+<Steps>
+1. Installez l'extension depuis le [Chrome Web Store ou Firefox Add-ons](/decouverte/installation).
+2. Ouvrez les Options et [importez un pack de règles](/reference/categories-et-packs), le chemin le plus rapide pour découvrir l'extension.
+3. Clic milieu sur un lien : le nouvel onglet rejoint automatiquement son groupe.
+</Steps>
+</Aside>
 
 Il y a des soirs où l'on retrouve son navigateur dans un état lamentable, rempli d'onglets dont on ne sait plus lesquels sont encore utiles. On aimerait tout garder, tout le temps, mais ce n'est pas toujours possible.
 

--- a/docs/src/content/docs/en/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/en/decouverte/pourquoi.mdx
@@ -3,7 +3,15 @@ title: Why this extension?
 description: The problem SmartTab Organizer solves, its three pillars (group, deduplicate, save) and how it stands apart from tools based on remote AI.
 ---
 
-import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Quick start">
+<Steps>
+1. Install the extension from the [Chrome Web Store or Firefox Add-ons](/decouverte/installation).
+2. Open the Options and [import a rule pack](/reference/categories-et-packs), the fastest way to explore the extension.
+3. Middle-click a link: the new tab automatically joins its group.
+</Steps>
+</Aside>
 
 Some evenings you come back to your browser in a sorry state, packed with tabs and unsure which ones are still useful. You would love to keep everything, all the time, but that is not always possible.
 

--- a/docs/src/content/docs/en/faq.mdx
+++ b/docs/src/content/docs/en/faq.mdx
@@ -51,6 +51,22 @@ Uninstalling then reinstalling the extension fully wipes `browser.storage.local`
 
 On the [GitHub issue tracker](https://github.com/EspritVorace/smart-tab-organizer/issues). Please include the browser (Chrome / Edge / Firefox + version), a description of the expected vs observed behavior, and ideally the steps to reproduce.
 
+## Does the extension use AI?
+
+No. No AI, neither local nor remote. Group naming relies solely on regular expressions executed in your browser (your own, or those from a built-in pack). See [Why this extension](/decouverte/pourquoi#tout-est-local-rien-ne-part-en-ligne).
+
+## Is it really free? What is the business model?
+
+Yes, free with no strings attached: no paid version, no premium tier, no gated feature. The extension is open source under the GPL v3 license, so anyone can audit it and contribute. See the [open source attribution page](/reference/licences-open-source).
+
+## How is it different from the browser's native tab groups?
+
+Chrome's native groups are created and named by hand. SmartTab Organizer creates them automatically based on your domain rules, closes duplicates, and saves your tab state as restorable sessions. It builds on native groups, it does not replace them. See [Grouping tabs](/guides/grouper-onglets).
+
+## Does it work offline?
+
+Yes. The extension needs no connection: grouping, deduplication, sessions, and statistics all run entirely locally. The only time the network is involved is when you open a page in a tab yourself.
+
 ## Next steps
 
 <CardGrid>

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -4,6 +4,10 @@ description: A Chrome and Firefox browser extension that groups your tabs by rul
 template: splash
 hero:
   tagline: Organize your tabs intelligently, without sending a single URL anywhere.
+  image:
+    alt: The SmartTab Organizer popup with its pinned profiles and workspace switcher.
+    light: ../../../assets/screenshots/en-light-journey-popup-with-pinned-and-workspace.png
+    dark: ../../../assets/screenshots/en-dark-journey-popup-with-pinned-and-workspace.png
   actions:
     - text: Get started
       link: /en/decouverte/pourquoi/
@@ -20,12 +24,14 @@ hero:
 ---
 
 import FeatureGrid from '../../../components/landing/FeatureGrid.astro';
+import Showcase from '../../../components/landing/Showcase.astro';
 import PrivacyBand from '../../../components/landing/PrivacyBand.astro';
 import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
 
 <FeatureGrid />
+<Showcase />
 <PrivacyBand />
 <ComparisonTable />
 <ValuesBand />

--- a/docs/src/content/docs/es/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/es/decouverte/pourquoi.mdx
@@ -3,7 +3,15 @@ title: ¿Por qué esta extensión?
 description: El problema que resuelve SmartTab Organizer, sus tres pilares (agrupar, deduplicar, guardar) y su posición frente a las herramientas basadas en IA en línea.
 ---
 
-import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+<Aside type="tip" title="Inicio rápido">
+<Steps>
+1. Instala la extensión desde la [Chrome Web Store o Firefox Add-ons](/decouverte/installation).
+2. Abre las Opciones e [importa un pack de reglas](/reference/categories-et-packs), el camino más rápido para descubrir la extensión.
+3. Clic central en un enlace: la nueva pestaña se une automáticamente a su grupo.
+</Steps>
+</Aside>
 
 Hay noches en las que abres el navegador y lo encuentras hecho un desastre, lleno de pestañas de las que ya no sabes cuáles siguen siendo útiles. Te gustaría conservarlas todas, siempre, pero no siempre es viable.
 

--- a/docs/src/content/docs/es/faq.mdx
+++ b/docs/src/content/docs/es/faq.mdx
@@ -51,6 +51,22 @@ Desinstalar y reinstalar la extensión vacía por completo `browser.storage.loca
 
 En el [tracker de incidencias de GitHub](https://github.com/EspritVorace/smart-tab-organizer/issues). Indica el navegador (Chrome / Edge / Firefox y versión), una descripción del comportamiento esperado frente al observado y, a ser posible, los pasos para reproducirlo.
 
+## ¿La extensión utiliza IA?
+
+No. Ninguna IA, ni local ni remota. El nombrado de los grupos se basa únicamente en expresiones regulares ejecutadas en tu navegador (las tuyas o las de un pack integrado). Consulta [Por qué esta extensión](/decouverte/pourquoi#tout-est-local-rien-ne-part-en-ligne).
+
+## ¿Es realmente gratis? ¿Cuál es el modelo de negocio?
+
+Sí, gratis y sin contrapartidas: sin versión de pago, sin nivel premium, sin funciones bloqueadas. La extensión es de código abierto bajo licencia GPL v3, así que cualquiera puede auditarla y contribuir. Consulta la [página de atribución de código abierto](/reference/licences-open-source).
+
+## ¿En qué se diferencia de los grupos de pestañas nativos del navegador?
+
+Los grupos nativos de Chrome se crean y se nombran a mano. SmartTab Organizer los crea automáticamente según tus reglas de dominio, cierra los duplicados y guarda el estado de tus pestañas como sesiones restaurables. Se apoya en los grupos nativos, no los reemplaza. Consulta [Agrupar pestañas](/guides/grouper-onglets).
+
+## ¿Funciona sin conexión?
+
+Sí. La extensión no necesita conexión: agrupación, deduplicación, sesiones y estadísticas funcionan por completo en local. La única vez que interviene la red es cuando abres tú mismo una página en una pestaña.
+
 ## Siguiente paso
 
 <CardGrid>

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -4,6 +4,10 @@ description: Extensión de navegador (Chrome / Firefox) que agrupa tus pestañas
 template: splash
 hero:
   tagline: Organiza tus pestañas de forma inteligente, sin enviar ni una sola URL a internet.
+  image:
+    alt: La ventana emergente de SmartTab Organizer con sus perfiles fijados y su selector de espacio de trabajo.
+    light: ../../../assets/screenshots/es-light-journey-popup-with-pinned-and-workspace.png
+    dark: ../../../assets/screenshots/es-dark-journey-popup-with-pinned-and-workspace.png
   actions:
     - text: Empezar
       link: /es/decouverte/pourquoi/
@@ -20,12 +24,14 @@ hero:
 ---
 
 import FeatureGrid from '../../../components/landing/FeatureGrid.astro';
+import Showcase from '../../../components/landing/Showcase.astro';
 import PrivacyBand from '../../../components/landing/PrivacyBand.astro';
 import ComparisonTable from '../../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../../components/landing/ClosingCTA.astro';
 
 <FeatureGrid />
+<Showcase />
 <PrivacyBand />
 <ComparisonTable />
 <ValuesBand />

--- a/docs/src/content/docs/faq.mdx
+++ b/docs/src/content/docs/faq.mdx
@@ -51,6 +51,22 @@ Désinstaller puis réinstaller l'extension purge complètement `browser.storage
 
 Sur le [tracker d'issues GitHub](https://github.com/EspritVorace/smart-tab-organizer/issues). Précisez le navigateur (Chrome / Edge / Firefox + version), une description du comportement attendu vs observé, et idéalement les étapes pour reproduire.
 
+## Est-ce que l'extension utilise de l'IA ?
+
+Non. Aucune IA, ni locale ni distante. Le nommage des groupes repose uniquement sur des expressions régulières exécutées dans votre navigateur (les vôtres, ou celles d'un pack intégré). Voir [Pourquoi cette extension](/decouverte/pourquoi#tout-est-local-rien-ne-part-en-ligne).
+
+## Est-ce vraiment gratuit ? Quel est le modèle économique ?
+
+Oui, gratuit et sans contrepartie : pas de version payante, pas de palier premium, pas de fonction bridée. L'extension est open source sous licence GPL v3, donc vérifiable et contribuable par tous. Voir la [page d'attribution open source](/reference/licences-open-source).
+
+## En quoi est-ce différent des groupes d'onglets natifs du navigateur ?
+
+Les groupes natifs de Chrome se créent et se nomment à la main. SmartTab Organizer les crée automatiquement selon vos règles de domaine, ferme les doublons, et sauvegarde l'état de vos onglets sous forme de sessions restaurables. Il s'appuie sur les groupes natifs, il ne les remplace pas. Voir [Grouper les onglets](/guides/grouper-onglets).
+
+## Est-ce que ça fonctionne hors ligne ?
+
+Oui. L'extension n'a besoin d'aucune connexion : groupement, déduplication, sessions et statistiques tournent entièrement en local. La seule intervention du réseau, c'est lorsque vous ouvrez vous-même une page dans un onglet.
+
 ## Aller plus loin
 
 <CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SmartTab Organizer
-description: Extension navigateur (Chrome / Firefox) qui groupe vos onglets par règles, dédupliquer les doublons et sauvegarde vos sessions de travail. Tout est local, rien ne part en ligne.
+description: Extension navigateur (Chrome / Firefox) qui groupe vos onglets par règles, déduplique les doublons et sauvegarde vos sessions de travail. Tout est local, rien ne part en ligne.
 template: splash
 hero:
   tagline: Organisez vos onglets intelligemment, sans envoyer la moindre URL en ligne.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -4,6 +4,10 @@ description: Extension navigateur (Chrome / Firefox) qui groupe vos onglets par 
 template: splash
 hero:
   tagline: Organisez vos onglets intelligemment, sans envoyer la moindre URL en ligne.
+  image:
+    alt: La popup de SmartTab Organizer avec ses profils epingles et son selecteur d'espace de travail.
+    light: ../../assets/screenshots/fr-light-journey-popup-with-pinned-and-workspace.png
+    dark: ../../assets/screenshots/fr-dark-journey-popup-with-pinned-and-workspace.png
   actions:
     - text: Commencer
       link: /decouverte/pourquoi/
@@ -20,12 +24,14 @@ hero:
 ---
 
 import FeatureGrid from '../../components/landing/FeatureGrid.astro';
+import Showcase from '../../components/landing/Showcase.astro';
 import PrivacyBand from '../../components/landing/PrivacyBand.astro';
 import ComparisonTable from '../../components/landing/ComparisonTable.astro';
 import ValuesBand from '../../components/landing/ValuesBand.astro';
 import ClosingCTA from '../../components/landing/ClosingCTA.astro';
 
 <FeatureGrid />
+<Showcase />
 <PrivacyBand />
 <ComparisonTable />
 <ValuesBand />

--- a/docs/src/i18n/landing.ts
+++ b/docs/src/i18n/landing.ts
@@ -34,6 +34,13 @@ export interface ValueItem {
   description: string;
 }
 
+export interface ShowcaseItem {
+  /** Screen name suffix in docs/src/assets/screenshots/{locale}-{theme}-{screen}.png. */
+  screen: string;
+  alt: string;
+  caption: string;
+}
+
 export interface LandingCopy {
   features: {
     title: string;
@@ -59,6 +66,11 @@ export interface LandingCopy {
     subtitle: string;
     items: ValueItem[];
   };
+  showcase: {
+    title: string;
+    subtitle: string;
+    items: ShowcaseItem[];
+  };
   cta: {
     title: string;
     subtitle: string;
@@ -66,10 +78,17 @@ export interface LandingCopy {
     installPath: string;
     github: string;
     githubHref: string;
+    chrome: string;
+    chromeHref: string;
+    firefox: string;
+    firefoxHref: string;
   };
 }
 
 const GITHUB_URL = 'https://github.com/EspritVorace/smart-tab-organizer';
+const CHROME_URL =
+  'https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah';
+const FIREFOX_URL = 'https://addons.mozilla.org/firefox/addon/smarttab-organizer/';
 
 export const landing: Record<Locale, LandingCopy> = {
   fr: {
@@ -149,7 +168,7 @@ export const landing: Record<Locale, LandingCopy> = {
         {
           criterion: 'Code source',
           sto: { ok: true, text: 'Open source' },
-          others: { ok: false, text: 'Proprietaire' },
+          others: { ok: false, text: 'Souvent proprietaire' },
         },
         {
           criterion: 'Compte utilisateur',
@@ -197,6 +216,22 @@ export const landing: Record<Locale, LandingCopy> = {
         },
       ],
     },
+    showcase: {
+      title: 'Un apercu en images',
+      subtitle: 'Vos regles groupent les onglets, vos sessions sauvegardent vos contextes de travail.',
+      items: [
+        {
+          screen: 'journey-rules-list-populated',
+          alt: 'Page Options de SmartTab Organizer affichant une liste de regles de domaine.',
+          caption: 'Des regles de domaine qui groupent vos onglets automatiquement.',
+        },
+        {
+          screen: 'journey-sessions-list-with-snapshot',
+          alt: 'Liste des sessions de SmartTab Organizer avec un instantane enregistre.',
+          caption: 'Vos sessions de travail, sauvegardees et restaurables en un clic.',
+        },
+      ],
+    },
     cta: {
       title: 'Reprenez le controle de vos onglets',
       subtitle: 'Installation en quelques secondes, sans compte ni configuration obligatoire.',
@@ -204,6 +239,10 @@ export const landing: Record<Locale, LandingCopy> = {
       installPath: '/decouverte/installation',
       github: 'Voir sur GitHub',
       githubHref: GITHUB_URL,
+      chrome: 'Ajouter a Chrome',
+      chromeHref: CHROME_URL,
+      firefox: 'Ajouter a Firefox',
+      firefoxHref: FIREFOX_URL,
     },
   },
 
@@ -284,7 +323,7 @@ export const landing: Record<Locale, LandingCopy> = {
         {
           criterion: 'Source code',
           sto: { ok: true, text: 'Open source' },
-          others: { ok: false, text: 'Proprietary' },
+          others: { ok: false, text: 'Often proprietary' },
         },
         {
           criterion: 'User account',
@@ -332,6 +371,22 @@ export const landing: Record<Locale, LandingCopy> = {
         },
       ],
     },
+    showcase: {
+      title: 'A look in pictures',
+      subtitle: 'Your rules group the tabs, your sessions save your work contexts.',
+      items: [
+        {
+          screen: 'journey-rules-list-populated',
+          alt: 'SmartTab Organizer Options page showing a list of domain rules.',
+          caption: 'Domain rules that group your tabs automatically.',
+        },
+        {
+          screen: 'journey-sessions-list-with-snapshot',
+          alt: 'SmartTab Organizer sessions list with a saved snapshot.',
+          caption: 'Your work sessions, saved and restorable in one click.',
+        },
+      ],
+    },
     cta: {
       title: 'Take back control of your tabs',
       subtitle: 'Install in seconds, with no account and no mandatory setup.',
@@ -339,6 +394,10 @@ export const landing: Record<Locale, LandingCopy> = {
       installPath: '/decouverte/installation',
       github: 'View on GitHub',
       githubHref: GITHUB_URL,
+      chrome: 'Add to Chrome',
+      chromeHref: CHROME_URL,
+      firefox: 'Add to Firefox',
+      firefoxHref: FIREFOX_URL,
     },
   },
 
@@ -419,7 +478,7 @@ export const landing: Record<Locale, LandingCopy> = {
         {
           criterion: 'Codigo fuente',
           sto: { ok: true, text: 'Codigo abierto' },
-          others: { ok: false, text: 'Propietario' },
+          others: { ok: false, text: 'A menudo propietario' },
         },
         {
           criterion: 'Cuenta de usuario',
@@ -467,6 +526,22 @@ export const landing: Record<Locale, LandingCopy> = {
         },
       ],
     },
+    showcase: {
+      title: 'Un vistazo en imagenes',
+      subtitle: 'Tus reglas agrupan las pestanas, tus sesiones guardan tus contextos de trabajo.',
+      items: [
+        {
+          screen: 'journey-rules-list-populated',
+          alt: 'Pagina de Opciones de SmartTab Organizer mostrando una lista de reglas de dominio.',
+          caption: 'Reglas de dominio que agrupan tus pestanas automaticamente.',
+        },
+        {
+          screen: 'journey-sessions-list-with-snapshot',
+          alt: 'Lista de sesiones de SmartTab Organizer con una instantanea guardada.',
+          caption: 'Tus sesiones de trabajo, guardadas y restaurables con un clic.',
+        },
+      ],
+    },
     cta: {
       title: 'Recupera el control de tus pestanas',
       subtitle: 'Instalacion en segundos, sin cuenta ni configuracion obligatoria.',
@@ -474,6 +549,10 @@ export const landing: Record<Locale, LandingCopy> = {
       installPath: '/decouverte/installation',
       github: 'Ver en GitHub',
       githubHref: GITHUB_URL,
+      chrome: 'Anadir a Chrome',
+      chromeHref: CHROME_URL,
+      firefox: 'Anadir a Firefox',
+      firefoxHref: FIREFOX_URL,
     },
   },
 };

--- a/docs/src/i18n/landing.ts
+++ b/docs/src/i18n/landing.ts
@@ -95,68 +95,68 @@ export const landing: Record<Locale, LandingCopy> = {
     features: {
       title: 'Tout ce dont vos onglets ont besoin',
       subtitle:
-        'Six fonctions complementaires pour transformer un navigateur surcharge en outil de travail organise.',
+        'Six fonctions complémentaires pour transformer un navigateur surchargé en outil de travail organisé.',
       items: [
         {
           icon: 'flat-color-icons:tree-structure',
           title: 'Groupement automatique',
           description:
-            "Les onglets ouverts depuis un meme parent rejoignent un groupe colore, selon vos regles, sans intervention manuelle.",
+            "Les onglets ouverts depuis un même parent rejoignent un groupe coloré, selon vos règles, sans intervention manuelle.",
         },
         {
           icon: 'flat-color-icons:reuse',
-          title: 'Deduplication',
+          title: 'Déduplication',
           description:
-            'Trois modes de correspondance (URL exacte, sans parametres ignores, inclusion) ferment les doublons en gardant le bon onglet.',
+            'Trois modes de correspondance (URL exacte, sans paramètres ignorés, inclusion) ferment les doublons en gardant le bon onglet.',
         },
         {
           icon: 'flat-color-icons:data-backup',
           title: 'Sessions et profils',
           description:
-            "Capturez l'etat du navigateur, epinglez les contextes recurrents, restaurez-les en un clic avec resolution des conflits.",
+            "Capturez l'état du navigateur, épinglez les contextes récurrents, restaurez-les en un clic avec résolution des conflits.",
         },
         {
           icon: 'flat-color-icons:rules',
-          title: 'Regles et packs regex',
+          title: 'Règles et packs regex',
           description:
-            "Ecrivez vos expressions regulieres ou partez de 49 packs prets a l'emploi, classes par categorie.",
+            "Écrivez vos expressions régulières ou partez de 49 packs prêts à l'emploi, classés par catégorie.",
         },
         {
           icon: 'flat-color-icons:data-configuration',
           title: 'Import et export',
           description:
-            'Sauvegardez et partagez vos regles et sessions en JSON valide, avec detection et resolution des conflits.',
+            'Sauvegardez et partagez vos règles et sessions en JSON valide, avec détection et résolution des conflits.',
         },
         {
           icon: 'flat-color-icons:briefcase',
           title: 'Espaces de travail',
           description:
-            "Separez travail et perso via des espaces distincts, chacun avec sa couleur d'accent et son exclusivite de fenetre.",
+            "Séparez travail et perso via des espaces distincts, chacun avec sa couleur d'accent et son exclusivité de fenêtre.",
         },
       ],
     },
     privacy: {
       title: 'Tout est local, rien ne part en ligne',
       subtitle:
-        "L'inverse exact des outils qui envoient vos URL a un service distant. Ici, vos donnees ne quittent jamais le navigateur.",
+        "L'inverse exact des outils qui envoient vos URL à un service distant. Ici, vos données ne quittent jamais le navigateur.",
       points: [
         { icon: 'flat-color-icons:data-protection', label: 'Stockage dans browser.storage.local, sur votre machine.' },
-        { icon: 'flat-color-icons:broken-link', label: 'Zero requete reseau initiee par l\'extension.' },
-        { icon: 'flat-color-icons:privacy', label: 'Zero telemetrie, zero analytics, zero pistage.' },
-        { icon: 'flat-color-icons:lock', label: 'Zero compte, zero cloud, zero IA distante.' },
+        { icon: 'flat-color-icons:broken-link', label: 'Zéro requête réseau initiée par l\'extension.' },
+        { icon: 'flat-color-icons:privacy', label: 'Zéro télémétrie, zéro analytics, zéro pistage.' },
+        { icon: 'flat-color-icons:lock', label: 'Zéro compte, zéro cloud, zéro IA distante.' },
       ],
-      note: 'Si vous synchronisez vos profils Chrome ou Firefox, les donnees suivent le profil, mais aucune communication reseau n\'est initiee par l\'extension elle-meme.',
+      note: 'Si vous synchronisez vos profils Chrome ou Firefox, les données suivent le profil, mais aucune communication réseau n\'est initiée par l\'extension elle-même.',
     },
     comparison: {
       title: 'Pourquoi pas une alternative ?',
       subtitle:
-        'Comparaison avec les categories courantes : gestionnaires cloud, outils de nommage par IA, extensions a abonnement.',
-      columnCriterion: 'Critere',
+        'Comparaison avec les catégories courantes : gestionnaires cloud, outils de nommage par IA, extensions à abonnement.',
+      columnCriterion: 'Critère',
       columnSto: 'Smart Tab Organizer',
       columnOthers: 'Alternatives courantes',
       rows: [
         {
-          criterion: 'Stockage des donnees',
+          criterion: 'Stockage des données',
           sto: { ok: true, text: '100% local' },
           others: { ok: false, text: 'Souvent dans le cloud' },
         },
@@ -168,7 +168,7 @@ export const landing: Record<Locale, LandingCopy> = {
         {
           criterion: 'Code source',
           sto: { ok: true, text: 'Open source' },
-          others: { ok: false, text: 'Souvent proprietaire' },
+          others: { ok: false, text: 'Souvent propriétaire' },
         },
         {
           criterion: 'Compte utilisateur',
@@ -176,17 +176,17 @@ export const landing: Record<Locale, LandingCopy> = {
           others: { ok: false, text: 'Compte souvent requis' },
         },
         {
-          criterion: 'Tracking et telemetrie',
+          criterion: 'Tracking et télémétrie',
           sto: { ok: true, text: 'Aucun' },
-          others: { ok: false, text: 'Frequent' },
+          others: { ok: false, text: 'Fréquent' },
         },
         {
           criterion: 'Nommage des groupes',
-          sto: { ok: true, text: 'Regles regex locales' },
-          others: { ok: false, text: 'IA distante (URL envoyees)' },
+          sto: { ok: true, text: 'Règles regex locales' },
+          others: { ok: false, text: 'IA distante (URL envoyées)' },
         },
         {
-          criterion: 'Accessibilite',
+          criterion: 'Accessibilité',
           sto: { ok: true, text: 'Polices dys, audits axe-core' },
           others: { ok: false, text: 'Variable' },
         },
@@ -194,54 +194,54 @@ export const landing: Record<Locale, LandingCopy> = {
     },
     values: {
       title: 'Des valeurs, pas seulement des fonctions',
-      subtitle: 'Ce qui guide chaque decision de conception.',
+      subtitle: 'Ce qui guide chaque décision de conception.',
       items: [
         {
           icon: 'flat-color-icons:copyleft',
           title: 'Open source',
           description:
-            'Code ouvert, verifiable et contribuable. Vous savez exactement ce que fait l\'extension, ligne par ligne.',
+            'Code ouvert, vérifiable et contribuable. Vous savez exactement ce que fait l\'extension, ligne par ligne.',
         },
         {
           icon: 'flat-color-icons:reading',
-          title: 'Accessibilite',
+          title: 'Accessibilité',
           description:
-            'Polices adaptees aux troubles dys (Luciole, Atkinson Hyperlegible), focus visibles, audits axe-core en continu.',
+            'Polices adaptées aux troubles dys (Luciole, Atkinson Hyperlegible), focus visibles, audits axe-core en continu.',
         },
         {
           icon: 'flat-color-icons:donate',
           title: 'Gratuit pour toujours',
           description:
-            'Pas de version payante, pas de palier premium, pas de fonction bridee. Tout, gratuitement, durablement.',
+            'Pas de version payante, pas de palier premium, pas de fonction bridée. Tout, gratuitement, durablement.',
         },
       ],
     },
     showcase: {
-      title: 'Un apercu en images',
-      subtitle: 'Vos regles groupent les onglets, vos sessions sauvegardent vos contextes de travail.',
+      title: 'Un aperçu en images',
+      subtitle: 'Vos règles groupent les onglets, vos sessions sauvegardent vos contextes de travail.',
       items: [
         {
           screen: 'journey-rules-list-populated',
-          alt: 'Page Options de SmartTab Organizer affichant une liste de regles de domaine.',
-          caption: 'Des regles de domaine qui groupent vos onglets automatiquement.',
+          alt: 'Page Options de SmartTab Organizer affichant une liste de règles de domaine.',
+          caption: 'Des règles de domaine qui groupent vos onglets automatiquement.',
         },
         {
           screen: 'journey-sessions-list-with-snapshot',
-          alt: 'Liste des sessions de SmartTab Organizer avec un instantane enregistre.',
-          caption: 'Vos sessions de travail, sauvegardees et restaurables en un clic.',
+          alt: 'Liste des sessions de SmartTab Organizer avec un instantané enregistré.',
+          caption: 'Vos sessions de travail, sauvegardées et restaurables en un clic.',
         },
       ],
     },
     cta: {
-      title: 'Reprenez le controle de vos onglets',
+      title: 'Reprenez le contrôle de vos onglets',
       subtitle: 'Installation en quelques secondes, sans compte ni configuration obligatoire.',
       install: 'Installer',
       installPath: '/decouverte/installation',
       github: 'Voir sur GitHub',
       githubHref: GITHUB_URL,
-      chrome: 'Ajouter a Chrome',
+      chrome: 'Ajouter à Chrome',
       chromeHref: CHROME_URL,
-      firefox: 'Ajouter a Firefox',
+      firefox: 'Ajouter à Firefox',
       firefoxHref: FIREFOX_URL,
     },
   },
@@ -403,39 +403,39 @@ export const landing: Record<Locale, LandingCopy> = {
 
   es: {
     features: {
-      title: 'Todo lo que tus pestanas necesitan',
+      title: 'Todo lo que tus pestañas necesitan',
       subtitle:
         'Seis funciones complementarias que convierten un navegador sobrecargado en una herramienta de trabajo organizada.',
       items: [
         {
           icon: 'flat-color-icons:tree-structure',
-          title: 'Agrupacion automatica',
+          title: 'Agrupación automática',
           description:
-            'Las pestanas abiertas desde un mismo padre se unen a un grupo de color, segun tus reglas, sin intervencion manual.',
+            'Las pestañas abiertas desde un mismo padre se unen a un grupo de color, según tus reglas, sin intervención manual.',
         },
         {
           icon: 'flat-color-icons:reuse',
-          title: 'Deduplicacion',
+          title: 'Deduplicación',
           description:
-            'Tres modos de coincidencia (URL exacta, sin parametros ignorados, inclusion) cierran los duplicados conservando la pestana correcta.',
+            'Tres modos de coincidencia (URL exacta, sin parámetros ignorados, inclusión) cierran los duplicados conservando la pestaña correcta.',
         },
         {
           icon: 'flat-color-icons:data-backup',
           title: 'Sesiones y perfiles',
           description:
-            'Captura el estado del navegador, fija los contextos recurrentes, restauralos con un clic y resolucion de conflictos.',
+            'Captura el estado del navegador, fija los contextos recurrentes, restáuralos con un clic y resolución de conflictos.',
         },
         {
           icon: 'flat-color-icons:rules',
           title: 'Reglas y paquetes regex',
           description:
-            'Escribe tus expresiones regulares o parte de 49 paquetes listos para usar, ordenados por categoria.',
+            'Escribe tus expresiones regulares o parte de 49 paquetes listos para usar, ordenados por categoría.',
         },
         {
           icon: 'flat-color-icons:data-configuration',
           title: 'Importar y exportar',
           description:
-            'Guarda y comparte tus reglas y sesiones en JSON validado, con deteccion y resolucion de conflictos.',
+            'Guarda y comparte tus reglas y sesiones en JSON validado, con detección y resolución de conflictos.',
         },
         {
           icon: 'flat-color-icons:briefcase',
@@ -448,19 +448,19 @@ export const landing: Record<Locale, LandingCopy> = {
     privacy: {
       title: 'Todo es local, nada sale a internet',
       subtitle:
-        'Lo contrario exacto de las herramientas que envian tus URL a un servicio remoto. Aqui, tus datos nunca salen del navegador.',
+        'Lo contrario exacto de las herramientas que envían tus URL a un servicio remoto. Aquí, tus datos nunca salen del navegador.',
       points: [
         { icon: 'flat-color-icons:data-protection', label: 'Almacenamiento en browser.storage.local, en tu equipo.' },
-        { icon: 'flat-color-icons:broken-link', label: 'Cero solicitudes de red iniciadas por la extension.' },
-        { icon: 'flat-color-icons:privacy', label: 'Cero telemetria, cero analiticas, cero rastreo.' },
+        { icon: 'flat-color-icons:broken-link', label: 'Cero solicitudes de red iniciadas por la extensión.' },
+        { icon: 'flat-color-icons:privacy', label: 'Cero telemetría, cero analíticas, cero rastreo.' },
         { icon: 'flat-color-icons:lock', label: 'Cero cuenta, cero nube, cero IA remota.' },
       ],
-      note: 'Si sincronizas tus perfiles de Chrome o Firefox, los datos siguen al perfil, pero la extension nunca inicia ninguna comunicacion de red por si misma.',
+      note: 'Si sincronizas tus perfiles de Chrome o Firefox, los datos siguen al perfil, pero la extensión nunca inicia ninguna comunicación de red por sí misma.',
     },
     comparison: {
-      title: 'Por que no una alternativa?',
+      title: '¿Por qué no una alternativa?',
       subtitle:
-        'Comparacion con las categorias habituales: gestores en la nube, herramientas de nombrado por IA, extensiones de suscripcion.',
+        'Comparación con las categorías habituales: gestores en la nube, herramientas de nombrado por IA, extensiones de suscripción.',
       columnCriterion: 'Criterio',
       columnSto: 'Smart Tab Organizer',
       columnOthers: 'Alternativas habituales',
@@ -473,11 +473,11 @@ export const landing: Record<Locale, LandingCopy> = {
         {
           criterion: 'Precio',
           sto: { ok: true, text: 'Gratis, para siempre' },
-          others: { ok: false, text: 'Freemium o suscripcion' },
+          others: { ok: false, text: 'Freemium o suscripción' },
         },
         {
-          criterion: 'Codigo fuente',
-          sto: { ok: true, text: 'Codigo abierto' },
+          criterion: 'Código fuente',
+          sto: { ok: true, text: 'Código abierto' },
           others: { ok: false, text: 'A menudo propietario' },
         },
         {
@@ -486,7 +486,7 @@ export const landing: Record<Locale, LandingCopy> = {
           others: { ok: false, text: 'Cuenta a menudo requerida' },
         },
         {
-          criterion: 'Rastreo y telemetria',
+          criterion: 'Rastreo y telemetría',
           sto: { ok: true, text: 'Ninguno' },
           others: { ok: false, text: 'Frecuente' },
         },
@@ -497,61 +497,61 @@ export const landing: Record<Locale, LandingCopy> = {
         },
         {
           criterion: 'Accesibilidad',
-          sto: { ok: true, text: 'Fuentes dys, auditorias axe-core' },
+          sto: { ok: true, text: 'Fuentes dys, auditorías axe-core' },
           others: { ok: false, text: 'Variable' },
         },
       ],
     },
     values: {
       title: 'Valores, no solo funciones',
-      subtitle: 'Lo que guia cada decision de diseno.',
+      subtitle: 'Lo que guía cada decisión de diseño.',
       items: [
         {
           icon: 'flat-color-icons:copyleft',
-          title: 'Codigo abierto',
+          title: 'Código abierto',
           description:
-            'Codigo abierto, verificable y al que puedes contribuir. Sabes exactamente que hace la extension, linea por linea.',
+            'Código abierto, verificable y al que puedes contribuir. Sabes exactamente qué hace la extensión, línea por línea.',
         },
         {
           icon: 'flat-color-icons:reading',
           title: 'Accesibilidad',
           description:
-            'Fuentes adaptadas a la dislexia (Luciole, Atkinson Hyperlegible), foco visible, auditorias axe-core continuas.',
+            'Fuentes adaptadas a la dislexia (Luciole, Atkinson Hyperlegible), foco visible, auditorías axe-core continuas.',
         },
         {
           icon: 'flat-color-icons:donate',
           title: 'Gratis para siempre',
           description:
-            'Sin version de pago, sin nivel premium, sin funciones bloqueadas. Todo, gratis, de forma duradera.',
+            'Sin versión de pago, sin nivel premium, sin funciones bloqueadas. Todo, gratis, de forma duradera.',
         },
       ],
     },
     showcase: {
-      title: 'Un vistazo en imagenes',
-      subtitle: 'Tus reglas agrupan las pestanas, tus sesiones guardan tus contextos de trabajo.',
+      title: 'Un vistazo en imágenes',
+      subtitle: 'Tus reglas agrupan las pestañas, tus sesiones guardan tus contextos de trabajo.',
       items: [
         {
           screen: 'journey-rules-list-populated',
-          alt: 'Pagina de Opciones de SmartTab Organizer mostrando una lista de reglas de dominio.',
-          caption: 'Reglas de dominio que agrupan tus pestanas automaticamente.',
+          alt: 'Página de Opciones de SmartTab Organizer mostrando una lista de reglas de dominio.',
+          caption: 'Reglas de dominio que agrupan tus pestañas automáticamente.',
         },
         {
           screen: 'journey-sessions-list-with-snapshot',
-          alt: 'Lista de sesiones de SmartTab Organizer con una instantanea guardada.',
+          alt: 'Lista de sesiones de SmartTab Organizer con una instantánea guardada.',
           caption: 'Tus sesiones de trabajo, guardadas y restaurables con un clic.',
         },
       ],
     },
     cta: {
-      title: 'Recupera el control de tus pestanas',
-      subtitle: 'Instalacion en segundos, sin cuenta ni configuracion obligatoria.',
+      title: 'Recupera el control de tus pestañas',
+      subtitle: 'Instalación en segundos, sin cuenta ni configuración obligatoria.',
       install: 'Instalar',
       installPath: '/decouverte/installation',
       github: 'Ver en GitHub',
       githubHref: GITHUB_URL,
-      chrome: 'Anadir a Chrome',
+      chrome: 'Añadir a Chrome',
       chromeHref: CHROME_URL,
-      firefox: 'Anadir a Firefox',
+      firefox: 'Añadir a Firefox',
       firefoxHref: FIREFOX_URL,
     },
   },


### PR DESCRIPTION
## Contexte

Revue de la documentation (`docs/src/content/docs/` + landing) du point de vue d'un visiteur ProductHunt qui decouvre l'extension. Cette PR applique les correctifs identifies, du plus trivial au plus structurant.

## Changements

### Correctifs rapides
- **Grammaire** : meta description FR de la landing (`index.mdx`), `dedupliquer` devient `deduplique`.
- **Coherence** : nombre de packs aligne sur `49` (etait `20+`) dans les 3 README.
- **Lien casse** : lien stack technique des 3 README repointe vers `docs/.../contribuer/stack.mdx` (l'ancien `annexes/stack-technique.mdx` n'existe plus).

### Item 1 : visuels sur la landing
- Image hero clair/sombre, declinee par locale (capture `journey-popup-with-pinned-and-workspace`), via le schema natif `hero.image.light/dark` de Starlight.
- Nouveau composant locale-aware `docs/src/components/landing/Showcase.astro` (regles + sessions), reutilisant `ThemeImage` et `import.meta.glob`. Insere entre `FeatureGrid` et `PrivacyBand`.

### Item 5 : boutons store
- Boutons directs Chrome Web Store et Firefox Add-ons ajoutes dans le `ClosingCTA` (hero laisse intact, choix retenu : version minimale).

### Item 6 : FAQ enrichie (3 locales)
4 questions d'adoption : usage de l'IA (non), gratuite et modele economique (open source GPL v3), difference avec les groupes d'onglets natifs, fonctionnement hors ligne.

### Item 7 : Quick Start (3 locales)
Encart `Aside` + `Steps` en tete de la page "Pourquoi" (installer, importer un pack, clic milieu).

### Item 8 : table de comparaison
Ligne "Code source" adoucie (`Souvent proprietaire` / `Often proprietary` / `A menudo propietario`).

### Qualite
- Re-accentuation complete des chaines FR et ES de `landing.ts` (accents, cedilles, tildes, `¿` espagnol). Chaines EN inchangees.

## Verification
- `pnpm docs:build` : succes (64 pages), toutes les images optimisees.
- Rendu HTML verifie : image hero, galerie Showcase, boutons store, et accents FR/ES presents.
- Aucun tiret cadratin ni demi-cadratin introduit (regle projet respectee).

https://claude.ai/code/session_019UkFGD8MtGfuZz7BGQxbVA

---
_Generated by [Claude Code](https://claude.ai/code/session_019UkFGD8MtGfuZz7BGQxbVA)_