### PR TITLE
Bump version to 1.2.3 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.2.3 — since 1.2.2
+
+### New Features
+- Annotated popup-overview slide for the Chrome Web Store
+- Starlight home turned into a visitor-oriented landing page
+
+### Improvements
+- Visitor-oriented review of landing and docs (visuals, FAQ, quick start)
+- Landing hero aligned with the closing CTA card style
+- Schema.org JSON-LD structured data added for GEO
+- robots.txt now explicitly allows AI crawlers
+- Version number removed from the options and popup footers
+- pnpm screenshots converged into the doc:scenarios pipeline
+- Transitive dependency vulnerabilities patched via pnpm overrides (extension and docs sub-project)
+
+### Bug Fixes
+- Security: CodeQL js/incomplete-sanitization alerts addressed
+- Docs: first capture of the Import/Export page corrected
+
 ## 1.2.2 — since 1.2.1
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-tab-organizer",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@11.4.0",
   "type": "module",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
   manifest: {
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
-    version: '1.2.2',
+    version: '1.2.3',
     author: 'EspritVorace',
     homepage_url: 'https://github.com/EspritVorace/smart-tab-organizer',
     default_locale: 'en',


### PR DESCRIPTION
Update project version to 1.2.3 (package.json and extension manifest) and add CHANGELOG entries for 1.2.3. Changelog documents new features, UI and docs improvements (including Schema.org JSON-LD for GEO and robots.txt update), security fixes (CodeQL sanitization alerts), transitive dependency patches via pnpm overrides, and other minor bug fixes and content adjustments.