### PR TITLE
docs: recentrer le message différenciant sur l'extraction du nom de groupe

### DIFF
--- a/docs/src/components/landing/ComparisonTable.astro
+++ b/docs/src/components/landing/ComparisonTable.astro
@@ -18,7 +18,8 @@ const t = landing[locale].comparison;
         <tr>
           <th scope="col">{t.columnCriterion}</th>
           <th scope="col" class="col-sto">{t.columnSto}</th>
-          <th scope="col">{t.columnOthers}</th>
+          <th scope="col">{t.columnLocalRegex}</th>
+          <th scope="col">{t.columnAiTools}</th>
         </tr>
       </thead>
       <tbody>
@@ -28,18 +29,47 @@ const t = landing[locale].comparison;
               <th scope="row">{row.criterion}</th>
               <td class="cell-sto">
                 <span class="cell">
-                  <span class="mark mark-ok" aria-hidden="true">
-                    <Icon name="flat-color-icons:ok" />
-                  </span>
+                  {row.sto.state === 'yes' && (
+                    <span class="mark mark-ok" aria-hidden="true">
+                      <Icon name="flat-color-icons:ok" />
+                    </span>
+                  )}
+                  {row.sto.state === 'no' && (
+                    <span class="mark mark-no" aria-hidden="true">
+                      <Icon name="flat-color-icons:cancel" />
+                    </span>
+                  )}
                   {row.sto.text}
                 </span>
               </td>
               <td>
                 <span class="cell">
-                  <span class="mark mark-no" aria-hidden="true">
-                    <Icon name="flat-color-icons:cancel" />
-                  </span>
-                  {row.others.text}
+                  {row.localRegex.state === 'yes' && (
+                    <span class="mark mark-ok" aria-hidden="true">
+                      <Icon name="flat-color-icons:ok" />
+                    </span>
+                  )}
+                  {row.localRegex.state === 'no' && (
+                    <span class="mark mark-no" aria-hidden="true">
+                      <Icon name="flat-color-icons:cancel" />
+                    </span>
+                  )}
+                  {row.localRegex.text}
+                </span>
+              </td>
+              <td>
+                <span class="cell">
+                  {row.aiTools.state === 'yes' && (
+                    <span class="mark mark-ok" aria-hidden="true">
+                      <Icon name="flat-color-icons:ok" />
+                    </span>
+                  )}
+                  {row.aiTools.state === 'no' && (
+                    <span class="mark mark-no" aria-hidden="true">
+                      <Icon name="flat-color-icons:cancel" />
+                    </span>
+                  )}
+                  {row.aiTools.text}
                 </span>
               </td>
             </tr>
@@ -79,7 +109,7 @@ const t = landing[locale].comparison;
   .comparison-table {
     width: 100%;
     border-collapse: collapse;
-    min-width: 38rem;
+    min-width: 52rem;
   }
 
   .comparison-table th,

--- a/docs/src/content/docs/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/decouverte/pourquoi.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pourquoi cette extension ?
-description: Le problème que résout SmartTab Organizer, ses trois piliers (grouper, dédupliquer, sauvegarder) et son positionnement face aux outils basés sur l'IA en ligne.
+description: "Le problème que résout SmartTab Organizer, ses trois piliers (grouper, dédupliquer, sauvegarder) et son vrai différenciateur : le nom de groupe extrait de l'URL ou du titre, en local."
 ---
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
@@ -41,7 +41,9 @@ L'extension s'organise autour de trois fonctions complémentaires.
 
 ## Tout est local, rien ne part en ligne
 
-La plupart des extensions concurrentes reposent sur de l'IA distante : elles envoient l'URL et le titre de chaque onglet à un service tiers pour décider du nommage. SmartTab Organizer fait exactement l'inverse : aucune donnée ne quitte votre navigateur. Le groupement repose sur des expressions régulières (que vous écrivez vous-même ou qui viennent d'un [pack intégré](/reference/categories-et-packs)), et les sessions vivent dans `browser.storage.local`.
+Les extensions de groupement existantes demandent un nom de groupe fixe, saisi à la main, avec une règle par valeur. SmartTab Organizer extrait le nom directement de l'URL ou du titre via une expression régulière : un groupe par dépôt, par ticket ou par client se crée automatiquement, sans multiplier les règles. Par exemple, une URL de dépôt comme `github.com/EspritVorace/smart-tab-organizer` produit un groupe nommé d'après le dépôt, sans règle dédiée à ce dépôt précis.
+
+Le groupement repose sur des expressions régulières exécutées localement, et toutes les données vivent dans `browser.storage.local`. Aucune donnée ne quitte le navigateur, et aucune IA, locale ou distante, n'intervient.
 
 <Aside type="note">
 Si vous synchronisez vos profils Chrome ou Firefox, l'extension reste compatible (les données suivent le profil), mais aucune communication réseau n'est initiée par l'extension elle-même.

--- a/docs/src/content/docs/en/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/en/decouverte/pourquoi.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why this extension?
-description: The problem SmartTab Organizer solves, its three pillars (group, deduplicate, save) and how it stands apart from tools based on remote AI.
+description: "The problem SmartTab Organizer solves, its three pillars (group, deduplicate, save) and its real differentiator: the group name extracted from the URL or title, locally."
 ---
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
@@ -41,7 +41,9 @@ The extension is built around three complementary functions.
 
 ## Everything local, nothing goes online
 
-Most competing extensions rely on remote AI: they send the URL and title of every tab to a third-party service to decide the naming. SmartTab Organizer does the exact opposite: no data ever leaves your browser. Grouping is driven by regular expressions (which you write yourself or that come from a [built-in pack](/reference/categories-et-packs)), and sessions live in `browser.storage.local`.
+Existing grouping extensions require a fixed group name, typed by hand, with one rule per value. SmartTab Organizer extracts the name straight from the URL or title using a regular expression: a group per repository, per ticket or per client is created automatically, without multiplying rules. For example, a repository URL such as `github.com/EspritVorace/smart-tab-organizer` produces a group named after the repository, with no rule dedicated to that specific repository.
+
+Grouping relies on regular expressions run locally, and all data lives in `browser.storage.local`. No data leaves the browser, and no AI, local or remote, is involved.
 
 <Aside type="note">
 If you sync your Chrome or Firefox profile, the extension stays compatible (data follows the profile), but no network communication is ever initiated by the extension itself.

--- a/docs/src/content/docs/en/index.mdx
+++ b/docs/src/content/docs/en/index.mdx
@@ -2,6 +2,9 @@
 title: SmartTab Organizer
 description: A Chrome and Firefox browser extension that groups your tabs by rules, removes duplicates, and saves your work sessions. Everything stays local, nothing goes online.
 template: splash
+head:
+  - tag: title
+    content: SmartTab Organizer · Rule-based tab grouping, no AI, no cloud
 hero:
   tagline: Organize your tabs intelligently, without sending a single URL anywhere.
   image:

--- a/docs/src/content/docs/es/decouverte/pourquoi.mdx
+++ b/docs/src/content/docs/es/decouverte/pourquoi.mdx
@@ -1,6 +1,6 @@
 ---
 title: ¿Por qué esta extensión?
-description: El problema que resuelve SmartTab Organizer, sus tres pilares (agrupar, deduplicar, guardar) y su posición frente a las herramientas basadas en IA en línea.
+description: "El problema que resuelve SmartTab Organizer, sus tres pilares (agrupar, deduplicar, guardar) y su verdadero diferenciador: el nombre de grupo extraído de la URL o del título, en local."
 ---
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
@@ -41,7 +41,9 @@ La extensión se organiza en torno a tres funciones complementarias.
 
 ## Todo es local, nada sale a internet
 
-La mayoría de las extensiones de la competencia se apoyan en IA remota: envían la URL y el título de cada pestaña a un servicio externo para decidir el nombre. SmartTab Organizer hace justo lo contrario: ningún dato sale de tu navegador. La agrupación se basa en expresiones regulares (que escribes tú o que vienen de un [pack integrado](/reference/categories-et-packs)), y las sesiones viven en `browser.storage.local`.
+Las extensiones de agrupación existentes requieren un nombre de grupo fijo, escrito a mano, con una regla por valor. SmartTab Organizer extrae el nombre directamente de la URL o del título mediante una expresión regular: se crea automáticamente un grupo por repositorio, por ticket o por cliente, sin multiplicar las reglas. Por ejemplo, una URL de repositorio como `github.com/EspritVorace/smart-tab-organizer` produce un grupo con el nombre del repositorio, sin una regla dedicada a ese repositorio concreto.
+
+La agrupación se basa en expresiones regulares ejecutadas localmente, y todos los datos viven en `browser.storage.local`. Ningún dato sale del navegador, y ninguna IA, local o remota, interviene.
 
 <Aside type="note">
 Si sincronizas tus perfiles de Chrome o Firefox, la extensión sigue siendo compatible (los datos acompañan al perfil), pero la propia extensión no inicia ninguna comunicación de red.

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -2,6 +2,9 @@
 title: SmartTab Organizer
 description: Extensión de navegador (Chrome / Firefox) que agrupa tus pestañas por reglas, elimina duplicados y guarda tus sesiones de trabajo. Todo es local, nada sale a internet.
 template: splash
+head:
+  - tag: title
+    content: SmartTab Organizer · Agrupación de pestañas por reglas, sin IA ni nube
 hero:
   tagline: Organiza tus pestañas de forma inteligente, sin enviar ni una sola URL a internet.
   image:

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -2,6 +2,9 @@
 title: SmartTab Organizer
 description: Extension navigateur (Chrome / Firefox) qui groupe vos onglets par règles, déduplique les doublons et sauvegarde vos sessions de travail. Tout est local, rien ne part en ligne.
 template: splash
+head:
+  - tag: title
+    content: SmartTab Organizer · Onglets groupés par règles, sans IA ni cloud
 hero:
   tagline: Organisez vos onglets intelligemment, sans envoyer la moindre URL en ligne.
   image:

--- a/docs/src/i18n/landing.ts
+++ b/docs/src/i18n/landing.ts
@@ -17,15 +17,21 @@ export interface PrivacyPoint {
 }
 
 export interface ComparisonCell {
-  /** true => positive (green check), false => negative (red cross). */
-  ok: boolean;
+  /**
+   * 'yes' => positive (green check), 'no' => negative (red cross),
+   * 'neutral' => not comparable / varies (no mark, text only).
+   */
+  state: 'yes' | 'no' | 'neutral';
   text: string;
 }
 
 export interface ComparisonRow {
   criterion: string;
   sto: ComparisonCell;
-  others: ComparisonCell;
+  /** Local regex grouping extensions (the real browser competitors). */
+  localRegex: ComparisonCell;
+  /** Tools that name groups through a remote AI service. */
+  aiTools: ComparisonCell;
 }
 
 export interface ValueItem {
@@ -58,7 +64,8 @@ export interface LandingCopy {
     subtitle: string;
     columnCriterion: string;
     columnSto: string;
-    columnOthers: string;
+    columnLocalRegex: string;
+    columnAiTools: string;
     rows: ComparisonRow[];
   };
   values: {
@@ -138,7 +145,7 @@ export const landing: Record<Locale, LandingCopy> = {
     privacy: {
       title: 'Tout est local, rien ne part en ligne',
       subtitle:
-        "L'inverse exact des outils qui envoient vos URL à un service distant. Ici, vos données ne quittent jamais le navigateur.",
+        "L'inverse exact des outils de nommage par IA, qui envoient vos URL à un service distant. Ici, vos données ne quittent jamais le navigateur.",
       points: [
         { icon: 'flat-color-icons:data-protection', label: 'Stockage dans browser.storage.local, sur votre machine.' },
         { icon: 'flat-color-icons:broken-link', label: 'Zéro requête réseau initiée par l\'extension.' },
@@ -150,45 +157,41 @@ export const landing: Record<Locale, LandingCopy> = {
     comparison: {
       title: 'Pourquoi pas une alternative ?',
       subtitle:
-        'Comparaison avec les catégories courantes : gestionnaires cloud, outils de nommage par IA, extensions à abonnement.',
+        "Face aux deux familles d'alternatives : les extensions de groupement par regex locales, et les outils qui nomment les groupes via une IA distante.",
       columnCriterion: 'Critère',
       columnSto: 'Smart Tab Organizer',
-      columnOthers: 'Alternatives courantes',
+      columnLocalRegex: 'Extensions regex locales',
+      columnAiTools: 'Outils de nommage par IA',
       rows: [
         {
-          criterion: 'Stockage des données',
-          sto: { ok: true, text: '100% local' },
-          others: { ok: false, text: 'Souvent dans le cloud' },
+          criterion: 'Nom de groupe',
+          sto: { state: 'yes', text: "Extrait de l'URL ou du titre" },
+          localRegex: { state: 'no', text: 'Fixe, une règle par valeur' },
+          aiTools: { state: 'no', text: 'Généré par IA distante' },
+        },
+        {
+          criterion: 'Données envoyées en ligne',
+          sto: { state: 'yes', text: 'Aucune' },
+          localRegex: { state: 'yes', text: 'Aucune' },
+          aiTools: { state: 'no', text: 'URL et titre envoyés à un tiers' },
         },
         {
           criterion: 'Prix',
-          sto: { ok: true, text: 'Gratuit, pour toujours' },
-          others: { ok: false, text: 'Freemium ou abonnement' },
+          sto: { state: 'yes', text: 'Gratuit, open source GPLv3' },
+          localRegex: { state: 'neutral', text: 'Souvent gratuit' },
+          aiTools: { state: 'neutral', text: 'Souvent freemium' },
         },
         {
           criterion: 'Code source',
-          sto: { ok: true, text: 'Open source' },
-          others: { ok: false, text: 'Souvent propriétaire' },
-        },
-        {
-          criterion: 'Compte utilisateur',
-          sto: { ok: true, text: 'Aucun compte' },
-          others: { ok: false, text: 'Compte souvent requis' },
-        },
-        {
-          criterion: 'Tracking et télémétrie',
-          sto: { ok: true, text: 'Aucun' },
-          others: { ok: false, text: 'Fréquent' },
-        },
-        {
-          criterion: 'Nommage des groupes',
-          sto: { ok: true, text: 'Règles regex locales' },
-          others: { ok: false, text: 'IA distante (URL envoyées)' },
+          sto: { state: 'yes', text: 'Open source (GPLv3)' },
+          localRegex: { state: 'neutral', text: 'Variable' },
+          aiTools: { state: 'neutral', text: 'Variable' },
         },
         {
           criterion: 'Accessibilité',
-          sto: { ok: true, text: 'Polices dys, audits axe-core' },
-          others: { ok: false, text: 'Variable' },
+          sto: { state: 'yes', text: 'Polices dys, audits axe-core' },
+          localRegex: { state: 'neutral', text: 'Variable' },
+          aiTools: { state: 'neutral', text: 'Variable' },
         },
       ],
     },
@@ -293,7 +296,7 @@ export const landing: Record<Locale, LandingCopy> = {
     privacy: {
       title: 'Everything is local, nothing goes online',
       subtitle:
-        'The exact opposite of tools that send your URLs to a remote service. Here, your data never leaves the browser.',
+        'The exact opposite of AI naming tools, which send your URLs to a remote service. Here, your data never leaves the browser.',
       points: [
         { icon: 'flat-color-icons:data-protection', label: 'Stored in browser.storage.local, on your machine.' },
         { icon: 'flat-color-icons:broken-link', label: 'Zero network request initiated by the extension.' },
@@ -305,45 +308,41 @@ export const landing: Record<Locale, LandingCopy> = {
     comparison: {
       title: 'Why not an alternative?',
       subtitle:
-        'Compared with the usual categories: cloud managers, AI naming tools, subscription extensions.',
+        'Compared with the two families of alternatives: local regex grouping extensions, and tools that name groups through remote AI.',
       columnCriterion: 'Criterion',
       columnSto: 'Smart Tab Organizer',
-      columnOthers: 'Common alternatives',
+      columnLocalRegex: 'Local regex extensions',
+      columnAiTools: 'AI naming tools',
       rows: [
         {
-          criterion: 'Data storage',
-          sto: { ok: true, text: '100% local' },
-          others: { ok: false, text: 'Often in the cloud' },
+          criterion: 'Group naming',
+          sto: { state: 'yes', text: 'Extracted from the URL or title' },
+          localRegex: { state: 'no', text: 'Fixed, one rule per value' },
+          aiTools: { state: 'no', text: 'Generated by remote AI' },
+        },
+        {
+          criterion: 'Data sent online',
+          sto: { state: 'yes', text: 'None' },
+          localRegex: { state: 'yes', text: 'None' },
+          aiTools: { state: 'no', text: 'URL and title sent to a third party' },
         },
         {
           criterion: 'Price',
-          sto: { ok: true, text: 'Free, forever' },
-          others: { ok: false, text: 'Freemium or subscription' },
+          sto: { state: 'yes', text: 'Free, open source GPLv3' },
+          localRegex: { state: 'neutral', text: 'Often free' },
+          aiTools: { state: 'neutral', text: 'Often freemium' },
         },
         {
           criterion: 'Source code',
-          sto: { ok: true, text: 'Open source' },
-          others: { ok: false, text: 'Often proprietary' },
-        },
-        {
-          criterion: 'User account',
-          sto: { ok: true, text: 'No account' },
-          others: { ok: false, text: 'Account often required' },
-        },
-        {
-          criterion: 'Tracking and telemetry',
-          sto: { ok: true, text: 'None' },
-          others: { ok: false, text: 'Frequent' },
-        },
-        {
-          criterion: 'Group naming',
-          sto: { ok: true, text: 'Local regex rules' },
-          others: { ok: false, text: 'Remote AI (URLs sent)' },
+          sto: { state: 'yes', text: 'Open source (GPLv3)' },
+          localRegex: { state: 'neutral', text: 'Varies' },
+          aiTools: { state: 'neutral', text: 'Varies' },
         },
         {
           criterion: 'Accessibility',
-          sto: { ok: true, text: 'Dys fonts, axe-core audits' },
-          others: { ok: false, text: 'Varies' },
+          sto: { state: 'yes', text: 'Dys fonts, axe-core audits' },
+          localRegex: { state: 'neutral', text: 'Varies' },
+          aiTools: { state: 'neutral', text: 'Varies' },
         },
       ],
     },
@@ -448,7 +447,7 @@ export const landing: Record<Locale, LandingCopy> = {
     privacy: {
       title: 'Todo es local, nada sale a internet',
       subtitle:
-        'Lo contrario exacto de las herramientas que envían tus URL a un servicio remoto. Aquí, tus datos nunca salen del navegador.',
+        'Lo contrario exacto de las herramientas de nombrado por IA, que envían tus URL a un servicio remoto. Aquí, tus datos nunca salen del navegador.',
       points: [
         { icon: 'flat-color-icons:data-protection', label: 'Almacenamiento en browser.storage.local, en tu equipo.' },
         { icon: 'flat-color-icons:broken-link', label: 'Cero solicitudes de red iniciadas por la extensión.' },
@@ -460,45 +459,41 @@ export const landing: Record<Locale, LandingCopy> = {
     comparison: {
       title: '¿Por qué no una alternativa?',
       subtitle:
-        'Comparación con las categorías habituales: gestores en la nube, herramientas de nombrado por IA, extensiones de suscripción.',
+        'Frente a las dos familias de alternativas: las extensiones de agrupación por regex locales y las herramientas que nombran los grupos mediante IA remota.',
       columnCriterion: 'Criterio',
       columnSto: 'Smart Tab Organizer',
-      columnOthers: 'Alternativas habituales',
+      columnLocalRegex: 'Extensiones regex locales',
+      columnAiTools: 'Herramientas de nombrado por IA',
       rows: [
         {
-          criterion: 'Almacenamiento de datos',
-          sto: { ok: true, text: '100% local' },
-          others: { ok: false, text: 'A menudo en la nube' },
+          criterion: 'Nombre de grupo',
+          sto: { state: 'yes', text: 'Extraído de la URL o del título' },
+          localRegex: { state: 'no', text: 'Fijo, una regla por valor' },
+          aiTools: { state: 'no', text: 'Generado por IA remota' },
+        },
+        {
+          criterion: 'Datos enviados en línea',
+          sto: { state: 'yes', text: 'Ninguno' },
+          localRegex: { state: 'yes', text: 'Ninguno' },
+          aiTools: { state: 'no', text: 'URL y título enviados a un tercero' },
         },
         {
           criterion: 'Precio',
-          sto: { ok: true, text: 'Gratis, para siempre' },
-          others: { ok: false, text: 'Freemium o suscripción' },
+          sto: { state: 'yes', text: 'Gratis, código abierto GPLv3' },
+          localRegex: { state: 'neutral', text: 'A menudo gratis' },
+          aiTools: { state: 'neutral', text: 'A menudo freemium' },
         },
         {
           criterion: 'Código fuente',
-          sto: { ok: true, text: 'Código abierto' },
-          others: { ok: false, text: 'A menudo propietario' },
-        },
-        {
-          criterion: 'Cuenta de usuario',
-          sto: { ok: true, text: 'Sin cuenta' },
-          others: { ok: false, text: 'Cuenta a menudo requerida' },
-        },
-        {
-          criterion: 'Rastreo y telemetría',
-          sto: { ok: true, text: 'Ninguno' },
-          others: { ok: false, text: 'Frecuente' },
-        },
-        {
-          criterion: 'Nombrado de grupos',
-          sto: { ok: true, text: 'Reglas regex locales' },
-          others: { ok: false, text: 'IA remota (URL enviadas)' },
+          sto: { state: 'yes', text: 'Código abierto (GPLv3)' },
+          localRegex: { state: 'neutral', text: 'Variable' },
+          aiTools: { state: 'neutral', text: 'Variable' },
         },
         {
           criterion: 'Accesibilidad',
-          sto: { ok: true, text: 'Fuentes dys, auditorías axe-core' },
-          others: { ok: false, text: 'Variable' },
+          sto: { state: 'yes', text: 'Fuentes dys, auditorías axe-core' },
+          localRegex: { state: 'neutral', text: 'Variable' },
+          aiTools: { state: 'neutral', text: 'Variable' },
         },
       ],
     },


### PR DESCRIPTION
## Contexte

La doc opposait SmartTab Organizer à « la plupart des extensions concurrentes » qui « reposent sur de l'IA distante ». Cette affirmation est fausse : la majorité des concurrents navigateur sont des outils regex locaux sans IA. Le vrai différenciateur, vérifié, est l'**extraction dynamique du nom de groupe** depuis l'URL ou le titre via une expression régulière (les concurrents demandent un nom fixe, une règle par valeur).

Principe directeur : ne revendiquer que ce qui est vérifié, aucune affirmation comparative non défendable. Périmètre strict `/docs`, parité fr/en/es.

## Lot 1 · Page « Pourquoi » (`decouverte/pourquoi.mdx` x3)

- Paragraphe sur l'IA distante remplacé par **deux paragraphes distincts** : différenciateur d'extraction (avec exemple sobre basé sur le dépôt public du projet), puis point « tout est local » conservé.
- Heading conservé (son ancre est liée depuis la FAQ des trois locales).
- Frontmatter `description` recentré sur le vrai différenciateur.

## Lot 2 · Tableau comparatif (`landing.ts` + `ComparisonTable.astro`)

- Refonte en **trois colonnes** : SmartTab Organizer / Extensions regex locales / Outils de nommage par IA.
- 5 lignes défendables, « Nom de groupe » en tête. Lignes stockage / compte / tracking abandonnées (non discriminantes face aux regex locales).
- Modèle de cellule à trois états (`yes` / `no` / `neutral`) ; `neutral` rend « Variable » sans marqueur vert/rouge trompeur.
- Sous-titre du PrivacyBand recentré sur la famille IA, sans généraliser à « les outils ».

## Lot 3 · Titre meta de la page d'accueil (`index.mdx` x3)

- Override `head > title` par locale (titre descriptif SEO), sans toucher au `titleDelimiter` global ni au `title` frontmatter (JSON-LD `name` inchangé).
- Corrige le doublon `SmartTab Organizer | SmartTab Organizer`. Sous-pages inchangées.

## Vérifications

- `pnpm docs:build` vert sur les trois locales.
- Titres home dédupliqués, sous-pages intactes.
- Disparition confirmée dans `dist/` des anciennes chaînes (« IA distante (URL envoyées) », « la plupart des extensions concurrentes », etc.).
- Nouveaux libellés de colonnes et ligne « Nom de groupe » présents en fr/en/es.
- Aucun tiret cadratin/demi-cadratin introduit.

https://claude.ai/code/session_01StYD4nsj1QTL6ALG3MbgQW

---
_Generated by [Claude Code](https://claude.ai/code/session_01StYD4nsj1QTL6ALG3MbgQW)_