### PR TITLE
test(e2e): de-flake domain rules keyboard drag-and-drop

### DIFF
--- a/tests/e2e/domain-rules-keyboard-dnd.spec.ts
+++ b/tests/e2e/domain-rules-keyboard-dnd.spec.ts
@@ -59,7 +59,30 @@ test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
     const handleA = ruleARow.locator('[data-testid$="-drag-handle"]');
 
     await handleA.focus();
+    await expect(handleA).toBeFocused();
+
     await page.keyboard.press('Space');
+
+    // Wait for dnd-kit to activate the drag (card opacity changes to 0.4).
+    // Without this, on slow CI the arrow presses may dispatch before the
+    // KeyboardSensor activates, causing no reorder.
+    // Target the Rule A card specifically by finding it via aria-label match.
+    await page.waitForFunction(() => {
+      const cards = [...document.querySelectorAll('[role="listitem"]')];
+      const ruleACard = cards.find(c => c.getAttribute('aria-label')?.includes('Rule A'));
+      if (!ruleACard) return false;
+      const computed = window.getComputedStyle(ruleACard);
+      const opacity = parseFloat(computed.opacity);
+      // isDragging opacity is 0.4; we check for < 0.5 to account for rounding
+      return opacity < 0.5;
+    }, undefined, { timeout: 5000 });
+
+    // The opacity flip confirms dnd-kit entered the dragging state, but its
+    // KeyboardSensor attaches the keydown listener a tick later. This short grace
+    // lets that listener register so the arrow presses are not dropped on slow CI.
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- waiting on a DnD activation race with no DOM signal to anchor on
+    await page.waitForTimeout(100);
+
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Space');
@@ -69,7 +92,7 @@ test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
       const iA = rows.findIndex(r => r.getAttribute('aria-label')?.includes('Rule A'));
       const iC = rows.findIndex(r => r.getAttribute('aria-label')?.includes('Rule C'));
       return iA > -1 && iC > -1 && iA > iC;
-    }, { timeout: 5000 });
+    }, undefined, { timeout: 5000 });
 
     await page.close();
 
@@ -98,7 +121,27 @@ test.describe('[KBD-DND] Domain rules keyboard drag-and-drop', () => {
       .locator('[data-testid$="-drag-handle"]');
 
     await handleA.focus();
+    await expect(handleA).toBeFocused();
+
     await page.keyboard.press('Space');
+
+    // Wait for dnd-kit to activate the drag before sending ArrowDown, to ensure
+    // the cancel via Escape actually cancels an active drag.
+    // Target the Rule A card specifically by finding it via aria-label match.
+    await page.waitForFunction(() => {
+      const cards = [...document.querySelectorAll('[role="listitem"]')];
+      const ruleACard = cards.find(c => c.getAttribute('aria-label')?.includes('Rule A'));
+      if (!ruleACard) return false;
+      const computed = window.getComputedStyle(ruleACard);
+      const opacity = parseFloat(computed.opacity);
+      return opacity < 0.5;
+    }, undefined, { timeout: 5000 });
+
+    // See the reorder test above: let dnd-kit's KeyboardSensor finish attaching
+    // its keydown listener before the arrow press, otherwise it can be dropped.
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- waiting on a DnD activation race with no DOM signal to anchor on
+    await page.waitForTimeout(100);
+
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Escape');
     await expect(handleA).toBeFocused();


### PR DESCRIPTION
## Context

The `keyboard reorders rules via Space + ArrowDown + Space` test in `tests/e2e/domain-rules-keyboard-dnd.spec.ts` fails consistently under the CI 1-worker configuration (`Test timeout of 30000ms exceeded` / `Target page, context or browser has been closed`). This is a pre-existing flake on `develop`, surfaced while watching an unrelated PR. Reproduced locally: stable with parallel workers, fails with `--workers=1` like CI.

## Root causes (both fixed)

1. **Mispassed timeout option.** Playwright's signature is `waitForFunction(pageFunction, arg?, options?)`. The call passed `{ timeout: 5000 }` as the second positional argument, so it was treated as the page-function argument (ignored), not as options. The intended 5s timeout was therefore never applied: the wait ran until the 30s test timeout fired, which tore down the context and produced the "page has been closed" error. Now passed correctly as the third argument.

2. **Keyboard DnD activation race.** The arrow presses could be dispatched before dnd-kit's `KeyboardSensor` activated the drag and attached its `keydown` listener, so no reorder happened. The test now waits for the dragging state (the card's opacity flips to `0.4`) before sending the arrows, plus a short grace for the listener to register (with a justified `eslint-disable` for the unavoidable `waitForTimeout`, as there is no DOM signal to anchor on).

The sibling `Escape during keyboard drag cancels the reorder` test gets the same activation wait so it reliably cancels an active drag.

## Validation

```
xvfb-run --auto-servernum -- playwright test tests/e2e/domain-rules-keyboard-dnd.spec.ts --workers=1 --repeat-each=8 --retries=0
# 32 passed
```

ESLint clean (`eslint src tests --max-warnings=0`). The change is scoped to the single spec file; test intent and post-conditions (DOM order + `helpers.getSettings()`) are preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkWNELJR7XkRdqoxbv6C2N)_