### PR TITLE
feat(rules): live regex syntax highlighting for title/url fields

### DIFF
--- a/e2e-shared/pages/RuleWizardPage.ts
+++ b/e2e-shared/pages/RuleWizardPage.ts
@@ -113,6 +113,16 @@ export class RuleWizardPage extends DialogPage {
     return this.dialog().locator('#presetId');
   }
 
+  /** Single-line CodeMirror editor for the title parsing regex (manual mode). */
+  titleRegexField(): Locator {
+    return this.dialog().getByTestId('title-regex-field');
+  }
+
+  /** Single-line CodeMirror editor for the URL parsing regex (manual + regex mode). */
+  urlRegexField(): Locator {
+    return this.dialog().getByTestId('url-regex-field');
+  }
+
   /** Deduplication enable/disable switch on step 3. */
   deduplicationSwitch(): Locator {
     return this.dialog().locator('[role="switch"]');
@@ -221,6 +231,29 @@ export class RuleWizardPage extends DialogPage {
       .getByRole('option', { name: new RegExp(`^${labels[source]}`, 'i') })
       .first()
       .click();
+  }
+
+  /**
+   * Type a pattern into a CodeMirror regex field. The editor exposes no
+   * `<input>`, so we focus the `.cm-content` node and drive it through the
+   * keyboard (a `.fill()` would target a non-existent form value).
+   */
+  private async typeRegexField(field: Locator, pattern: string): Promise<void> {
+    const content = field.locator('.cm-content');
+    await content.click();
+    await this.page.keyboard.press('ControlOrMeta+a');
+    await this.page.keyboard.press('Delete');
+    if (pattern) await this.page.keyboard.type(pattern);
+  }
+
+  /** Fill the title parsing regex editor (manual mode, title-based source). */
+  async fillTitleRegex(pattern: string): Promise<void> {
+    await this.typeRegexField(this.titleRegexField(), pattern);
+  }
+
+  /** Fill the URL parsing regex editor (manual mode, URL regex extraction). */
+  async fillUrlRegex(pattern: string): Promise<void> {
+    await this.typeRegexField(this.urlRegexField(), pattern);
   }
 
   // ─── Atomic actions: options (step 3) ────────────────────────────────────

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -95,6 +95,8 @@
   "domainFilterPlaceholder": { "message": "e.g., atlassian.net" },
   "titleRegex": { "message": "Title RegEx" },
   "urlRegex": { "message": "URL RegEx" },
+  "titleRegexEditorAriaLabel": { "message": "Title regular expression editor" },
+  "urlRegexEditorAriaLabel": { "message": "URL regular expression editor" },
   "deduplicationMode": { "message": "Deduplication Mode" },
   "exactMatch": { "message": "Exact URL" },
   "includesMatch": { "message": "URL Includes" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -95,6 +95,8 @@
   "domainFilterPlaceholder": { "message": "ej: atlassian.net" },
   "titleRegex": { "message": "RegEx Título" },
   "urlRegex": { "message": "RegEx URL" },
+  "titleRegexEditorAriaLabel": { "message": "Editor de expresión regular del título" },
+  "urlRegexEditorAriaLabel": { "message": "Editor de expresión regular de la URL" },
   "deduplicationMode": { "message": "Modo Deduplicación" },
   "exactMatch": { "message": "URL Exacta" },
   "includesMatch": { "message": "URL Incluida" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -95,6 +95,8 @@
   "domainFilterPlaceholder": { "message": "ex: atlassian.net" },
   "titleRegex": { "message": "RegEx Titre" },
   "urlRegex": { "message": "RegEx URL" },
+  "titleRegexEditorAriaLabel": { "message": "Éditeur d'expression régulière du titre" },
+  "urlRegexEditorAriaLabel": { "message": "Éditeur d'expression régulière de l'URL" },
   "deduplicationMode": { "message": "Mode Déduplication" },
   "exactMatch": { "message": "URL Exacte" },
   "includesMatch": { "message": "URL Incluse" },

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.stories.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { within, userEvent, expect } from 'storybook/test';
+import { within, userEvent, expect, waitFor } from 'storybook/test';
+import { setRegexFieldValue } from '@/components/UI/RegexCodeField';
 import { DomainRuleConfigForm, type DomainRuleConfigFormProps } from './DomainRuleConfigForm';
 import type { ConfigMode } from './ConfigModeSelector';
 import type { GroupNameSourceValue, UrlExtractionModeValue } from '@/schemas/enums';
@@ -124,10 +125,12 @@ export const DomainRuleConfigFormManualWithRegex: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const inputs = canvas.getAllByRole('textbox');
-    if (inputs.length > 0) {
-      await userEvent.clear(inputs[0]);
-      await userEvent.type(inputs[0], '(.+)');
-    }
+    // The title regex field is a single-line CodeMirror editor (no <input>);
+    // drive it through the dispatch seam rather than userEvent.type.
+    await setRegexFieldValue(canvasElement, 'title-regex-field', '^(?<id>\\d+)-(.+)$');
+    await waitFor(() => {
+      const content = canvas.getByTestId('title-regex-field').querySelector('.cm-content');
+      expect(content?.textContent).toContain('(?<id>');
+    });
   },
 };

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/schemas/enums';
 import type { PresetCategory } from '@/utils/presetUtils';
 import { presetsToSearchableGroups } from '@/utils/presetsToSearchableGroups';
+import { RegexCodeField } from '@/components/UI/RegexCodeField';
 import { ConfigModeSelector, MODE_HELP_LABELS, type ConfigMode } from './ConfigModeSelector';
 
 const GROUP_NAME_SOURCE_HELP_KEYS: Record<GroupNameSourceValue, Parameters<typeof getMessage>[0]> = {
@@ -234,15 +235,20 @@ export function DomainRuleConfigForm({
               required={true}
               error={titleParsingRegExError}
             >
-              {(fieldId) => (
-                <TextField.Root
-                  id={fieldId}
-                  value={titleParsingRegEx}
-                  onChange={(e) => onTitleParsingRegExChange(e.target.value)}
-                  name="titleParsingRegEx"
-                  placeholder="(.+)"
-                  style={{ marginTop: '4px' }}
-                />
+              {(fieldId, errorId) => (
+                <Box style={{ marginTop: '4px' }}>
+                  <RegexCodeField
+                    id={fieldId}
+                    describedById={titleParsingRegExError ? errorId : undefined}
+                    value={titleParsingRegEx}
+                    onChange={onTitleParsingRegExChange}
+                    name="titleParsingRegEx"
+                    testId="title-regex-field"
+                    placeholder="(.+)"
+                    ariaLabel={getMessage('titleRegexEditorAriaLabel')}
+                    hasError={Boolean(titleParsingRegExError)}
+                  />
+                </Box>
               )}
             </FormField>
           )}
@@ -280,15 +286,20 @@ export function DomainRuleConfigForm({
                   required={true}
                   error={urlParsingRegExError}
                 >
-                  {(fieldId) => (
-                    <TextField.Root
-                      id={fieldId}
-                      value={urlParsingRegEx}
-                      onChange={(e) => onUrlParsingRegExChange(e.target.value)}
-                      name="urlParsingRegEx"
-                      placeholder="(.+)"
-                      style={{ marginTop: '4px' }}
-                    />
+                  {(fieldId, errorId) => (
+                    <Box style={{ marginTop: '4px' }}>
+                      <RegexCodeField
+                        id={fieldId}
+                        describedById={urlParsingRegExError ? errorId : undefined}
+                        value={urlParsingRegEx}
+                        onChange={onUrlParsingRegExChange}
+                        name="urlParsingRegEx"
+                        testId="url-regex-field"
+                        placeholder="(.+)"
+                        ariaLabel={getMessage('urlRegexEditorAriaLabel')}
+                        hasError={Boolean(urlParsingRegExError)}
+                      />
+                    </Box>
                   )}
                 </FormField>
               ) : (

--- a/src/components/Form/FormFields/FieldError.tsx
+++ b/src/components/Form/FormFields/FieldError.tsx
@@ -4,13 +4,15 @@ interface FieldErrorProps {
   error?: {
     message?: string;
   };
+  /** Id wired onto the message so a control can reference it via aria-describedby. */
+  id?: string;
 }
 
-export function FieldError({ error }: FieldErrorProps) {
+export function FieldError({ error, id }: FieldErrorProps) {
   if (!error) return null;
-  
+
   return (
-    <Text size="1" color="red" style={{ marginTop: '2px' }}>
+    <Text id={id} size="1" color="red" style={{ marginTop: '2px' }}>
       {error.message}
     </Text>
   );

--- a/src/components/Form/FormFields/FormField.tsx
+++ b/src/components/Form/FormFields/FormField.tsx
@@ -10,11 +10,12 @@ interface FormFieldProps {
     message?: string;
   };
   /**
-   * Children can be a ReactNode or a render function receiving the generated id.
-   * Use the render function to associate a non-wrappable control (TextField, TextArea,
-   * Select.Trigger, SearchableSelect) with the field's <label>.
+   * Children can be a ReactNode or a render function receiving the generated
+   * field id and the error element id. Use the render function to associate a
+   * non-wrappable control (TextField, TextArea, Select.Trigger, SearchableSelect)
+   * with the field's <label>, and optionally wire `aria-describedby` to the error.
    */
-  children: React.ReactNode | ((id: string) => React.ReactNode);
+  children: React.ReactNode | ((id: string, errorId: string) => React.ReactNode);
   /** Explicit id for the field control. Defaults to a useId(). */
   id?: string;
 }
@@ -28,11 +29,12 @@ export function FormField({
 }: FormFieldProps) {
   const fallbackId = useId();
   const fieldId = id ?? fallbackId;
+  const errorId = `${fieldId}-error`;
   return (
     <Box>
       <FieldLabel required={required} htmlFor={fieldId}>{label}</FieldLabel>
-      {typeof children === 'function' ? children(fieldId) : children}
-      <FieldError error={error} />
+      {typeof children === 'function' ? children(fieldId, errorId) : children}
+      <FieldError error={error} id={error ? errorId : undefined} />
     </Box>
   );
 }

--- a/src/components/UI/RegexCodeField/RegexCodeField.stories.tsx
+++ b/src/components/UI/RegexCodeField/RegexCodeField.stories.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, expect, waitFor } from 'storybook/test';
+import { RegexCodeField } from './RegexCodeField';
+
+interface HarnessProps {
+  initialValue: string;
+  hasError?: boolean;
+}
+
+function RegexFieldHarness({ initialValue, hasError }: HarnessProps) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <div style={{ width: 360 }}>
+      <RegexCodeField
+        value={value}
+        onChange={setValue}
+        ariaLabel="Title regular expression editor"
+        placeholder="(.+)"
+        hasError={hasError}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof RegexFieldHarness> = {
+  title: 'Components/UI/RegexCodeField',
+  component: RegexFieldHarness,
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RegexCodeFieldEmpty: Story = {
+  args: { initialValue: '' },
+  play: async ({ canvasElement }) => {
+    const field = within(canvasElement).getByTestId('regex-code-field');
+    await waitFor(() => expect(field.querySelector('.cm-content')).not.toBeNull());
+    const content = field.querySelector<HTMLElement>('.cm-content');
+    expect(content?.getAttribute('aria-label')).toBe('Title regular expression editor');
+    expect(content?.getAttribute('spellcheck')).toBe('false');
+  },
+};
+
+export const RegexCodeFieldHighlighted: Story = {
+  // Exercises groups, named groups, character classes, quantifiers, anchors,
+  // alternation and escapes so every token color is visible.
+  args: { initialValue: '^(?<id>\\d{2,4})-(foo|bar)?[A-Z]+\\s*$' },
+};
+
+export const RegexCodeFieldWithError: Story = {
+  args: { initialValue: '(unclosed', hasError: true },
+  play: async ({ canvasElement }) => {
+    const field = within(canvasElement).getByTestId('regex-code-field');
+    await waitFor(() => {
+      expect(field.querySelector('.cm-content')?.getAttribute('aria-invalid')).toBe('true');
+    });
+  },
+};

--- a/src/components/UI/RegexCodeField/RegexCodeField.tsx
+++ b/src/components/UI/RegexCodeField/RegexCodeField.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from 'react';
+import { useTheme } from 'next-themes';
+import { Compartment, EditorState } from '@codemirror/state';
+import {
+  EditorView,
+  keymap,
+  drawSelection,
+  placeholder as placeholderExtension,
+} from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { syntaxHighlighting } from '@codemirror/language';
+import { regexLanguage, regexHighlightStyle } from './regexHighlight';
+import { createRegexEditorTheme } from './cmRegexTheme';
+
+export interface RegexCodeFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Mirrors the wrapping `<label>` `htmlFor`; set on the editor content node. */
+  id?: string;
+  placeholder?: string;
+  /** Accessible name for the editing area (distinct from the visible label). */
+  ariaLabel: string;
+  /** Toggles `aria-invalid` on the content node when the field is in error. */
+  hasError?: boolean;
+  /** Error element id wired onto `aria-describedby` when an error is present. */
+  describedById?: string;
+  /** Forwarded onto the wrapper for parity with the former input `name`. */
+  name?: string;
+  /** Stable hook for tests / Page Objects. Distinguishes the title vs url field. */
+  testId?: string;
+}
+
+/**
+ * Single-line CodeMirror editor that highlights a regular expression live while
+ * preserving the accessibility and theming contract of a Radix `TextField`.
+ *
+ * Built as a slimmed variant of `JsonCodeEditor`: it mounts the editor once and
+ * funnels reactive prop changes through dedicated effects and `Compartment`s.
+ * Newlines are rejected so the value stays a single-line pattern.
+ */
+export function RegexCodeField({
+  value,
+  onChange,
+  id,
+  placeholder,
+  ariaLabel,
+  hasError = false,
+  describedById,
+  name,
+  testId = 'regex-code-field',
+}: RegexCodeFieldProps) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Props the mount-once setup reads without re-running.
+  const onChangeRef = useRef(onChange);
+  const valueRef = useRef(value);
+  const idRef = useRef(id);
+  const placeholderRef = useRef(placeholder);
+  const ariaLabelRef = useRef(ariaLabel);
+  const describedByRef = useRef(describedById);
+  const hasErrorRef = useRef(hasError);
+  const isDarkRef = useRef(isDark);
+
+  const themeCompartment = useRef(new Compartment());
+  const ariaCompartment = useRef(new Compartment());
+
+  onChangeRef.current = onChange;
+
+  // Create the editor once. Reactive updates flow through the effects below.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const state = EditorState.create({
+      doc: valueRef.current,
+      extensions: [
+        regexLanguage,
+        syntaxHighlighting(regexHighlightStyle),
+        history(),
+        drawSelection(),
+        // Keep the value single-line: drop any transaction adding a line break.
+        EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr)),
+        placeholderExtension(placeholderRef.current ?? ''),
+        EditorView.contentAttributes.of({
+          id: idRef.current ?? '',
+          'aria-label': ariaLabelRef.current,
+          'aria-describedby': describedByRef.current ?? '',
+          spellcheck: 'false',
+          autocapitalize: 'off',
+          autocorrect: 'off',
+          'data-1p-ignore': 'true',
+        }),
+        ariaCompartment.current.of(
+          EditorView.contentAttributes.of({
+            'aria-invalid': hasErrorRef.current ? 'true' : 'false',
+          }),
+        ),
+        themeCompartment.current.of(createRegexEditorTheme(isDarkRef.current)),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+      ],
+    });
+
+    const view = new EditorView({ state, parent: containerRef.current });
+    viewRef.current = view;
+    // Make the (horizontally) scrollable viewport reachable by keyboard so a
+    // long pattern can be scrolled without a pointer (axe scrollable-region).
+    view.scrollDOM.setAttribute('tabindex', '0');
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Mount-once: subsequent prop changes are handled by the effects below.
+     
+  }, []);
+
+  // Sync externally driven value changes (form reset, edit of another rule).
+  useEffect(() => {
+    valueRef.current = value;
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (value !== current) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
+
+  useEffect(() => {
+    hasErrorRef.current = hasError;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: ariaCompartment.current.reconfigure(
+          EditorView.contentAttributes.of({ 'aria-invalid': hasError ? 'true' : 'false' }),
+        ),
+      });
+    }
+  }, [hasError]);
+
+  useEffect(() => {
+    isDarkRef.current = isDark;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: themeCompartment.current.reconfigure(createRegexEditorTheme(isDark)),
+      });
+    }
+  }, [isDark]);
+
+  return <div ref={containerRef} data-testid={testId} data-name={name} />;
+}
+
+export default RegexCodeField;

--- a/src/components/UI/RegexCodeField/cmRegexTheme.ts
+++ b/src/components/UI/RegexCodeField/cmRegexTheme.ts
@@ -1,0 +1,47 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+/**
+ * Single-line editor chrome for the regex field. Mirrors the visible look of a
+ * Radix `TextField` (size 2) so the editor blends into the surrounding form:
+ * same border, radius, surface and focus ring. Unlike the multi-line JSON
+ * editor it has no gutters, no fold markers and no max height; long patterns
+ * scroll horizontally. Every visible color is a Radix token, so the look stays
+ * aligned with the active accent and appearance.
+ */
+export function createRegexEditorTheme(isDark: boolean): Extension {
+  return EditorView.theme(
+    {
+      '&': {
+        color: 'var(--gray-12)',
+        backgroundColor: 'var(--color-surface)',
+        fontSize: 'var(--font-size-2)',
+        border: '1px solid var(--gray-a7)',
+        borderRadius: 'var(--radius-3)',
+      },
+      '&.cm-focused': {
+        outline: '2px solid var(--accent-8)',
+        outlineOffset: '-1px',
+      },
+      '.cm-scroller': {
+        fontFamily:
+          'var(--code-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)',
+        lineHeight: '1.5',
+        alignItems: 'center',
+        overflowX: 'auto',
+      },
+      // Single editing line, vertically centered, matching a Radix size-2 input.
+      '.cm-content': {
+        padding: '0 var(--space-2)',
+        minHeight: '28px',
+        caretColor: 'var(--gray-12)',
+      },
+      '.cm-line': { padding: '0' },
+      '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
+      '.cm-placeholder': { color: 'var(--gray-a9)' },
+      '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
+      '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
+    },
+    { dark: isDark },
+  );
+}

--- a/src/components/UI/RegexCodeField/index.ts
+++ b/src/components/UI/RegexCodeField/index.ts
@@ -1,0 +1,3 @@
+export { RegexCodeField, type RegexCodeFieldProps } from './RegexCodeField';
+export { setRegexFieldValue, waitForRegexField } from './setRegexFieldValue';
+export { regexLanguage, regexHighlightStyle } from './regexHighlight';

--- a/src/components/UI/RegexCodeField/regexHighlight.ts
+++ b/src/components/UI/RegexCodeField/regexHighlight.ts
@@ -1,0 +1,143 @@
+import {
+  StreamLanguage,
+  HighlightStyle,
+  type StreamParser,
+  type StringStream,
+} from '@codemirror/language';
+import { tags as t, type Tag } from '@lezer/highlight';
+
+/**
+ * Token names emitted by the single-line regex tokenizer. Each maps to a
+ * `@lezer/highlight` tag through {@link regexTokenTable} so the colors flow
+ * through the standard `syntaxHighlighting(HighlightStyle)` path, exactly like
+ * the JSON editor (`cmTheme.ts`).
+ */
+interface RegexParserState {
+  /** Inside a `[...]` character class: most metacharacters become literals. */
+  inClass: boolean;
+}
+
+/** Tokenize one character while inside a `[...]` class (only `\` and `]` matter). */
+function tokenInClass(stream: StringStream, state: RegexParserState, ch: string): string {
+  if (ch === '\\') {
+    stream.next(); // consume the escaped character
+    return 'escapeLiteral';
+  }
+  if (ch === ']') {
+    state.inClass = false;
+    return 'classBracket';
+  }
+  return 'classContent';
+}
+
+/** Tokenize an escape sequence: `\d \w \s \b`, backreferences, literals. */
+function tokenEscape(stream: StringStream): string {
+  const next = stream.next();
+  if (next == null) return 'invalid'; // dangling backslash
+  if (/[dDwWsSbBAZ]/.test(next)) return 'escapeClass';
+  if (/[1-9]/.test(next)) return 'backref';
+  if (next === 'k' && stream.peek() === '<') {
+    stream.match(/^<[^>]*>/); // named backreference \k<name>
+    return 'backref';
+  }
+  return 'escapeLiteral';
+}
+
+/** Tokenize a group opening, consuming any non-capturing / lookaround / named prefix. */
+function tokenGroupOpen(stream: StringStream): string {
+  if (stream.peek() !== '?') return 'group';
+  stream.next(); // '?'
+  const p = stream.peek();
+  if (p === '<') {
+    stream.next(); // '<'
+    const after = stream.peek();
+    if (after === '=' || after === '!') {
+      stream.next(); // lookbehind (?<= / (?<!
+      return 'group';
+    }
+    stream.match(/^[^>]*>/); // named group (?<name>
+    return 'groupName';
+  }
+  if (p === ':' || p === '=' || p === '!') stream.next();
+  return 'group';
+}
+
+/** Tokenize a quantifier: `* + ?`, lazy variants, and counted `{n,m}`. */
+function tokenQuantifier(stream: StringStream, ch: string): string | null {
+  if (ch === '*' || ch === '+' || ch === '?') {
+    stream.eat('?'); // lazy modifier
+    return 'quantifier';
+  }
+  // ch === '{'
+  if (stream.match(/^\d+(,\d*)?\}/)) {
+    stream.eat('?');
+    return 'count';
+  }
+  return null; // literal brace
+}
+
+/**
+ * Minimal regular-expression tokenizer for a single-line field. It is not a
+ * full grammar: it recognises the common JavaScript regex constructs (groups,
+ * character classes, quantifiers, anchors, alternation, escapes,
+ * backreferences) so the user gets live visual feedback while typing a pattern.
+ */
+const regexParser: StreamParser<RegexParserState> = {
+  name: 'regex',
+  startState: () => ({ inClass: false }),
+  token(stream, state) {
+    const ch = stream.next();
+    if (ch == null) return null;
+
+    if (state.inClass) return tokenInClass(stream, state, ch);
+    if (ch === '\\') return tokenEscape(stream);
+    if (ch === '[') {
+      state.inClass = true;
+      stream.eat('^'); // optional negation
+      return 'classBracket';
+    }
+    if (ch === '(') return tokenGroupOpen(stream);
+    if (ch === ')') return 'group';
+    if (ch === '^' || ch === '$') return 'anchor';
+    if (ch === '.') return 'dot';
+    if (ch === '|') return 'alternation';
+    if (ch === '*' || ch === '+' || ch === '?' || ch === '{') {
+      return tokenQuantifier(stream, ch);
+    }
+    return null; // literal character (inherits the editor text color)
+  },
+  tokenTable: {
+    group: t.paren,
+    groupName: t.propertyName,
+    classBracket: t.squareBracket,
+    classContent: t.string,
+    quantifier: t.operator,
+    count: t.number,
+    anchor: t.keyword,
+    dot: t.keyword,
+    alternation: t.operator,
+    escapeClass: t.escape,
+    escapeLiteral: t.escape,
+    backref: t.special(t.variableName),
+    invalid: t.invalid,
+  } satisfies Record<string, Tag>,
+};
+
+/** CodeMirror language extension highlighting a single-line regex pattern. */
+export const regexLanguage = StreamLanguage.define(regexParser);
+
+/**
+ * Token colors mapped onto Radix scale variables so the field follows the
+ * active accent and flips automatically between light and dark appearances
+ * (mirrors `jsonHighlightStyle` in the JSON editor).
+ */
+export const regexHighlightStyle = HighlightStyle.define([
+  { tag: [t.paren, t.propertyName], color: 'var(--accent-11)' }, // groups, named groups
+  { tag: t.squareBracket, color: 'var(--iris-11)' }, // character class brackets
+  { tag: t.string, color: 'var(--gray-12)' }, // character class contents
+  { tag: [t.operator, t.number], color: 'var(--amber-11)' }, // quantifiers, alternation, counts
+  { tag: t.keyword, color: 'var(--purple-11)' }, // anchors, dot
+  { tag: t.escape, color: 'var(--grass-11)' }, // \d \w escapes and literals
+  { tag: t.variableName, color: 'var(--cyan-11)' }, // backreferences
+  { tag: t.invalid, color: 'var(--red-11)' }, // dangling escapes
+]);

--- a/src/components/UI/RegexCodeField/setRegexFieldValue.ts
+++ b/src/components/UI/RegexCodeField/setRegexFieldValue.ts
@@ -1,0 +1,33 @@
+import { EditorView } from '@codemirror/view';
+
+/**
+ * Test seam for driving the lazily mounted {@link RegexCodeField}. The editor
+ * exposes no `<input>`, so tests and Storybook play functions set its document
+ * straight on the CodeMirror view. Works in a real browser and in happy-dom
+ * alike (a dispatched transaction does not require layout).
+ */
+export async function waitForRegexField(
+  root: ParentNode,
+  testId = 'regex-code-field',
+  timeoutMs = 3000,
+): Promise<EditorView> {
+  const start = Date.now();
+  for (;;) {
+    const cmEl = root.querySelector<HTMLElement>(`[data-testid="${testId}"] .cm-editor`);
+    const view = cmEl ? EditorView.findFromDOM(cmEl) : null;
+    if (view) return view;
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error(`Regex field "${testId}" did not mount in time`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+export async function setRegexFieldValue(
+  root: ParentNode,
+  testId: string,
+  pattern: string,
+): Promise<void> {
+  const view = await waitForRegexField(root, testId);
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: pattern } });
+}

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -211,8 +211,8 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     await expect(wizard.configModeRadio('ask')).toHaveAttribute('data-state', 'checked');
 
     await expect(wizard.dialog().getByTestId('config-mode-description')).toBeVisible();
-    await expect(wizard.dialog().locator('input[name="titleParsingRegEx"]')).not.toBeAttached();
-    await expect(wizard.dialog().locator('input[name="urlParsingRegEx"]')).not.toBeAttached();
+    await expect(wizard.dialog().getByTestId('title-regex-field')).toHaveCount(0);
+    await expect(wizard.dialog().getByTestId('url-regex-field')).toHaveCount(0);
     await page.close();
   });
 


### PR DESCRIPTION
Replace the plain Radix TextField regex inputs in the domain rule config
form with a single-line CodeMirror editor that highlights regex syntax
live (groups, named groups, character classes, quantifiers, anchors,
alternation, escapes, backreferences), reusing the existing CodeMirror
stack rather than adding shiki.

- New RegexCodeField (UI): single-line CM editor, newline-blocking
  transaction filter, Radix-token theming (light/dark + accent), and a
  StreamLanguage regex tokenizer mapped to a HighlightStyle.
- FormField/FieldError: expose an error id so the editor can wire
  aria-describedby; render-prop now yields (fieldId, errorId).
- i18n: titleRegexEditorAriaLabel / urlRegexEditorAriaLabel in en/fr/es.
- e2e: RuleWizardPage gains title/url regex CodeMirror locators and
  fillTitleRegex/fillUrlRegex; rule-wizard spec asserts the field testids.
- Storybook + story seam (setRegexFieldValue) for the new component.

https://claude.ai/code/session_01GCYqphcuzNerR1wPFEYSyt