### PR TITLE
feat(rules): preserve per-mode internal state in config step

### DIFF
--- a/src/components/Core/DomainRule/ConfigEditModal.tsx
+++ b/src/components/Core/DomainRule/ConfigEditModal.tsx
@@ -1,5 +1,5 @@
 import { Flex } from '@radix-ui/themes';
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { type GroupNameSourceValue, type UrlExtractionModeValue } from '@/schemas/enums';
@@ -9,6 +9,14 @@ import { getPresetById } from '@/utils/presetUtils';
 import { logger } from '@/utils/logger';
 import { DomainRuleConfigForm } from './DomainRuleConfigForm';
 import type { ConfigMode } from './ConfigModeSelector';
+import {
+  type ConfigFields,
+  type ConfigSnapshots,
+  applyPresetSelection,
+  enterModePatch,
+  initSnapshots,
+  saveModeSnapshot,
+} from './configModeState';
 import { EditModalShell } from './EditModalShell';
 
 const regexValidator = createRegexValidator(true);
@@ -49,6 +57,18 @@ interface ConfigEditModalProps {
   isLoadingPresets: boolean;
 }
 
+function initialToFields(initial: ConfigEditValues): ConfigFields {
+  return {
+    presetId: initial.presetId,
+    groupNameSource: initial.groupNameSource,
+    titleParsingRegEx: initial.titleParsingRegEx,
+    urlParsingRegEx: initial.urlParsingRegEx,
+    urlExtractionMode: initial.urlExtractionMode,
+    urlQueryParamName: initial.urlQueryParamName,
+    fallbackLabel: initial.fallbackLabel,
+  };
+}
+
 export function ConfigEditModal({
   isOpen,
   onClose,
@@ -66,6 +86,9 @@ export function ConfigEditModal({
   const [urlQueryParamName, setUrlQueryParamName] = useState(initial.urlQueryParamName);
   const [fallbackLabel, setFallbackLabel] = useState(initial.fallbackLabel);
 
+  // Per-mode internal state preserved across mode switches for the modal session.
+  const snapshotsRef = useRef<ConfigSnapshots>(initSnapshots(initialToFields(initial), initial.configMode));
+
   // Reset to initial values whenever modal opens
   useEffect(() => {
     if (isOpen) {
@@ -77,25 +100,37 @@ export function ConfigEditModal({
       setUrlExtractionMode(initial.urlExtractionMode);
       setUrlQueryParamName(initial.urlQueryParamName);
       setFallbackLabel(initial.fallbackLabel);
+      snapshotsRef.current = initSnapshots(initialToFields(initial), initial.configMode);
     }
   }, [isOpen, initial]);
 
-  const handleConfigModeChange = useCallback((newMode: ConfigMode) => {
-    setConfigMode(newMode);
-    // Clear presetId when leaving preset mode: otherwise inferConfigMode silently
-    // re-classifies the rule as 'preset' on next open, undoing the user's mode change
-    // (presetId would also be persisted alongside a non-preset configMode, corrupt state).
-    if (newMode !== 'preset') {
-      setPresetId(null);
-    }
-    // Ask mode persists groupNameSource as 'manual', matches RuleWizardModal convention.
-    if (newMode === 'ask') {
-      setGroupNameSource('manual');
-    }
-    if (newMode === 'label') {
-      setGroupNameSource('label');
-    }
+  const readFields = useCallback((): ConfigFields => ({
+    presetId,
+    groupNameSource,
+    titleParsingRegEx,
+    urlParsingRegEx,
+    urlExtractionMode,
+    urlQueryParamName,
+    fallbackLabel,
+  }), [presetId, groupNameSource, titleParsingRegEx, urlParsingRegEx, urlExtractionMode, urlQueryParamName, fallbackLabel]);
+
+  const applyPatch = useCallback((patch: Partial<ConfigFields>) => {
+    if (patch.presetId !== undefined) setPresetId(patch.presetId);
+    if (patch.groupNameSource !== undefined) setGroupNameSource(patch.groupNameSource);
+    if (patch.titleParsingRegEx !== undefined) setTitleParsingRegEx(patch.titleParsingRegEx);
+    if (patch.urlParsingRegEx !== undefined) setUrlParsingRegEx(patch.urlParsingRegEx);
+    if (patch.urlExtractionMode !== undefined) setUrlExtractionMode(patch.urlExtractionMode);
+    if (patch.urlQueryParamName !== undefined) setUrlQueryParamName(patch.urlQueryParamName);
+    if (patch.fallbackLabel !== undefined) setFallbackLabel(patch.fallbackLabel);
   }, []);
+
+  const handleConfigModeChange = useCallback((newMode: ConfigMode) => {
+    if (configMode !== newMode) {
+      snapshotsRef.current = saveModeSnapshot(snapshotsRef.current, configMode, readFields());
+    }
+    applyPatch(enterModePatch(snapshotsRef.current, newMode, { label: '', fallbackLabel }));
+    setConfigMode(newMode);
+  }, [configMode, readFields, applyPatch, fallbackLabel]);
 
   const handlePresetChange = useCallback(async (selectedPresetId: string) => {
     if (!selectedPresetId) {
@@ -105,17 +140,14 @@ export function ConfigEditModal({
     try {
       const preset = await getPresetById(selectedPresetId);
       if (preset) {
-        setPresetId(selectedPresetId);
-        setGroupNameSource(preset.groupNameSource as GroupNameSourceValue);
-        if (preset.titleRegex) setTitleParsingRegEx(preset.titleRegex);
-        if (preset.urlRegex) setUrlParsingRegEx(preset.urlRegex);
-        if (preset.urlExtractionMode) setUrlExtractionMode(preset.urlExtractionMode);
-        if (preset.urlQueryParamName) setUrlQueryParamName(preset.urlQueryParamName);
+        const { snapshots, fields } = applyPresetSelection(snapshotsRef.current, selectedPresetId, preset);
+        snapshotsRef.current = snapshots;
+        applyPatch(fields);
       }
     } catch (error) {
       logger.debug('[ConfigEditModal] Error loading preset:', error);
     }
-  }, []);
+  }, [applyPatch]);
 
   const titleFieldVisible =
     configMode === 'manual' && (groupNameSource === 'title' || groupNameSource.startsWith('smart'));

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -15,6 +15,15 @@ import { ConfigEditModal, type ConfigEditValues } from './ConfigEditModal';
 import { IdentityEditModal, type IdentityEditValues } from './IdentityEditModal';
 import { OptionsEditModal, type OptionsEditValues } from './OptionsEditModal';
 import type { ConfigMode } from './ConfigModeSelector';
+import {
+  type ConfigFields,
+  type ConfigSnapshots,
+  applyPresetSelection,
+  enterModePatch,
+  inferConfigMode,
+  initSnapshots,
+  saveModeSnapshot,
+} from './configModeState';
 import { generateUUID } from '@/utils/utils';
 import { createDomainRuleSchemaWithUniqueness, type DomainRule } from '@/schemas/domainRule';
 import { groupNameSourceOptions, type GroupNameSourceValue, type UrlExtractionModeValue } from '@/schemas/enums';
@@ -32,31 +41,6 @@ interface RuleWizardModalProps {
 }
 
 const VALID_GROUP_NAME_SOURCES = groupNameSourceOptions.map(o => o.value) as GroupNameSourceValue[];
-
-interface ModeStateSnapshot {
-  groupNameSource: GroupNameSourceValue;
-  titleParsingRegEx: string;
-  urlParsingRegEx: string;
-  urlExtractionMode: UrlExtractionModeValue;
-  urlQueryParamName: string;
-}
-
-interface PresetStateSnapshot extends ModeStateSnapshot {
-  presetId: string | null;
-}
-
-const emptyModeState: ModeStateSnapshot = {
-  groupNameSource: 'title',
-  titleParsingRegEx: '',
-  urlParsingRegEx: '',
-  urlExtractionMode: 'regex',
-  urlQueryParamName: '',
-};
-
-const emptyPresetState: PresetStateSnapshot = {
-  presetId: null,
-  ...emptyModeState,
-};
 
 const getDefaultValues = (rule?: DomainRule): Partial<DomainRule> => {
   return rule ? {
@@ -94,12 +78,20 @@ const getDefaultValues = (rule?: DomainRule): Partial<DomainRule> => {
   };
 };
 
-function inferConfigMode(rule?: DomainRule): ConfigMode {
-  if (!rule) return 'preset';
-  if (rule.presetId) return 'preset';
-  if (rule.groupNameSource === 'label') return 'label';
-  if (rule.groupNameSource === 'manual') return 'ask';
-  return 'manual';
+/** Build the snapshot-relevant fields from the rule being edited (or empty). */
+function ruleToFields(rule?: DomainRule): ConfigFields {
+  const groupNameSource = (rule && VALID_GROUP_NAME_SOURCES.includes(rule.groupNameSource)
+    ? rule.groupNameSource
+    : 'title') as GroupNameSourceValue;
+  return {
+    presetId: rule?.presetId ?? null,
+    groupNameSource,
+    titleParsingRegEx: rule?.titleParsingRegEx ?? '',
+    urlParsingRegEx: rule?.urlParsingRegEx ?? '',
+    urlExtractionMode: rule?.urlExtractionMode ?? 'regex',
+    urlQueryParamName: rule?.urlQueryParamName ?? '',
+    fallbackLabel: rule?.fallbackLabel ?? rule?.label ?? '',
+  };
 }
 
 function getManualModeFieldsToValidate(
@@ -153,9 +145,10 @@ export function RuleWizardModal({
   // aria-live announcement
   const [stepAnnouncement, setStepAnnouncement] = useState('');
 
-  // State preservation refs for mode switching
-  const lastManualState = useRef<ModeStateSnapshot>({ ...emptyModeState });
-  const lastPresetState = useRef<PresetStateSnapshot>({ ...emptyPresetState });
+  // Per-mode internal state preserved across mode switches for the modal session.
+  const snapshotsRef = useRef<ConfigSnapshots>(
+    initSnapshots(ruleToFields(domainRule), inferConfigMode(domainRule)),
+  );
 
   const {
     control,
@@ -180,6 +173,28 @@ export function RuleWizardModal({
   // Reactive snapshot of the full rule, used to feed the edit-mode summary so
   // it refreshes after each sub-dialog Apply (getValues() is not reactive).
   const watchedValues = useWatch({ control }) as DomainRule;
+
+  // Read the current snapshot-relevant fields from the form.
+  const readFields = useCallback((): ConfigFields => ({
+    presetId: getValues('presetId') ?? null,
+    groupNameSource: getValues('groupNameSource') as GroupNameSourceValue,
+    titleParsingRegEx: getValues('titleParsingRegEx') ?? '',
+    urlParsingRegEx: getValues('urlParsingRegEx') ?? '',
+    urlExtractionMode: (getValues('urlExtractionMode') ?? 'regex') as UrlExtractionModeValue,
+    urlQueryParamName: getValues('urlQueryParamName') ?? '',
+    fallbackLabel: getValues('fallbackLabel') ?? '',
+  }), [getValues]);
+
+  // Apply a partial field patch onto the form (only provided fields change).
+  const writeFields = useCallback((patch: Partial<ConfigFields>) => {
+    if (patch.presetId !== undefined) setValue('presetId', patch.presetId);
+    if (patch.groupNameSource !== undefined) setValue('groupNameSource', patch.groupNameSource);
+    if (patch.titleParsingRegEx !== undefined) setValue('titleParsingRegEx', patch.titleParsingRegEx);
+    if (patch.urlParsingRegEx !== undefined) setValue('urlParsingRegEx', patch.urlParsingRegEx);
+    if (patch.urlExtractionMode !== undefined) setValue('urlExtractionMode', patch.urlExtractionMode);
+    if (patch.urlQueryParamName !== undefined) setValue('urlQueryParamName', patch.urlQueryParamName);
+    if (patch.fallbackLabel !== undefined) setValue('fallbackLabel', patch.fallbackLabel);
+  }, [setValue]);
 
   // Load presets when modal opens
   useEffect(() => {
@@ -211,126 +226,32 @@ export function RuleWizardModal({
     setIsOptionsModalOpen(false);
     const mode = inferConfigMode(domainRule);
     setConfigMode(mode);
-    if (!domainRule || domainRule.groupNameSource === 'manual') {
-      lastManualState.current = { ...emptyModeState };
-      lastPresetState.current = { ...emptyPresetState };
-    } else if (domainRule.presetId) {
-      const snapshot: ModeStateSnapshot = {
-        groupNameSource: domainRule.groupNameSource,
-        titleParsingRegEx: domainRule.titleParsingRegEx ?? '',
-        urlParsingRegEx: domainRule.urlParsingRegEx ?? '',
-        urlExtractionMode: domainRule.urlExtractionMode ?? 'regex',
-        urlQueryParamName: domainRule.urlQueryParamName ?? '',
-      };
-      lastPresetState.current = { presetId: domainRule.presetId, ...snapshot };
-      lastManualState.current = { ...snapshot };
-    } else {
-      lastManualState.current = {
-        groupNameSource: domainRule.groupNameSource as GroupNameSourceValue,
-        titleParsingRegEx: domainRule.titleParsingRegEx ?? '',
-        urlParsingRegEx: domainRule.urlParsingRegEx ?? '',
-        urlExtractionMode: domainRule.urlExtractionMode ?? 'regex',
-        urlQueryParamName: domainRule.urlQueryParamName ?? '',
-      };
-      lastPresetState.current = { ...emptyPresetState };
-    }
+    snapshotsRef.current = initSnapshots(ruleToFields(domainRule), mode);
   }, [domainRule, isOpen, reset]);
 
   const handlePresetChange = useCallback(async (selectedPresetId: string) => {
     if (!selectedPresetId) { setValue('presetId', null); return; }
     const preset = await getPresetById(selectedPresetId);
-    if (preset) {
-      setValue('presetId', selectedPresetId);
-      setValue('groupNameSource', preset.groupNameSource);
-      if (preset.titleRegex) setValue('titleParsingRegEx', preset.titleRegex);
-      if (preset.urlRegex) setValue('urlParsingRegEx', preset.urlRegex);
-      const presetExtractionMode = (preset.urlExtractionMode ?? 'regex') as UrlExtractionModeValue;
-      setValue('urlExtractionMode', presetExtractionMode);
-      if (preset.urlQueryParamName) setValue('urlQueryParamName', preset.urlQueryParamName);
-      setPresetName(preset.name);
-      const snapshot: ModeStateSnapshot = {
-        groupNameSource: preset.groupNameSource,
-        titleParsingRegEx: preset.titleRegex ?? '',
-        urlParsingRegEx: preset.urlRegex ?? '',
-        urlExtractionMode: presetExtractionMode,
-        urlQueryParamName: preset.urlQueryParamName ?? '',
-      };
-      lastPresetState.current = { presetId: selectedPresetId, ...snapshot };
-      lastManualState.current = { ...snapshot };
-      trigger();
-    }
-  }, [setValue, trigger]);
-
-  const readModeState = useCallback((): ModeStateSnapshot => ({
-    groupNameSource: getValues('groupNameSource') as GroupNameSourceValue,
-    titleParsingRegEx: getValues('titleParsingRegEx') ?? '',
-    urlParsingRegEx: getValues('urlParsingRegEx') ?? '',
-    urlExtractionMode: (getValues('urlExtractionMode') ?? 'regex') as UrlExtractionModeValue,
-    urlQueryParamName: getValues('urlQueryParamName') ?? '',
-  }), [getValues]);
-
-  const captureSnapshot = readModeState;
-
-  const applySnapshot = useCallback((snapshot: ModeStateSnapshot) => {
-    setValue('groupNameSource', snapshot.groupNameSource);
-    setValue('titleParsingRegEx', snapshot.titleParsingRegEx);
-    setValue('urlParsingRegEx', snapshot.urlParsingRegEx);
-    setValue('urlExtractionMode', snapshot.urlExtractionMode);
-    setValue('urlQueryParamName', snapshot.urlQueryParamName);
-  }, [setValue]);
-
-  const saveCurrentModeState = useCallback((prevMode: ConfigMode) => {
-    if (prevMode === 'manual') {
-      lastManualState.current = captureSnapshot();
-    } else if (prevMode === 'preset') {
-      lastPresetState.current = {
-        presetId: getValues('presetId') ?? null,
-        ...captureSnapshot(),
-      };
-    }
-  }, [captureSnapshot, getValues]);
-
-  const restorePresetMode = useCallback(() => {
-    setValue('presetId', lastPresetState.current.presetId);
-    applySnapshot(lastPresetState.current);
-  }, [setValue, applySnapshot]);
-
-  const restoreManualMode = useCallback(() => {
-    setValue('presetId', null);
-    applySnapshot(lastManualState.current);
-  }, [setValue, applySnapshot]);
-
-  const enterAskMode = useCallback(() => {
-    setValue('presetId', null);
-    setValue('groupNameSource', 'manual');
-  }, [setValue]);
-
-  const enterLabelMode = useCallback(() => {
-    setValue('presetId', null);
-    setValue('groupNameSource', 'label');
-    setValue('titleParsingRegEx', '');
-    setValue('urlParsingRegEx', '');
-    setValue('urlQueryParamName', '');
-    const currentFallback = getValues('fallbackLabel');
-    if (!currentFallback || currentFallback.trim() === '') {
-      setValue('fallbackLabel', getValues('label') ?? '');
-    }
-  }, [setValue, getValues]);
+    if (!preset) return;
+    const { snapshots, fields } = applyPresetSelection(snapshotsRef.current, selectedPresetId, preset);
+    snapshotsRef.current = snapshots;
+    writeFields(fields);
+    setPresetName(preset.name);
+    trigger();
+  }, [setValue, writeFields, trigger]);
 
   const handleConfigModeChange = useCallback((newMode: ConfigMode) => {
     const prevMode = configMode;
     if (prevMode !== newMode) {
-      saveCurrentModeState(prevMode);
+      snapshotsRef.current = saveModeSnapshot(snapshotsRef.current, prevMode, readFields());
     }
-    switch (newMode) {
-      case 'preset': restorePresetMode(); break;
-      case 'manual': restoreManualMode(); break;
-      case 'ask': enterAskMode(); break;
-      case 'label': enterLabelMode(); break;
-    }
+    writeFields(enterModePatch(snapshotsRef.current, newMode, {
+      label: getValues('label') ?? '',
+      fallbackLabel: getValues('fallbackLabel') ?? '',
+    }));
     setConfigMode(newMode);
     trigger();
-  }, [configMode, saveCurrentModeState, restorePresetMode, restoreManualMode, enterAskMode, enterLabelMode, trigger]);
+  }, [configMode, readFields, writeFields, getValues, trigger]);
 
   const announceStep = (newStep: number) => {
     const label = getMessage(STEP_LABELS_KEYS[newStep]);
@@ -404,21 +325,20 @@ export function RuleWizardModal({
   };
 
   const handleApplyConfig = (values: ConfigEditValues) => {
-    saveCurrentModeState(configMode);
     setConfigMode(values.configMode);
-    setValue('presetId', values.presetId);
-    setValue('groupNameSource', values.groupNameSource);
-    setValue('titleParsingRegEx', values.titleParsingRegEx);
-    setValue('urlParsingRegEx', values.urlParsingRegEx);
-    setValue('urlExtractionMode', values.urlExtractionMode);
-    setValue('urlQueryParamName', values.urlQueryParamName);
+    const fields: ConfigFields = {
+      presetId: values.presetId,
+      groupNameSource: values.groupNameSource,
+      titleParsingRegEx: values.titleParsingRegEx,
+      urlParsingRegEx: values.urlParsingRegEx,
+      urlExtractionMode: values.urlExtractionMode,
+      urlQueryParamName: values.urlQueryParamName,
+      fallbackLabel: values.fallbackLabel,
+    };
+    writeFields(fields);
     setValue('fallbackLabel', values.fallbackLabel, { shouldDirty: true });
-    if (values.configMode === 'ask') {
-      setValue('groupNameSource', 'manual');
-    }
-    if (values.configMode === 'label') {
-      setValue('groupNameSource', 'label');
-    }
+    // Keep the per-mode snapshots consistent with the applied configuration.
+    snapshotsRef.current = initSnapshots(fields, values.configMode);
     trigger();
     // Refresh preset name
     if (values.presetId) {
@@ -473,9 +393,7 @@ export function RuleWizardModal({
 
   const currentConfigValues: ConfigEditValues = {
     configMode,
-    presetId: getValues('presetId') ?? null,
-    fallbackLabel: getValues('fallbackLabel') ?? '',
-    ...readModeState(),
+    ...readFields(),
   };
 
   const currentIdentityValues: IdentityEditValues = {

--- a/src/components/Core/DomainRule/configModeState.ts
+++ b/src/components/Core/DomainRule/configModeState.ts
@@ -1,0 +1,209 @@
+import type { GroupNameSourceValue, UrlExtractionModeValue } from '@/schemas/enums';
+import type { ConfigMode } from './ConfigModeSelector';
+
+/**
+ * Pure state machine for the rule "configuration mode" selector (preset / manual /
+ * label / ask) shared by RuleWizardModal (react-hook-form driven) and
+ * ConfigEditModal (useState driven).
+ *
+ * Each mode keeps its own internal snapshot for the lifetime of a modal session.
+ * The only intentional cross-mode bleed is preset -> manual: selecting/changing a
+ * preset reseeds the manual snapshot from that preset. Merely passing through
+ * `label` or `ask` never disturbs the manual snapshot.
+ *
+ * `fallbackLabel` is a shared field (group name in label mode, fallback in manual
+ * mode) so it is never snapshotted/cleared per mode. `ask` carries no editable
+ * state. Only `manual` and `preset` need a snapshot.
+ */
+
+/** The regex-related fields a manual/preset snapshot tracks. */
+export interface ModeSnapshot {
+  groupNameSource: GroupNameSourceValue;
+  titleParsingRegEx: string;
+  urlParsingRegEx: string;
+  urlExtractionMode: UrlExtractionModeValue;
+  urlQueryParamName: string;
+}
+
+export interface PresetSnapshot extends ModeSnapshot {
+  presetId: string | null;
+}
+
+export interface ConfigSnapshots {
+  manual: ModeSnapshot;
+  preset: PresetSnapshot;
+}
+
+/** Mutable configuration fields the transitions read from / write to. */
+export interface ConfigFields extends ModeSnapshot {
+  presetId: string | null;
+  fallbackLabel: string;
+}
+
+/** Minimal preset shape consumed when reseeding from a preset selection. */
+export interface PresetSeed {
+  groupNameSource: GroupNameSourceValue;
+  titleRegex?: string;
+  urlRegex?: string;
+  urlExtractionMode?: UrlExtractionModeValue;
+  urlQueryParamName?: string;
+}
+
+export const EMPTY_MODE_SNAPSHOT: ModeSnapshot = {
+  groupNameSource: 'title',
+  titleParsingRegEx: '',
+  urlParsingRegEx: '',
+  urlExtractionMode: 'regex',
+  urlQueryParamName: '',
+};
+
+export const EMPTY_PRESET_SNAPSHOT: PresetSnapshot = {
+  presetId: null,
+  ...EMPTY_MODE_SNAPSHOT,
+};
+
+export const EMPTY_CONFIG_SNAPSHOTS: ConfigSnapshots = {
+  manual: { ...EMPTY_MODE_SNAPSHOT },
+  preset: { ...EMPTY_PRESET_SNAPSHOT },
+};
+
+/**
+ * `manual` and `label` are not valid sources for manual editing: `manual` is the
+ * "ask" sentinel and `label` belongs to label mode. Coerce them back to `title`
+ * so entering manual mode always shows an editable source + regex fields.
+ */
+function sanitizeManualSource(source: GroupNameSourceValue): GroupNameSourceValue {
+  return source === 'label' || source === 'manual' ? 'title' : source;
+}
+
+/** Extract the regex-related fields from a full ConfigFields object. */
+export function extractModeSnapshot(fields: ModeSnapshot): ModeSnapshot {
+  return {
+    groupNameSource: fields.groupNameSource,
+    titleParsingRegEx: fields.titleParsingRegEx,
+    urlParsingRegEx: fields.urlParsingRegEx,
+    urlExtractionMode: fields.urlExtractionMode,
+    urlQueryParamName: fields.urlQueryParamName,
+  };
+}
+
+/**
+ * Classify a rule (or absence of one) into its initial config mode.
+ * Mirrors the data model: a preset wins, then the `label`/`manual` group-name
+ * sentinels, otherwise it is a hand-written manual rule.
+ */
+export function inferConfigMode(rule?: {
+  presetId?: string | null;
+  groupNameSource?: GroupNameSourceValue;
+}): ConfigMode {
+  if (!rule) return 'preset';
+  if (rule.presetId) return 'preset';
+  if (rule.groupNameSource === 'label') return 'label';
+  if (rule.groupNameSource === 'manual') return 'ask';
+  return 'manual';
+}
+
+/**
+ * Save the current field values into the leaving mode's snapshot.
+ * `ask`/`label` have no per-mode snapshot, so they leave the snapshots untouched.
+ */
+export function saveModeSnapshot(
+  snapshots: ConfigSnapshots,
+  leavingMode: ConfigMode,
+  fields: ConfigFields,
+): ConfigSnapshots {
+  if (leavingMode === 'manual') {
+    return { ...snapshots, manual: extractModeSnapshot(fields) };
+  }
+  if (leavingMode === 'preset') {
+    return { ...snapshots, preset: { presetId: fields.presetId, ...extractModeSnapshot(fields) } };
+  }
+  return snapshots;
+}
+
+/**
+ * Compute the partial fields to write when entering a mode. Fields absent from
+ * the patch keep their current value (e.g. entering `ask` only touches presetId
+ * and groupNameSource).
+ */
+export function enterModePatch(
+  snapshots: ConfigSnapshots,
+  enteringMode: ConfigMode,
+  context: { label: string; fallbackLabel: string },
+): Partial<ConfigFields> {
+  switch (enteringMode) {
+    case 'preset':
+      return { presetId: snapshots.preset.presetId, ...extractModeSnapshot(snapshots.preset) };
+    case 'manual':
+      return {
+        presetId: null,
+        ...extractModeSnapshot(snapshots.manual),
+        groupNameSource: sanitizeManualSource(snapshots.manual.groupNameSource),
+      };
+    case 'ask':
+      return { presetId: null, groupNameSource: 'manual' };
+    case 'label': {
+      const hasFallback = context.fallbackLabel.trim() !== '';
+      return {
+        presetId: null,
+        groupNameSource: 'label',
+        titleParsingRegEx: '',
+        urlParsingRegEx: '',
+        urlQueryParamName: '',
+        fallbackLabel: hasFallback ? context.fallbackLabel : context.label,
+      };
+    }
+  }
+}
+
+/**
+ * Selecting/changing a preset reseeds both the preset snapshot and the manual
+ * snapshot from the preset, and returns the field patch to apply. This is the
+ * single intentional preset -> manual carryover.
+ */
+export function applyPresetSelection(
+  snapshots: ConfigSnapshots,
+  presetId: string,
+  preset: PresetSeed,
+): { snapshots: ConfigSnapshots; fields: Partial<ConfigFields> } {
+  const modeSnapshot: ModeSnapshot = {
+    groupNameSource: preset.groupNameSource,
+    titleParsingRegEx: preset.titleRegex ?? '',
+    urlParsingRegEx: preset.urlRegex ?? '',
+    urlExtractionMode: preset.urlExtractionMode ?? 'regex',
+    urlQueryParamName: preset.urlQueryParamName ?? '',
+  };
+  return {
+    snapshots: {
+      manual: { ...modeSnapshot },
+      preset: { presetId, ...modeSnapshot },
+    },
+    fields: { presetId, ...modeSnapshot },
+  };
+}
+
+/**
+ * Build the initial snapshots from the rule being edited (or empty for a new
+ * rule). A `label`/`ask` rule yields empty manual/preset snapshots so switching
+ * to manual starts from a clean, editable state.
+ */
+export function initSnapshots(fields: ConfigFields, mode: ConfigMode): ConfigSnapshots {
+  const modeSnapshot = extractModeSnapshot(fields);
+  if (mode === 'preset') {
+    return {
+      preset: { presetId: fields.presetId, ...modeSnapshot },
+      manual: { ...modeSnapshot, groupNameSource: sanitizeManualSource(modeSnapshot.groupNameSource) },
+    };
+  }
+  if (mode === 'manual') {
+    return {
+      manual: { ...modeSnapshot, groupNameSource: sanitizeManualSource(modeSnapshot.groupNameSource) },
+      preset: { ...EMPTY_PRESET_SNAPSHOT },
+    };
+  }
+  // ask / label: no meaningful manual or preset state to capture from the rule.
+  return {
+    manual: { ...EMPTY_MODE_SNAPSHOT },
+    preset: { ...EMPTY_PRESET_SNAPSHOT },
+  };
+}

--- a/tests/components/ConfigEditModal.test.tsx
+++ b/tests/components/ConfigEditModal.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { ConfigEditModal, type ConfigEditValues } from '../../src/components/Core/DomainRule/ConfigEditModal';
+
+const baseInitial: ConfigEditValues = {
+  configMode: 'manual',
+  presetId: null,
+  groupNameSource: 'title',
+  titleParsingRegEx: 'orig-(.+)',
+  urlParsingRegEx: '',
+  urlExtractionMode: 'regex',
+  urlQueryParamName: '',
+  fallbackLabel: '',
+};
+
+function renderModal(initial: ConfigEditValues, onApply = vi.fn()) {
+  render(
+    <Theme>
+      <ConfigEditModal
+        isOpen
+        onClose={vi.fn()}
+        onApply={onApply}
+        initial={initial}
+        presetCategories={[]}
+        isLoadingPresets={false}
+      />
+    </Theme>,
+  );
+  return { onApply };
+}
+
+describe('ConfigEditModal — per-mode state preservation', () => {
+  it('label -> manual restores a valid manual source and keeps the regex (no "lose everything")', () => {
+    const { onApply } = renderModal(baseInitial);
+
+    fireEvent.click(screen.getByTestId('config-mode-label'));
+    fireEvent.click(screen.getByTestId('config-mode-manual'));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const values = onApply.mock.calls[0][0] as ConfigEditValues;
+    expect(values.configMode).toBe('manual');
+    // groupNameSource must NOT stay stuck on 'label' (that hid the regex fields).
+    expect(values.groupNameSource).toBe('title');
+    expect(values.titleParsingRegEx).toBe('orig-(.+)');
+  });
+
+  it('manual -> ask -> manual preserves the manual regex', () => {
+    const { onApply } = renderModal(baseInitial);
+
+    fireEvent.click(screen.getByTestId('config-mode-ask'));
+    fireEvent.click(screen.getByTestId('config-mode-manual'));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    const values = onApply.mock.calls[0][0] as ConfigEditValues;
+    expect(values.groupNameSource).toBe('title');
+    expect(values.titleParsingRegEx).toBe('orig-(.+)');
+  });
+
+  it('switching to ask persists groupNameSource as the "manual" sentinel', () => {
+    const { onApply } = renderModal(baseInitial);
+
+    fireEvent.click(screen.getByTestId('config-mode-ask'));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    const values = onApply.mock.calls[0][0] as ConfigEditValues;
+    expect(values.configMode).toBe('ask');
+    expect(values.groupNameSource).toBe('manual');
+    expect(values.presetId).toBeNull();
+  });
+});

--- a/tests/components/RuleWizardModal.stories.test.tsx
+++ b/tests/components/RuleWizardModal.stories.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/Core/DomainRule/RuleWizardModal.stories';
 
@@ -97,5 +97,19 @@ describe('RuleWizardModal — step navigation', () => {
 
     // isOpen is controlled externally so dialog stays in DOM after mock onClose
     expect(screen.getByTestId('wizard-rule')).toBeInTheDocument();
+  });
+});
+
+describe('RuleWizardModal — step 2 config mode state', () => {
+  it('keeps an editable manual config after transiting through ask (no empty manual)', async () => {
+    await RuleWizardModalStep2.run();
+    expect(screen.getByTestId('wizard-rule-step-2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('config-mode-ask'));
+    fireEvent.click(screen.getByTestId('config-mode-manual'));
+
+    // Manual mode must render its source selector + title regex editor,
+    // never the empty "label" view that caused "on perd tout".
+    expect(screen.getByTestId('title-regex-field')).toBeInTheDocument();
   });
 });

--- a/tests/components/configModeState.test.ts
+++ b/tests/components/configModeState.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type ConfigFields,
+  type ConfigSnapshots,
+  EMPTY_CONFIG_SNAPSHOTS,
+  applyPresetSelection,
+  enterModePatch,
+  inferConfigMode,
+  initSnapshots,
+  saveModeSnapshot,
+} from '../../src/components/Core/DomainRule/configModeState';
+
+/* ── Helpers ──────────────────────────────────────────────────────────────── */
+
+const makeFields = (overrides: Partial<ConfigFields> = {}): ConfigFields => ({
+  presetId: null,
+  groupNameSource: 'title',
+  titleParsingRegEx: '',
+  urlParsingRegEx: '',
+  urlExtractionMode: 'regex',
+  urlQueryParamName: '',
+  fallbackLabel: '',
+  ...overrides,
+});
+
+/**
+ * Simulate a full modal session driven only by the pure helpers: apply each mode
+ * change as the components do (save the leaving mode, then apply the enter patch).
+ */
+function switchMode(
+  snapshots: ConfigSnapshots,
+  fields: ConfigFields,
+  from: Parameters<typeof saveModeSnapshot>[1],
+  to: Parameters<typeof enterModePatch>[1],
+): { snapshots: ConfigSnapshots; fields: ConfigFields } {
+  const saved = from !== to ? saveModeSnapshot(snapshots, from, fields) : snapshots;
+  const patch = enterModePatch(saved, to, { label: fields.fallbackLabel, fallbackLabel: fields.fallbackLabel });
+  return { snapshots: saved, fields: { ...fields, ...patch } };
+}
+
+const PRESET_X = {
+  groupNameSource: 'url' as const,
+  urlRegex: 'x-(\\d+)',
+  urlExtractionMode: 'regex' as const,
+};
+const PRESET_Y = {
+  groupNameSource: 'title' as const,
+  titleRegex: 'y-(.+)',
+};
+
+/* ── inferConfigMode ────────────────────────────────────────────────────────── */
+
+describe('inferConfigMode', () => {
+  it('defaults to preset for a new rule', () => {
+    expect(inferConfigMode(undefined)).toBe('preset');
+  });
+  it('classifies by presetId, then label/manual sentinels, else manual', () => {
+    expect(inferConfigMode({ presetId: 'p1', groupNameSource: 'title' })).toBe('preset');
+    expect(inferConfigMode({ presetId: null, groupNameSource: 'label' })).toBe('label');
+    expect(inferConfigMode({ presetId: null, groupNameSource: 'manual' })).toBe('ask');
+    expect(inferConfigMode({ presetId: null, groupNameSource: 'url' })).toBe('manual');
+  });
+});
+
+/* ── Transition matrix (the core of the user request) ───────────────────────── */
+
+describe('config mode transitions', () => {
+  it('preset(X) -> manual carries the preset regex', () => {
+    let snapshots = EMPTY_CONFIG_SNAPSHOTS;
+    let fields = makeFields();
+    // Select preset X while in preset mode.
+    const sel = applyPresetSelection(snapshots, 'X', PRESET_X);
+    snapshots = sel.snapshots;
+    fields = { ...fields, ...sel.fields };
+    // preset -> manual
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'preset', 'manual'));
+
+    expect(fields.presetId).toBeNull();
+    expect(fields.groupNameSource).toBe('url');
+    expect(fields.urlParsingRegEx).toBe('x-(\\d+)');
+  });
+
+  it('preset(X) -> label -> manual still carries the preset regex', () => {
+    let snapshots = EMPTY_CONFIG_SNAPSHOTS;
+    let fields = makeFields({ fallbackLabel: 'Docs' });
+    const sel = applyPresetSelection(snapshots, 'X', PRESET_X);
+    snapshots = sel.snapshots;
+    fields = { ...fields, ...sel.fields };
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'preset', 'label'));
+    expect(fields.groupNameSource).toBe('label');
+    expect(fields.urlParsingRegEx).toBe(''); // cleared in the form...
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'label', 'manual'));
+    // ...but restored from the manual snapshot.
+    expect(fields.urlParsingRegEx).toBe('x-(\\d+)');
+    expect(fields.groupNameSource).toBe('url');
+  });
+
+  it('preset(X) -> ask -> manual still carries the preset regex', () => {
+    let snapshots = EMPTY_CONFIG_SNAPSHOTS;
+    let fields = makeFields();
+    const sel = applyPresetSelection(snapshots, 'X', PRESET_X);
+    snapshots = sel.snapshots;
+    fields = { ...fields, ...sel.fields };
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'preset', 'ask'));
+    expect(fields.groupNameSource).toBe('manual');
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'ask', 'manual'));
+    expect(fields.urlParsingRegEx).toBe('x-(\\d+)');
+    expect(fields.groupNameSource).toBe('url');
+  });
+
+  it('manual(custom) -> label -> manual preserves the custom regex', () => {
+    let snapshots = initSnapshots(makeFields(), 'manual');
+    let fields = makeFields({ groupNameSource: 'title', titleParsingRegEx: 'custom-(.+)' });
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'manual', 'label'));
+    expect(fields.titleParsingRegEx).toBe('');
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'label', 'manual'));
+    expect(fields.titleParsingRegEx).toBe('custom-(.+)');
+    expect(fields.groupNameSource).toBe('title');
+  });
+
+  it('manual(custom) -> preset(Y) -> manual shows Y (preset reseeds manual)', () => {
+    let snapshots = initSnapshots(makeFields(), 'manual');
+    let fields = makeFields({ groupNameSource: 'title', titleParsingRegEx: 'custom-(.+)' });
+
+    // manual -> preset
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'manual', 'preset'));
+    // Select preset Y in preset mode.
+    const sel = applyPresetSelection(snapshots, 'Y', PRESET_Y);
+    snapshots = sel.snapshots;
+    fields = { ...fields, ...sel.fields };
+    // preset -> manual
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'preset', 'manual'));
+
+    expect(fields.titleParsingRegEx).toBe('y-(.+)');
+    expect(fields.groupNameSource).toBe('title');
+  });
+
+  it('label fallbackLabel is preserved across label -> manual -> label', () => {
+    let snapshots = EMPTY_CONFIG_SNAPSHOTS;
+    let fields = makeFields();
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'preset', 'label'));
+    fields = { ...fields, fallbackLabel: 'My Group' };
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'label', 'manual'));
+    expect(fields.fallbackLabel).toBe('My Group'); // shared field, never cleared
+
+    ({ snapshots, fields } = switchMode(snapshots, fields, 'manual', 'label'));
+    expect(fields.fallbackLabel).toBe('My Group');
+    expect(fields.groupNameSource).toBe('label');
+  });
+
+  it('entering label seeds fallbackLabel from the rule label only when empty', () => {
+    const seeded = enterModePatch(EMPTY_CONFIG_SNAPSHOTS, 'label', { label: 'RuleLabel', fallbackLabel: '' });
+    expect(seeded.fallbackLabel).toBe('RuleLabel');
+
+    const kept = enterModePatch(EMPTY_CONFIG_SNAPSHOTS, 'label', { label: 'RuleLabel', fallbackLabel: 'Existing' });
+    expect(kept.fallbackLabel).toBe('Existing');
+  });
+});
+
+/* ── groupNameSource sanitization ───────────────────────────────────────────── */
+
+describe('manual mode source sanitization', () => {
+  it('coerces a label/manual snapshot source back to title when entering manual', () => {
+    const labelSnapshots: ConfigSnapshots = {
+      ...EMPTY_CONFIG_SNAPSHOTS,
+      manual: { ...EMPTY_CONFIG_SNAPSHOTS.manual, groupNameSource: 'label' },
+    };
+    expect(enterModePatch(labelSnapshots, 'manual', { label: '', fallbackLabel: '' }).groupNameSource).toBe('title');
+
+    const manualSnapshots: ConfigSnapshots = {
+      ...EMPTY_CONFIG_SNAPSHOTS,
+      manual: { ...EMPTY_CONFIG_SNAPSHOTS.manual, groupNameSource: 'manual' },
+    };
+    expect(enterModePatch(manualSnapshots, 'manual', { label: '', fallbackLabel: '' }).groupNameSource).toBe('title');
+  });
+});
+
+/* ── initSnapshots ──────────────────────────────────────────────────────────── */
+
+describe('initSnapshots', () => {
+  it('seeds both preset and manual snapshots for a preset rule', () => {
+    const snapshots = initSnapshots(
+      makeFields({ presetId: 'X', groupNameSource: 'url', urlParsingRegEx: 'x-(\\d+)' }),
+      'preset',
+    );
+    expect(snapshots.preset.presetId).toBe('X');
+    expect(snapshots.preset.urlParsingRegEx).toBe('x-(\\d+)');
+    expect(snapshots.manual.urlParsingRegEx).toBe('x-(\\d+)');
+  });
+
+  it('seeds the manual snapshot for a manual rule', () => {
+    const snapshots = initSnapshots(
+      makeFields({ groupNameSource: 'title', titleParsingRegEx: 'm-(.+)' }),
+      'manual',
+    );
+    expect(snapshots.manual.titleParsingRegEx).toBe('m-(.+)');
+    expect(snapshots.preset.presetId).toBeNull();
+  });
+
+  it('yields empty manual snapshot for a label rule (no stuck label source)', () => {
+    const snapshots = initSnapshots(
+      makeFields({ groupNameSource: 'label', fallbackLabel: 'L' }),
+      'label',
+    );
+    expect(snapshots.manual.groupNameSource).toBe('title');
+    expect(snapshots.manual.titleParsingRegEx).toBe('');
+  });
+
+  it('yields empty manual snapshot for an ask rule', () => {
+    const snapshots = initSnapshots(makeFields({ groupNameSource: 'manual' }), 'ask');
+    expect(snapshots.manual.groupNameSource).toBe('title');
+    expect(snapshots.preset.presetId).toBeNull();
+  });
+});


### PR DESCRIPTION
Each configuration mode (preset, manual, label, ask) now keeps its own
internal state for the lifetime of the rule modal. The only intentional
cross-mode bleed is preset -> manual: selecting or changing a preset
reseeds the manual regex fields from that preset. Transiting through
label or ask no longer wipes the manual configuration.

The transition logic is extracted into a pure, shared module
(configModeState.ts) consumed identically by the creation wizard
(RuleWizardModal, react-hook-form driven) and the edit-rule config
modal (ConfigEditModal, useState driven), so both surfaces behave the
same. This also fixes ConfigEditModal leaving groupNameSource stuck on
'label' after label -> manual, which hid the regex fields and looked
like total data loss.

Covered by pure unit tests of the transition matrix plus component
tests on both surfaces.