### PR TITLE
feat(domain-rules): live syntax highlighting for the domain filter (step 1)

### DIFF
--- a/e2e-shared/actions/rules-management.ts
+++ b/e2e-shared/actions/rules-management.ts
@@ -151,7 +151,15 @@ export async function editRule(
       await modal.getByTestId('modal-edit-identity-field-label').fill(patch.label);
     }
     if (patch.domainFilter !== undefined) {
-      await modal.getByTestId('modal-edit-identity-field-domain').fill(patch.domainFilter);
+      // The domain filter is a CodeMirror editor (no <input>): drive its
+      // contenteditable content node through the keyboard.
+      const domainContent = modal
+        .getByTestId('modal-edit-identity-field-domain')
+        .locator('.cm-content');
+      await domainContent.click();
+      await page.keyboard.press('ControlOrMeta+a');
+      await page.keyboard.press('Delete');
+      if (patch.domainFilter) await page.keyboard.type(patch.domainFilter);
     }
     await modal.getByTestId('modal-edit-identity-btn-apply').click();
   }

--- a/e2e-shared/pages/RuleWizardPage.ts
+++ b/e2e-shared/pages/RuleWizardPage.ts
@@ -178,9 +178,9 @@ export class RuleWizardPage extends DialogPage {
     await this.labelInput().fill(label);
   }
 
-  /** Fill the domain filter input. */
+  /** Fill the domain filter editor (CodeMirror, no `<input>`). */
   async fillDomainFilter(domain: string): Promise<void> {
-    await this.domainFilterInput().fill(domain);
+    await this.typeCodeField(this.domainFilterInput(), domain);
   }
 
   /**
@@ -234,26 +234,26 @@ export class RuleWizardPage extends DialogPage {
   }
 
   /**
-   * Type a pattern into a CodeMirror regex field. The editor exposes no
+   * Type into a CodeMirror field (regex or domain). The editor exposes no
    * `<input>`, so we focus the `.cm-content` node and drive it through the
    * keyboard (a `.fill()` would target a non-existent form value).
    */
-  private async typeRegexField(field: Locator, pattern: string): Promise<void> {
+  private async typeCodeField(field: Locator, text: string): Promise<void> {
     const content = field.locator('.cm-content');
     await content.click();
     await this.page.keyboard.press('ControlOrMeta+a');
     await this.page.keyboard.press('Delete');
-    if (pattern) await this.page.keyboard.type(pattern);
+    if (text) await this.page.keyboard.type(text);
   }
 
   /** Fill the title parsing regex editor (manual mode, title-based source). */
   async fillTitleRegex(pattern: string): Promise<void> {
-    await this.typeRegexField(this.titleRegexField(), pattern);
+    await this.typeCodeField(this.titleRegexField(), pattern);
   }
 
   /** Fill the URL parsing regex editor (manual mode, URL regex extraction). */
   async fillUrlRegex(pattern: string): Promise<void> {
-    await this.typeRegexField(this.urlRegexField(), pattern);
+    await this.typeCodeField(this.urlRegexField(), pattern);
   }
 
   // ─── Atomic actions: options (step 3) ────────────────────────────────────

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -93,6 +93,7 @@
   "addRule": { "message": "Add Rule" },
   "domainFilter": { "message": "Domain Filter" },
   "domainFilterPlaceholder": { "message": "e.g., atlassian.net" },
+  "domainFilterEditorAriaLabel": { "message": "Domain filter editor" },
   "titleRegex": { "message": "Title RegEx" },
   "urlRegex": { "message": "URL RegEx" },
   "titleRegexEditorAriaLabel": { "message": "Title regular expression editor" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -93,6 +93,7 @@
   "addRule": { "message": "Añadir Regla" },
   "domainFilter": { "message": "Filtro Dominio" },
   "domainFilterPlaceholder": { "message": "ej: atlassian.net" },
+  "domainFilterEditorAriaLabel": { "message": "Editor del filtro de dominio" },
   "titleRegex": { "message": "RegEx Título" },
   "urlRegex": { "message": "RegEx URL" },
   "titleRegexEditorAriaLabel": { "message": "Editor de expresión regular del título" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -93,6 +93,7 @@
   "addRule": { "message": "Ajouter une Règle" },
   "domainFilter": { "message": "Filtre Domaine" },
   "domainFilterPlaceholder": { "message": "ex: atlassian.net" },
+  "domainFilterEditorAriaLabel": { "message": "Éditeur du filtre de domaine" },
   "titleRegex": { "message": "RegEx Titre" },
   "urlRegex": { "message": "RegEx URL" },
   "titleRegexEditorAriaLabel": { "message": "Éditeur d'expression régulière du titre" },

--- a/src/components/Core/DomainRule/IdentityEditModal.tsx
+++ b/src/components/Core/DomainRule/IdentityEditModal.tsx
@@ -4,6 +4,7 @@ import type { FieldError } from 'react-hook-form';
 import { getMessage } from '@/utils/i18n';
 import { EditModalShell } from './EditModalShell';
 import { FormField } from '@/components/Form/FormFields';
+import { DomainCodeField } from '@/components/UI/DomainCodeField';
 import { CategoryRadioGroup } from '@/components/Core/DomainRule/CategoryRadioGroup';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
 import { createDomainFilterValidator } from '@/schemas/common';
@@ -122,17 +123,21 @@ export function IdentityEditModal({
     >
       <Flex direction="column" gap="4" mt="4">
         <FormField label={getMessage('domainFilter')} required error={domainError}>
-          {(fieldId) => (
-            <TextField.Root
-              id={fieldId}
-              name="domainFilter"
-              data-testid="modal-edit-identity-field-domain"
-              data-autofocus="true"
-              value={domainFilter}
-              onChange={(e) => handleDomainFilterChange(e.target.value)}
-              placeholder={getMessage('domainFilterPlaceholder')}
-              style={{ marginTop: '4px' }}
-            />
+          {(fieldId, errorId) => (
+            <div style={{ marginTop: '4px' }}>
+              <DomainCodeField
+                id={fieldId}
+                describedById={domainError ? errorId : undefined}
+                name="domainFilter"
+                testId="modal-edit-identity-field-domain"
+                focusOnMount
+                value={domainFilter}
+                onChange={handleDomainFilterChange}
+                placeholder={getMessage('domainFilterPlaceholder')}
+                ariaLabel={getMessage('domainFilterEditorAriaLabel')}
+                hasError={Boolean(domainError)}
+              />
+            </div>
           )}
         </FormField>
 

--- a/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, userEvent, expect } from 'storybook/test';
 import { RuleWizardModal } from './RuleWizardModal';
+import { setDomainFieldValue } from '@/components/UI/DomainCodeField';
 const action = (name: string) => (...args: unknown[]) => console.log(name, ...args);
 import type { DomainRule } from '@/schemas/domainRule';
 import type { AppSettings } from '@/types/syncSettings';
@@ -145,9 +146,8 @@ export const RuleWizardModalStep2: Story = {
     await userEvent.clear(labelInput);
     await userEvent.type(labelInput, 'GitHub');
 
-    const domainInput = body.getByTestId('wizard-rule-field-domain');
-    await userEvent.clear(domainInput);
-    await userEvent.type(domainInput, 'github.com');
+    // Domain filter is a CodeMirror editor (no <input>): drive it via the seam.
+    await setDomainFieldValue(canvasElement.ownerDocument.body, 'wizard-rule-field-domain', 'github.com');
 
     const nextBtn = body.getByTestId('wizard-rule-btn-next');
     await expect(nextBtn).not.toBeDisabled();

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -419,8 +419,12 @@ export function RuleWizardModal({
       fillHeight={!isEditing && step === 1}
       onOpenAutoFocus={(e) => {
         e.preventDefault();
-        const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[name="domainFilter"]');
-        input?.focus();
+        // The domain filter is a CodeMirror editor (no <input>): focus its
+        // contenteditable content node so step 1 still lands on the domain.
+        const content = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
+          '[data-testid="wizard-rule-field-domain"] .cm-content',
+        );
+        content?.focus();
       }}
     >
       <form onSubmit={handleSubmit(handleFormSubmit)} style={{ display: 'contents' }}>

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -12,6 +12,7 @@ import { getMessage } from '@/utils/i18n';
 import { FormField } from '@/components/Form/FormFields';
 import { CategoryRadioGroup } from '@/components/Core/DomainRule/CategoryRadioGroup';
 import { ChromeColorPicker } from '@/components/Core/TabTree/ChromeColorPicker';
+import { DomainCodeField } from '@/components/UI/DomainCodeField';
 import { deriveLabelFromDomain } from '@/utils/labelFromDomain';
 import type { DomainRule } from '@/schemas/domainRule';
 import type { ChromeGroupColor } from '@/types/tabTree';
@@ -52,19 +53,24 @@ export function WizardStep1Identity({ control, errors, setValue }: WizardStep1Id
         required={true}
         error={errors.domainFilter}
       >
-        {(fieldId) => (
+        {(fieldId, errorId) => (
           <Controller
             name="domainFilter"
             control={control}
             render={({ field }) => (
-              <TextField.Root
-                {...field}
-                id={fieldId}
-                data-testid="wizard-rule-field-domain"
-                name="domainFilter"
-                placeholder={getMessage('domainFilterPlaceholder')}
-                style={{ marginTop: '4px' }}
-              />
+              <div style={{ marginTop: '4px' }}>
+                <DomainCodeField
+                  id={fieldId}
+                  describedById={errors.domainFilter ? errorId : undefined}
+                  value={field.value ?? ''}
+                  onChange={field.onChange}
+                  name="domainFilter"
+                  testId="wizard-rule-field-domain"
+                  placeholder={getMessage('domainFilterPlaceholder')}
+                  ariaLabel={getMessage('domainFilterEditorAriaLabel')}
+                  hasError={Boolean(errors.domainFilter)}
+                />
+              </div>
             )}
           />
         )}

--- a/src/components/UI/DomainCodeField/DomainCodeField.stories.tsx
+++ b/src/components/UI/DomainCodeField/DomainCodeField.stories.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, expect, waitFor } from 'storybook/test';
+import { DomainCodeField } from './DomainCodeField';
+
+interface HarnessProps {
+  initialValue: string;
+  hasError?: boolean;
+}
+
+function DomainFieldHarness({ initialValue, hasError }: HarnessProps) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <div style={{ width: 360 }}>
+      <DomainCodeField
+        value={value}
+        onChange={setValue}
+        ariaLabel="Domain filter editor"
+        placeholder="e.g., atlassian.net"
+        hasError={hasError}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof DomainFieldHarness> = {
+  title: 'Components/UI/DomainCodeField',
+  component: DomainFieldHarness,
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DomainCodeFieldEmpty: Story = {
+  args: { initialValue: '' },
+  play: async ({ canvasElement }) => {
+    const field = within(canvasElement).getByTestId('domain-code-field');
+    await waitFor(() => expect(field.querySelector('.cm-content')).not.toBeNull());
+    const content = field.querySelector<HTMLElement>('.cm-content');
+    expect(content?.getAttribute('aria-label')).toBe('Domain filter editor');
+    expect(content?.getAttribute('spellcheck')).toBe('false');
+  },
+};
+
+export const DomainCodeFieldPlainDomain: Story = {
+  // Exercises subdomain + domain + tld + dot coloring.
+  args: { initialValue: 'mail.google.com' },
+};
+
+export const DomainCodeFieldSubdomainCompound: Story = {
+  // Compound public suffix (co.uk) plus a multi-label subdomain.
+  args: { initialValue: 'a.b.example.co.uk' },
+};
+
+export const DomainCodeFieldRegexValueNeutral: Story = {
+  // Not a plain domain: stays neutral (no coloring), no error.
+  args: { initialValue: 'github\\.com' },
+};
+
+export const DomainCodeFieldWithError: Story = {
+  args: { initialValue: 'example', hasError: true },
+  play: async ({ canvasElement }) => {
+    const field = within(canvasElement).getByTestId('domain-code-field');
+    await waitFor(() => {
+      expect(field.querySelector('.cm-content')?.getAttribute('aria-invalid')).toBe('true');
+    });
+  },
+};

--- a/src/components/UI/DomainCodeField/DomainCodeField.tsx
+++ b/src/components/UI/DomainCodeField/DomainCodeField.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef } from 'react';
+import { useTheme } from 'next-themes';
+import { Compartment, EditorState } from '@codemirror/state';
+import {
+  EditorView,
+  keymap,
+  drawSelection,
+  placeholder as placeholderExtension,
+} from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { domainHighlighter } from './domainHighlight';
+import { createDomainEditorTheme } from './cmDomainTheme';
+
+export interface DomainCodeFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Mirrors the wrapping `<label>` `htmlFor`; set on the editor content node. */
+  id?: string;
+  placeholder?: string;
+  /** Accessible name for the editing area (distinct from the visible label). */
+  ariaLabel: string;
+  /** Toggles `aria-invalid` on the content node when the field is in error. */
+  hasError?: boolean;
+  /** Error element id wired onto `aria-describedby` when an error is present. */
+  describedById?: string;
+  /** Forwarded onto the wrapper for parity with the former input `name`. */
+  name?: string;
+  /** Stable hook for tests / Page Objects. */
+  testId?: string;
+  /**
+   * When true, marks the content node with `[data-autofocus]` (so `DialogShell`
+   * focuses it on open) and focuses the editor on mount.
+   */
+  focusOnMount?: boolean;
+}
+
+/**
+ * Single-line CodeMirror editor that highlights a plain domain live while
+ * preserving the accessibility and theming contract of a Radix `TextField`.
+ *
+ * Twin of `RegexCodeField`: mounts the editor once and funnels reactive prop
+ * changes through dedicated effects and `Compartment`s. Newlines are rejected so
+ * the value stays a single-line domain. Coloring (subdomain / domain / tld /
+ * dots) is handled by {@link domainHighlighter}; values that are not plain
+ * domains stay rendered as neutral text.
+ */
+export function DomainCodeField({
+  value,
+  onChange,
+  id,
+  placeholder,
+  ariaLabel,
+  hasError = false,
+  describedById,
+  name,
+  testId = 'domain-code-field',
+  focusOnMount = false,
+}: DomainCodeFieldProps) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Props the mount-once setup reads without re-running.
+  const onChangeRef = useRef(onChange);
+  const valueRef = useRef(value);
+  const idRef = useRef(id);
+  const placeholderRef = useRef(placeholder);
+  const ariaLabelRef = useRef(ariaLabel);
+  const describedByRef = useRef(describedById);
+  const hasErrorRef = useRef(hasError);
+  const isDarkRef = useRef(isDark);
+  const focusOnMountRef = useRef(focusOnMount);
+
+  const themeCompartment = useRef(new Compartment());
+  const ariaCompartment = useRef(new Compartment());
+
+  onChangeRef.current = onChange;
+
+  // Create the editor once. Reactive updates flow through the effects below.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const state = EditorState.create({
+      doc: valueRef.current,
+      extensions: [
+        domainHighlighter,
+        history(),
+        drawSelection(),
+        // Keep the value single-line: drop any transaction adding a line break.
+        EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr)),
+        placeholderExtension(placeholderRef.current ?? ''),
+        EditorView.contentAttributes.of({
+          id: idRef.current ?? '',
+          'aria-label': ariaLabelRef.current,
+          'aria-describedby': describedByRef.current ?? '',
+          spellcheck: 'false',
+          autocapitalize: 'off',
+          autocorrect: 'off',
+          'data-1p-ignore': 'true',
+          ...(focusOnMountRef.current ? { 'data-autofocus': 'true' } : {}),
+        }),
+        ariaCompartment.current.of(
+          EditorView.contentAttributes.of({
+            'aria-invalid': hasErrorRef.current ? 'true' : 'false',
+          }),
+        ),
+        themeCompartment.current.of(createDomainEditorTheme(isDarkRef.current)),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+      ],
+    });
+
+    const view = new EditorView({ state, parent: containerRef.current });
+    viewRef.current = view;
+    // Make the (horizontally) scrollable viewport reachable by keyboard so a
+    // long domain can be scrolled without a pointer (axe scrollable-region).
+    view.scrollDOM.setAttribute('tabindex', '0');
+    if (focusOnMountRef.current) view.focus();
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Mount-once: subsequent prop changes are handled by the effects below.
+
+  }, []);
+
+  // Sync externally driven value changes (form reset, edit of another rule).
+  useEffect(() => {
+    valueRef.current = value;
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (value !== current) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
+
+  useEffect(() => {
+    hasErrorRef.current = hasError;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: ariaCompartment.current.reconfigure(
+          EditorView.contentAttributes.of({ 'aria-invalid': hasError ? 'true' : 'false' }),
+        ),
+      });
+    }
+  }, [hasError]);
+
+  useEffect(() => {
+    isDarkRef.current = isDark;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: themeCompartment.current.reconfigure(createDomainEditorTheme(isDark)),
+      });
+    }
+  }, [isDark]);
+
+  return <div ref={containerRef} data-testid={testId} data-name={name} />;
+}
+
+export default DomainCodeField;

--- a/src/components/UI/DomainCodeField/cmDomainTheme.ts
+++ b/src/components/UI/DomainCodeField/cmDomainTheme.ts
@@ -42,7 +42,9 @@ export function createDomainEditorTheme(isDark: boolean): Extension {
       },
       '.cm-line': { padding: '0' },
       '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
-      '.cm-placeholder': { color: 'var(--gray-a9)' },
+      // gray-a11 is the most muted gray that still meets WCAG AA (4.5:1) for
+      // text; gray-a9/a10 (Radix's default placeholder tone) fail axe contrast.
+      '.cm-placeholder': { color: 'var(--gray-a11)' },
       '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
       '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
       // Domain part colors.

--- a/src/components/UI/DomainCodeField/cmDomainTheme.ts
+++ b/src/components/UI/DomainCodeField/cmDomainTheme.ts
@@ -28,8 +28,9 @@ export function createDomainEditorTheme(isDark: boolean): Extension {
         outlineOffset: '-1px',
       },
       '.cm-scroller': {
-        fontFamily:
-          'var(--code-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)',
+        // A domain is not code: use the UI font (like the sibling Radix
+        // TextField) so dots are not spaced out by monospace cells.
+        fontFamily: 'var(--default-font-family, system-ui, sans-serif)',
         lineHeight: '1.5',
         alignItems: 'center',
         overflowX: 'auto',

--- a/src/components/UI/DomainCodeField/cmDomainTheme.ts
+++ b/src/components/UI/DomainCodeField/cmDomainTheme.ts
@@ -32,13 +32,15 @@ export function createDomainEditorTheme(isDark: boolean): Extension {
         // TextField) so dots are not spaced out by monospace cells.
         fontFamily: 'var(--default-font-family, system-ui, sans-serif)',
         lineHeight: '1.5',
+        // Hold the size-2 input height here (not on .cm-content) so the single
+        // line is vertically centered by alignItems instead of pinned to top.
+        minHeight: '28px',
         alignItems: 'center',
         overflowX: 'auto',
       },
-      // Single editing line, vertically centered, matching a Radix size-2 input.
+      // Single editing line, vertically centered by the scroller above.
       '.cm-content': {
         padding: '0 var(--space-2)',
-        minHeight: '28px',
         caretColor: 'var(--gray-12)',
       },
       '.cm-line': { padding: '0' },

--- a/src/components/UI/DomainCodeField/cmDomainTheme.ts
+++ b/src/components/UI/DomainCodeField/cmDomainTheme.ts
@@ -1,0 +1,56 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+/**
+ * Single-line editor chrome for the domain field. Mirrors the visible look of a
+ * Radix `TextField` (size 2), exactly like `cmRegexTheme.ts`, and adds the four
+ * domain-part colors. Every color is a Radix token so the field follows the
+ * active accent and flips automatically between light and dark appearances.
+ *
+ * Part colors:
+ * - subdomain: muted (it is optional / less significant)
+ * - domain: accent + medium weight (the meaningful part)
+ * - tld (extension): a distinct stable hue
+ * - dot: discreet separators
+ */
+export function createDomainEditorTheme(isDark: boolean): Extension {
+  return EditorView.theme(
+    {
+      '&': {
+        color: 'var(--gray-12)',
+        backgroundColor: 'var(--color-surface)',
+        fontSize: 'var(--font-size-2)',
+        border: '1px solid var(--gray-a7)',
+        borderRadius: 'var(--radius-3)',
+      },
+      '&.cm-focused': {
+        outline: '2px solid var(--accent-8)',
+        outlineOffset: '-1px',
+      },
+      '.cm-scroller': {
+        fontFamily:
+          'var(--code-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)',
+        lineHeight: '1.5',
+        alignItems: 'center',
+        overflowX: 'auto',
+      },
+      // Single editing line, vertically centered, matching a Radix size-2 input.
+      '.cm-content': {
+        padding: '0 var(--space-2)',
+        minHeight: '28px',
+        caretColor: 'var(--gray-12)',
+      },
+      '.cm-line': { padding: '0' },
+      '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
+      '.cm-placeholder': { color: 'var(--gray-a9)' },
+      '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
+      '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
+      // Domain part colors.
+      '.cm-domain-subdomain': { color: 'var(--gray-a11)' },
+      '.cm-domain-domain': { color: 'var(--accent-11)', fontWeight: '500' },
+      '.cm-domain-tld': { color: 'var(--jade-11)' },
+      '.cm-domain-dot': { color: 'var(--gray-a8)' },
+    },
+    { dark: isDark },
+  );
+}

--- a/src/components/UI/DomainCodeField/domainHighlight.ts
+++ b/src/components/UI/DomainCodeField/domainHighlight.ts
@@ -1,0 +1,54 @@
+import { RangeSetBuilder } from '@codemirror/state';
+import {
+  Decoration,
+  ViewPlugin,
+  type DecorationSet,
+  type EditorView,
+  type ViewUpdate,
+} from '@codemirror/view';
+import { splitDomainParts, type DomainPartKind } from '@/utils/domainParts';
+
+/**
+ * Mark decoration per domain part. The classes are styled in `cmDomainTheme.ts`
+ * with Radix tokens, so colors follow the active accent and appearance.
+ */
+const DOMAIN_PART_MARK: Record<DomainPartKind, Decoration> = {
+  subdomain: Decoration.mark({ class: 'cm-domain-subdomain' }),
+  domain: Decoration.mark({ class: 'cm-domain-domain' }),
+  tld: Decoration.mark({ class: 'cm-domain-tld' }),
+  dot: Decoration.mark({ class: 'cm-domain-dot' }),
+};
+
+/** Build the decoration set for the single document line (the domain value). */
+function buildDecorations(view: EditorView): DecorationSet {
+  const value = view.state.doc.toString();
+  const parts = splitDomainParts(value); // [] when not a plain domain -> neutral text
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const part of parts) {
+    builder.add(part.from, part.to, DOMAIN_PART_MARK[part.kind]);
+  }
+  return builder.finish();
+}
+
+/**
+ * View plugin that colorizes a plain domain (subdomain / domain / tld / dots)
+ * live as it is typed. Regex-like or unrecognized values yield no decorations
+ * and stay rendered as neutral text. Single line, so a full rebuild on every
+ * document change is cheap.
+ */
+export const domainHighlighter = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);

--- a/src/components/UI/DomainCodeField/index.ts
+++ b/src/components/UI/DomainCodeField/index.ts
@@ -1,0 +1,3 @@
+export { DomainCodeField, type DomainCodeFieldProps } from './DomainCodeField';
+export { setDomainFieldValue, waitForDomainField } from './setDomainFieldValue';
+export { domainHighlighter } from './domainHighlight';

--- a/src/components/UI/DomainCodeField/setDomainFieldValue.ts
+++ b/src/components/UI/DomainCodeField/setDomainFieldValue.ts
@@ -1,0 +1,9 @@
+/**
+ * Test seam for driving the lazily mounted {@link DomainCodeField}. The domain
+ * editor shares CodeMirror's no-`<input>` shape with `RegexCodeField`, so it
+ * reuses the same generic seam (it operates purely by `data-testid`).
+ */
+export {
+  setRegexFieldValue as setDomainFieldValue,
+  waitForRegexField as waitForDomainField,
+} from '@/components/UI/RegexCodeField/setRegexFieldValue';

--- a/src/utils/domainParts.ts
+++ b/src/utils/domainParts.ts
@@ -1,0 +1,91 @@
+import { SECOND_LEVEL_PUBLIC_SUFFIXES } from './labelFromDomain';
+
+/**
+ * Plain domain shape accepted by the domain filter field: at least two
+ * dot-separated labels, no trailing dot. Deliberately mirrors the regex used by
+ * `createDomainFilterValidator` (`src/schemas/common.ts`); kept as a local copy
+ * so the highlighter never has to import (and risk coupling to) the validator.
+ */
+const PLAIN_DOMAIN_REGEX =
+  /^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)+$/;
+
+/** Kind of a highlighted slice of a plain domain. */
+export type DomainPartKind = 'subdomain' | 'domain' | 'tld' | 'dot';
+
+/** A character range `[from, to)` of the input string with its semantic role. */
+export interface DomainPart {
+  from: number;
+  to: number;
+  kind: DomainPartKind;
+}
+
+/**
+ * True when `value` is a plain domain the field can colorize: `localhost` or a
+ * dotted hostname (`example.com`, `mail.google.com`). Regex-like or otherwise
+ * unrecognized values return false so they stay rendered as neutral text.
+ */
+export function isPlainDomain(value: string): boolean {
+  if (value === 'localhost') return true;
+  if (value.endsWith('.')) return false;
+  return PLAIN_DOMAIN_REGEX.test(value);
+}
+
+/**
+ * Split a plain domain into colorizable parts (subdomain / domain / tld / dots).
+ *
+ * Classification is anchored on the END of the hostname: the last label is the
+ * extension, unless the last two labels form a known compound public suffix
+ * (e.g. `co.uk`) in which case both are the extension. The label immediately
+ * before the extension is the domain; anything before that is the subdomain.
+ * `localhost` (single label) is treated as a bare domain.
+ *
+ * Returns an empty array when `value` is not a plain domain, so callers render
+ * it as neutral text.
+ */
+export function splitDomainParts(value: string): DomainPart[] {
+  if (!isPlainDomain(value)) return [];
+
+  // Collect label ranges and dot ranges in a single left-to-right pass so the
+  // offsets map exactly onto the original string (no trim, no normalization).
+  const labels: { from: number; to: number }[] = [];
+  const dots: number[] = [];
+  let labelStart = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] === '.') {
+      labels.push({ from: labelStart, to: i });
+      dots.push(i);
+      labelStart = i + 1;
+    }
+  }
+  labels.push({ from: labelStart, to: value.length });
+
+  // Determine how many trailing labels make up the extension.
+  let tldCount = 1;
+  if (
+    labels.length >= 3 &&
+    SECOND_LEVEL_PUBLIC_SUFFIXES.has(value.slice(labels[labels.length - 2].from, labels[labels.length - 2].to))
+  ) {
+    tldCount = 2;
+  }
+
+  const tldStartIndex = labels.length - tldCount;
+  const domainIndex = tldStartIndex - 1; // -1 when only the extension is present
+
+  const parts: DomainPart[] = labels.map((label, index) => {
+    let kind: DomainPartKind;
+    // A single-label host (e.g. `localhost`) is the domain, not an extension.
+    if (labels.length === 1) kind = 'domain';
+    else if (index >= tldStartIndex) kind = 'tld';
+    else if (index === domainIndex) kind = 'domain';
+    else kind = 'subdomain';
+    return { from: label.from, to: label.to, kind };
+  });
+
+  for (const at of dots) {
+    parts.push({ from: at, to: at + 1, kind: 'dot' });
+  }
+
+  // CodeMirror's RangeSetBuilder requires ranges sorted by start offset.
+  parts.sort((a, b) => a.from - b.from);
+  return parts;
+}

--- a/src/utils/labelFromDomain.ts
+++ b/src/utils/labelFromDomain.ts
@@ -1,6 +1,6 @@
 const COMMON_SUBDOMAINS = new Set(['www', 'mail', 'app', 'm', 'web', 'api', 'static', 'cdn']);
 
-const SECOND_LEVEL_PUBLIC_SUFFIXES = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac']);
+export const SECOND_LEVEL_PUBLIC_SUFFIXES = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac']);
 
 const REGEX_SPECIAL_CHARS = /[*+?^${}()|[\]\\]/;
 

--- a/tests/e2e/dialog-initial-focus.spec.ts
+++ b/tests/e2e/dialog-initial-focus.spec.ts
@@ -44,8 +44,11 @@ test.describe('[US-A11Y001] Rule creation wizard', () => {
     await page.getByTestId('page-rules-btn-add').click();
     await page.getByTestId('wizard-rule').waitFor({ state: 'visible' });
 
-    // Domain filter input must have focus (label is auto-derived from it).
-    await expect(page.getByTestId('wizard-rule-field-domain')).toBeFocused();
+    // Domain filter editor must have focus (label is auto-derived from it).
+    // It is a CodeMirror editor, so focus lands on its contenteditable node.
+    await expect(
+      page.getByTestId('wizard-rule-field-domain').locator('.cm-content'),
+    ).toBeFocused();
     // Close button must NOT have focus
     expect(await isCloseFocused(page)).toBe(false);
 

--- a/tests/e2e/domain-rules.spec.ts
+++ b/tests/e2e/domain-rules.spec.ts
@@ -133,7 +133,10 @@ test.describe('Edit rule via dropdown', () => {
     await dialog.getByRole('button', { name: /modify/i }).first().click();
     const identityModal = page.getByTestId('modal-edit-identity');
     await expect(identityModal.getByTestId('modal-edit-identity-field-label')).toHaveValue('Notion');
-    await expect(identityModal.getByTestId('modal-edit-identity-field-domain')).toHaveValue('notion.so');
+    // CodeMirror editor has no form value: assert its rendered text instead.
+    await expect(
+      identityModal.getByTestId('modal-edit-identity-field-domain').locator('.cm-content'),
+    ).toHaveText('notion.so');
     await page.close();
   });
 });

--- a/tests/e2e/rule-wizard.spec.ts
+++ b/tests/e2e/rule-wizard.spec.ts
@@ -241,7 +241,8 @@ test.describe('Creation wizard — Step 2: Configuration', () => {
     await wizard.clickBack();
 
     await expect(wizard.labelInput()).toHaveValue('Preserved Label');
-    await expect(wizard.domainFilterInput()).toHaveValue('preserved.com');
+    // CodeMirror editor has no form value: assert its rendered text instead.
+    await expect(wizard.domainFilterInput().locator('.cm-content')).toHaveText('preserved.com');
     await page.close();
   });
 });

--- a/tests/utils/domainParts.test.ts
+++ b/tests/utils/domainParts.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { isPlainDomain, splitDomainParts, type DomainPart } from '../../src/utils/domainParts';
+
+/** Helper: map parts to a compact `{ text, kind }[]` for readable assertions. */
+function annotate(value: string): { text: string; kind: DomainPart['kind'] }[] {
+  return splitDomainParts(value).map((p) => ({ text: value.slice(p.from, p.to), kind: p.kind }));
+}
+
+describe('isPlainDomain', () => {
+  it('accepts localhost and dotted hostnames', () => {
+    expect(isPlainDomain('localhost')).toBe(true);
+    expect(isPlainDomain('example.com')).toBe(true);
+    expect(isPlainDomain('mail.google.com')).toBe(true);
+  });
+
+  it('rejects regex-like, bare, or trailing-dot values', () => {
+    expect(isPlainDomain('github\\.com')).toBe(false);
+    expect(isPlainDomain('^.*\\.foo\\.com$')).toBe(false);
+    expect(isPlainDomain('example')).toBe(false);
+    expect(isPlainDomain('example.com.')).toBe(false);
+    expect(isPlainDomain('')).toBe(false);
+  });
+});
+
+describe('splitDomainParts', () => {
+  it('returns empty for non-plain-domain values', () => {
+    expect(splitDomainParts('github\\.com')).toEqual([]);
+    expect(splitDomainParts('example')).toEqual([]);
+  });
+
+  it('classifies a simple domain (domain + tld + dot)', () => {
+    expect(annotate('example.com')).toEqual([
+      { text: 'example', kind: 'domain' },
+      { text: '.', kind: 'dot' },
+      { text: 'com', kind: 'tld' },
+    ]);
+  });
+
+  it('classifies a subdomain', () => {
+    expect(annotate('mail.google.com')).toEqual([
+      { text: 'mail', kind: 'subdomain' },
+      { text: '.', kind: 'dot' },
+      { text: 'google', kind: 'domain' },
+      { text: '.', kind: 'dot' },
+      { text: 'com', kind: 'tld' },
+    ]);
+  });
+
+  it('treats a compound public suffix (co.uk) as the extension', () => {
+    expect(annotate('a.b.example.co.uk')).toEqual([
+      { text: 'a', kind: 'subdomain' },
+      { text: '.', kind: 'dot' },
+      { text: 'b', kind: 'subdomain' },
+      { text: '.', kind: 'dot' },
+      { text: 'example', kind: 'domain' },
+      { text: '.', kind: 'dot' },
+      { text: 'co', kind: 'tld' },
+      { text: '.', kind: 'dot' },
+      { text: 'uk', kind: 'tld' },
+    ]);
+  });
+
+  it('treats a single-label host (localhost) as the domain', () => {
+    expect(annotate('localhost')).toEqual([{ text: 'localhost', kind: 'domain' }]);
+  });
+});


### PR DESCRIPTION
Replace the plain TextField of the domain filter with a CodeMirror
editor (DomainCodeField), twin of RegexCodeField, that colorizes a plain
domain live: subdomain (muted), domain (accent), extension/TLD and dots
each get a distinct Radix-token color. Values that are not plain domains
(regex, partials) stay neutral, no error added. The domain filter
contract is unchanged: createDomainFilterValidator is left untouched.

- new util splitDomainParts / isPlainDomain (heuristic, reuses the
  SECOND_LEVEL_PUBLIC_SUFFIXES set from labelFromDomain)
- new UI component DomainCodeField (highlighter ViewPlugin + Radix theme
  + focusOnMount + test seam + Storybook stories)
- wire it into WizardStep1Identity and IdentityEditModal
- fix initial focus: the wizard and DialogShell now target the
  contenteditable .cm-content instead of an <input>
- add domainFilterEditorAriaLabel in en/fr/es
- adapt Page Objects and specs that drove the field as an <input>

https://claude.ai/code/session_01G2kD7d3FRdcMhPzP3W5aL7