### PR TITLE
fix(shortcuts): replace conflicting global keyboard shortcuts

### DIFF
--- a/docs/src/content/docs/en/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/en/reference/raccourcis-clavier.mdx
@@ -118,7 +118,7 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 
 | Shortcut | Action |
 | --- | --- |
-| `Alt + Shift + O` | Organize all tabs |
-| `Alt + Shift + S` | Save current window as a session |
-| `Alt + Shift + P` | Open the extension popup |
+| Not set | Organize all tabs |
+| Not set | Save current window as a session |
+| `Ctrl + Shift + 1` | Open the extension popup |
 

--- a/docs/src/content/docs/es/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/es/reference/raccourcis-clavier.mdx
@@ -118,7 +118,7 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 
 | Atajo | Acción |
 | --- | --- |
-| `Alt + Shift + O` | Organizar todas las pestañas |
-| `Alt + Shift + S` | Guardar la ventana como sesión |
-| `Alt + Shift + P` | Abrir el popup de la extensión |
+| Sin definir | Organizar todas las pestañas |
+| Sin definir | Guardar la ventana como sesión |
+| `Ctrl + Shift + 1` | Abrir el popup de la extensión |
 

--- a/docs/src/content/docs/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/reference/raccourcis-clavier.mdx
@@ -118,7 +118,7 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 
 | Raccourci | Action |
 | --- | --- |
-| `Alt + Shift + O` | Organiser tous les onglets |
-| `Alt + Shift + S` | Enregistrer la fenêtre comme session |
-| `Alt + Shift + P` | Ouvrir la popup de l'extension |
+| Non défini | Organiser tous les onglets |
+| Non défini | Enregistrer la fenêtre comme session |
+| `Ctrl + Shift + 1` | Ouvrir la popup de l'extension |
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -913,7 +913,7 @@
   "homepageTipsT37Title": { "message": "Express popup actions" },
   "homepageTipsT37Text": { "message": "A single key: s saves, r restores, o organizes, p opens the options page." },
   "homepageTipsT38Title": { "message": "Browser-wide shortcuts" },
-  "homepageTipsT38Text": { "message": "Alt+Shift+O organizes without opening the popup. Alt+Shift+S captures the current window. Customizable in chrome://extensions/shortcuts." },
+  "homepageTipsT38Text": { "message": "Ctrl+Shift+1 opens the popup; from there press O to organize or S to save the current window. Assign your own shortcuts in chrome://extensions/shortcuts." },
   "homepageTipsT39Title": { "message": "Instant search" },
   "homepageTipsT39Text": { "message": "Press / to focus the search bar of a list. Esc clears it." },
   "homepageTipsT40Title": { "message": "Clickable counters" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -914,7 +914,7 @@
   "homepageTipsT37Title": { "message": "Acciones rápidas desde el popup" },
   "homepageTipsT37Text": { "message": "Una sola tecla: s guarda, r restaura, o organiza, p abre las opciones." },
   "homepageTipsT38Title": { "message": "Atajos globales del navegador" },
-  "homepageTipsT38Text": { "message": "Alt+Shift+O organiza sin abrir el popup. Alt+Shift+S captura la ventana actual. Personalizables en chrome://extensions/shortcuts." },
+  "homepageTipsT38Text": { "message": "Ctrl+Shift+1 abre el popup; desde ahí pulsa O para organizar o S para guardar la ventana actual. Asigna tus propios atajos en chrome://extensions/shortcuts." },
   "homepageTipsT39Title": { "message": "Búsqueda instantánea" },
   "homepageTipsT39Text": { "message": "Pulsa / para enfocar la barra de búsqueda de una lista. Esc la vacía." },
   "homepageTipsT40Title": { "message": "Contadores clicables" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -914,7 +914,7 @@
   "homepageTipsT37Title": { "message": "Actions express depuis le popup" },
   "homepageTipsT37Text": { "message": "Une seule touche : s sauvegarde, r restaure, o organise, p ouvre les options." },
   "homepageTipsT38Title": { "message": "Raccourcis globaux navigateur" },
-  "homepageTipsT38Text": { "message": "Alt+Shift+O organise sans ouvrir le popup. Alt+Shift+S capture la fenêtre courante. Personnalisables dans chrome://extensions/shortcuts." },
+  "homepageTipsT38Text": { "message": "Ctrl+Shift+1 ouvre le popup ; ensuite, appuyez sur O pour organiser ou S pour enregistrer la fenêtre courante. Attribuez vos propres raccourcis dans chrome://extensions/shortcuts." },
   "homepageTipsT39Title": { "message": "Recherche instantanée" },
   "homepageTipsT39Text": { "message": "Tape / pour mettre le focus dans la barre de recherche d'une liste. Échap pour la vider." },
   "homepageTipsT40Title": { "message": "Compteurs cliquables" },

--- a/scripts/generate-shortcuts-doc.mjs
+++ b/scripts/generate-shortcuts-doc.mjs
@@ -85,7 +85,12 @@ function renderGroupTable(groupId, t, locale) {
     `| --- | --- |\n`;
   const rows = entries
     .map((entry) => {
-      const combo = escapeTableCell(formatBindings(entry.defaultBindings, locale));
+      // Commands assignable by the user but shipped without a default key
+      // (empty bindings) are surfaced as "not set" rather than a blank cell.
+      const combo =
+        entry.defaultBindings.length === 0
+          ? escapeTableCell(t('shortcutNotSet'))
+          : escapeTableCell(formatBindings(entry.defaultBindings, locale));
       const action = escapeTableCell(t(entry.descriptionKey));
       return `| ${combo} | ${action} |`;
     })

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -11,10 +11,16 @@ import type { ShortcutEntry, ShortcutGroupId, ShortcutScope } from './types';
 export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
   // Browser-wide commands declared in the manifest. Bindings shown in the panel
   // come from `browser.commands.getAll()`, not from `defaultBindings` (those
-  // serve as documentation and Storybook fallback).
+  // serve as documentation and Storybook fallback). Only the popup ships a
+  // default (`Ctrl+Shift+1`); organize/save have no default binding because
+  // every letter combo clashes with a browser built-in (Firefox treats
+  // `Alt+Shift+<letter>` as the page accesskey modifier, and most
+  // `Ctrl+Shift+<letter>` are Firefox built-ins). They stay assignable by the
+  // user via chrome://extensions/shortcuts, and are reachable from the popup
+  // (`popup.organize` = o, `popup.save` = s).
   'global.organize': {
     id: 'global.organize',
-    defaultBindings: ['Alt+Shift+O'],
+    defaultBindings: [],
     descriptionKey: 'shortcutDescOrganize',
     group: 'global',
     scope: 'global',
@@ -22,7 +28,7 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
   },
   'global.saveSession': {
     id: 'global.saveSession',
-    defaultBindings: ['Alt+Shift+S'],
+    defaultBindings: [],
     descriptionKey: 'shortcutDescSaveSession',
     group: 'global',
     scope: 'global',
@@ -30,7 +36,7 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
   },
   'global.openPopup': {
     id: 'global.openPopup',
-    defaultBindings: ['Alt+Shift+P'],
+    defaultBindings: ['Ctrl+Shift+1'],
     descriptionKey: 'shortcutDescOpenPopup',
     group: 'global',
     scope: 'global',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -91,16 +91,24 @@ export default defineConfig({
     permissions: ['tabs', 'tabGroups', 'storage', 'notifications'],
     host_permissions: ['<all_urls>'],
     commands: {
+      // `organize-all-tabs` and `save-current-window-session` ship without a
+      // `suggested_key` on purpose. Any letter-based default clashes with
+      // built-in browser bindings: on Firefox `Alt+Shift+<letter>` is the
+      // web-page accesskey modifier (silently shadowed by pages), and almost
+      // every `Ctrl+Shift+<letter>` is already a Firefox built-in. These two
+      // stay assignable by the user via chrome://extensions/shortcuts; day to
+      // day they are reachable from the popup (open it, then press O / S).
       'organize-all-tabs': {
-        suggested_key: { default: 'Alt+Shift+O' },
         description: '__MSG_cmdOrganizeAllTabs__',
       },
       'save-current-window-session': {
-        suggested_key: { default: 'Alt+Shift+S' },
         description: '__MSG_cmdSaveSession__',
       },
+      // Single global default: a digit combo avoids the letter conflicts above
+      // and is free on Chrome and Firefox (Ctrl+Shift+digit is unbound; plain
+      // Ctrl+1..8 selects tabs). On macOS Cmd+Shift+1 is not OS-reserved.
       _execute_action: {
-        suggested_key: { default: 'Alt+Shift+P' },
+        suggested_key: { default: 'Ctrl+Shift+1' },
       },
     },
     action: {


### PR DESCRIPTION
The three browser-wide commands used Alt+Shift defaults that clash with
built-in browser bindings, so they only worked partially. On Firefox
Alt+Shift is the web-page accesskey modifier, so Alt+Shift+<letter> is
shadowed by any page exposing that accesskey; Alt+Shift+S also hit a
Firefox History binding. Nearly every Ctrl+Shift+<letter> is already a
Firefox built-in too.

Reduce to a single memorable global default and rely on the popup for
the rest:

- _execute_action (open popup): Ctrl+Shift+1 (free on Chrome and Firefox,
  no macOS conflict).
- organize-all-tabs and save-current-window-session: keep declared but
  ship no suggested_key. They stay assignable via the browser's shortcut
  settings, and are reachable from the popup (press O / S, which already
  exist as popup-scope shortcuts).

The help panel already renders unbound commands as "Not set" with a
warning banner. Updated the docs generator to do the same for empty
default bindings, refreshed the generated shortcut reference pages, and
reworded the homepage tip in all three locales.