### PR TITLE
build: raise chunkSizeWarningLimit to silence CodeMirror chunk warning

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -155,11 +155,15 @@ export default defineConfig({
     },
     build: {
       emptyOutDir: true,
+      // JsonCodeEditor (CodeMirror + codemirror-json-schema) is already lazy-loaded
+      // and only imported when the import wizard is opened. Extension chunks are
+      // served locally so network cost does not apply; suppress the warning.
+      chunkSizeWarningLimit: 600,
       rollupOptions: {
         output: {
           assetFileNames: 'assets/[name].[hash].[ext]',
           chunkFileNames: 'chunks/[name].[hash].js',
-          entryFileNames: 'chunks/[name].[hash].js'
+          entryFileNames: 'chunks/[name].[hash].js',
         }
       }
     },


### PR DESCRIPTION
JsonCodeEditor (CodeMirror + codemirror-json-schema, ~551 kB) is already
lazy-loaded behind React.lazy: it is only fetched when the user opens the
import wizard. Extension chunks are served from the local filesystem, so
the 500 kB network heuristic does not apply. Raising the limit to 600 kB
suppresses the spurious warning without touching the actual bundle graph.

manualChunks is not usable here because WXT/Rolldown disables codeSplitting
for the background service worker build, which makes the option illegal.

https://claude.ai/code/session_016W16HxjtNLbrPMTCdbqMeU