### PR TITLE
feat(popup): focus initial sur la premiere session epinglee ou le bouton Organiser

### DIFF
--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -89,7 +89,14 @@ async function openRefreshFromPopup(session: Session) {
   await openSessionsPage(suffix);
 }
 
-export function PopupProfilesList() {
+export interface PopupProfilesListProps {
+  /** When true, focus the first pinned session card once sessions have loaded. */
+  autoFocusFirstPinned?: boolean;
+  /** Called once after sessions load, reporting whether any pinned session exists. */
+  onLoaded?: (hasPinned: boolean) => void;
+}
+
+export function PopupProfilesList({ autoFocusFirstPinned, onLoaded }: PopupProfilesListProps = {}) {
   const { scopedItems } = useActiveWorkspaceContext();
   const popupPinnedEmptyCollapsedItem = scopedItems.popupPinnedEmptyCollapsedItem;
   const [pinnedSessions, setPinnedSessions] = useState<Session[]>([]);
@@ -97,6 +104,7 @@ export function PopupProfilesList() {
   const [loaded, setLoaded] = useState(false);
   const [emptyCollapsed, setEmptyCollapsed] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const initialFocusAppliedRef = useRef(false);
 
   useEffect(() => {
     Promise.all([loadPinnedSessions(), loadActiveSessions()]).then(([pinned, active]) => {
@@ -106,6 +114,22 @@ export function PopupProfilesList() {
     });
     popupPinnedEmptyCollapsedItem.getValue().then((v) => setEmptyCollapsed(v ?? false));
   }, [popupPinnedEmptyCollapsedItem]);
+
+  // Initial focus orchestration: once sessions have loaded, focus the first
+  // pinned card here (we own its DOM) and report `hasPinned` so the parent can
+  // fall back to the "Organize" button when there is no pinned session. Guarded
+  // to run only once, so later re-renders never steal focus from the user.
+  useEffect(() => {
+    if (!loaded || initialFocusAppliedRef.current) return;
+    initialFocusAppliedRef.current = true;
+    const hasPinned = pinnedSessions.length > 0;
+    if (autoFocusFirstPinned && hasPinned) {
+      listRef.current
+        ?.querySelector<HTMLElement>('[data-popup-pinned-card]')
+        ?.focus();
+    }
+    onLoaded?.(hasPinned);
+  }, [loaded, pinnedSessions, autoFocusFirstPinned, onLoaded]);
 
   const handleRestore = useCallback((session: Session, target: RestoreTarget) => {
     // The popup is not a tab, so browser.tabs.getCurrent() returns undefined,

--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, type Ref } from 'react';
 import { Flex, Kbd, Tooltip } from '@radix-ui/themes';
 import { browser } from 'wxt/browser';
 import { Camera, RotateCcw, Wand2 } from 'lucide-react';
@@ -16,6 +16,8 @@ export interface PopupToolbarProps {
   canSave?: boolean;
   isOrganizing?: boolean;
   activeTabGroupId?: number | null;
+  /** Ref forwarded to the "Organize tabs" button so the popup can manage initial focus. */
+  organizeButtonRef?: Ref<HTMLButtonElement>;
 }
 
 function withTooltip(content: React.ReactNode, node: React.ReactElement) {
@@ -126,6 +128,7 @@ export function PopupToolbar(props: PopupToolbarProps = {}) {
   return (
     <div data-testid="popup-toolbar" className={styles.toolbar}>
       <button
+        ref={props.organizeButtonRef}
         type="button"
         data-testid="popup-toolbar-btn-organize"
         className={styles.hero}

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Box, Flex, Separator, Theme } from '@radix-ui/themes';
@@ -25,6 +25,17 @@ export function PopupContent() {
   const { settings, isLoaded, setGlobalGroupingEnabled, setGlobalDeduplicationEnabled } = useSettings();
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const openShortcuts = useCallback(() => setShortcutsOpen(true), []);
+
+  // Initial focus: land on the first pinned session card when one exists, and
+  // fall back to the "Organize tabs" button otherwise. PopupProfilesList focuses
+  // its own first card and reports `hasPinned` here once sessions have loaded.
+  const organizeButtonRef = useRef<HTMLButtonElement>(null);
+  const initialFocusDoneRef = useRef(false);
+  const handleProfilesLoaded = useCallback((hasPinned: boolean) => {
+    if (initialFocusDoneRef.current) return;
+    initialFocusDoneRef.current = true;
+    if (!hasPinned) organizeButtonRef.current?.focus();
+  }, []);
 
   const openOptionsPage = useCallback(() => {
     browser.runtime.openOptionsPage();
@@ -77,7 +88,7 @@ export function PopupContent() {
         <Flex gap="3" direction="column" width="100%">
           <PopupHeader title={getMessage('popupTitle')} onSettingsOpen={openOptionsPage} />
 
-          <PopupToolbar />
+          <PopupToolbar organizeButtonRef={organizeButtonRef} />
 
           <PopupWorkspaceSwitcher onManage={handleManageWorkspaces} />
 
@@ -90,7 +101,7 @@ export function PopupContent() {
             />
           ) : null}
 
-          <PopupProfilesList />
+          <PopupProfilesList autoFocusFirstPinned onLoaded={handleProfilesLoaded} />
 
           {hasRules ? (
             <>


### PR DESCRIPTION
Au montage de la popup, le focus se posait selon l'ordre de tabulation
naturel du navigateur. On le rend deterministe :

- s'il existe au moins une session epinglee, le focus va sur la premiere
  carte epinglee (PopupProfilesList focalise le DOM qu'il possede) ;
- sinon, le focus va sur le bouton "Organiser les onglets".

La decision est orchestree dans PopupContent : PopupToolbar recoit un ref
vers le bouton organize, et PopupProfilesList remonte hasPinned une fois
les sessions chargees. Un garde garantit que le focus initial n'est
applique qu'une seule fois et ne vole jamais le focus a l'utilisateur.

https://claude.ai/code/session_012z1TqPdUN8bFm9SRHjLLvB