### PR TITLE
fix(shortcuts): keep popup o/s/p active when a pinned card is focused

### DIFF
--- a/src/components/UI/PopupToolbar/PopupToolbar.tsx
+++ b/src/components/UI/PopupToolbar/PopupToolbar.tsx
@@ -6,6 +6,7 @@ import { getMessage, getPluralMessage } from '@/utils/i18n';
 import { loadActiveSessions, loadPinnedSessions } from '@/utils/sessionStorage';
 import { getActiveTabGroupId, hasCapturableTabs } from '@/utils/tabCapture';
 import { openOptionsWithHash } from '@/utils/openOptions';
+import { buildSnapshotHash } from '@/utils/snapshotHash';
 import { useSettings } from '@/hooks/useSettings';
 import styles from './PopupToolbar.module.css';
 
@@ -70,9 +71,7 @@ export function PopupToolbar(props: PopupToolbarProps = {}) {
   const restoreDisabledHint = !hasSessions ? getMessage('popupRestoreDisabledHint') : undefined;
 
   const isInGroup = activeTabGroupId !== null && canSave;
-  const saveHash = isInGroup
-    ? `#sessions?action=snapshot&groupId=${activeTabGroupId}`
-    : '#sessions?action=snapshot';
+  const saveHash = buildSnapshotHash(isInGroup ? activeTabGroupId : null);
   const saveAriaLabel = isInGroup
     ? getMessage('popupSaveActiveGroup')
     : getMessage('popupSaveSession');

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -23,7 +23,6 @@ import { getEffectiveBindings } from '@/shortcuts/getEffectiveBindings';
 import { SHORTCUTS_REGISTRY } from '@/shortcuts/registry';
 import type { Binding, ShortcutEntry, ShortcutScope } from '@/shortcuts/types';
 import {
-  WIDGET_SCOPE_SELECTOR,
   isDialogOpen,
   isSequencePrefix,
   isTypingTarget,
@@ -49,6 +48,26 @@ export interface UseShortcutsOptions {
 
 const DEFAULT_SEQUENCE_TIMEOUT_MS = 1500;
 
+/**
+ * Module-level registry of "claim checkers" contributed by every mounted
+ * `widget:*` hook. A checker reports whether its widget would handle a given
+ * event (focus on the matching scope element AND one of its registered
+ * bindings matches the combo). Page-level entries flagged
+ * `excludeIfInsideWidget` consult these so they only yield the combos a
+ * focused widget actually owns: pressing `r` on a pinned card belongs to the
+ * card (`sessionCard.restore.*`), but `o`/`s`/`p`, which no card claims, keep
+ * firing the popup-level action instead of being swallowed.
+ */
+type WidgetClaimChecker = (event: KeyboardEvent) => boolean;
+const widgetClaimCheckers = new Set<WidgetClaimChecker>();
+
+function anyWidgetClaims(event: KeyboardEvent): boolean {
+  for (const check of widgetClaimCheckers) {
+    if (check(event)) return true;
+  }
+  return false;
+}
+
 function entryScopeFilter(entry: ShortcutEntry, event: KeyboardEvent): boolean {
   if (entry.scope.startsWith('widget:')) {
     if (!(event.target instanceof Element)) return false;
@@ -56,7 +75,7 @@ function entryScopeFilter(entry: ShortcutEntry, event: KeyboardEvent): boolean {
     return true;
   }
   if (entry.excludeIfInsideWidget && event.target instanceof Element) {
-    if (event.target.closest(WIDGET_SCOPE_SELECTOR)) return false;
+    if (anyWidgetClaims(event)) return false;
   }
   return true;
 }
@@ -85,6 +104,30 @@ export function useShortcuts(
 
   useEffect(() => {
     if (!enabled) return undefined;
+
+    // Widget scopes contribute a claim checker so page-level entries flagged
+    // `excludeIfInsideWidget` only yield the combos this widget actually owns.
+    // The checker reads `bindingsRef.current` lazily, so it always reflects the
+    // currently registered bindings even if they change between renders.
+    let widgetChecker: WidgetClaimChecker | null = null;
+    if (scope.startsWith('widget:')) {
+      const selector = widgetScopeSelector(scope);
+      widgetChecker = (event: KeyboardEvent): boolean => {
+        if (!(event.target instanceof Element)) return false;
+        if (!event.target.matches(selector)) return false;
+        const combo = serializeKeyEvent(event);
+        if (combo === null) return false;
+        for (const id of Object.keys(bindingsRef.current)) {
+          const entry = SHORTCUTS_REGISTRY[id];
+          if (!entry || entry.scope !== scope) continue;
+          for (const binding of getEffectiveBindings(id)) {
+            if (matchesBinding([combo], binding as Binding, event)) return true;
+          }
+        }
+        return false;
+      };
+      widgetClaimCheckers.add(widgetChecker);
+    }
 
     let buffer: string[] = [];
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -195,6 +238,7 @@ export function useShortcuts(
     return () => {
       document.removeEventListener('keydown', handler);
       document.removeEventListener('focusin', focusHandler);
+      if (widgetChecker) widgetClaimCheckers.delete(widgetChecker);
       clearTimer();
       if (buffer.length > 0) {
         buffer = [];

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -12,6 +12,8 @@ import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfil
 import { PopupWorkspaceSwitcher } from '@/components/UI/Workspace/PopupWorkspaceSwitcher';
 import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
 import { openOptionsWithHash } from '@/utils/openOptions';
+import { getActiveTabGroupId } from '@/utils/tabCapture';
+import { buildSnapshotHash } from '@/utils/snapshotHash';
 import { useSettings } from '@/hooks/useSettings';
 import { useShortcuts } from '@/hooks/useShortcuts';
 import {
@@ -51,8 +53,12 @@ export function PopupContent() {
     window.close();
   }, []);
 
-  const handlePopupSave = useCallback(() => {
-    void openOptionsWithHash('#sessions?action=snapshot');
+  const handlePopupSave = useCallback(async () => {
+    // Mirror the toolbar Save button: when the active tab sits in a group,
+    // scope the snapshot to that group so the wizard pre-fills its name and
+    // filters on it. Pressing `s` must behave exactly like clicking the button.
+    const groupId = await getActiveTabGroupId();
+    void openOptionsWithHash(buildSnapshotHash(groupId));
   }, []);
 
   const handlePopupRestore = useCallback(() => {

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -43,10 +43,12 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     commandName: '_execute_action',
   },
 
-  // Popup. The four action-binding shortcuts (s/r/o/p) yield to a focused
-  // pinned card so the card's own widget bindings (sessionCard.restore.*)
-  // stay authoritative; `?` is intentionally never widget-suppressed so the
-  // help drawer can be summoned from anywhere in the popup.
+  // Popup. The four action-binding shortcuts (s/r/o/p) only yield a combo a
+  // focused pinned card actually claims: `r` belongs to the card's own widget
+  // bindings (sessionCard.restore.*), while o/s/p, which no card registers,
+  // keep firing the popup-level action even when a card has focus. `?` is
+  // intentionally never widget-suppressed so the help drawer can be summoned
+  // from anywhere in the popup.
   'popup.save': {
     id: 'popup.save',
     defaultBindings: ['s'],

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -56,10 +56,11 @@ export interface ShortcutEntry {
 
   /**
    * When true (only meaningful for `global` and `page:*` scopes), the
-   * shortcut is suppressed if the event target is inside any element flagged
-   * with `data-shortcut-scope="widget:..."`. Lets a focused widget claim
-   * conflicting key combos (e.g. `r` belongs to the focused session card,
-   * not the popup-level restore action).
+   * shortcut is suppressed only when the focused widget actually registers a
+   * binding for the same combo. Lets a focused widget claim the conflicting
+   * combos it owns (e.g. `r` belongs to the focused session card, not the
+   * popup-level restore action) while leaving the others (`o`/`s`/`p`), which
+   * no widget claims, free to fire the page-level action.
    */
   excludeIfInsideWidget?: boolean;
 

--- a/src/utils/mountExtensionApp.ts
+++ b/src/utils/mountExtensionApp.ts
@@ -1,7 +1,17 @@
 import React from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { browser } from 'wxt/browser';
 import { logger } from './logger.js';
+
+/**
+ * Container augmented with the React root we created for it. Reusing the root
+ * across an HMR re-execution of an entrypoint avoids mounting a second
+ * parallel React tree on the same node, which would leave the first tree's
+ * document-level listeners attached and fire every keyboard shortcut twice
+ * (or more, after further hot reloads). No effect in production: each
+ * entrypoint mounts exactly once.
+ */
+type RootContainer = HTMLElement & { __extReactRoot?: Root };
 
 /**
  * Bootstrap utility shared by all extension entry points.
@@ -26,12 +36,13 @@ export function mountExtensionApp(rootId: string, app: React.ReactNode): void {
     logger.debug('[mountExtensionApp] getUILanguage unavailable, falling back to HTML default lang.', err);
   }
 
-  const container = document.getElementById(rootId);
+  const container = document.getElementById(rootId) as RootContainer | null;
   if (!container) {
     logger.error(`[mountExtensionApp] DOM element #${rootId} not found. Cannot mount app.`);
     return;
   }
 
-  const root = createRoot(container);
+  const root = container.__extReactRoot ?? createRoot(container);
+  container.__extReactRoot = root;
   root.render(app);
 }

--- a/src/utils/snapshotHash.ts
+++ b/src/utils/snapshotHash.ts
@@ -1,0 +1,13 @@
+/**
+ * Builds the deep-link hash that opens the session snapshot wizard. When the
+ * active tab sits in a tab group, the hash carries its `groupId` so the wizard
+ * pre-fills the group name and scopes the selection to that group.
+ *
+ * Shared by the popup Save button (`PopupToolbar`) and the `s` keyboard
+ * shortcut (`popup.tsx`) so both produce the exact same navigation.
+ */
+export function buildSnapshotHash(groupId: number | null): string {
+  return groupId !== null
+    ? `#sessions?action=snapshot&groupId=${groupId}`
+    : '#sessions?action=snapshot';
+}

--- a/tests/e2e/keyboard-shortcuts.spec.ts
+++ b/tests/e2e/keyboard-shortcuts.spec.ts
@@ -359,4 +359,63 @@ test.describe('[US-KB-popup-pinned] Popup pinned card shortcuts', () => {
     await newPage.close();
     await page.close().catch(() => {});
   });
+
+  // The pinned card only claims r/Shift+r/Alt+r/Alt+Shift+r/u. The remaining
+  // popup-level shortcuts (s/o/p) must keep firing even while a card is
+  // focused, instead of being swallowed by `excludeIfInsideWidget`. (`o`
+  // sends ORGANIZE_ALL_TABS then closes the popup with no observable page,
+  // so it is covered by the useShortcuts unit tests instead.)
+  test('S on a focused pinned card opens the snapshot page (not swallowed by the card)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createPinnedSession({ name: 'Pin A' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    const card = page.getByTestId(`popup-profile-item-${session.id}`);
+    await card.focus();
+    await expect(card).toBeFocused();
+
+    const [newPage] = await Promise.all([
+      extensionContext.waitForEvent('page'),
+      page.keyboard.press('s'),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    expect(newPage.url()).toContain('options.html');
+    expect(newPage.url()).toContain('action=snapshot');
+
+    await newPage.close();
+    await page.close().catch(() => {});
+  });
+
+  test('P on a focused pinned card opens the options page (not swallowed by the card)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const session = createPinnedSession({ name: 'Pin A' });
+    await seedSessions(extensionContext, [session]);
+
+    const page = await extensionContext.newPage();
+    await goToPopup(page, extensionId);
+
+    const card = page.getByTestId(`popup-profile-item-${session.id}`);
+    await card.focus();
+    await expect(card).toBeFocused();
+
+    const [newPage] = await Promise.all([
+      extensionContext.waitForEvent('page'),
+      page.keyboard.press('p'),
+    ]);
+    await newPage.waitForLoadState('domcontentloaded');
+    expect(newPage.url()).toContain('options.html');
+    // Distinguishes the global options action from the card's own restore
+    // (which would carry action=restore).
+    expect(newPage.url()).not.toContain('action=restore');
+
+    await newPage.close();
+    await page.close().catch(() => {});
+  });
 });

--- a/tests/hooks/useShortcuts.test.tsx
+++ b/tests/hooks/useShortcuts.test.tsx
@@ -190,6 +190,78 @@ describe('useShortcuts (widget scope)', () => {
     expect(widgetAction).toHaveBeenCalledTimes(1);
   });
 
+  it('still fires a page-level excludeIfInsideWidget binding when the focused widget does not claim that combo', () => {
+    const organizeAction = vi.fn();
+    const saveAction = vi.fn();
+    const optionsAction = vi.fn();
+    const restoreWidgetAction = vi.fn();
+
+    renderHook(() => {
+      useShortcuts(
+        {
+          'popup.organize': organizeAction,
+          'popup.save': saveAction,
+          'popup.options': optionsAction,
+        },
+        { scope: 'page:popup' },
+      );
+      // The pinned card only registers the restore bindings (r/Shift+r/...),
+      // so o/s/p are not claimed and must fall through to the popup actions.
+      useShortcuts(
+        { 'sessionCard.restore.custom': restoreWidgetAction },
+        { scope: 'widget:session-card' },
+      );
+    });
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:session-card');
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+    card.focus();
+
+    dispatchOn(card, { key: 'o' });
+    dispatchOn(card, { key: 's' });
+    dispatchOn(card, { key: 'p' });
+
+    expect(organizeAction).toHaveBeenCalledTimes(1);
+    expect(saveAction).toHaveBeenCalledTimes(1);
+    expect(optionsAction).toHaveBeenCalledTimes(1);
+    expect(restoreWidgetAction).not.toHaveBeenCalled();
+  });
+
+  it('restores the page-level binding once the focused widget hook unmounts', () => {
+    const pageAction = vi.fn();
+    const widgetAction = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ withWidget }: { withWidget: boolean }) => {
+        useShortcuts({ 'popup.restore': pageAction }, { scope: 'page:popup' });
+        useShortcuts(
+          { 'sessionCard.restore.custom': widgetAction },
+          { scope: 'widget:session-card', enabled: withWidget },
+        );
+      },
+      { initialProps: { withWidget: true } },
+    );
+
+    const card = document.createElement('div');
+    card.setAttribute('data-shortcut-scope', 'widget:session-card');
+    card.tabIndex = 0;
+    document.body.appendChild(card);
+    card.focus();
+
+    // While the widget claims `r`, the page-level restore stays suppressed.
+    dispatchOn(card, { key: 'r' });
+    expect(pageAction).not.toHaveBeenCalled();
+    expect(widgetAction).toHaveBeenCalledTimes(1);
+
+    // Unmounting the widget hook removes its claim; `r` now reaches the page.
+    rerender({ withWidget: false });
+    dispatchOn(card, { key: 'r' });
+    expect(pageAction).toHaveBeenCalledTimes(1);
+    expect(widgetAction).toHaveBeenCalledTimes(1);
+  });
+
   it('still fires the page-level binding when focus is outside any widget scope', () => {
     const pageAction = vi.fn();
     renderHook(() =>

--- a/tests/utils/snapshotHash.test.ts
+++ b/tests/utils/snapshotHash.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildSnapshotHash } from '../../src/utils/snapshotHash';
+
+describe('buildSnapshotHash', () => {
+  it('scopes the snapshot to the active tab group when one is provided', () => {
+    expect(buildSnapshotHash(42)).toBe('#sessions?action=snapshot&groupId=42');
+  });
+
+  it('omits the groupId when the active tab is not in a group', () => {
+    expect(buildSnapshotHash(null)).toBe('#sessions?action=snapshot');
+  });
+
+  it('keeps groupId 0 (a valid Chrome group id), not treated as "no group"', () => {
+    expect(buildSnapshotHash(0)).toBe('#sessions?action=snapshot&groupId=0');
+  });
+});


### PR DESCRIPTION
The popup actions s/r/o/p carry excludeIfInsideWidget, which suppressed
them as soon as focus landed inside any widget scope, regardless of
whether the focused widget actually bound that combo. A focused pinned
card only claims r/Shift+r/Alt+r/Alt+Shift+r/u, so o (organize), s (save)
and p (options) ended up doing nothing.

Make the suppression conditional: page-level excludeIfInsideWidget
entries now yield only the combos a mounted widget hook actually
registers. Each widget:* hook contributes a claim checker; entryScopeFilter
suppresses the page binding only when a checker matches the event.

Result on a focused pinned card: r keeps opening the card restore, while
o/s/p fire their popup-level actions again. Also benefits the Home page
(home.action.*).

Covered by useShortcuts unit tests and keyboard-shortcuts e2e (S/P on a
focused pinned card).

https://claude.ai/code/session_013XRhXB8LyQgQPrU19Dfi7Z