### PR TITLE
feat: focus the right element on arrival on list pages

### DIFF
--- a/e2e-shared/pages/SessionsListPage.ts
+++ b/e2e-shared/pages/SessionsListPage.ts
@@ -45,6 +45,15 @@ export class SessionsListPage {
     return this.page.getByTestId(`session-card-${sessionId}`);
   }
 
+  /**
+   * First session card in the list (pinned section renders first, so a
+   * pinned session takes priority over an unpinned one). Anchors on the
+   * `data-session-card` attribute borne by `SessionCard`.
+   */
+  firstCard(): Locator {
+    return this.list().locator('[data-session-card]').first();
+  }
+
   /** HoverCard trigger anchored on the session card name. */
   cardNameTrigger(sessionId: string): Locator {
     return this.page.getByTestId(`session-card-${sessionId}-name`);

--- a/e2e-shared/pages/WorkspaceListPage.ts
+++ b/e2e-shared/pages/WorkspaceListPage.ts
@@ -1,0 +1,32 @@
+/**
+ * Page Object for the Workspaces list (`WorkspacesPage` options view).
+ *
+ * Wraps the list-driven surface around the workspace rows: list container
+ * and per-row lookup. Page Objects in this folder stay close to the DOM
+ * (locators + atomic actions + atomic assertions).
+ *
+ * Selectors anchor on stable `data-testid` / `data-workspace-card`
+ * attributes so the helper works across the doc-scenarios locale matrix
+ * (en/fr/es) without subclassing.
+ */
+import { type Locator, type Page } from '@playwright/test';
+
+export class WorkspaceListPage {
+  constructor(protected readonly page: Page) {}
+
+  // ─── Locators ────────────────────────────────────────────────────────────
+
+  /** Workspaces list container (`<Box data-testid="workspace-list">`). */
+  list(): Locator {
+    return this.page.getByTestId('workspace-list');
+  }
+
+  /**
+   * First workspace row in the list. There is always at least one
+   * workspace, so this locator is always resolvable. Anchors on the
+   * `data-workspace-card` attribute.
+   */
+  firstCard(): Locator {
+    return this.list().locator('[data-workspace-card]').first();
+  }
+}

--- a/e2e-shared/pages/index.ts
+++ b/e2e-shared/pages/index.ts
@@ -26,6 +26,7 @@ export {
   type GroupConflictAction,
 } from './RestoreWizardPage.js';
 export { SessionsListPage } from './SessionsListPage.js';
+export { WorkspaceListPage } from './WorkspaceListPage.js';
 export { SessionEditorPage } from './SessionEditorPage.js';
 export { DomainRulesListPage } from './DomainRulesListPage.js';
 export {

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, type RefObject, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useRef, type RefObject, type KeyboardEvent } from 'react';
 
 export type NavigationAxis = 'vertical' | 'horizontal' | 'both';
 
@@ -10,6 +10,18 @@ export interface UseListNavigationOptions {
    * only the focused one is reachable via Tab (roving tabindex pattern).
    */
   rovingTabIndex?: boolean;
+  /**
+   * Focus an element once when the component mounts, as soon as `ready` is true
+   * (defaults to true). Targets the first `itemSelector` item inside the list;
+   * if the list has no such item (empty or not rendered, so `listRef.current`
+   * is null), focuses `fallbackSelector` (looked up at the document level) when
+   * provided. The guard resets on remount, so navigating away and back
+   * re-applies the focus.
+   */
+  autoFocus?: {
+    ready?: boolean;
+    fallbackSelector?: string;
+  };
 }
 
 export interface ListNavigationApi {
@@ -33,7 +45,29 @@ export function useListNavigation<T extends HTMLElement>(
   itemSelector: string,
   options: UseListNavigationOptions = {},
 ): ListNavigationApi {
-  const { axis = 'vertical', rovingTabIndex = false } = options;
+  const { axis = 'vertical', rovingTabIndex = false, autoFocus } = options;
+
+  const autoFocusEnabled = autoFocus != null;
+  const autoFocusReady = autoFocus?.ready ?? true;
+  const fallbackSelector = autoFocus?.fallbackSelector;
+  const autoFocusAppliedRef = useRef(false);
+
+  useEffect(() => {
+    if (!autoFocusEnabled || !autoFocusReady || autoFocusAppliedRef.current) return;
+    autoFocusAppliedRef.current = true;
+    const list = listRef.current;
+    const active = document.activeElement;
+    // Never steal focus the user already moved into this list's content between
+    // mount and this effect firing (e.g. they tabbed straight to a card or its
+    // drag handle). Focus arriving from outside the list (sidebar, fresh load
+    // where `activeElement` is the body) is fair game.
+    if (list && active instanceof HTMLElement && list.contains(active)) return;
+    const first = list?.querySelector<HTMLElement>(itemSelector) ?? null;
+    const target =
+      first ??
+      (fallbackSelector ? document.querySelector<HTMLElement>(fallbackSelector) : null);
+    if (target && target !== active) target.focus({ preventScroll: true });
+  }, [autoFocusEnabled, autoFocusReady, fallbackSelector, itemSelector, listRef]);
 
   const handleNavigationKey = useCallback(
     (e: KeyboardEvent<HTMLElement>, index: number): boolean => {

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -199,7 +199,9 @@ export function DomainRulesPage({
 
   const listRef = useRef<HTMLDivElement>(null);
 
-  const { handleNavigationKey } = useListNavigation(listRef, '[role="listitem"]');
+  const { handleNavigationKey } = useListNavigation(listRef, '[role="listitem"]', {
+    autoFocus: { fallbackSelector: '[data-testid="page-rules-btn-import-pack"]' },
+  });
 
   // The card keydown handler now only forwards arrow/Home/End to
   // useListNavigation. The Enter binding is kept here because Enter to

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -772,6 +772,19 @@ export function SessionsPage({
   const totalForTab = archivedOnlyView ? archivedBucket.length : pinnedBucket.length + activeBucket.length;
   const hasAnyOverall = pinnedBucket.length + activeBucket.length + archivedBucket.length > 0;
 
+  // Initial focus on arrival (active view): focus the first session card
+  // (pinned section renders before unpinned, so the first card is pinned when
+  // any), or fall back to the empty-state snapshot button when there is none.
+  // This page-level instance is used only for the autofocus; per-section arrow
+  // navigation keeps its own useListNavigation hooks.
+  const sessionsListRef = useRef<HTMLDivElement>(null);
+  useListNavigation(sessionsListRef, '[data-session-card]', {
+    autoFocus: {
+      ready: isLoaded && !archivedOnlyView,
+      fallbackSelector: '[data-testid="page-sessions-btn-snapshot"]',
+    },
+  });
+
   return (
     <PageLayout
       titleKey="sessionsTab"
@@ -896,7 +909,7 @@ export function SessionsPage({
               <EmptyState compact icon={Archive} message={getMessage('noSessionsFound')} />
             )}
             {isLoaded && !archivedOnlyView && displayedSessions.length > 0 && (
-              <Flex data-testid="page-sessions-list" direction="column" gap="3">
+              <Flex data-testid="page-sessions-list" direction="column" gap="3" ref={sessionsListRef}>
                 <SessionSection
                   icon={Pin}
                   titleKey="pinnedSessionsSection"

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -135,6 +135,7 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
     renameWorkspace,
     setWorkspaceColor,
     removeWorkspace,
+    isLoaded,
   } = useActiveWorkspaceContext();
 
   const [createOpen, setCreateOpen] = useState(false);
@@ -143,7 +144,9 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
   const [searchTerm, setSearchTerm] = useState('');
 
   const listRef = useRef<HTMLDivElement>(null);
-  const { handleNavigationKey } = useListNavigation(listRef, '[data-workspace-card]');
+  const { handleNavigationKey } = useListNavigation(listRef, '[data-workspace-card]', {
+    autoFocus: { ready: isLoaded },
+  });
 
   const handleCardKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLElement>, index: number) => {

--- a/tests/e2e/page-initial-focus.spec.ts
+++ b/tests/e2e/page-initial-focus.spec.ts
@@ -13,6 +13,7 @@
  */
 import { test, expect } from './fixtures';
 import type { Page } from '@playwright/test';
+import { SessionsListPage, WorkspaceListPage } from '../../e2e-shared/pages/index.js';
 import { goToDomainRulesSection, goToSessionsSection } from './helpers/navigation';
 import {
   seedSessions,
@@ -24,7 +25,7 @@ import {
 async function goToWorkspacesSection(page: Page, extensionId: string): Promise<void> {
   await page.goto(`chrome-extension://${extensionId}/options.html#workspaces`);
   await page.waitForLoadState('domcontentloaded');
-  await page.getByTestId('workspace-list').waitFor({ state: 'visible', timeout: 10_000 });
+  await new WorkspaceListPage(page).list().waitFor({ state: 'visible', timeout: 10_000 });
 }
 
 // ---------------------------------------------------------------------------
@@ -110,7 +111,7 @@ test.describe('[focus-management] Sessions initial focus', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    const firstCard = page.locator('[data-testid="page-sessions-list"] [data-session-card]').first();
+    const firstCard = new SessionsListPage(page).firstCard();
     await expect(firstCard).toBeFocused();
     // It must be the pinned session, not the normal one.
     await expect(firstCard).toHaveAttribute('data-session-id', pinned.id);
@@ -143,9 +144,7 @@ test.describe('[focus-management] Workspaces initial focus', () => {
     const page = await extensionContext.newPage();
     await goToWorkspacesSection(page, extensionId);
 
-    await expect(
-      page.locator('[data-testid="workspace-list"] [data-workspace-card]').first(),
-    ).toBeFocused();
+    await expect(new WorkspaceListPage(page).firstCard()).toBeFocused();
 
     await page.close();
   });

--- a/tests/e2e/page-initial-focus.spec.ts
+++ b/tests/e2e/page-initial-focus.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * E2E tests for initial focus when arriving on a list page.
+ *
+ * Rule (US focus-management-page-load):
+ *   - Domain Rules: focus the first rule card when rules exist, otherwise the
+ *     "import a pack" button.
+ *   - Sessions: focus the first session card (pinned first, then unpinned)
+ *     when sessions exist, otherwise the empty-state snapshot button.
+ *   - Workspaces: there is always at least one workspace, so focus the first
+ *     workspace row.
+ *
+ * Powered by the `autoFocus` option of useListNavigation.
+ */
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+import { goToDomainRulesSection, goToSessionsSection } from './helpers/navigation';
+import {
+  seedSessions,
+  clearSessions,
+  createTestSession,
+  createPinnedSession,
+} from './helpers/seed';
+
+async function goToWorkspacesSection(page: Page, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html#workspaces`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.getByTestId('workspace-list').waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Domain Rules
+// ---------------------------------------------------------------------------
+
+test.describe('[focus-management] Domain Rules initial focus', () => {
+  test.beforeEach(async ({ helpers }) => {
+    await helpers.clearDomainRules();
+  });
+
+  test('focuses the first rule card when rules exist', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'FirstRule', domainFilter: '*.first.com' });
+    await helpers.addDomainRule({ label: 'SecondRule', domainFilter: '*.second.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await expect(
+      page.getByTestId('page-rules-list').getByRole('listitem').first(),
+    ).toBeFocused();
+
+    await page.close();
+  });
+
+  test('focuses the import-pack button when there are no rules', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    await expect(page.getByTestId('page-rules-btn-import-pack')).toBeFocused();
+
+    await page.close();
+  });
+
+  test('re-applies focus when navigating away and back', async ({
+    extensionContext,
+    extensionId,
+    helpers,
+  }) => {
+    await helpers.addDomainRule({ label: 'FirstRule', domainFilter: '*.first.com' });
+
+    const page = await extensionContext.newPage();
+    await goToDomainRulesSection(page, extensionId);
+
+    const firstCard = page.getByTestId('page-rules-list').getByRole('listitem').first();
+    await expect(firstCard).toBeFocused();
+
+    // Navigate away (home) and back via the sidebar: the page remounts, so the
+    // initial-focus guard resets and the first card is focused again.
+    await page.getByTestId('sidebar-nav-item-home').click();
+    await page.getByTestId('sidebar-nav-item-rules').click();
+
+    await expect(firstCard).toBeFocused();
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+test.describe('[focus-management] Sessions initial focus', () => {
+  test.beforeEach(async ({ extensionContext }) => {
+    await clearSessions(extensionContext);
+  });
+
+  test('focuses the first (pinned) session card when sessions exist', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const pinned = createPinnedSession({ name: 'Pinned One' });
+    const normal = createTestSession({ name: 'Normal One' });
+    await seedSessions(extensionContext, [pinned, normal]);
+
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    const firstCard = page.locator('[data-testid="page-sessions-list"] [data-session-card]').first();
+    await expect(firstCard).toBeFocused();
+    // It must be the pinned session, not the normal one.
+    await expect(firstCard).toHaveAttribute('data-session-id', pinned.id);
+
+    await page.close();
+  });
+
+  test('focuses the snapshot button when there are no sessions', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToSessionsSection(page, extensionId);
+
+    await expect(page.getByTestId('page-sessions-btn-snapshot')).toBeFocused();
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspaces
+// ---------------------------------------------------------------------------
+
+test.describe('[focus-management] Workspaces initial focus', () => {
+  test('focuses the first workspace row on arrival', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToWorkspacesSection(page, extensionId);
+
+    await expect(
+      page.locator('[data-testid="workspace-list"] [data-workspace-card]').first(),
+    ).toBeFocused();
+
+    await page.close();
+  });
+});

--- a/tests/hooks/useListNavigation.test.tsx
+++ b/tests/hooks/useListNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useRef, type ReactNode } from 'react';
 import { render, renderHook } from '@testing-library/react';
 import {
@@ -150,5 +150,134 @@ describe('useListNavigation', () => {
       </Harness>,
     );
     expect(getByTestId('list')).toBeDefined();
+  });
+});
+
+describe('useListNavigation autoFocus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function makeList(itemCount: number): HTMLDivElement {
+    const list = document.createElement('div');
+    for (let i = 0; i < itemCount; i++) {
+      const btn = document.createElement('button');
+      btn.setAttribute('data-item', '');
+      btn.setAttribute('tabindex', '0');
+      btn.textContent = `Item ${i}`;
+      list.appendChild(btn);
+    }
+    document.body.appendChild(list);
+    return list;
+  }
+
+  it('focuses the first item on mount when ready (default true)', () => {
+    const list = makeList(3);
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', { autoFocus: {} });
+    });
+    expect(document.activeElement).toBe(list.querySelector('[data-item]'));
+  });
+
+  it('falls back to fallbackSelector when the list has no items', () => {
+    const list = makeList(0);
+    const fallback = document.createElement('button');
+    fallback.setAttribute('data-testid', 'fallback-btn');
+    document.body.appendChild(fallback);
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', {
+        autoFocus: { fallbackSelector: '[data-testid="fallback-btn"]' },
+      });
+    });
+    expect(document.activeElement).toBe(fallback);
+  });
+
+  it('falls back when the list ref is null (list not rendered)', () => {
+    const fallback = document.createElement('button');
+    fallback.setAttribute('data-testid', 'fallback-btn');
+    document.body.appendChild(fallback);
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(null);
+      return useListNavigation(ref, '[data-item]', {
+        autoFocus: { fallbackSelector: '[data-testid="fallback-btn"]' },
+      });
+    });
+    expect(document.activeElement).toBe(fallback);
+  });
+
+  it('does not focus while not ready, then focuses once ready flips', () => {
+    const list = makeList(2);
+    const { rerender } = renderHook(
+      ({ ready }: { ready: boolean }) => {
+        const ref = useRef<HTMLDivElement | null>(list);
+        return useListNavigation(ref, '[data-item]', { autoFocus: { ready } });
+      },
+      { initialProps: { ready: false } },
+    );
+    expect(document.activeElement).not.toBe(list.querySelector('[data-item]'));
+    rerender({ ready: true });
+    expect(document.activeElement).toBe(list.querySelector('[data-item]'));
+  });
+
+  it('focuses only once across re-renders', () => {
+    const list = makeList(2);
+    const first = list.querySelector<HTMLButtonElement>('[data-item]')!;
+    const { rerender } = renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', { autoFocus: {} });
+    });
+    expect(document.activeElement).toBe(first);
+    // Move focus elsewhere, then re-render: the guard must not steal it back.
+    const other = document.createElement('button');
+    document.body.appendChild(other);
+    other.focus();
+    rerender();
+    expect(document.activeElement).toBe(other);
+  });
+
+  it('focuses with preventScroll to avoid scroll jumps', () => {
+    const list = makeList(1);
+    const item = list.querySelector<HTMLButtonElement>('[data-item]')!;
+    const focusSpy = vi.spyOn(item, 'focus');
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', { autoFocus: {} });
+    });
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('does not steal focus already inside the list', () => {
+    const list = makeList(2);
+    const items = list.querySelectorAll<HTMLButtonElement>('[data-item]');
+    // Simulate the user/test having tabbed to the second item before the effect.
+    items[1].focus();
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', { autoFocus: {} });
+    });
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('still focuses when current focus is outside the list (e.g. sidebar)', () => {
+    const list = makeList(2);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]', { autoFocus: {} });
+    });
+    expect(document.activeElement).toBe(list.querySelector('[data-item]'));
+  });
+
+  it('does nothing when autoFocus is not set', () => {
+    const list = makeList(2);
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement | null>(list);
+      return useListNavigation(ref, '[data-item]');
+    });
+    expect(document.activeElement).toBe(document.body);
   });
 });


### PR DESCRIPTION
Add an `autoFocus` option to `useListNavigation` so each list page lands
keyboard focus on the most useful element when the user arrives:

- Domain Rules: first rule card, or the "import a pack" button when empty.
- Sessions: first session card (pinned section renders first, so pinned
  takes priority), or the empty-state snapshot button when empty.
- Workspaces: first workspace row (there is always at least one).

The option focuses the first `itemSelector` item inside the list and
falls back to a document-level `fallbackSelector` when the list has no
item (empty state) or is not rendered. It runs once per mount (the guard
resets on remount, so navigating away and back re-applies the focus) and
never steals focus the user already moved into the list's own content.

Pages reuse the existing hook instance (rules, workspaces) or add a
page-level instance dedicated to the autofocus (sessions, whose arrow
navigation stays per section).

Covered by unit tests on the hook and an e2e spec (page-initial-focus).