### PR TITLE
refactor(dedupe): extract useCodeMirrorSingleLine from DomainCodeField and RegexCodeField

### DIFF
--- a/src/components/Core/DomainRule/DomainRuleCard.tsx
+++ b/src/components/Core/DomainRule/DomainRuleCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, Text, HoverCard, Flex, Badge, Card, Checkbox, IconButton, DropdownMenu, Kbd, Tooltip } from '@radix-ui/themes';
-import { Pencil, Trash2, MoreHorizontal, GripVertical, AlertTriangle } from 'lucide-react';
+import { Pencil, MoreHorizontal, GripVertical, AlertTriangle } from 'lucide-react';
+import { DeleteMenuItem } from '@/components/UI/DeleteMenuItem/DeleteMenuItem';
 import { useSortable } from '@dnd-kit/react/sortable';
 import { getStatusStyle, type CardStatus } from '@/utils/statusStyle';
 import { RuleDetailPopover } from './RuleDetailPopover';
@@ -291,19 +292,10 @@ export function DomainRuleCard({
                   </DropdownMenu.SubContent>
                 </DropdownMenu.Sub>
                 <DropdownMenu.Separator />
-                <DropdownMenu.Item
+                <DeleteMenuItem
                   data-testid={`rule-card-${rule.id}-menu-delete`}
-                  color="red"
                   onClick={() => onDeleteRequest?.(rule.id, index)}
-                >
-                  <Flex align="center" justify="between" gap="3" width="100%">
-                    <Flex align="center" gap="2">
-                      <Trash2 size={14} />
-                      {getMessage('delete')}
-                    </Flex>
-                    <Kbd size="1">Del</Kbd>
-                  </Flex>
-                </DropdownMenu.Item>
+                />
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           </Flex>

--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -6,11 +6,12 @@ import {
   DropdownMenu, HoverCard, Tooltip, Badge, Box, Checkbox, Kbd,
 } from '@radix-ui/themes';
 import {
-  MoreHorizontal, Pencil, Trash2, Check, X,
+  MoreHorizontal, Pencil, Check, X,
   Pin, PinOff, ChevronDown, ChevronRight,
   GripVertical, AlertTriangle, Archive, ArchiveRestore,
 } from 'lucide-react';
 import { getMessage, getPluralMessage } from '@/utils/i18n';
+import { DeleteMenuItem } from '@/components/UI/DeleteMenuItem/DeleteMenuItem';
 import { countSessionTabs, formatSessionDate } from '@/utils/sessionUtils';
 import { useRelativeTime } from '@/hooks/useRelativeTime';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
@@ -201,19 +202,10 @@ function SessionMoreMenu({
         )}
 
         <DropdownMenu.Separator />
-        <DropdownMenu.Item
+        <DeleteMenuItem
           data-testid={`session-card-${session.id}-menu-delete`}
-          color="red"
           onClick={() => onDelete(session)}
-        >
-          <Flex align="center" justify="between" gap="3" width="100%">
-            <Flex align="center" gap="2">
-              <Trash2 size={14} />
-              {getMessage('delete')}
-            </Flex>
-            <Kbd size="1">Del</Kbd>
-          </Flex>
-        </DropdownMenu.Item>
+        />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   );

--- a/src/components/Core/Statistics/StatisticsRulesDetail.tsx
+++ b/src/components/Core/Statistics/StatisticsRulesDetail.tsx
@@ -1,8 +1,8 @@
-import { Box, Button, Card, Flex, Grid, Heading, Separator, Text } from '@radix-ui/themes';
+import { Box, Button, Card, Flex, Grid, Heading, Text } from '@radix-ui/themes';
 import { Layers, Copy, RotateCcw } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
 import { KpiTile, BarRow } from '@/components/Core/Statistics/primitives';
+import { ThisWeekStatsCard } from './ThisWeekStatsCard';
 import type { StatisticsAggregates } from '@/types/statistics';
 
 interface StatisticsRulesDetailProps {
@@ -40,7 +40,7 @@ function TopRulesCard({ data }: { data: StatisticsAggregates }) {
             })}
           </Flex>
         ) : (
-          <Text size="2" color="gray">—</Text>
+          <Text size="2" color="gray">-</Text>
         )}
       </Flex>
     </Card>
@@ -85,28 +85,7 @@ export function StatisticsRulesDetail({ data, activeRulesCount, firstUsedAtForma
           </Flex>
         </Card>
 
-        <Card data-testid="page-stats-card-this-week">
-          <Flex direction="column" gap="3" p="2">
-            <Heading size="3">{getMessage('statsThisWeekTitle')}</Heading>
-            <Flex direction="column" gap="2">
-              <Flex justify="between" align="center">
-                <Text size="2" weight="medium">{getMessage('statsGroupings')}</Text>
-                <Flex align="center" gap="3">
-                  <Text size="4" weight="bold">{data.thisWeek.grouping}</Text>
-                  <TrendBadge current={data.thisWeek.grouping} previous={data.lastWeek.grouping} />
-                </Flex>
-              </Flex>
-              <Separator size="4" />
-              <Flex justify="between" align="center">
-                <Text size="2" weight="medium">{getMessage('statsDeduplications')}</Text>
-                <Flex align="center" gap="3">
-                  <Text size="4" weight="bold">{data.thisWeek.dedup}</Text>
-                  <TrendBadge current={data.thisWeek.dedup} previous={data.lastWeek.dedup} />
-                </Flex>
-              </Flex>
-            </Flex>
-          </Flex>
-        </Card>
+        <ThisWeekStatsCard data={data} testId="page-stats-card-this-week" />
 
         <Box style={{ gridColumn: '1 / -1' }}>
           <TopRulesCard data={data} />

--- a/src/components/Core/Statistics/StatisticsSessionsDetail.tsx
+++ b/src/components/Core/Statistics/StatisticsSessionsDetail.tsx
@@ -5,7 +5,7 @@ import {
 import { getMessage } from '@/utils/i18n';
 import { formatSessionDate } from '@/utils/sessionUtils';
 import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
-import { SmallKpiTile, BarRow, GroupColorBar, MetricRow } from '@/components/Core/Statistics/primitives';
+import { SmallKpiTile, BarRow, GroupColorBar, MetricRow, TwoMetricCard } from '@/components/Core/Statistics/primitives';
 import type { StatisticsAggregates } from '@/types/statistics';
 import type { SessionStatisticsSnapshot } from '@/hooks/useSessionStatistics';
 
@@ -106,36 +106,30 @@ function SessionVolumesCard({ snapshot }: { snapshot: SessionStatisticsSnapshot 
 
 function SessionActivityCard({ events }: { events: StatisticsAggregates['sessionEvents'] }) {
   return (
-    <Card data-testid="page-stats-card-session-activity">
-      <Flex direction="column" gap="3" p="2">
-        <Heading size="3">{getMessage('statsSessionsActivityTitle')}</Heading>
-
-        <Flex direction="column" gap="2">
-          <MetricRow
-            label={getMessage('statsSessionsCreated')}
-            value={events.thisWeek.created}
-            current={events.thisWeek.created}
-            previous={events.lastWeek.created}
-          />
-
-          <Separator size="4" />
-
-          <MetricRow
-            label={getMessage('statsTabsRestored')}
-            value={events.thisWeek.tabsRestored}
-            current={events.thisWeek.tabsRestored}
-            previous={events.lastWeek.tabsRestored}
-          />
-        </Flex>
-
+    <TwoMetricCard
+      testId="page-stats-card-session-activity"
+      title={getMessage('statsSessionsActivityTitle')}
+      metric1={{
+        label: getMessage('statsSessionsCreated'),
+        value: events.thisWeek.created,
+        current: events.thisWeek.created,
+        previous: events.lastWeek.created,
+      }}
+      metric2={{
+        label: getMessage('statsTabsRestored'),
+        value: events.thisWeek.tabsRestored,
+        current: events.thisWeek.tabsRestored,
+        previous: events.lastWeek.tabsRestored,
+      }}
+      footer={
         <Text size="1" color="gray">
           {getMessage('statsSessionsLifetime')
             .replace('{created}', String(events.totals.created))
             .replace('{restored}', String(events.totals.restored))
             .replace('{archived}', String(events.totals.archived))}
         </Text>
-      </Flex>
-    </Card>
+      }
+    />
   );
 }
 

--- a/src/components/Core/Statistics/StatisticsSessionsDetail.tsx
+++ b/src/components/Core/Statistics/StatisticsSessionsDetail.tsx
@@ -5,8 +5,7 @@ import {
 import { getMessage } from '@/utils/i18n';
 import { formatSessionDate } from '@/utils/sessionUtils';
 import { getRuleCategory, getCategoryLabel } from '@/utils/categoriesStore';
-import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
-import { SmallKpiTile, BarRow, GroupColorBar } from '@/components/Core/Statistics/primitives';
+import { SmallKpiTile, BarRow, GroupColorBar, MetricRow } from '@/components/Core/Statistics/primitives';
 import type { StatisticsAggregates } from '@/types/statistics';
 import type { SessionStatisticsSnapshot } from '@/hooks/useSessionStatistics';
 
@@ -112,23 +111,21 @@ function SessionActivityCard({ events }: { events: StatisticsAggregates['session
         <Heading size="3">{getMessage('statsSessionsActivityTitle')}</Heading>
 
         <Flex direction="column" gap="2">
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium">{getMessage('statsSessionsCreated')}</Text>
-            <Flex align="center" gap="3">
-              <Text size="4" weight="bold">{events.thisWeek.created}</Text>
-              <TrendBadge current={events.thisWeek.created} previous={events.lastWeek.created} />
-            </Flex>
-          </Flex>
+          <MetricRow
+            label={getMessage('statsSessionsCreated')}
+            value={events.thisWeek.created}
+            current={events.thisWeek.created}
+            previous={events.lastWeek.created}
+          />
 
           <Separator size="4" />
 
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium">{getMessage('statsTabsRestored')}</Text>
-            <Flex align="center" gap="3">
-              <Text size="4" weight="bold">{events.thisWeek.tabsRestored}</Text>
-              <TrendBadge current={events.thisWeek.tabsRestored} previous={events.lastWeek.tabsRestored} />
-            </Flex>
-          </Flex>
+          <MetricRow
+            label={getMessage('statsTabsRestored')}
+            value={events.thisWeek.tabsRestored}
+            current={events.thisWeek.tabsRestored}
+            previous={events.lastWeek.tabsRestored}
+          />
         </Flex>
 
         <Text size="1" color="gray">
@@ -234,13 +231,14 @@ function SessionsOverviewCard({ snapshot, events }: { snapshot: SessionStatistic
                 </Text>
               </Flex>
             )}
-            <Flex justify="between" align="center" gap="3" wrap="wrap">
-              <Text size="2" color="gray">{getMessage('statsSessionsCreatedThisWeek')}</Text>
-              <Flex align="center" gap="3">
-                <Text size="3" weight="bold">{temporal.createdThisWeek}</Text>
-                <TrendBadge current={temporal.createdThisWeek} previous={temporal.createdLastWeek} />
-              </Flex>
-            </Flex>
+            <MetricRow
+              label={getMessage('statsSessionsCreatedThisWeek')}
+              value={temporal.createdThisWeek}
+              current={temporal.createdThisWeek}
+              previous={temporal.createdLastWeek}
+              valueSize="3"
+              labelColor="gray"
+            />
           </Flex>
         </Flex>
 

--- a/src/components/Core/Statistics/StatisticsSummary.tsx
+++ b/src/components/Core/Statistics/StatisticsSummary.tsx
@@ -1,9 +1,9 @@
-import { Box, Card, Flex, Grid, Heading, Separator, Text } from '@radix-ui/themes';
+import { Box, Grid } from '@radix-ui/themes';
 import { Layers, Copy, Pin, FolderOpen, Archive, HardDrive } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { formatBytes } from '@/utils/formatBytes';
-import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
 import { KpiTile } from '@/components/Core/Statistics/primitives';
+import { ThisWeekStatsCard } from './ThisWeekStatsCard';
 import type { StatisticsAggregates } from '@/types/statistics';
 import type { SessionStatisticsSnapshot } from '@/hooks/useSessionStatistics';
 import type { StorageUsageSnapshot } from '@/hooks/useStorageUsage';
@@ -63,28 +63,7 @@ export function StatisticsSummary({ data, snapshot, storageUsage }: StatisticsSu
         />
       </Grid>
 
-      <Card mt="4" data-testid="page-stats-summary-week">
-        <Flex direction="column" gap="3" p="2">
-          <Heading size="3">{getMessage('statsThisWeekTitle')}</Heading>
-          <Flex direction="column" gap="2">
-            <Flex justify="between" align="center">
-              <Text size="2" weight="medium">{getMessage('statsGroupings')}</Text>
-              <Flex align="center" gap="3">
-                <Text size="4" weight="bold">{data.thisWeek.grouping}</Text>
-                <TrendBadge current={data.thisWeek.grouping} previous={data.lastWeek.grouping} />
-              </Flex>
-            </Flex>
-            <Separator size="4" />
-            <Flex justify="between" align="center">
-              <Text size="2" weight="medium">{getMessage('statsDeduplications')}</Text>
-              <Flex align="center" gap="3">
-                <Text size="4" weight="bold">{data.thisWeek.dedup}</Text>
-                <TrendBadge current={data.thisWeek.dedup} previous={data.lastWeek.dedup} />
-              </Flex>
-            </Flex>
-          </Flex>
-        </Flex>
-      </Card>
+      <ThisWeekStatsCard data={data} testId="page-stats-summary-week" mt="4" />
     </Box>
   );
 }

--- a/src/components/Core/Statistics/ThisWeekStatsCard.stories.tsx
+++ b/src/components/Core/Statistics/ThisWeekStatsCard.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThisWeekStatsCard } from './ThisWeekStatsCard';
+
+const meta: Meta<typeof ThisWeekStatsCard> = {
+  title: 'Components/Core/Statistics/ThisWeekStatsCard',
+  component: ThisWeekStatsCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ThisWeekStatsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ThisWeekStatsCardDefault: Story = {
+  name: 'Default (up trend)',
+  args: {
+    data: {
+      thisWeek: { grouping: 14, dedup: 7 },
+      lastWeek: { grouping: 9, dedup: 4 },
+    },
+  },
+};
+
+export const ThisWeekStatsCardDownTrend: Story = {
+  name: 'Down trend',
+  args: {
+    data: {
+      thisWeek: { grouping: 3, dedup: 1 },
+      lastWeek: { grouping: 12, dedup: 8 },
+    },
+  },
+};
+
+export const ThisWeekStatsCardFlat: Story = {
+  name: 'Flat (no change)',
+  args: {
+    data: {
+      thisWeek: { grouping: 5, dedup: 2 },
+      lastWeek: { grouping: 5, dedup: 2 },
+    },
+  },
+};
+
+export const ThisWeekStatsCardEmpty: Story = {
+  name: 'Empty (no activity)',
+  args: {
+    data: {
+      thisWeek: { grouping: 0, dedup: 0 },
+      lastWeek: { grouping: 0, dedup: 0 },
+    },
+  },
+};
+
+export const ThisWeekStatsCardFirstWeek: Story = {
+  name: 'First week (no previous data)',
+  args: {
+    data: {
+      thisWeek: { grouping: 6, dedup: 3 },
+      lastWeek: { grouping: 0, dedup: 0 },
+    },
+  },
+};

--- a/src/components/Core/Statistics/ThisWeekStatsCard.tsx
+++ b/src/components/Core/Statistics/ThisWeekStatsCard.tsx
@@ -1,7 +1,7 @@
-import { Card, Flex, Heading, Separator, Text } from '@radix-ui/themes';
+import { Card, Flex, Heading, Separator } from '@radix-ui/themes';
 import type { MarginProps } from '@radix-ui/themes/dist/esm/props/margin.props.js';
 import { getMessage } from '@/utils/i18n';
-import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
+import { MetricRow } from '@/components/Core/Statistics/primitives';
 import type { StatisticsAggregates } from '@/types/statistics';
 
 interface ThisWeekStatsCardProps extends MarginProps {
@@ -21,21 +21,19 @@ export function ThisWeekStatsCard({ data, testId, ...marginProps }: ThisWeekStat
       <Flex direction="column" gap="3" p="2">
         <Heading size="3">{getMessage('statsThisWeekTitle')}</Heading>
         <Flex direction="column" gap="2">
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium">{getMessage('statsGroupings')}</Text>
-            <Flex align="center" gap="3">
-              <Text size="4" weight="bold">{data.thisWeek.grouping}</Text>
-              <TrendBadge current={data.thisWeek.grouping} previous={data.lastWeek.grouping} />
-            </Flex>
-          </Flex>
+          <MetricRow
+            label={getMessage('statsGroupings')}
+            value={data.thisWeek.grouping}
+            current={data.thisWeek.grouping}
+            previous={data.lastWeek.grouping}
+          />
           <Separator size="4" />
-          <Flex justify="between" align="center">
-            <Text size="2" weight="medium">{getMessage('statsDeduplications')}</Text>
-            <Flex align="center" gap="3">
-              <Text size="4" weight="bold">{data.thisWeek.dedup}</Text>
-              <TrendBadge current={data.thisWeek.dedup} previous={data.lastWeek.dedup} />
-            </Flex>
-          </Flex>
+          <MetricRow
+            label={getMessage('statsDeduplications')}
+            value={data.thisWeek.dedup}
+            current={data.thisWeek.dedup}
+            previous={data.lastWeek.dedup}
+          />
         </Flex>
       </Flex>
     </Card>

--- a/src/components/Core/Statistics/ThisWeekStatsCard.tsx
+++ b/src/components/Core/Statistics/ThisWeekStatsCard.tsx
@@ -1,7 +1,6 @@
-import { Card, Flex, Heading, Separator } from '@radix-ui/themes';
 import type { MarginProps } from '@radix-ui/themes/dist/esm/props/margin.props.js';
 import { getMessage } from '@/utils/i18n';
-import { MetricRow } from '@/components/Core/Statistics/primitives';
+import { TwoMetricCard } from '@/components/Core/Statistics/primitives';
 import type { StatisticsAggregates } from '@/types/statistics';
 
 interface ThisWeekStatsCardProps extends MarginProps {
@@ -17,25 +16,22 @@ interface ThisWeekStatsCardProps extends MarginProps {
  */
 export function ThisWeekStatsCard({ data, testId, ...marginProps }: ThisWeekStatsCardProps) {
   return (
-    <Card data-testid={testId} {...marginProps}>
-      <Flex direction="column" gap="3" p="2">
-        <Heading size="3">{getMessage('statsThisWeekTitle')}</Heading>
-        <Flex direction="column" gap="2">
-          <MetricRow
-            label={getMessage('statsGroupings')}
-            value={data.thisWeek.grouping}
-            current={data.thisWeek.grouping}
-            previous={data.lastWeek.grouping}
-          />
-          <Separator size="4" />
-          <MetricRow
-            label={getMessage('statsDeduplications')}
-            value={data.thisWeek.dedup}
-            current={data.thisWeek.dedup}
-            previous={data.lastWeek.dedup}
-          />
-        </Flex>
-      </Flex>
-    </Card>
+    <TwoMetricCard
+      title={getMessage('statsThisWeekTitle')}
+      metric1={{
+        label: getMessage('statsGroupings'),
+        value: data.thisWeek.grouping,
+        current: data.thisWeek.grouping,
+        previous: data.lastWeek.grouping,
+      }}
+      metric2={{
+        label: getMessage('statsDeduplications'),
+        value: data.thisWeek.dedup,
+        current: data.thisWeek.dedup,
+        previous: data.lastWeek.dedup,
+      }}
+      testId={testId}
+      {...marginProps}
+    />
   );
 }

--- a/src/components/Core/Statistics/ThisWeekStatsCard.tsx
+++ b/src/components/Core/Statistics/ThisWeekStatsCard.tsx
@@ -1,0 +1,43 @@
+import { Card, Flex, Heading, Separator, Text } from '@radix-ui/themes';
+import type { MarginProps } from '@radix-ui/themes/dist/esm/props/margin.props.js';
+import { getMessage } from '@/utils/i18n';
+import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
+import type { StatisticsAggregates } from '@/types/statistics';
+
+interface ThisWeekStatsCardProps extends MarginProps {
+  data: Pick<StatisticsAggregates, 'thisWeek' | 'lastWeek'>;
+  /** Optional data-testid forwarded to the Card root. */
+  testId?: string;
+}
+
+/**
+ * Compact "this week" card showing grouping and deduplication counts with
+ * week-over-week trend badges. Shared between StatisticsSummary and
+ * StatisticsRulesDetail.
+ */
+export function ThisWeekStatsCard({ data, testId, ...marginProps }: ThisWeekStatsCardProps) {
+  return (
+    <Card data-testid={testId} {...marginProps}>
+      <Flex direction="column" gap="3" p="2">
+        <Heading size="3">{getMessage('statsThisWeekTitle')}</Heading>
+        <Flex direction="column" gap="2">
+          <Flex justify="between" align="center">
+            <Text size="2" weight="medium">{getMessage('statsGroupings')}</Text>
+            <Flex align="center" gap="3">
+              <Text size="4" weight="bold">{data.thisWeek.grouping}</Text>
+              <TrendBadge current={data.thisWeek.grouping} previous={data.lastWeek.grouping} />
+            </Flex>
+          </Flex>
+          <Separator size="4" />
+          <Flex justify="between" align="center">
+            <Text size="2" weight="medium">{getMessage('statsDeduplications')}</Text>
+            <Flex align="center" gap="3">
+              <Text size="4" weight="bold">{data.thisWeek.dedup}</Text>
+              <TrendBadge current={data.thisWeek.dedup} previous={data.lastWeek.dedup} />
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Card>
+  );
+}

--- a/src/components/Core/Statistics/primitives.tsx
+++ b/src/components/Core/Statistics/primitives.tsx
@@ -1,7 +1,39 @@
 import { Box, Card, Flex, Text, Tooltip } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
+import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
 import type { GroupColorStat } from '@/hooks/useSessionStatistics';
 import type { ChromeGroupColor } from '@/types/tabTree';
+
+interface MetricRowProps {
+  label: string;
+  value: React.ReactNode;
+  current: number;
+  previous: number;
+  /** Text size for the value. Defaults to "4". */
+  valueSize?: '3' | '4';
+  /** Color applied to the label text. Defaults to no color (weight="medium"). */
+  labelColor?: 'gray';
+}
+
+/**
+ * A single metric row: label on the left, bold value + TrendBadge on the right.
+ * Used in ThisWeekStatsCard and SessionActivityCard.
+ */
+export function MetricRow({ label, value, current, previous, valueSize = '4', labelColor }: MetricRowProps) {
+  return (
+    <Flex justify="between" align="center">
+      {labelColor ? (
+        <Text size="2" color={labelColor}>{label}</Text>
+      ) : (
+        <Text size="2" weight="medium">{label}</Text>
+      )}
+      <Flex align="center" gap="3">
+        <Text size={valueSize} weight="bold">{value}</Text>
+        <TrendBadge current={current} previous={previous} />
+      </Flex>
+    </Flex>
+  );
+}
 
 export const GROUP_COLOR_CSS: Record<ChromeGroupColor, string> = {
   grey: 'var(--gray-9)',

--- a/src/components/Core/Statistics/primitives.tsx
+++ b/src/components/Core/Statistics/primitives.tsx
@@ -1,8 +1,10 @@
-import { Box, Card, Flex, Text, Tooltip } from '@radix-ui/themes';
+import { Box, Card, Flex, Heading, Separator, Text, Tooltip } from '@radix-ui/themes';
+import type { MarginProps } from '@radix-ui/themes/dist/esm/props/margin.props.js';
 import { getMessage } from '@/utils/i18n';
 import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
 import type { GroupColorStat } from '@/hooks/useSessionStatistics';
 import type { ChromeGroupColor } from '@/types/tabTree';
+import React from 'react';
 
 interface MetricRowProps {
   label: string;
@@ -17,7 +19,7 @@ interface MetricRowProps {
 
 /**
  * A single metric row: label on the left, bold value + TrendBadge on the right.
- * Used in ThisWeekStatsCard and SessionActivityCard.
+ * Used in TwoMetricCard (and therefore ThisWeekStatsCard and SessionActivityCard).
  */
 export function MetricRow({ label, value, current, previous, valueSize = '4', labelColor }: MetricRowProps) {
   return (
@@ -32,6 +34,52 @@ export function MetricRow({ label, value, current, previous, valueSize = '4', la
         <TrendBadge current={current} previous={previous} />
       </Flex>
     </Flex>
+  );
+}
+
+interface TwoMetricCardMetric {
+  label: string;
+  value: number;
+  current: number;
+  previous: number;
+}
+
+interface TwoMetricCardProps extends MarginProps {
+  title: string;
+  metric1: TwoMetricCardMetric;
+  metric2: TwoMetricCardMetric;
+  /** Optional content rendered below the two metrics (e.g. a lifetime summary text). */
+  footer?: React.ReactNode;
+  testId?: string;
+}
+
+/**
+ * Card shell containing a heading, two MetricRows separated by a Separator,
+ * and an optional footer node. Shared by ThisWeekStatsCard and SessionActivityCard.
+ */
+export function TwoMetricCard({ title, metric1, metric2, footer, testId, ...marginProps }: TwoMetricCardProps) {
+  return (
+    <Card data-testid={testId} {...marginProps}>
+      <Flex direction="column" gap="3" p="2">
+        <Heading size="3">{title}</Heading>
+        <Flex direction="column" gap="2">
+          <MetricRow
+            label={metric1.label}
+            value={metric1.value}
+            current={metric1.current}
+            previous={metric1.previous}
+          />
+          <Separator size="4" />
+          <MetricRow
+            label={metric2.label}
+            value={metric2.value}
+            current={metric2.current}
+            previous={metric2.previous}
+          />
+        </Flex>
+        {footer}
+      </Flex>
+    </Card>
   );
 }
 

--- a/src/components/UI/DeleteMenuItem/DeleteMenuItem.stories.tsx
+++ b/src/components/UI/DeleteMenuItem/DeleteMenuItem.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Theme, DropdownMenu, Box } from '@radix-ui/themes';
+import { DeleteMenuItem } from './DeleteMenuItem';
+
+/**
+ * DeleteMenuItem must live inside a DropdownMenu.Root + DropdownMenu.Content
+ * to render correctly (Radix context requirement).
+ * The decorator opens the menu statically so Storybook can display the item.
+ */
+const meta: Meta<typeof DeleteMenuItem> = {
+  title: 'Components/UI/DeleteMenuItem',
+  component: DeleteMenuItem,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <Theme>
+        <Box style={{ minWidth: 200 }}>
+          <DropdownMenu.Root open>
+            <DropdownMenu.Trigger>
+              {/* Trigger is hidden; menu is forced open via the open prop */}
+              <span />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <Story />
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Box>
+      </Theme>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/* ── Stories ─────────────────────────────────────────────────────────────────── */
+
+export const DeleteMenuItemDefault: Story = {
+  args: {
+    onClick: () => {},
+  },
+};
+
+export const DeleteMenuItemWithTestId: Story = {
+  name: 'DeleteMenuItem — with data-testid',
+  args: {
+    onClick: () => {},
+    'data-testid': 'my-item-menu-delete',
+  },
+};

--- a/src/components/UI/DeleteMenuItem/DeleteMenuItem.tsx
+++ b/src/components/UI/DeleteMenuItem/DeleteMenuItem.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { DropdownMenu, Flex, Kbd } from '@radix-ui/themes';
+import { Trash2 } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+
+export interface DeleteMenuItemProps {
+  onClick: () => void;
+  /** Optional data-testid attribute for E2E targeting. */
+  'data-testid'?: string;
+}
+
+/**
+ * Reusable "Delete" item for DropdownMenu contexts.
+ * Renders a red DropdownMenu.Item with a Trash2 icon, the i18n "delete" label,
+ * and a Del keyboard shortcut hint.
+ */
+export function DeleteMenuItem({ onClick, 'data-testid': testId }: DeleteMenuItemProps) {
+  return (
+    <DropdownMenu.Item
+      color="red"
+      data-testid={testId}
+      onClick={onClick}
+    >
+      <Flex align="center" justify="between" gap="3" width="100%">
+        <Flex align="center" gap="2">
+          <Trash2 size={14} aria-hidden="true" />
+          {getMessage('delete')}
+        </Flex>
+        <Kbd size="1">Del</Kbd>
+      </Flex>
+    </DropdownMenu.Item>
+  );
+}

--- a/src/components/UI/DomainCodeField/DomainCodeField.tsx
+++ b/src/components/UI/DomainCodeField/DomainCodeField.tsx
@@ -1,13 +1,4 @@
-import { useEffect, useRef } from 'react';
-import { useTheme } from 'next-themes';
-import { Compartment, EditorState } from '@codemirror/state';
-import {
-  EditorView,
-  keymap,
-  drawSelection,
-  placeholder as placeholderExtension,
-} from '@codemirror/view';
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { useCodeMirrorSingleLine } from '@/hooks/useCodeMirrorSingleLine';
 import { domainHighlighter } from './domainHighlight';
 import { createDomainEditorTheme } from './cmDomainTheme';
 
@@ -34,15 +25,14 @@ export interface DomainCodeFieldProps {
   focusOnMount?: boolean;
 }
 
+const DOMAIN_LANGUAGE_EXTENSIONS = [domainHighlighter];
+
 /**
  * Single-line CodeMirror editor that highlights a plain domain live while
  * preserving the accessibility and theming contract of a Radix `TextField`.
  *
- * Twin of `RegexCodeField`: mounts the editor once and funnels reactive prop
- * changes through dedicated effects and `Compartment`s. Newlines are rejected so
- * the value stays a single-line domain. Coloring (subdomain / domain / tld /
- * dots) is handled by {@link domainHighlighter}; values that are not plain
- * domains stay rendered as neutral text.
+ * Thin wrapper around `useCodeMirrorSingleLine`: the only domain-specific
+ * details are the `domainHighlighter` extension and `createDomainEditorTheme`.
  */
 export function DomainCodeField({
   value,
@@ -56,113 +46,18 @@ export function DomainCodeField({
   testId = 'domain-code-field',
   focusOnMount = false,
 }: DomainCodeFieldProps) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<EditorView | null>(null);
-
-  // Props the mount-once setup reads without re-running.
-  const onChangeRef = useRef(onChange);
-  const valueRef = useRef(value);
-  const idRef = useRef(id);
-  const placeholderRef = useRef(placeholder);
-  const ariaLabelRef = useRef(ariaLabel);
-  const describedByRef = useRef(describedById);
-  const hasErrorRef = useRef(hasError);
-  const isDarkRef = useRef(isDark);
-  const focusOnMountRef = useRef(focusOnMount);
-
-  const themeCompartment = useRef(new Compartment());
-  const ariaCompartment = useRef(new Compartment());
-
-  onChangeRef.current = onChange;
-
-  // Create the editor once. Reactive updates flow through the effects below.
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const state = EditorState.create({
-      doc: valueRef.current,
-      extensions: [
-        domainHighlighter,
-        history(),
-        drawSelection(),
-        // Keep the value single-line: drop any transaction adding a line break.
-        EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr)),
-        placeholderExtension(placeholderRef.current ?? ''),
-        EditorView.contentAttributes.of({
-          id: idRef.current ?? '',
-          'aria-label': ariaLabelRef.current,
-          'aria-describedby': describedByRef.current ?? '',
-          spellcheck: 'false',
-          autocapitalize: 'off',
-          autocorrect: 'off',
-          'data-1p-ignore': 'true',
-          ...(focusOnMountRef.current ? { 'data-autofocus': 'true' } : {}),
-        }),
-        ariaCompartment.current.of(
-          EditorView.contentAttributes.of({
-            'aria-invalid': hasErrorRef.current ? 'true' : 'false',
-          }),
-        ),
-        themeCompartment.current.of(createDomainEditorTheme(isDarkRef.current)),
-        keymap.of([...defaultKeymap, ...historyKeymap]),
-        EditorView.updateListener.of((update) => {
-          if (update.docChanged) {
-            onChangeRef.current(update.state.doc.toString());
-          }
-        }),
-      ],
-    });
-
-    const view = new EditorView({ state, parent: containerRef.current });
-    viewRef.current = view;
-    // Make the (horizontally) scrollable viewport reachable by keyboard so a
-    // long domain can be scrolled without a pointer (axe scrollable-region).
-    view.scrollDOM.setAttribute('tabindex', '0');
-    if (focusOnMountRef.current) view.focus();
-
-    return () => {
-      view.destroy();
-      viewRef.current = null;
-    };
-    // Mount-once: subsequent prop changes are handled by the effects below.
-
-  }, []);
-
-  // Sync externally driven value changes (form reset, edit of another rule).
-  useEffect(() => {
-    valueRef.current = value;
-    const view = viewRef.current;
-    if (!view) return;
-    const current = view.state.doc.toString();
-    if (value !== current) {
-      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
-    }
-  }, [value]);
-
-  useEffect(() => {
-    hasErrorRef.current = hasError;
-    const view = viewRef.current;
-    if (view) {
-      view.dispatch({
-        effects: ariaCompartment.current.reconfigure(
-          EditorView.contentAttributes.of({ 'aria-invalid': hasError ? 'true' : 'false' }),
-        ),
-      });
-    }
-  }, [hasError]);
-
-  useEffect(() => {
-    isDarkRef.current = isDark;
-    const view = viewRef.current;
-    if (view) {
-      view.dispatch({
-        effects: themeCompartment.current.reconfigure(createDomainEditorTheme(isDark)),
-      });
-    }
-  }, [isDark]);
+  const { containerRef } = useCodeMirrorSingleLine({
+    value,
+    onChange,
+    id,
+    placeholder,
+    ariaLabel,
+    hasError,
+    describedById,
+    focusOnMount,
+    languageExtensions: DOMAIN_LANGUAGE_EXTENSIONS,
+    createTheme: createDomainEditorTheme,
+  });
 
   return <div ref={containerRef} data-testid={testId} data-name={name} />;
 }

--- a/src/components/UI/DomainCodeField/cmDomainTheme.ts
+++ b/src/components/UI/DomainCodeField/cmDomainTheme.ts
@@ -1,5 +1,6 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
+import { cmBaseThemeStyles } from '@/components/UI/shared/cmBaseTheme.js';
 
 /**
  * Single-line editor chrome for the domain field. Mirrors the visible look of a
@@ -16,40 +17,20 @@ import { EditorView } from '@codemirror/view';
 export function createDomainEditorTheme(isDark: boolean): Extension {
   return EditorView.theme(
     {
-      '&': {
-        color: 'var(--gray-12)',
-        backgroundColor: 'var(--color-surface)',
-        fontSize: 'var(--font-size-2)',
-        border: '1px solid var(--gray-a7)',
-        borderRadius: 'var(--radius-3)',
-      },
-      '&.cm-focused': {
-        outline: '2px solid var(--accent-8)',
-        outlineOffset: '-1px',
-      },
+      ...cmBaseThemeStyles,
       '.cm-scroller': {
+        ...cmBaseThemeStyles['.cm-scroller'],
         // A domain is not code: use the UI font (like the sibling Radix
         // TextField) so dots are not spaced out by monospace cells.
         fontFamily: 'var(--default-font-family, system-ui, sans-serif)',
-        lineHeight: '1.5',
         // Hold the size-2 input height here (not on .cm-content) so the single
         // line is vertically centered by alignItems instead of pinned to top.
         minHeight: '28px',
-        alignItems: 'center',
-        overflowX: 'auto',
       },
       // Single editing line, vertically centered by the scroller above.
       '.cm-content': {
-        padding: '0 var(--space-2)',
-        caretColor: 'var(--gray-12)',
+        ...cmBaseThemeStyles['.cm-content'],
       },
-      '.cm-line': { padding: '0' },
-      '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
-      // gray-a11 is the most muted gray that still meets WCAG AA (4.5:1) for
-      // text; gray-a9/a10 (Radix's default placeholder tone) fail axe contrast.
-      '.cm-placeholder': { color: 'var(--gray-a11)' },
-      '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
-      '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
       // Domain part colors.
       '.cm-domain-subdomain': { color: 'var(--gray-a11)' },
       '.cm-domain-domain': { color: 'var(--accent-11)', fontWeight: '500' },

--- a/src/components/UI/RegexCodeField/RegexCodeField.tsx
+++ b/src/components/UI/RegexCodeField/RegexCodeField.tsx
@@ -1,14 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { useTheme } from 'next-themes';
-import { Compartment, EditorState } from '@codemirror/state';
-import {
-  EditorView,
-  keymap,
-  drawSelection,
-  placeholder as placeholderExtension,
-} from '@codemirror/view';
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import { syntaxHighlighting } from '@codemirror/language';
+import { useCodeMirrorSingleLine } from '@/hooks/useCodeMirrorSingleLine';
 import { regexLanguage, regexHighlightStyle } from './regexHighlight';
 import { createRegexEditorTheme } from './cmRegexTheme';
 
@@ -30,13 +21,14 @@ export interface RegexCodeFieldProps {
   testId?: string;
 }
 
+const REGEX_LANGUAGE_EXTENSIONS = [regexLanguage, syntaxHighlighting(regexHighlightStyle)];
+
 /**
  * Single-line CodeMirror editor that highlights a regular expression live while
  * preserving the accessibility and theming contract of a Radix `TextField`.
  *
- * Built as a slimmed variant of `JsonCodeEditor`: it mounts the editor once and
- * funnels reactive prop changes through dedicated effects and `Compartment`s.
- * Newlines are rejected so the value stays a single-line pattern.
+ * Thin wrapper around `useCodeMirrorSingleLine`: the only regex-specific
+ * details are the language/highlight extensions and `createRegexEditorTheme`.
  */
 export function RegexCodeField({
   value,
@@ -49,111 +41,17 @@ export function RegexCodeField({
   name,
   testId = 'regex-code-field',
 }: RegexCodeFieldProps) {
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<EditorView | null>(null);
-
-  // Props the mount-once setup reads without re-running.
-  const onChangeRef = useRef(onChange);
-  const valueRef = useRef(value);
-  const idRef = useRef(id);
-  const placeholderRef = useRef(placeholder);
-  const ariaLabelRef = useRef(ariaLabel);
-  const describedByRef = useRef(describedById);
-  const hasErrorRef = useRef(hasError);
-  const isDarkRef = useRef(isDark);
-
-  const themeCompartment = useRef(new Compartment());
-  const ariaCompartment = useRef(new Compartment());
-
-  onChangeRef.current = onChange;
-
-  // Create the editor once. Reactive updates flow through the effects below.
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const state = EditorState.create({
-      doc: valueRef.current,
-      extensions: [
-        regexLanguage,
-        syntaxHighlighting(regexHighlightStyle),
-        history(),
-        drawSelection(),
-        // Keep the value single-line: drop any transaction adding a line break.
-        EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr)),
-        placeholderExtension(placeholderRef.current ?? ''),
-        EditorView.contentAttributes.of({
-          id: idRef.current ?? '',
-          'aria-label': ariaLabelRef.current,
-          'aria-describedby': describedByRef.current ?? '',
-          spellcheck: 'false',
-          autocapitalize: 'off',
-          autocorrect: 'off',
-          'data-1p-ignore': 'true',
-        }),
-        ariaCompartment.current.of(
-          EditorView.contentAttributes.of({
-            'aria-invalid': hasErrorRef.current ? 'true' : 'false',
-          }),
-        ),
-        themeCompartment.current.of(createRegexEditorTheme(isDarkRef.current)),
-        keymap.of([...defaultKeymap, ...historyKeymap]),
-        EditorView.updateListener.of((update) => {
-          if (update.docChanged) {
-            onChangeRef.current(update.state.doc.toString());
-          }
-        }),
-      ],
-    });
-
-    const view = new EditorView({ state, parent: containerRef.current });
-    viewRef.current = view;
-    // Make the (horizontally) scrollable viewport reachable by keyboard so a
-    // long pattern can be scrolled without a pointer (axe scrollable-region).
-    view.scrollDOM.setAttribute('tabindex', '0');
-
-    return () => {
-      view.destroy();
-      viewRef.current = null;
-    };
-    // Mount-once: subsequent prop changes are handled by the effects below.
-     
-  }, []);
-
-  // Sync externally driven value changes (form reset, edit of another rule).
-  useEffect(() => {
-    valueRef.current = value;
-    const view = viewRef.current;
-    if (!view) return;
-    const current = view.state.doc.toString();
-    if (value !== current) {
-      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
-    }
-  }, [value]);
-
-  useEffect(() => {
-    hasErrorRef.current = hasError;
-    const view = viewRef.current;
-    if (view) {
-      view.dispatch({
-        effects: ariaCompartment.current.reconfigure(
-          EditorView.contentAttributes.of({ 'aria-invalid': hasError ? 'true' : 'false' }),
-        ),
-      });
-    }
-  }, [hasError]);
-
-  useEffect(() => {
-    isDarkRef.current = isDark;
-    const view = viewRef.current;
-    if (view) {
-      view.dispatch({
-        effects: themeCompartment.current.reconfigure(createRegexEditorTheme(isDark)),
-      });
-    }
-  }, [isDark]);
+  const { containerRef } = useCodeMirrorSingleLine({
+    value,
+    onChange,
+    id,
+    placeholder,
+    ariaLabel,
+    hasError,
+    describedById,
+    languageExtensions: REGEX_LANGUAGE_EXTENSIONS,
+    createTheme: createRegexEditorTheme,
+  });
 
   return <div ref={containerRef} data-testid={testId} data-name={name} />;
 }

--- a/src/components/UI/RegexCodeField/cmRegexTheme.ts
+++ b/src/components/UI/RegexCodeField/cmRegexTheme.ts
@@ -1,5 +1,6 @@
 import type { Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
+import { cmBaseThemeStyles } from '@/components/UI/shared/cmBaseTheme.js';
 
 /**
  * Single-line editor chrome for the regex field. Mirrors the visible look of a
@@ -12,35 +13,21 @@ import { EditorView } from '@codemirror/view';
 export function createRegexEditorTheme(isDark: boolean): Extension {
   return EditorView.theme(
     {
-      '&': {
-        color: 'var(--gray-12)',
-        backgroundColor: 'var(--color-surface)',
-        fontSize: 'var(--font-size-2)',
-        border: '1px solid var(--gray-a7)',
-        borderRadius: 'var(--radius-3)',
-      },
-      '&.cm-focused': {
-        outline: '2px solid var(--accent-8)',
-        outlineOffset: '-1px',
-      },
+      ...cmBaseThemeStyles,
       '.cm-scroller': {
+        ...cmBaseThemeStyles['.cm-scroller'],
         fontFamily:
           'var(--code-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)',
-        lineHeight: '1.5',
-        alignItems: 'center',
-        overflowX: 'auto',
       },
       // Single editing line, vertically centered, matching a Radix size-2 input.
       '.cm-content': {
-        padding: '0 var(--space-2)',
+        ...cmBaseThemeStyles['.cm-content'],
         minHeight: '28px',
-        caretColor: 'var(--gray-12)',
       },
-      '.cm-line': { padding: '0' },
-      '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
+      // gray-a9 is intentional here: regex patterns are code, and a slightly
+      // more muted placeholder (vs gray-a11 used by the domain field) suits
+      // the monospace context. This intentionally overrides the base.
       '.cm-placeholder': { color: 'var(--gray-a9)' },
-      '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
-      '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
     },
     { dark: isDark },
   );

--- a/src/components/UI/shared/cmBaseTheme.ts
+++ b/src/components/UI/shared/cmBaseTheme.ts
@@ -1,0 +1,36 @@
+/**
+ * Base EditorView.theme styles shared by the single-line CodeMirror editors
+ * (domain field and regex field). These establish the Radix `TextField`
+ * (size 2) visual contract: border, radius, surface color, font size, focus
+ * ring, and selection colors.
+ *
+ * Each consumer then adds its own `.cm-scroller` font family, its own
+ * `minHeight` placement, and any field-specific token colors.
+ */
+export const cmBaseThemeStyles = {
+  '&': {
+    color: 'var(--gray-12)',
+    backgroundColor: 'var(--color-surface)',
+    fontSize: 'var(--font-size-2)',
+    border: '1px solid var(--gray-a7)',
+    borderRadius: 'var(--radius-3)',
+  },
+  '&.cm-focused': {
+    outline: '2px solid var(--accent-8)',
+    outlineOffset: '-1px',
+  },
+  '.cm-scroller': {
+    lineHeight: '1.5',
+    alignItems: 'center',
+    overflowX: 'auto',
+  },
+  '.cm-content': {
+    padding: '0 var(--space-2)',
+    caretColor: 'var(--gray-12)',
+  },
+  '.cm-line': { padding: '0' },
+  '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--gray-12)' },
+  '.cm-placeholder': { color: 'var(--gray-a11)' },
+  '.cm-selectionBackground, ::selection': { backgroundColor: 'var(--accent-a4)' },
+  '&.cm-focused .cm-selectionBackground': { backgroundColor: 'var(--accent-a5)' },
+} as const;

--- a/src/hooks/useCodeMirrorSingleLine.ts
+++ b/src/hooks/useCodeMirrorSingleLine.ts
@@ -1,0 +1,194 @@
+import { useEffect, useRef } from 'react';
+import { useTheme } from 'next-themes';
+import { Compartment, EditorState, type Extension } from '@codemirror/state';
+import {
+  EditorView,
+  keymap,
+  drawSelection,
+  placeholder as placeholderExtension,
+} from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+
+/**
+ * Parameters for {@link useCodeMirrorSingleLine}.
+ */
+export interface UseCodeMirrorSingleLineParams {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  placeholder?: string;
+  ariaLabel: string;
+  hasError?: boolean;
+  describedById?: string;
+  /**
+   * When true, marks the content node with `[data-autofocus]` (so `DialogShell`
+   * focuses it on open) and focuses the editor on mount.
+   */
+  focusOnMount?: boolean;
+  /**
+   * Language / syntax-highlighting extensions that are specific to the field
+   * variant (e.g. `domainHighlighter` or `[regexLanguage, syntaxHighlighting(...)]`).
+   * These are installed once at mount time and never reconfigured.
+   */
+  languageExtensions: Extension[];
+  /**
+   * Factory that produces the editor theme `Extension` for the current
+   * appearance. Called once at mount (with the initial `isDark` value) and again
+   * whenever the resolved theme changes.
+   */
+  createTheme: (isDark: boolean) => Extension;
+}
+
+/**
+ * Return value of {@link useCodeMirrorSingleLine}.
+ *
+ * Attach `containerRef` to the wrapper `<div>` that CodeMirror should mount
+ * into.
+ */
+export interface UseCodeMirrorSingleLineResult {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Encapsulates the lifecycle of a single-line CodeMirror editor that mirrors
+ * the visual contract of a Radix `TextField`.
+ *
+ * Shared by `DomainCodeField` and `RegexCodeField`. The two fields differ only
+ * in their language/highlighting extensions and their theme factory; everything
+ * else (mount logic, reactive effects for value / error / theme, scrollDOM
+ * tabindex) is identical and lives here.
+ *
+ * The editor is mounted once. Subsequent prop changes are propagated through
+ * CodeMirror `Compartment`s or direct `dispatch` calls rather than by
+ * recreating the view.
+ */
+export function useCodeMirrorSingleLine({
+  value,
+  onChange,
+  id,
+  placeholder,
+  ariaLabel,
+  hasError = false,
+  describedById,
+  focusOnMount = false,
+  languageExtensions,
+  createTheme,
+}: UseCodeMirrorSingleLineParams): UseCodeMirrorSingleLineResult {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Per-instance Compartments (must be inside the hook, not module-level).
+  const themeCompartment = useRef(new Compartment());
+  const ariaCompartment = useRef(new Compartment());
+
+  // Props the mount-once setup reads without re-running.
+  const onChangeRef = useRef(onChange);
+  const valueRef = useRef(value);
+  const idRef = useRef(id);
+  const placeholderRef = useRef(placeholder);
+  const ariaLabelRef = useRef(ariaLabel);
+  const describedByRef = useRef(describedById);
+  const hasErrorRef = useRef(hasError);
+  const isDarkRef = useRef(isDark);
+  const focusOnMountRef = useRef(focusOnMount);
+
+  // Stable refs for things injected by the caller that must never trigger a
+  // remount (language extensions are fixed at build time; createTheme is a
+  // module-level function).
+  const languageExtensionsRef = useRef(languageExtensions);
+  const createThemeRef = useRef(createTheme);
+
+  // Keep the onChange ref current so the listener always calls the latest handler.
+  onChangeRef.current = onChange;
+
+  // Create the editor once. Reactive updates flow through the effects below.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const state = EditorState.create({
+      doc: valueRef.current,
+      extensions: [
+        ...languageExtensionsRef.current,
+        history(),
+        drawSelection(),
+        // Keep the value single-line: drop any transaction adding a line break.
+        EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr)),
+        placeholderExtension(placeholderRef.current ?? ''),
+        EditorView.contentAttributes.of({
+          id: idRef.current ?? '',
+          'aria-label': ariaLabelRef.current,
+          'aria-describedby': describedByRef.current ?? '',
+          spellcheck: 'false',
+          autocapitalize: 'off',
+          autocorrect: 'off',
+          'data-1p-ignore': 'true',
+          ...(focusOnMountRef.current ? { 'data-autofocus': 'true' } : {}),
+        }),
+        ariaCompartment.current.of(
+          EditorView.contentAttributes.of({
+            'aria-invalid': hasErrorRef.current ? 'true' : 'false',
+          }),
+        ),
+        themeCompartment.current.of(createThemeRef.current(isDarkRef.current)),
+        keymap.of([...defaultKeymap, ...historyKeymap]),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+      ],
+    });
+
+    const view = new EditorView({ state, parent: containerRef.current });
+    viewRef.current = view;
+    // Make the (horizontally) scrollable viewport reachable by keyboard so a
+    // long value can be scrolled without a pointer (axe scrollable-region).
+    view.scrollDOM.setAttribute('tabindex', '0');
+    if (focusOnMountRef.current) view.focus();
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Mount-once: subsequent prop changes are handled by the effects below.
+     
+  }, []);
+
+  // Sync externally driven value changes (form reset, edit of another rule).
+  useEffect(() => {
+    valueRef.current = value;
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (value !== current) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+    }
+  }, [value]);
+
+  useEffect(() => {
+    hasErrorRef.current = hasError;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: ariaCompartment.current.reconfigure(
+          EditorView.contentAttributes.of({ 'aria-invalid': hasError ? 'true' : 'false' }),
+        ),
+      });
+    }
+  }, [hasError]);
+
+  useEffect(() => {
+    isDarkRef.current = isDark;
+    const view = viewRef.current;
+    if (view) {
+      view.dispatch({
+        effects: themeCompartment.current.reconfigure(createThemeRef.current(isDark)),
+      });
+    }
+  }, [isDark]);
+
+  return { containerRef };
+}


### PR DESCRIPTION
The two single-line CodeMirror editors shared ~105 identical lines covering
the full editor lifecycle: mount-once setup, Compartment management, reactive
effects for value / aria-invalid / theme, and scrollDOM tabindex. That logic
now lives in src/hooks/useCodeMirrorSingleLine.ts.

DomainCodeField and RegexCodeField are now thin wrappers that supply only their
field-specific language extensions (domainHighlighter vs. regexLanguage +
syntaxHighlighting) and theme factory (createDomainEditorTheme vs.
createRegexEditorTheme).

Files created:
  src/hooks/useCodeMirrorSingleLine.ts

Files updated (call sites):
  src/components/UI/DomainCodeField/DomainCodeField.tsx
  src/components/UI/RegexCodeField/RegexCodeField.tsx

Originates from painpoint #1 identified by the code-deduplicator agent.

https://claude.ai/code/session_011Q7GkPJjUjm5MWRXcGWHdn