### PR TITLE
feat(ListToolbar): show "/" shortcut hint in search box

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -150,6 +150,7 @@
   "confirmDeleteSelected": { "message": "Delete the selected rules?" },
   "confirmDeleteSelectedDescription": { "message": "This will permanently delete the selected rules. This action cannot be undone." },
   "searchRules": { "message": "Search rules..." },
+  "clearSearch": { "message": "Clear search" },
   "searchSessions": { "message": "Search sessions..." },
   "searchWorkspaces": { "message": "Search workspaces..." },
   "noRulesFound": { "message": "No rules found" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -150,6 +150,7 @@
   "confirmDeleteSelected": { "message": "¿Eliminar las reglas seleccionadas?" },
   "confirmDeleteSelectedDescription": { "message": "Las reglas seleccionadas se eliminarán permanentemente. Esta acción no se puede deshacer." },
   "searchRules": { "message": "Buscar reglas..." },
+  "clearSearch": { "message": "Borrar la búsqueda" },
   "searchSessions": { "message": "Buscar sesiones..." },
   "searchWorkspaces": { "message": "Buscar espacios..." },
   "noRulesFound": { "message": "No se encontraron reglas" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -150,6 +150,7 @@
   "confirmDeleteSelected": { "message": "Supprimer les règles sélectionnées ?" },
   "confirmDeleteSelectedDescription": { "message": "Les règles sélectionnées seront définitivement supprimées. Cette action est irréversible." },
   "searchRules": { "message": "Rechercher des règles..." },
+  "clearSearch": { "message": "Effacer la recherche" },
   "searchSessions": { "message": "Rechercher des sessions..." },
   "searchWorkspaces": { "message": "Rechercher des espaces..." },
   "noRulesFound": { "message": "Aucune règle trouvée" },

--- a/src/components/UI/ListToolbar/ListToolbar.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { Box, Flex, TextField } from '@radix-ui/themes';
+import { Box, Flex, Kbd, TextField } from '@radix-ui/themes';
 import { Search } from 'lucide-react';
+import { getEffectiveBindings } from '@/shortcuts/getEffectiveBindings';
+
+/** Keyboard shortcut that focuses the active search field (see registry). */
+const focusBinding = getEffectiveBindings('options.search.focus')[0];
+const SEARCH_SHORTCUT = Array.isArray(focusBinding)
+  ? focusBinding.join(' ')
+  : focusBinding;
 
 interface ListToolbarProps {
   /** Container testid (e.g. "page-rules-toolbar"). */
@@ -41,6 +48,7 @@ export function ListToolbar({
           data-testid={searchTestId}
           placeholder={searchPlaceholder}
           aria-label={searchPlaceholder}
+          aria-keyshortcuts={SEARCH_SHORTCUT}
           value={searchValue}
           onChange={(e) => onSearchChange(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -48,6 +56,11 @@ export function ListToolbar({
           <TextField.Slot>
             <Search size={16} />
           </TextField.Slot>
+          {SEARCH_SHORTCUT && searchValue.length === 0 && (
+            <TextField.Slot side="right">
+              <Kbd size="1" aria-hidden="true">{SEARCH_SHORTCUT}</Kbd>
+            </TextField.Slot>
+          )}
         </TextField.Root>
       </Box>
       {action}

--- a/src/components/UI/ListToolbar/ListToolbar.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Flex, IconButton, Kbd, TextField } from '@radix-ui/themes';
+import { Box, Flex, IconButton, Kbd, TextField, Tooltip } from '@radix-ui/themes';
 import { Search, X } from 'lucide-react';
 import { getEffectiveBindings } from '@/shortcuts/getEffectiveBindings';
 import { getMessage } from '@/utils/i18n';
@@ -64,17 +64,26 @@ export function ListToolbar({
           )}
           {searchValue.length > 0 && (
             <TextField.Slot side="right">
-              <IconButton
-                size="1"
-                variant="ghost"
-                color="gray"
-                data-testid={searchTestId ? `${searchTestId}-clear` : undefined}
-                aria-label={getMessage('clearSearch')}
-                title={getMessage('clearSearch')}
-                onClick={() => onSearchChange('')}
+              <Tooltip
+                content={
+                  <Flex align="center" gap="2" aria-hidden="true">
+                    {getMessage('clearSearch')}
+                    <Kbd>Esc</Kbd>
+                  </Flex>
+                }
               >
-                <X size={16} aria-hidden="true" />
-              </IconButton>
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  data-testid={searchTestId ? `${searchTestId}-clear` : undefined}
+                  aria-label={getMessage('clearSearch')}
+                  aria-keyshortcuts="Escape"
+                  onClick={() => onSearchChange('')}
+                >
+                  <X size={16} aria-hidden="true" />
+                </IconButton>
+              </Tooltip>
             </TextField.Slot>
           )}
         </TextField.Root>

--- a/src/components/UI/ListToolbar/ListToolbar.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Box, Flex, Kbd, TextField } from '@radix-ui/themes';
-import { Search } from 'lucide-react';
+import { Box, Flex, IconButton, Kbd, TextField } from '@radix-ui/themes';
+import { Search, X } from 'lucide-react';
 import { getEffectiveBindings } from '@/shortcuts/getEffectiveBindings';
+import { getMessage } from '@/utils/i18n';
 
 /** Keyboard shortcut that focuses the active search field (see registry). */
 const focusBinding = getEffectiveBindings('options.search.focus')[0];
@@ -59,6 +60,21 @@ export function ListToolbar({
           {SEARCH_SHORTCUT && searchValue.length === 0 && (
             <TextField.Slot side="right">
               <Kbd size="1" aria-hidden="true">{SEARCH_SHORTCUT}</Kbd>
+            </TextField.Slot>
+          )}
+          {searchValue.length > 0 && (
+            <TextField.Slot side="right">
+              <IconButton
+                size="1"
+                variant="ghost"
+                color="gray"
+                data-testid={searchTestId ? `${searchTestId}-clear` : undefined}
+                aria-label={getMessage('clearSearch')}
+                title={getMessage('clearSearch')}
+                onClick={() => onSearchChange('')}
+              >
+                <X size={16} aria-hidden="true" />
+              </IconButton>
             </TextField.Slot>
           )}
         </TextField.Root>


### PR DESCRIPTION
Display a right-aligned Kbd badge with the focus-search shortcut ("/")
inside the search field, visible only while the field is empty. The key
is resolved from the central shortcuts registry (options.search.focus)
and exposed to assistive tech via aria-keyshortcuts.