### PR TITLE
feat(stats): split storage breakdown by workspace

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -700,6 +700,7 @@
   "statsStorageCatSessionsArchived": { "message": "Archived sessions" },
   "statsStorageCatStatistics": { "message": "Statistics" },
   "statsStorageCatSettings": { "message": "Miscellaneous settings" },
+  "statsStorageByWorkspace": { "message": "By workspace" },
   "statsStorageUnitBytes": { "message": "{value} B" },
   "statsStorageUnitKb": { "message": "{value} KB" },
   "statsStorageUnitMb": { "message": "{value} MB" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -701,6 +701,7 @@
   "statsStorageCatSessionsArchived": { "message": "Sesiones archivadas" },
   "statsStorageCatStatistics": { "message": "Estadísticas" },
   "statsStorageCatSettings": { "message": "Ajustes varios" },
+  "statsStorageByWorkspace": { "message": "Por espacio de trabajo" },
   "statsStorageUnitBytes": { "message": "{value} B" },
   "statsStorageUnitKb": { "message": "{value} KB" },
   "statsStorageUnitMb": { "message": "{value} MB" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -701,6 +701,7 @@
   "statsStorageCatSessionsArchived": { "message": "Sessions archivées" },
   "statsStorageCatStatistics": { "message": "Statistiques" },
   "statsStorageCatSettings": { "message": "Réglages divers" },
+  "statsStorageByWorkspace": { "message": "Par espace de travail" },
   "statsStorageUnitBytes": { "message": "{value} o" },
   "statsStorageUnitKb": { "message": "{value} Ko" },
   "statsStorageUnitMb": { "message": "{value} Mo" },

--- a/src/components/Core/Statistics/StatisticsStorageDetail.tsx
+++ b/src/components/Core/Statistics/StatisticsStorageDetail.tsx
@@ -1,21 +1,111 @@
-import { Box, Card, Flex, Heading, Separator, Text } from '@radix-ui/themes';
+import { Box, Card, Flex, Heading, Separator, Text, Theme } from '@radix-ui/themes';
 import { HardDrive } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { formatBytes } from '@/utils/formatBytes';
 import { BarRow } from '@/components/Core/Statistics/primitives';
-import type { StorageUsageSnapshot } from '@/hooks/useStorageUsage';
+import { WorkspaceAvatar } from '@/components/UI/Workspace/WorkspaceAvatar';
+import type { StorageUsageSnapshot, WorkspaceUsageBreakdown } from '@/hooks/useStorageUsage';
 
 interface StatisticsStorageDetailProps {
   usage: StorageUsageSnapshot;
 }
 
+/** Flat per-category breakdown (single-workspace view). */
+function CategoryBreakdown({ categories }: { categories: StorageUsageSnapshot['categories'] }) {
+  const maxBytes = categories.length > 0 ? categories[0].bytes : 0;
+
+  if (categories.length === 0) {
+    return <Text size="2" color="gray">—</Text>;
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      {categories.map((cat, index) => (
+        <BarRow
+          key={cat.id}
+          index={index}
+          label={getMessage(cat.labelKey)}
+          value={cat.bytes}
+          valueLabel={formatBytes(cat.bytes)}
+          maxValue={maxBytes}
+          testId={`page-stats-storage-row-${cat.id}`}
+        />
+      ))}
+    </Flex>
+  );
+}
+
 /**
- * Storage sub-page: global quota usage plus a per-category breakdown of the
- * local storage footprint.
+ * One workspace section: identity header (avatar + name + total) plus its
+ * non-empty categories. Wrapped in a nested `Theme` so the bars (and avatar)
+ * adopt the workspace accent color via the re-scoped `--accent-*` tokens.
+ */
+function WorkspaceSection({
+  workspace,
+  maxBytes,
+}: {
+  workspace: WorkspaceUsageBreakdown;
+  maxBytes: number;
+}) {
+  const visibleCategories = workspace.categories.filter((cat) => cat.bytes > 0);
+
+  return (
+    <Theme accentColor={workspace.accentColor}>
+      <Flex
+        direction="column"
+        gap="3"
+        data-testid={`page-stats-storage-ws-${workspace.workspaceId}`}
+      >
+        <Flex align="center" gap="2" justify="between">
+          <Flex align="center" gap="2" style={{ minWidth: 0 }}>
+            <WorkspaceAvatar name={workspace.name} accentColor={workspace.accentColor} size="sm" />
+            <Text
+              size="2"
+              weight="medium"
+              style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {workspace.name}
+            </Text>
+          </Flex>
+          <Text size="2" weight="bold" style={{ flexShrink: 0 }}>
+            {formatBytes(workspace.totalBytes)}
+          </Text>
+        </Flex>
+
+        {visibleCategories.length > 0 ? (
+          <Flex direction="column" gap="3">
+            {visibleCategories.map((cat, index) => (
+              <BarRow
+                key={cat.id}
+                index={index}
+                label={getMessage(cat.labelKey)}
+                value={cat.bytes}
+                valueLabel={formatBytes(cat.bytes)}
+                maxValue={maxBytes}
+                testId={`page-stats-storage-row-${workspace.workspaceId}-${cat.id}`}
+              />
+            ))}
+          </Flex>
+        ) : (
+          <Text size="2" color="gray">—</Text>
+        )}
+      </Flex>
+    </Theme>
+  );
+}
+
+/**
+ * Storage sub-page: global quota usage plus a breakdown of the local storage
+ * footprint. With several workspaces, the breakdown is split into one section
+ * per workspace; otherwise it stays a flat per-category list.
  */
 export function StatisticsStorageDetail({ usage }: StatisticsStorageDetailProps) {
-  const maxBytes = usage.categories.length > 0 ? usage.categories[0].bytes : 0;
   const quotaPct = usage.quotaBytes > 0 ? Math.min(100, Math.round(usage.quotaPercent)) : 0;
+  const isSplit = usage.workspaces.length > 1;
+  // Comparable bar scale across every workspace section.
+  const splitMaxBytes = isSplit
+    ? Math.max(0, ...usage.workspaces.flatMap((ws) => ws.categories.map((c) => c.bytes)))
+    : 0;
 
   return (
     <Box data-testid="page-stats-storage">
@@ -50,22 +140,17 @@ export function StatisticsStorageDetail({ usage }: StatisticsStorageDetailProps)
 
           <Separator size="4" />
 
-          {usage.categories.length > 0 ? (
-            <Flex direction="column" gap="3">
-              {usage.categories.map((cat, index) => (
-                <BarRow
-                  key={cat.id}
-                  index={index}
-                  label={getMessage(cat.labelKey)}
-                  value={cat.bytes}
-                  valueLabel={formatBytes(cat.bytes)}
-                  maxValue={maxBytes}
-                  testId={`page-stats-storage-row-${cat.id}`}
-                />
+          {isSplit ? (
+            <Flex direction="column" gap="4">
+              <Text size="2" color="gray" weight="medium">
+                {getMessage('statsStorageByWorkspace')}
+              </Text>
+              {usage.workspaces.map((ws) => (
+                <WorkspaceSection key={ws.workspaceId} workspace={ws} maxBytes={splitMaxBytes} />
               ))}
             </Flex>
           ) : (
-            <Text size="2" color="gray">—</Text>
+            <CategoryBreakdown categories={usage.categories} />
           )}
         </Flex>
       </Card>

--- a/src/hooks/useStorageUsage.ts
+++ b/src/hooks/useStorageUsage.ts
@@ -1,18 +1,31 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext.js';
 import {
-  measureWorkspaceStorageUsage,
+  measureAllWorkspacesStorageUsage,
   measureGlobalStorageUsage,
   getStorageQuotaBytes,
   type StorageCategoryUsage,
 } from '@/utils/storageUsageUtils.js';
+import type { WorkspaceAccentColor } from '@/schemas/workspace.js';
 import { logger } from '@/utils/logger.js';
+
+/** Per-workspace storage breakdown, used to split the usage view by workspace. */
+export interface WorkspaceUsageBreakdown {
+  workspaceId: string;
+  name: string;
+  accentColor: WorkspaceAccentColor;
+  /** Per-category breakdown for this workspace, sorted by size desc. */
+  categories: StorageCategoryUsage[];
+  totalBytes: number;
+}
 
 export interface StorageUsageSnapshot {
   /** Per-category breakdown for the active workspace, sorted by size desc. */
   categories: StorageCategoryUsage[];
   /** Sum of the active workspace categories. */
   workspaceTotalBytes: number;
+  /** Per-workspace breakdowns, sorted by total size desc. */
+  workspaces: WorkspaceUsageBreakdown[];
   /** Total bytes used across the whole `storage.local` area (all workspaces). */
   globalTotalBytes: number;
   /** `storage.local` quota in bytes (with portable fallback). */
@@ -25,6 +38,7 @@ export interface StorageUsageSnapshot {
 const EMPTY_SNAPSHOT: StorageUsageSnapshot = {
   categories: [],
   workspaceTotalBytes: 0,
+  workspaces: [],
   globalTotalBytes: 0,
   quotaBytes: 0,
   quotaPercent: 0,
@@ -37,24 +51,46 @@ const EMPTY_SNAPSHOT: StorageUsageSnapshot = {
  * measured storage items changes, so sizes stay fresh while the page is open.
  */
 export function useStorageUsage(): StorageUsageSnapshot {
-  const { activeId, scopedItems } = useActiveWorkspaceContext();
+  const { activeId, workspaces, scopedItems } = useActiveWorkspaceContext();
   const [snapshot, setSnapshot] = useState<StorageUsageSnapshot>(EMPTY_SNAPSHOT);
   const mountedRef = useRef(true);
 
   const recompute = useCallback(async () => {
     try {
-      const [usage, globalTotalBytes] = await Promise.all([
-        measureWorkspaceStorageUsage(activeId),
+      const [entries, globalTotalBytes] = await Promise.all([
+        measureAllWorkspacesStorageUsage(workspaces.map((w) => w.id)),
         measureGlobalStorageUsage(),
       ]);
       if (!mountedRef.current) return;
+
+      const metaById = new Map(workspaces.map((w) => [w.id, w]));
+      const breakdowns: WorkspaceUsageBreakdown[] = entries
+        .map((entry) => {
+          const meta = metaById.get(entry.workspaceId);
+          return {
+            workspaceId: entry.workspaceId,
+            name: meta?.name ?? entry.workspaceId,
+            accentColor: meta?.accentColor ?? 'indigo',
+            categories: [...entry.categories].sort((a, b) => b.bytes - a.bytes),
+            totalBytes: entry.workspaceTotalBytes,
+          };
+        })
+        .sort((a, b) => b.totalBytes - a.totalBytes);
+
+      // Active-workspace breakdown, kept for the single-workspace view and
+      // backward compatibility with the summary KPI.
+      const activeEntry = entries.find((e) => e.workspaceId === activeId);
+      const activeCategories = activeEntry
+        ? [...activeEntry.categories].sort((a, b) => b.bytes - a.bytes)
+        : [];
 
       const quotaBytes = getStorageQuotaBytes();
       const quotaPercent = quotaBytes > 0 ? (globalTotalBytes / quotaBytes) * 100 : 0;
 
       setSnapshot({
-        categories: [...usage.categories].sort((a, b) => b.bytes - a.bytes),
-        workspaceTotalBytes: usage.workspaceTotalBytes,
+        categories: activeCategories,
+        workspaceTotalBytes: activeEntry?.workspaceTotalBytes ?? 0,
+        workspaces: breakdowns,
         globalTotalBytes,
         quotaBytes,
         quotaPercent,
@@ -63,7 +99,7 @@ export function useStorageUsage(): StorageUsageSnapshot {
     } catch (error) {
       logger.error('[STORAGE_USAGE] recompute failed:', error);
     }
-  }, [activeId]);
+  }, [activeId, workspaces]);
 
   useEffect(() => {
     mountedRef.current = true;

--- a/src/pages/StatisticsPage.stories.tsx
+++ b/src/pages/StatisticsPage.stories.tsx
@@ -130,6 +130,7 @@ const richSessionStats: SessionStatisticsSnapshot = {
 const emptyStorageUsage: StorageUsageSnapshot = {
   categories: [],
   workspaceTotalBytes: 0,
+  workspaces: [],
   globalTotalBytes: 0,
   quotaBytes: 10_485_760,
   quotaPercent: 0,
@@ -146,10 +147,47 @@ const richStorageUsage: StorageUsageSnapshot = {
     { id: 'settings', labelKey: 'statsStorageCatSettings', bytes: 240 },
   ],
   workspaceTotalBytes: 363_060,
+  workspaces: [],
   globalTotalBytes: 512_000,
   quotaBytes: 10_485_760,
   quotaPercent: (512_000 / 10_485_760) * 100,
   isLoaded: true,
+};
+
+const multiWorkspaceStorageUsage: StorageUsageSnapshot = {
+  ...richStorageUsage,
+  globalTotalBytes: 506_180,
+  quotaPercent: (506_180 / 10_485_760) * 100,
+  workspaces: [
+    {
+      workspaceId: 'default',
+      name: 'Personnel',
+      accentColor: 'indigo',
+      totalBytes: 322_620,
+      categories: [
+        { id: 'sessions-archived', labelKey: 'statsStorageCatSessionsArchived', bytes: 184_320 },
+        { id: 'sessions-active', labelKey: 'statsStorageCatSessionsActive', bytes: 96_400 },
+        { id: 'domain-rules', labelKey: 'statsStorageCatDomainRules', bytes: 41_200 },
+        { id: 'statistics', labelKey: 'statsStorageCatStatistics', bytes: 700 },
+        { id: 'sessions-pinned', labelKey: 'statsStorageCatSessionsPinned', bytes: 0 },
+        { id: 'settings', labelKey: 'statsStorageCatSettings', bytes: 0 },
+      ],
+    },
+    {
+      workspaceId: 'ws-work',
+      name: 'Travail',
+      accentColor: 'jade',
+      totalBytes: 183_560,
+      categories: [
+        { id: 'domain-rules', labelKey: 'statsStorageCatDomainRules', bytes: 102_400 },
+        { id: 'sessions-pinned', labelKey: 'statsStorageCatSessionsPinned', bytes: 58_300 },
+        { id: 'statistics', labelKey: 'statsStorageCatStatistics', bytes: 22_100 },
+        { id: 'settings', labelKey: 'statsStorageCatSettings', bytes: 760 },
+        { id: 'sessions-active', labelKey: 'statsStorageCatSessionsActive', bytes: 0 },
+        { id: 'sessions-archived', labelKey: 'statsStorageCatSessionsArchived', bytes: 0 },
+      ],
+    },
+  ],
 };
 
 const meta: Meta<typeof StatisticsPage> = {
@@ -216,6 +254,15 @@ export const StatisticsPageSessions: Story = {
 
 export const StatisticsPageStorage: Story = {
   args: { statisticsData: richData, sessionStats: richSessionStats, statsTab: 'storage' },
+};
+
+export const StatisticsPageStorageMultiWorkspace: Story = {
+  args: {
+    statisticsData: richData,
+    sessionStats: richSessionStats,
+    statsTab: 'storage',
+    storageUsage: multiWorkspaceStorageUsage,
+  },
 };
 
 export const StatisticsPageResetClick: Story = {

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -39,6 +39,14 @@ const SUB_TAB_DESCRIPTION_KEY: Record<Exclude<StatsSubTab, 'summary'>, string> =
   storage: 'statsStoragePageDescription',
 };
 
+/** Tab label per sub-tab, reused as the accessible name of the scroll region. */
+const SUB_TAB_LABEL_KEY: Record<StatsSubTab, string> = {
+  summary: 'statsSummaryTab',
+  rules: 'statsRulesTab',
+  sessions: 'statsSessionsTab',
+  storage: 'statsStorageTab',
+};
+
 export function StatisticsPage({ syncSettings, statisticsData, sessionStats, storageUsage, onReset, statsTab, onStatsTabChange }: StatisticsPageProps) {
   const activeRulesCount = syncSettings.domainRules.filter(r => r.enabled).length;
 
@@ -131,7 +139,10 @@ export function StatisticsPage({ syncSettings, statisticsData, sessionStats, sto
       syncSettings={syncSettings}
     >
       {() => (
-        <Box data-testid="page-stats">
+        <Box
+          data-testid="page-stats"
+          style={{ height: '100%', display: 'flex', flexDirection: 'column', minHeight: 0 }}
+        >
           <Box mb="3">
             <TabNav.Root data-testid="page-stats-tabs">
               <TabNav.Link
@@ -169,23 +180,35 @@ export function StatisticsPage({ syncSettings, statisticsData, sessionStats, sto
             </TabNav.Root>
           </Box>
 
-          {statsTab === 'summary' && (
-            <StatisticsSummary data={data} snapshot={snapshot} storageUsage={storageUsage} />
-          )}
-          {statsTab === 'rules' && (
-            <StatisticsRulesDetail
-              data={data}
-              activeRulesCount={activeRulesCount}
-              firstUsedAtFormatted={firstUsedAtFormatted}
-              onReset={onReset}
-            />
-          )}
-          {statsTab === 'sessions' && (
-            <StatisticsSessionsDetail snapshot={snapshot} events={data.sessionEvents} />
-          )}
-          {statsTab === 'storage' && (
-            <StatisticsStorageDetail usage={storageUsage} />
-          )}
+          {/* Only the sub-tab content scrolls; the tabs above stay fixed. The
+              region is focusable (tabIndex={0}) so keyboard users get a tab stop
+              and native arrow / PageUp-Down / Space scrolling on pages that have
+              no other focusable content (e.g. the summary sub-tab). */}
+          <Box
+            data-testid="page-stats-scroll"
+            role="region"
+            aria-label={getMessage(SUB_TAB_LABEL_KEY[statsTab])}
+            tabIndex={0}
+            style={{ flex: 1, overflow: 'auto', minHeight: 0 }}
+          >
+            {statsTab === 'summary' && (
+              <StatisticsSummary data={data} snapshot={snapshot} storageUsage={storageUsage} />
+            )}
+            {statsTab === 'rules' && (
+              <StatisticsRulesDetail
+                data={data}
+                activeRulesCount={activeRulesCount}
+                firstUsedAtFormatted={firstUsedAtFormatted}
+                onReset={onReset}
+              />
+            )}
+            {statsTab === 'sessions' && (
+              <StatisticsSessionsDetail snapshot={snapshot} events={data.sessionEvents} />
+            )}
+            {statsTab === 'storage' && (
+              <StatisticsStorageDetail usage={storageUsage} />
+            )}
+          </Box>
         </Box>
       )}
     </PageLayout>

--- a/src/styles/radix-themes.css
+++ b/src/styles/radix-themes.css
@@ -42,6 +42,16 @@
   border-radius: var(--radius-3);
 }
 
+/* Focus ring for the keyboard-scrollable statistics content region.
+ * The region is focusable (tabindex=0) so keyboard users can reach it and
+ * scroll with the arrow keys on sub-tabs that hold no other focusable control.
+ * focus-visible keeps the outline off on pointer interaction. */
+[data-testid="page-stats-scroll"]:focus-visible {
+  outline: 2px solid var(--accent-9);
+  outline-offset: -2px;
+  border-radius: var(--radius-3);
+}
+
 /* Focusable controls using aria-disabled instead of native disabled (keeps element in tab order). */
 [aria-disabled="true"] {
   opacity: 0.5;

--- a/src/utils/storageUsageUtils.ts
+++ b/src/utils/storageUsageUtils.ts
@@ -154,3 +154,23 @@ export async function measureWorkspaceStorageUsage(
   const workspaceTotalBytes = categories.reduce((sum, c) => sum + c.bytes, 0);
   return { categories, workspaceTotalBytes };
 }
+
+export interface WorkspaceStorageUsageEntry extends WorkspaceStorageUsage {
+  workspaceId: string;
+}
+
+/**
+ * Measures the per-category `storage.local` usage of several workspaces in
+ * parallel, tagging each result with its workspace ID. Used to split the
+ * storage breakdown by workspace when more than one exists.
+ */
+export async function measureAllWorkspacesStorageUsage(
+  wsIds: string[],
+): Promise<WorkspaceStorageUsageEntry[]> {
+  return Promise.all(
+    wsIds.map(async (id) => ({
+      workspaceId: id,
+      ...(await measureWorkspaceStorageUsage(id)),
+    })),
+  );
+}

--- a/tests/storageUsageUtils.test.ts
+++ b/tests/storageUsageUtils.test.ts
@@ -4,6 +4,7 @@ import {
   measureKeysBytes,
   measureGlobalStorageUsage,
   measureWorkspaceStorageUsage,
+  measureAllWorkspacesStorageUsage,
   getStorageQuotaBytes,
 } from '../src/utils/storageUsageUtils';
 
@@ -75,6 +76,34 @@ describe('measureWorkspaceStorageUsage', () => {
     for (const cat of usage.categories) {
       expect(cat.labelKey).toMatch(/^statsStorageCat/);
     }
+  });
+});
+
+describe('measureAllWorkspacesStorageUsage', () => {
+  it('measures each workspace independently, tagging results with the id', async () => {
+    const defaultRules = [{ id: 'r1', domainFilter: 'example.com' }];
+    const workRules = [{ id: 'r2', domainFilter: 'work.com' }, { id: 'r3', domainFilter: 'crm.com' }];
+    await fakeBrowser.storage.local.set({
+      // Default workspace keeps legacy unprefixed keys.
+      domainRules: defaultRules,
+      // Extra workspace uses the namespaced form `ws:{id}:{field}`.
+      'ws:work:domainRules': workRules,
+    });
+
+    const entries = await measureAllWorkspacesStorageUsage(['default', 'work']);
+
+    expect(entries.map((e) => e.workspaceId)).toEqual(['default', 'work']);
+
+    const defaultEntry = entries.find((e) => e.workspaceId === 'default')!;
+    const workEntry = entries.find((e) => e.workspaceId === 'work')!;
+
+    const defaultDomainRules = defaultEntry.categories.find((c) => c.id === 'domain-rules');
+    const workDomainRules = workEntry.categories.find((c) => c.id === 'domain-rules');
+
+    expect(defaultDomainRules?.bytes).toBe(entryBytes('domainRules', defaultRules));
+    expect(workDomainRules?.bytes).toBe(entryBytes('ws:work:domainRules', workRules));
+    // Each workspace only counts its own keys.
+    expect(workEntry.workspaceTotalBytes).toBe(entryBytes('ws:work:domainRules', workRules));
   });
 });
 


### PR DESCRIPTION
When more than one workspace exists, the Statistics > Storage sub-page now
shows one section per workspace (identity header + total + its non-empty
category bars) instead of only the active workspace breakdown. Each section
is wrapped in a nested Radix Theme so its bars adopt the workspace accent
color. With a single workspace, the flat per-category view is unchanged.

https://claude.ai/code/session_011GAsWx7keaQWvCKpsHRda4