### PR TITLE
feat: mémoriser dates de dernière utilisation/restauration/activation

### DIFF
--- a/src/background/deduplication.ts
+++ b/src/background/deduplication.ts
@@ -1,5 +1,5 @@
 import { browser, Browser } from 'wxt/browser';
-import { incrementStat } from '@/utils/statisticsUtils.js';
+import { incrementStat, stampRuleLastUsed } from '@/utils/statisticsUtils.js';
 import { logger } from '@/utils/logger.js';
 import { matchesDomain } from '@/utils/utils';
 import { getSettings } from './settings.js';
@@ -217,6 +217,7 @@ export async function checkAndDeduplicateTab(
         );
 
         await incrementStat('dedup', ruleId);
+        await stampRuleLastUsed(ruleId);
 
         const keepIsExisting = tabToKeep.id === duplicateTab.id;
         if (keepIsExisting) {

--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -1,5 +1,5 @@
 import { browser, Browser } from 'wxt/browser';
-import { incrementStat } from '@/utils/statisticsUtils.js';
+import { incrementStat, stampRuleLastUsed } from '@/utils/statisticsUtils.js';
 import { matchesDomain, extractGroupNameFromTitle, extractGroupNameFromUrlByMode } from '@/utils/utils';
 import { getSettings } from './settings.js';
 import { promptForGroupName } from './messaging.js';
@@ -220,6 +220,7 @@ export async function createNewGroup(
     logger.debug(`[GROUPING_DEBUG] New group created with ID: ${newGroupId}. Calling browser.tabGroups.update with payload:`, updatePayload);
     await browser.tabGroups.update(newGroupId, updatePayload as Parameters<typeof browser.tabGroups.update>[1]);
     await incrementStat('grouping', ruleId);
+    await stampRuleLastUsed(ruleId);
 
     return newGroupId;
 }

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -136,6 +136,7 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
         conflictResolution: target === 'current' ? conflictResolution : undefined,
         conflictAnalysis: target === 'current' ? analysis ?? undefined : undefined,
         protectedTabId,
+        sessionId: session.id,
       });
 
       onOpenChange(false);

--- a/src/contexts/ActiveWorkspaceContext.tsx
+++ b/src/contexts/ActiveWorkspaceContext.tsx
@@ -104,6 +104,14 @@ export function ActiveWorkspaceProvider({ children }: ActiveWorkspaceProviderPro
   }, []);
 
   const switchTo = useCallback(async (id: string) => {
+    // Stamp lastActivatedAt on the target workspace. The default workspace may
+    // be absent from the index: the map leaves it untouched, and we still flip
+    // the active id below so the switch always happens.
+    const current = (await workspacesIndexItem.getValue()) ?? [];
+    const next = current.map((w) =>
+      w.id === id ? { ...w, lastActivatedAt: new Date().toISOString() } : w,
+    );
+    await workspacesIndexItem.setValue(next);
     await activeWorkspaceIdItem.setValue(id);
   }, []);
 

--- a/src/schemas/domainRule.ts
+++ b/src/schemas/domainRule.ts
@@ -50,7 +50,10 @@ export const domainRuleSchema = z.object({
     { error: () => getMessage('errorInvalidQueryParamName') }
   ).optional(),
   createdAt: z.string().optional(),
-  updatedAt: z.string().optional()
+  updatedAt: z.string().optional(),
+  // ISO 8601 timestamp of the last time the rule actually grouped tabs or
+  // closed a duplicate at runtime. Distinct from updatedAt (last edit).
+  lastUsedAt: z.string().optional()
 }).refine((data) => {
   // When presetId is null, the conditional validations below apply.
   if (data.presetId === null) {

--- a/src/schemas/importExport.ts
+++ b/src/schemas/importExport.ts
@@ -41,7 +41,8 @@ export const importDomainRuleSchema = z.object({
   enabled: z.boolean(),
   badge: z.string().optional(),
   createdAt: z.string().optional(),
-  updatedAt: z.string().optional()
+  updatedAt: z.string().optional(),
+  lastUsedAt: z.string().optional()
 });
 
 export type ImportDomainRule = z.infer<typeof importDomainRuleSchema>;

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -34,6 +34,9 @@ export const sessionSchema = z.object({
   categoryId: z.string().optional().nullable(),
   note: z.string().optional(),
   position: z.number().optional(),
+  // ISO 8601 timestamp of the last time this session was restored. Distinct
+  // from updatedAt (last edit): a restore does not modify the session content.
+  lastRestoredAt: z.string().optional(),
 });
 
 export const sessionsArraySchema = z.array(sessionSchema);

--- a/src/schemas/workspace.ts
+++ b/src/schemas/workspace.ts
@@ -19,6 +19,8 @@ export const workspaceMetaSchema = z.object({
   accentColor: z.enum(workspaceAccentColors),
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1),
+  // ISO 8601 timestamp of the last time this workspace became the active one.
+  lastActivatedAt: z.string().optional(),
 });
 
 export type WorkspaceMeta = z.infer<typeof workspaceMetaSchema>;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -44,4 +44,6 @@ export interface Session {
   note?: string;
   /** Display order (lower index = first); assigned automatically if missing */
   position?: number;
+  /** ISO 8601 date string: last time this session was restored (not an edit) */
+  lastRestoredAt?: string;
 }

--- a/src/utils/statisticsUtils.ts
+++ b/src/utils/statisticsUtils.ts
@@ -89,6 +89,29 @@ export async function incrementStat(type: 'grouping' | 'dedup', ruleId: string):
   }
 }
 
+/**
+ * Stamp `lastUsedAt` (ISO 8601) on the rule that just grouped tabs or closed a
+ * duplicate. Re-reads the active-workspace rules right before writing to keep
+ * the race window with a concurrent user edit minimal. The synthetic
+ * `'__unmatched__'` id (used by dedup when no rule matched) is ignored.
+ */
+export async function stampRuleLastUsed(ruleId: string): Promise<void> {
+  if (!ruleId || ruleId === '__unmatched__') return;
+  try {
+    const { domainRulesItem } = await getActiveScopedItems();
+    const rules = (await domainRulesItem.getValue()) ?? [];
+    let changed = false;
+    const next = rules.map((rule) => {
+      if (rule.id !== ruleId) return rule;
+      changed = true;
+      return { ...rule, lastUsedAt: new Date().toISOString() };
+    });
+    if (changed) await domainRulesItem.setValue(next);
+  } catch (error) {
+    logger.error(`Error stamping lastUsedAt for rule ${ruleId}:`, error);
+  }
+}
+
 export async function incrementSessionEvent(
   event: SessionEventType,
   opts?: { tabsRestored?: number },

--- a/src/utils/tabRestore.ts
+++ b/src/utils/tabRestore.ts
@@ -8,6 +8,7 @@ import type {
   GroupConflictAction,
 } from './conflictDetection';
 import { incrementSessionEvent } from './statisticsUtils';
+import { updateSession } from './sessionStorage';
 
 export type RestoreTarget = 'current' | 'new' | 'replace';
 
@@ -28,6 +29,12 @@ export interface RestoreOptions {
    * Pinned tabs are always preserved regardless of this value.
    */
   protectedTabId?: number;
+  /**
+   * Id of the session being restored. When provided and at least one tab is
+   * created, the session's `lastRestoredAt` is stamped (without touching
+   * `updatedAt`). Omitted for ad-hoc restores not tied to a stored session.
+   */
+  sessionId?: string;
 }
 
 export interface RestoreResult {
@@ -48,7 +55,7 @@ export interface RestoreResult {
  * a filtered subset of tabs/groups plus conflict resolution data.
  */
 export async function restoreSessionTabs(
-  session: Pick<Session, 'ungroupedTabs' | 'groups'>,
+  session: Pick<Session, 'id' | 'ungroupedTabs' | 'groups'>,
   target: RestoreTarget,
   protectedTabId?: number,
 ): Promise<RestoreResult> {
@@ -57,6 +64,7 @@ export async function restoreSessionTabs(
     groups: session.groups,
     target,
     protectedTabId,
+    sessionId: session.id,
   });
 }
 
@@ -80,7 +88,7 @@ async function requestSkipDeduplication(urls: string[]): Promise<void> {
 
 /** Restore tabs and groups in Chrome */
 export async function restoreTabs(options: RestoreOptions): Promise<RestoreResult> {
-  const { tabs, groups, target, conflictResolution, conflictAnalysis, protectedTabId } = options;
+  const { tabs, groups, target, conflictResolution, conflictAnalysis, protectedTabId, sessionId } = options;
   const result: RestoreResult = {
     tabsCreated: 0,
     duplicatesSkipped: 0,
@@ -105,6 +113,10 @@ export async function restoreTabs(options: RestoreOptions): Promise<RestoreResul
 
   if (result.tabsCreated > 0) {
     await incrementSessionEvent('restored', { tabsRestored: result.tabsCreated });
+    // touch:false so a restore does not masquerade as a content edit (updatedAt).
+    if (sessionId) {
+      await updateSession(sessionId, { lastRestoredAt: new Date().toISOString() }, { touch: false });
+    }
   }
 
   return result;

--- a/tests/background/deduplication-async.test.ts
+++ b/tests/background/deduplication-async.test.ts
@@ -14,6 +14,7 @@ vi.mock('wxt/browser', async () => ({ browser: (await import('./_helpers')).brow
 
 vi.mock('../../src/utils/statisticsUtils.js', () => ({
   incrementStat: vi.fn().mockResolvedValue(undefined),
+  stampRuleLastUsed: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../src/background/settings.js', () => ({

--- a/tests/background/grouping-async.test.ts
+++ b/tests/background/grouping-async.test.ts
@@ -14,6 +14,7 @@ vi.mock('wxt/browser', async () => ({ browser: (await import('./_helpers')).brow
 
 vi.mock('../../src/utils/statisticsUtils.js', () => ({
   incrementStat: vi.fn(),
+  stampRuleLastUsed: vi.fn(),
 }));
 
 vi.mock('../../src/background/settings.js', () => ({

--- a/tests/contexts/activeWorkspaceContext.test.tsx
+++ b/tests/contexts/activeWorkspaceContext.test.tsx
@@ -101,6 +101,31 @@ describe('ActiveWorkspaceContext — setWorkspaceColor', () => {
   });
 });
 
+describe('ActiveWorkspaceContext — switchTo', () => {
+  it('stamps lastActivatedAt on the target workspace and leaves others untouched', async () => {
+    const { result } = await renderContext();
+    let createdId = '';
+    await act(async () => {
+      const created = await result.current.createWorkspace('Second', 'teal');
+      createdId = created.id;
+    });
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(2));
+    // createWorkspace switches active but does not stamp lastActivatedAt.
+    expect(result.current.workspaces.find((w) => w.id === createdId)?.lastActivatedAt).toBeUndefined();
+
+    await act(async () => {
+      await result.current.switchTo(DEFAULT_WORKSPACE_ID);
+    });
+
+    await waitFor(() => expect(result.current.activeId).toBe(DEFAULT_WORKSPACE_ID));
+    expect(
+      result.current.workspaces.find((w) => w.id === DEFAULT_WORKSPACE_ID)?.lastActivatedAt,
+    ).toBeDefined();
+    // The previously active workspace keeps no activation timestamp.
+    expect(result.current.workspaces.find((w) => w.id === createdId)?.lastActivatedAt).toBeUndefined();
+  });
+});
+
 describe('ActiveWorkspaceContext — removeWorkspace', () => {
   it('removes a non-default workspace and switches active to default when needed', async () => {
     const { result } = await renderContext();

--- a/tests/deduplication.test.ts
+++ b/tests/deduplication.test.ts
@@ -34,7 +34,8 @@ vi.mock('wxt/browser', () => {
 
 // Mock dependencies.
 vi.mock('../src/utils/statisticsUtils.js', () => ({
-  incrementStat: vi.fn()
+  incrementStat: vi.fn(),
+  stampRuleLastUsed: vi.fn()
 }));
 
 vi.mock('../src/background/settings.js', () => ({

--- a/tests/grouping.test.ts
+++ b/tests/grouping.test.ts
@@ -33,7 +33,8 @@ vi.mock('wxt/browser', () => ({
 
 // Mock dependent modules.
 vi.mock('../src/utils/statisticsUtils.js', () => ({
-  incrementStat: vi.fn()
+  incrementStat: vi.fn(),
+  stampRuleLastUsed: vi.fn()
 }));
 
 vi.mock('../src/background/settings.js', () => ({

--- a/tests/tabRestore.test.ts
+++ b/tests/tabRestore.test.ts
@@ -23,7 +23,16 @@ vi.mock('wxt/browser', () => {
   };
 });
 
+// updateSession touches workspace-scoped storage, which the minimal browser
+// mock above does not provide. Stub it so we can assert the restore stamping.
+vi.mock('../src/utils/sessionStorage', () => ({
+  updateSession: vi.fn(),
+}));
+
 import { browser } from 'wxt/browser';
+import { updateSession } from '../src/utils/sessionStorage';
+
+const mockUpdateSession = updateSession as ReturnType<typeof vi.fn>;
 
 const mockTabsCreate = browser.tabs.create as ReturnType<typeof vi.fn>;
 const mockTabsRemove = browser.tabs.remove as ReturnType<typeof vi.fn>;
@@ -56,6 +65,48 @@ beforeEach(() => {
   mockTabGroupsUpdate.mockResolvedValue(undefined);
   mockTabsQuery.mockResolvedValue([]);
   mockTabsRemove.mockResolvedValue(undefined);
+});
+
+describe('restoreTabs — lastRestoredAt stamping', () => {
+  it('stamps lastRestoredAt (touch:false) when a sessionId is given and tabs are created', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    await restoreTabs({
+      tabs: [makeTab('https://a.com')],
+      groups: [],
+      target: 'new',
+      sessionId: 'session-1',
+    });
+
+    expect(mockUpdateSession).toHaveBeenCalledTimes(1);
+    const [id, updates, options] = mockUpdateSession.mock.calls[0];
+    expect(id).toBe('session-1');
+    expect(typeof (updates as { lastRestoredAt?: string }).lastRestoredAt).toBe('string');
+    expect(options).toEqual({ touch: false });
+  });
+
+  it('does not stamp when no sessionId is provided', async () => {
+    mockWindowsCreate.mockResolvedValue({ id: 42, tabs: [{ id: 1 }] });
+
+    await restoreTabs({
+      tabs: [makeTab('https://a.com')],
+      groups: [],
+      target: 'new',
+    });
+
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+  });
+
+  it('does not stamp when no tab was created', async () => {
+    await restoreTabs({
+      tabs: [],
+      groups: [],
+      target: 'current',
+      sessionId: 'session-1',
+    });
+
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+  });
 });
 
 describe('restoreTabs — new window', () => {

--- a/tests/utils/statisticsUtils.test.ts
+++ b/tests/utils/statisticsUtils.test.ts
@@ -6,6 +6,7 @@ import {
   setStatisticsData,
   updateStatisticsData,
   incrementStat,
+  stampRuleLastUsed,
   resetStatisticsData,
   watchStatisticsData,
   purgeOldBuckets,
@@ -123,6 +124,40 @@ describe('statisticsUtils', () => {
       await incrementStat('grouping', 'rule-1');
       const stats = await getStatisticsData();
       expect(stats.firstUsedAt).toBe(existingDate);
+    });
+  });
+
+  describe('stampRuleLastUsed', () => {
+    type StoredRule = { id: string; lastUsedAt?: string };
+
+    async function readRules(): Promise<StoredRule[]> {
+      return (await fakeBrowser.storage.local.get('domainRules')).domainRules as StoredRule[];
+    }
+
+    it('stamps lastUsedAt on the matching rule only', async () => {
+      await fakeBrowser.storage.local.set({
+        domainRules: [{ id: 'r1' }, { id: 'r2' }],
+      });
+      await stampRuleLastUsed('r1');
+      const rules = await readRules();
+      expect(rules.find((r) => r.id === 'r1')?.lastUsedAt).toBeDefined();
+      expect(rules.find((r) => r.id === 'r2')?.lastUsedAt).toBeUndefined();
+    });
+
+    it("ignores the synthetic '__unmatched__' id", async () => {
+      await fakeBrowser.storage.local.set({ domainRules: [{ id: 'r1' }] });
+      await stampRuleLastUsed('__unmatched__');
+      expect((await readRules())[0].lastUsedAt).toBeUndefined();
+    });
+
+    it('does nothing when the rule id is unknown', async () => {
+      await fakeBrowser.storage.local.set({ domainRules: [{ id: 'r1' }] });
+      await stampRuleLastUsed('does-not-exist');
+      expect((await readRules())[0].lastUsedAt).toBeUndefined();
+    });
+
+    it('does not throw when there are no rules', async () => {
+      await expect(stampRuleLastUsed('r1')).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Ajoute trois timestamps ISO 8601 optionnels, persistés sans affichage UI
pour préparer de futures fonctionnalités (tri par usage, nettoyage des
règles dormantes, statistiques) :

- Règle de domaine: `lastUsedAt`, stampé via `stampRuleLastUsed` aux
  mêmes points que `incrementStat` (création de groupe + fermeture de
  doublon), couvrant groupement ET déduplication.
- Session: `lastRestoredAt`, stampé après une restauration réussie via
  un `sessionId` optionnel sur `RestoreOptions`, avec `touch: false`
  pour ne pas fausser `updatedAt`.
- Espace de travail: `lastActivatedAt`, stampé dans `switchTo`.

Champs optionnels: aucune migration de backfill nécessaire. La
classification d'import ignore déjà les timestamps, donc pas de
nouveau conflit. Tests unitaires ajoutés pour les trois chemins.

https://claude.ai/code/session_017cEEqC73YqdQoXdLsKtnaK