### PR TITLE
feat(toolbar): add import/export overflow menu to list toolbars

### DIFF
--- a/DATA_TESTID_REFERENCE.md
+++ b/DATA_TESTID_REFERENCE.md
@@ -23,6 +23,9 @@ page-rules                        # Main page container
 page-rules-toolbar                # Toolbar area (search + add button), hidden when no rules
 page-rules-search                 # Search input
 page-rules-btn-add                # "Add rule" button (toolbar OR empty placeholder, mutually exclusive)
+page-rules-toolbar-menu           # Toolbar "..." overflow menu trigger
+page-rules-toolbar-menu-export    # Overflow menu: export rules
+page-rules-toolbar-menu-import    # Overflow menu: import rules
 page-rules-list                   # List container (role="grid")
 page-rules-empty                  # Empty state container
 page-rules-bulk-bar               # Bulk action bar
@@ -34,6 +37,9 @@ page-sessions                     # Main page container
 page-sessions-toolbar             # Toolbar area (search + snapshot button), hidden when no sessions
 page-sessions-search              # Search input
 page-sessions-btn-snapshot        # "Snapshot" button (toolbar OR empty placeholder, mutually exclusive)
+page-sessions-toolbar-menu        # Toolbar "..." overflow menu trigger
+page-sessions-toolbar-menu-export # Overflow menu: export sessions
+page-sessions-toolbar-menu-import # Overflow menu: import sessions
 page-sessions-list                # Sessions list container
 page-sessions-empty               # Empty state message
 ```

--- a/e2e-shared/pages/SessionEditorPage.ts
+++ b/e2e-shared/pages/SessionEditorPage.ts
@@ -109,13 +109,13 @@ export class SessionEditorPage extends DialogPage {
 
   /**
    * Open the editor from the More-actions dropdown on the (only) visible
-   * session card. The seeded-then-rendered Sessions list exposes a single
-   * "More actions" trigger when one session is present; the Edit item is
-   * targeted by its stable `*-menu-edit` testid (locale-agnostic, and
-   * unaffected by the trailing keyboard-shortcut Kbd hint).
+   * session card. The card trigger is targeted by its stable
+   * `session-card-*-btn-dropdown` testid (locale-agnostic, and distinct from
+   * the page toolbar's own "..." menu); the Edit item is targeted by its
+   * stable `*-menu-edit` testid (unaffected by the trailing Kbd hint).
    */
   async openFromFirstSessionMenu(): Promise<void> {
-    await this.page.getByRole('button', { name: /more actions/i }).click();
+    await this.page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
     await this.page.locator('[data-testid$="-menu-edit"]').click();
     await this.expectVisible();
   }

--- a/e2e-shared/pages/SessionsListPage.ts
+++ b/e2e-shared/pages/SessionsListPage.ts
@@ -87,7 +87,24 @@ export class SessionsListPage {
     return this.page.getByTestId(`session-card-${sessionId}-name`);
   }
 
+  /**
+   * "..." (More actions) dropdown trigger on the first session card. Anchored
+   * on the `session-card-{uuid}-btn-dropdown` testid so it stays distinct from
+   * the page toolbar's own "..." menu (`page-sessions-toolbar-menu`) and works
+   * across the locale matrix.
+   */
+  firstCardMenuButton(): Locator {
+    return this.page
+      .locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]')
+      .first();
+  }
+
   // ─── Atomic actions ──────────────────────────────────────────────────────
+
+  /** Open the "..." (More actions) dropdown on the first session card. */
+  async openFirstCardMenu(): Promise<void> {
+    await this.firstCardMenuButton().click();
+  }
 
   /**
    * Type a query into the search input. Search filtering is purely

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Workspace accent color" },
   "workspaceSwitchLabel": { "message": "Switch" },
   "workspaceMoreActions": { "message": "More actions" },
-  "moreActions": { "message": "More actions" },
+  "importExportMenu": { "message": "Import and export" },
   "workspaceEditLabel": { "message": "Edit" },
   "workspaceDeleteLabel": { "message": "Delete workspace" },
   "workspaceDeleteTitle": { "message": "Delete this workspace?" },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -19,6 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Workspace accent color" },
   "workspaceSwitchLabel": { "message": "Switch" },
   "workspaceMoreActions": { "message": "More actions" },
+  "moreActions": { "message": "More actions" },
   "workspaceEditLabel": { "message": "Edit" },
   "workspaceDeleteLabel": { "message": "Delete workspace" },
   "workspaceDeleteTitle": { "message": "Delete this workspace?" },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Workspace accent color" },
   "workspaceSwitchLabel": { "message": "Switch" },
   "workspaceMoreActions": { "message": "More actions" },
-  "importExportMenu": { "message": "Import and export" },
+  "moreActions": { "message": "More actions" },
   "workspaceEditLabel": { "message": "Edit" },
   "workspaceDeleteLabel": { "message": "Delete workspace" },
   "workspaceDeleteTitle": { "message": "Delete this workspace?" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -19,6 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Color de acento del espacio" },
   "workspaceSwitchLabel": { "message": "Activar" },
   "workspaceMoreActions": { "message": "Más acciones" },
+  "moreActions": { "message": "Más acciones" },
   "workspaceEditLabel": { "message": "Editar" },
   "workspaceDeleteLabel": { "message": "Eliminar espacio" },
   "workspaceDeleteTitle": { "message": "¿Eliminar este espacio de trabajo?" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Color de acento del espacio" },
   "workspaceSwitchLabel": { "message": "Activar" },
   "workspaceMoreActions": { "message": "Más acciones" },
-  "moreActions": { "message": "Más acciones" },
+  "importExportMenu": { "message": "Importar y exportar" },
   "workspaceEditLabel": { "message": "Editar" },
   "workspaceDeleteLabel": { "message": "Eliminar espacio" },
   "workspaceDeleteTitle": { "message": "¿Eliminar este espacio de trabajo?" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Color de acento del espacio" },
   "workspaceSwitchLabel": { "message": "Activar" },
   "workspaceMoreActions": { "message": "Más acciones" },
-  "importExportMenu": { "message": "Importar y exportar" },
+  "moreActions": { "message": "Más acciones" },
   "workspaceEditLabel": { "message": "Editar" },
   "workspaceDeleteLabel": { "message": "Eliminar espacio" },
   "workspaceDeleteTitle": { "message": "¿Eliminar este espacio de trabajo?" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -19,6 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Couleur d'accentuation de l'espace" },
   "workspaceSwitchLabel": { "message": "Activer" },
   "workspaceMoreActions": { "message": "Plus d'actions" },
+  "moreActions": { "message": "Plus d'actions" },
   "workspaceEditLabel": { "message": "Modifier" },
   "workspaceDeleteLabel": { "message": "Supprimer l'espace" },
   "workspaceDeleteTitle": { "message": "Supprimer cet espace de travail ?" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Couleur d'accentuation de l'espace" },
   "workspaceSwitchLabel": { "message": "Activer" },
   "workspaceMoreActions": { "message": "Plus d'actions" },
-  "moreActions": { "message": "Plus d'actions" },
+  "importExportMenu": { "message": "Importer et exporter" },
   "workspaceEditLabel": { "message": "Modifier" },
   "workspaceDeleteLabel": { "message": "Supprimer l'espace" },
   "workspaceDeleteTitle": { "message": "Supprimer cet espace de travail ?" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -19,7 +19,7 @@
   "workspaceColorPickerLabel": { "message": "Couleur d'accentuation de l'espace" },
   "workspaceSwitchLabel": { "message": "Activer" },
   "workspaceMoreActions": { "message": "Plus d'actions" },
-  "importExportMenu": { "message": "Importer et exporter" },
+  "moreActions": { "message": "Plus d'actions" },
   "workspaceEditLabel": { "message": "Modifier" },
   "workspaceDeleteLabel": { "message": "Supprimer l'espace" },
   "workspaceDeleteTitle": { "message": "Supprimer cet espace de travail ?" },

--- a/src/components/UI/ListToolbar/ListToolbar.stories.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.stories.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from '@radix-ui/themes';
-import { Plus, Camera } from 'lucide-react';
+import { Plus, Camera, Download, Upload } from 'lucide-react';
 import { ListToolbar } from './ListToolbar';
+import { ListToolbarMenu } from './ListToolbarMenu';
 import { RuleViewMenu } from '@/components/UI/RuleViewMenu';
 import { DEFAULT_RULE_VIEW_STATE, type RuleViewState } from '@/utils/ruleViewUtils';
 
@@ -85,6 +86,32 @@ export const ListToolbarWithFilter: Story = {
         <Plus size={16} />
         Add Rule
       </Button>
+    ),
+  },
+  render: (args) => <ControlledListToolbar {...args} />,
+};
+
+export const ListToolbarWithMenu: Story = {
+  args: {
+    testId: 'page-rules-toolbar',
+    searchTestId: 'page-rules-search',
+    searchPlaceholder: 'Search rules',
+    searchValue: '',
+    onSearchChange: () => {},
+    action: (
+      <Button onClick={() => {}}>
+        <Plus size={16} />
+        Add Rule
+      </Button>
+    ),
+    menu: (
+      <ListToolbarMenu
+        testId="page-rules-toolbar-menu"
+        items={[
+          { key: 'export', icon: Download, label: 'Export rules', onSelect: () => {} },
+          { key: 'import', icon: Upload, label: 'Import rules', onSelect: () => {} },
+        ]}
+      />
     ),
   },
   render: (args) => <ControlledListToolbar {...args} />,

--- a/src/components/UI/ListToolbar/ListToolbar.tsx
+++ b/src/components/UI/ListToolbar/ListToolbar.tsx
@@ -23,6 +23,8 @@ interface ListToolbarProps {
   filter?: React.ReactNode;
   /** Action button (Add Rule / Take Snapshot) supplied by the caller. */
   action: React.ReactNode;
+  /** Optional overflow ("...") menu rendered at the right edge, after the action (e.g. import/export). */
+  menu?: React.ReactNode;
 }
 
 export function ListToolbar({
@@ -33,6 +35,7 @@ export function ListToolbar({
   onSearchChange,
   filter,
   action,
+  menu,
 }: ListToolbarProps) {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Escape') return;
@@ -93,6 +96,7 @@ export function ListToolbar({
       </Box>
       {filter}
       {action}
+      {menu}
     </Flex>
   );
 }

--- a/src/components/UI/ListToolbar/ListToolbarMenu.stories.tsx
+++ b/src/components/UI/ListToolbar/ListToolbarMenu.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Download, Upload } from 'lucide-react';
+import { ListToolbarMenu } from './ListToolbarMenu';
+
+const meta = {
+  title: 'Components/UI/ListToolbar/ListToolbarMenu',
+  component: ListToolbarMenu,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ListToolbarMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ListToolbarMenuExportImport: Story = {
+  args: {
+    testId: 'page-rules-toolbar-menu',
+    items: [
+      {
+        key: 'export',
+        testId: 'page-rules-toolbar-menu-export',
+        icon: Download,
+        label: 'Export rules',
+        onSelect: () => {},
+      },
+      {
+        key: 'import',
+        testId: 'page-rules-toolbar-menu-import',
+        icon: Upload,
+        label: 'Import rules',
+        onSelect: () => {},
+      },
+    ],
+  },
+};
+
+export const ListToolbarMenuImportOnly: Story = {
+  args: {
+    testId: 'page-workspaces-toolbar-menu',
+    items: [
+      {
+        key: 'import',
+        testId: 'page-workspaces-toolbar-menu-import',
+        icon: Upload,
+        label: 'Import workspace',
+        onSelect: () => {},
+      },
+    ],
+  },
+};

--- a/src/components/UI/ListToolbar/ListToolbarMenu.tsx
+++ b/src/components/UI/ListToolbar/ListToolbarMenu.tsx
@@ -17,7 +17,7 @@ export interface ListToolbarMenuItem {
 interface ListToolbarMenuProps {
   /** Trigger testid (e.g. "page-rules-toolbar-menu"). */
   testId?: string;
-  /** Accessible label for the icon-only trigger. Defaults to getMessage('moreActions'). */
+  /** Accessible label for the icon-only trigger. Defaults to getMessage('importExportMenu'). */
   ariaLabel?: string;
   items: ListToolbarMenuItem[];
 }
@@ -28,7 +28,7 @@ interface ListToolbarMenuProps {
  * points (export + import on rules and sessions, import only on workspaces).
  */
 export function ListToolbarMenu({ testId, ariaLabel, items }: ListToolbarMenuProps) {
-  const label = ariaLabel ?? getMessage('moreActions');
+  const label = ariaLabel ?? getMessage('importExportMenu');
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>

--- a/src/components/UI/ListToolbar/ListToolbarMenu.tsx
+++ b/src/components/UI/ListToolbar/ListToolbarMenu.tsx
@@ -17,7 +17,7 @@ export interface ListToolbarMenuItem {
 interface ListToolbarMenuProps {
   /** Trigger testid (e.g. "page-rules-toolbar-menu"). */
   testId?: string;
-  /** Accessible label for the icon-only trigger. Defaults to getMessage('importExportMenu'). */
+  /** Accessible label for the icon-only trigger. Defaults to getMessage('moreActions'). */
   ariaLabel?: string;
   items: ListToolbarMenuItem[];
 }
@@ -28,7 +28,7 @@ interface ListToolbarMenuProps {
  * points (export + import on rules and sessions, import only on workspaces).
  */
 export function ListToolbarMenu({ testId, ariaLabel, items }: ListToolbarMenuProps) {
-  const label = ariaLabel ?? getMessage('importExportMenu');
+  const label = ariaLabel ?? getMessage('moreActions');
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>

--- a/src/components/UI/ListToolbar/ListToolbarMenu.tsx
+++ b/src/components/UI/ListToolbar/ListToolbarMenu.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { DropdownMenu, Flex, IconButton } from '@radix-ui/themes';
+import { MoreHorizontal, type LucideIcon } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+
+export interface ListToolbarMenuItem {
+  /** Stable React key + DropdownMenu.Item identity. */
+  key: string;
+  /** Already-resolved label (via getMessage by the caller). */
+  label: string;
+  icon: LucideIcon;
+  onSelect: () => void;
+  /** Item testid (e.g. "page-rules-toolbar-menu-export"). */
+  testId?: string;
+}
+
+interface ListToolbarMenuProps {
+  /** Trigger testid (e.g. "page-rules-toolbar-menu"). */
+  testId?: string;
+  /** Accessible label for the icon-only trigger. Defaults to getMessage('moreActions'). */
+  ariaLabel?: string;
+  items: ListToolbarMenuItem[];
+}
+
+/**
+ * Overflow ("...") menu rendered at the right edge of the {@link ListToolbar},
+ * after the primary action button. Hosts the page-level import/export entry
+ * points (export + import on rules and sessions, import only on workspaces).
+ */
+export function ListToolbarMenu({ testId, ariaLabel, items }: ListToolbarMenuProps) {
+  const label = ariaLabel ?? getMessage('moreActions');
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <IconButton
+          data-testid={testId}
+          variant="ghost"
+          color="gray"
+          aria-label={label}
+          title={label}
+          style={{ flexShrink: 0 }}
+        >
+          <MoreHorizontal size={16} aria-hidden="true" />
+        </IconButton>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end">
+        {items.map(({ key, label: itemLabel, icon: Icon, onSelect, testId: itemTestId }) => (
+          <DropdownMenu.Item key={key} data-testid={itemTestId} onSelect={onSelect}>
+            <Flex align="center" gap="2">
+              <Icon size={14} aria-hidden="true" />
+              {itemLabel}
+            </Flex>
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/components/UI/ListToolbar/index.ts
+++ b/src/components/UI/ListToolbar/index.ts
@@ -1,2 +1,3 @@
 export { ListToolbar } from './ListToolbar';
 export { ListToolbarSkeleton } from './ListToolbarSkeleton';
+export { ListToolbarMenu, type ListToolbarMenuItem } from './ListToolbarMenu';

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Button, Flex, Box, Kbd, Tooltip, Separator } from '@radix-ui/themes';
-import { Plus, Eye, EyeOff, Shield, AlertCircle, Trash2, FileDown, PackagePlus } from 'lucide-react';
+import { Plus, Eye, EyeOff, Shield, AlertCircle, Trash2, FileDown, PackagePlus, Download, Upload } from 'lucide-react';
 import { DragDropProvider, type DragEndEvent, type DragOverEvent } from '@dnd-kit/react';
 import { move } from '@dnd-kit/helpers';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
@@ -10,7 +10,7 @@ import { EmptyState } from '@/components/UI/EmptyState';
 import { RuleWizardModal } from '@/components/Core/DomainRule/RuleWizardModal';
 import { ExportWizard } from '@/components/UI/ImportExportWizards/ExportWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
-import { ListToolbar } from '@/components/UI/ListToolbar';
+import { ListToolbar, ListToolbarMenu } from '@/components/UI/ListToolbar';
 import { BulkActionsBar } from '@/components/UI/BulkActionsBar';
 import { RuleViewMenu } from '@/components/UI/RuleViewMenu';
 import { RuleGroupHeader } from '@/components/Core/DomainRule/RuleGroupHeader';
@@ -142,7 +142,7 @@ export function DomainRulesPage({
   pendingAction,
   onPendingActionConsumed,
 }: DomainRulesPageProps) {
-  const { openImportRules } = useImportExportWizards();
+  const { openImportRules, openExportRules } = useImportExportWizards();
   const { scopedItems } = useActiveWorkspaceContext();
   const rulesViewStateItem = scopedItems.rulesViewStateItem;
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -573,6 +573,27 @@ export function DomainRulesPage({
                       {getMessage('addRule')}
                     </Button>
                   </Tooltip>
+                }
+                menu={
+                  <ListToolbarMenu
+                    testId="page-rules-toolbar-menu"
+                    items={[
+                      {
+                        key: 'export',
+                        testId: 'page-rules-toolbar-menu-export',
+                        icon: Download,
+                        label: getMessage('exportRulesTitle'),
+                        onSelect: () => openExportRules(),
+                      },
+                      {
+                        key: 'import',
+                        testId: 'page-rules-toolbar-menu-import',
+                        icon: Upload,
+                        label: getMessage('importRulesTitle'),
+                        onSelect: () => openImportRules(),
+                      },
+                    ]}
+                  />
                 }
               />
             )}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, Flex, Button, Text, Callout, Separator, Badge, TabNav, Kbd, Tooltip } from '@radix-ui/themes';
-import { Camera, Archive, ArchiveRestore, CheckCircle, Pin, PinOff, Upload, Trash2, FileDown, Boxes, type LucideIcon } from 'lucide-react';
+import { Camera, Archive, ArchiveRestore, CheckCircle, Pin, PinOff, Upload, Download, Trash2, FileDown, Boxes, type LucideIcon } from 'lucide-react';
 import { DragDropProvider, type DragOverEvent, type DragEndEvent } from '@dnd-kit/react';
 import { RestrictToVerticalAxis } from '@dnd-kit/abstract/modifiers';
 import { move } from '@dnd-kit/helpers';
@@ -11,7 +11,7 @@ import { SessionEditDialog } from '@/components/Core/Session/SessionEditDialog';
 import { SnapshotWizard } from '@/components/UI/SessionWizards/SnapshotWizard';
 import { RestoreWizard } from '@/components/UI/SessionWizards/RestoreWizard';
 import { ConfirmDialog } from '@/components/UI/ConfirmDialog/ConfirmDialog';
-import { ListToolbar } from '@/components/UI/ListToolbar';
+import { ListToolbar, ListToolbarMenu } from '@/components/UI/ListToolbar';
 import { BulkActionsBar } from '@/components/UI/BulkActionsBar';
 import { ExportSessionsWizard } from '@/components/UI/ImportExportWizards/ExportSessionsWizard';
 import { SessionViewMenu } from '@/components/UI/SessionViewMenu/SessionViewMenu';
@@ -428,7 +428,7 @@ export function SessionsPage({
   sessionsTab = 'active',
   onSessionsTabChange,
 }: SessionsPageProps) {
-  const { openImportSessions } = useImportExportWizards();
+  const { openImportSessions, openExportSessions } = useImportExportWizards();
   const { scopedItems } = useActiveWorkspaceContext();
   const [bulkExportIds, setBulkExportIds] = useState<string[] | null>(null);
   // Archives are watched continuously here: the PageUp/PageDown section
@@ -1077,6 +1077,27 @@ export function SessionsPage({
                     </Button>
                   </Tooltip>
                 ) : undefined
+              }
+              menu={
+                <ListToolbarMenu
+                  testId="page-sessions-toolbar-menu"
+                  items={[
+                    {
+                      key: 'export',
+                      testId: 'page-sessions-toolbar-menu-export',
+                      icon: Download,
+                      label: getMessage('exportSessionsTitle'),
+                      onSelect: () => openExportSessions(),
+                    },
+                    {
+                      key: 'import',
+                      testId: 'page-sessions-toolbar-menu-import',
+                      icon: Upload,
+                      label: getMessage('importSessionsTitle'),
+                      onSelect: () => openImportSessions(),
+                    },
+                  ]}
+                />
               }
             />
           )}

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Box, Button, Card, DropdownMenu, Flex, IconButton, Kbd, Text, Tooltip } from '@radix-ui/themes';
-import { AlertCircle, Check, MoreHorizontal, Pencil, Plus } from 'lucide-react';
+import { AlertCircle, Check, MoreHorizontal, Pencil, Plus, Upload } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
-import { ListToolbar } from '@/components/UI/ListToolbar';
+import { ListToolbar, ListToolbarMenu } from '@/components/UI/ListToolbar';
 import { EmptyState } from '@/components/UI/EmptyState';
 import { DeleteMenuItem } from '@/components/UI/DeleteMenuItem/DeleteMenuItem';
 import { AccessibleHighlight } from '@/components/UI/AccessibleHighlight/AccessibleHighlight';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
+import { useImportExportWizards } from '@/contexts/ImportExportWizardsContext';
 import { WorkspaceAvatar } from '@/components/UI/Workspace/WorkspaceAvatar';
 import { WorkspaceFormDialog } from '@/components/UI/Workspace/WorkspaceFormDialog';
 import { WorkspaceDeleteConfirmDialog } from '@/components/UI/Workspace/WorkspaceDeleteConfirmDialog';
@@ -145,6 +146,7 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
     removeWorkspace,
     isLoaded,
   } = useActiveWorkspaceContext();
+  const { openImportWorkspace } = useImportExportWizards();
 
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<WorkspaceMeta | null>(null);
@@ -273,6 +275,20 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
                     {getMessage('workspaceCreateLabel')}
                   </Button>
                 </Tooltip>
+              }
+              menu={
+                <ListToolbarMenu
+                  testId="page-workspaces-toolbar-menu"
+                  items={[
+                    {
+                      key: 'import',
+                      testId: 'page-workspaces-toolbar-menu-import',
+                      icon: Upload,
+                      label: getMessage('importWorkspaceTitle'),
+                      onSelect: () => openImportWorkspace(),
+                    },
+                  ]}
+                />
               }
             />
           )}

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -279,6 +279,7 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
               menu={
                 <ListToolbarMenu
                   testId="page-workspaces-toolbar-menu"
+                  ariaLabel={getMessage('importWorkspaceTitle')}
                   items={[
                     {
                       key: 'import',

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -279,7 +279,6 @@ export function WorkspacesPage({ syncSettings }: WorkspacesPageProps) {
               menu={
                 <ListToolbarMenu
                   testId="page-workspaces-toolbar-menu"
-                  ariaLabel={getMessage('importWorkspaceTitle')}
                   items={[
                     {
                       key: 'import',

--- a/tests/components/WorkspacesPage.test.tsx
+++ b/tests/components/WorkspacesPage.test.tsx
@@ -42,8 +42,14 @@ vi.mock('../../src/components/UI/PageLayout/PageLayout', () => ({
 }));
 
 import { WorkspacesPage } from '../../src/pages/WorkspacesPage';
+import { MockImportExportWizardsProvider } from '../../src/test-utils/MockImportExportWizardsProvider';
 
-const wrap = (ui: React.ReactNode) => render(<Theme>{ui}</Theme>);
+const wrap = (ui: React.ReactNode) =>
+  render(
+    <Theme>
+      <MockImportExportWizardsProvider>{ui}</MockImportExportWizardsProvider>
+    </Theme>,
+  );
 
 const baseSettings: AppSettings = {
   globalGroupingEnabled: true,

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -207,7 +207,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
     await expect(page.getByRole('menuitem', { name: /delete/i })).toBeVisible();
     await page.close();
   });
@@ -219,7 +219,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
 
     await expect(page.getByRole('alertdialog')).toBeVisible();
@@ -233,7 +233,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByTestId('confirm-dialog-btn-confirm').click();
 
@@ -249,7 +249,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.getByRole('button', { name: 'More actions' }).click();
+    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByTestId('confirm-dialog-btn-cancel').click();
 
@@ -376,7 +376,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await expect(page.getByRole('button', { name: 'More actions' }).first()).toBeVisible();
+    await expect(page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]')).toBeVisible();
     await page.close();
   });
 

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -21,6 +21,7 @@ import {
   openCustomizeRestoreWizard,
   openSnapshotWizard,
 } from '../../e2e-shared/actions/index.js';
+import { SessionsListPage } from '../../e2e-shared/pages/index.js';
 
 test.beforeEach(async ({ extensionContext }) => {
   await clearSessions(extensionContext);
@@ -207,7 +208,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
+    await new SessionsListPage(page).openFirstCardMenu();
     await expect(page.getByRole('menuitem', { name: /delete/i })).toBeVisible();
     await page.close();
   });
@@ -219,7 +220,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
+    await new SessionsListPage(page).openFirstCardMenu();
     await page.getByRole('menuitem', { name: /delete/i }).click();
 
     await expect(page.getByRole('alertdialog')).toBeVisible();
@@ -233,7 +234,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
+    await new SessionsListPage(page).openFirstCardMenu();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByTestId('confirm-dialog-btn-confirm').click();
 
@@ -249,7 +250,7 @@ test.describe('[US-S07] Delete', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]').click();
+    await new SessionsListPage(page).openFirstCardMenu();
     await page.getByRole('menuitem', { name: /delete/i }).click();
     await page.getByTestId('confirm-dialog-btn-cancel').click();
 
@@ -376,7 +377,7 @@ test.describe('[US-S04][US-S06] Restore — More actions menu', () => {
     const page = await extensionContext.newPage();
     await goToSessionsSection(page, extensionId);
 
-    await expect(page.locator('[data-testid^="session-card-"][data-testid$="-btn-dropdown"]')).toBeVisible();
+    await expect(new SessionsListPage(page).firstCardMenuButton()).toBeVisible();
     await page.close();
   });
 


### PR DESCRIPTION
Introduce a "..." overflow menu rendered to the right of the primary
action button in the ListToolbar:

- Domain rules: export + import rules
- Sessions: export + import sessions
- Workspaces: import only

The new reusable ListToolbarMenu component hosts the page-level
import/export entry points (icon-only DropdownMenu trigger). Wired
through the existing ImportExportWizards context.

Adds the generic "moreActions" i18n key (fr/en/es), a Storybook story,
the new data-testids in the reference, and wraps WorkspacesPage tests in
the mock wizards provider.