### PR TITLE
feat(shortcuts): bascule d'espace de travail au clavier (suivant/précédent/dernier)

### DIFF
--- a/docs/src/content/docs/en/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/en/reference/raccourcis-clavier.mdx
@@ -103,6 +103,14 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 | `E` | Edit focused item |
 | `Delete` | Delete focused item |
 
+## Workspace switching
+
+| Shortcut | Action |
+| --- | --- |
+| `W` then `N` | Switch to next workspace |
+| `W` then `P` | Switch to previous workspace |
+| `W` then `L` | Switch to last used workspace |
+
 ## Options page
 
 | Shortcut | Action |
@@ -136,5 +144,8 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 | Not set | Organize all tabs |
 | Not set | Save current window as a session |
 | `Ctrl + Shift + 1` | Open the extension popup |
+| Not set | Switch to next workspace |
+| Not set | Switch to previous workspace |
+| Not set | Switch to last used workspace |
 | `D` | Switch theme (light, dark, system) |
 

--- a/docs/src/content/docs/es/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/es/reference/raccourcis-clavier.mdx
@@ -103,6 +103,14 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 | `E` | Editar el elemento con foco |
 | `Delete` | Eliminar el elemento con foco |
 
+## Cambio de espacio
+
+| Atajo | Acción |
+| --- | --- |
+| `W` luego `N` | Cambiar al espacio siguiente |
+| `W` luego `P` | Cambiar al espacio anterior |
+| `W` luego `L` | Cambiar al último espacio usado |
+
 ## Página de opciones
 
 | Atajo | Acción |
@@ -136,5 +144,8 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 | Sin definir | Organizar todas las pestañas |
 | Sin definir | Guardar la ventana como sesión |
 | `Ctrl + Shift + 1` | Abrir el popup de la extensión |
+| Sin definir | Cambiar al espacio siguiente |
+| Sin definir | Cambiar al espacio anterior |
+| Sin definir | Cambiar al último espacio usado |
 | `D` | Cambiar de tema (claro, oscuro, sistema) |
 

--- a/docs/src/content/docs/reference/raccourcis-clavier.mdx
+++ b/docs/src/content/docs/reference/raccourcis-clavier.mdx
@@ -103,6 +103,14 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 | `E` | Modifier l'élément focus |
 | `Delete` | Supprimer l'élément focus |
 
+## Changement d'espace
+
+| Raccourci | Action |
+| --- | --- |
+| `W` puis `N` | Passer à l'espace suivant |
+| `W` puis `P` | Passer à l'espace précédent |
+| `W` puis `L` | Passer au dernier espace utilisé |
+
 ## Page d'options
 
 | Raccourci | Action |
@@ -136,5 +144,8 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 | Non défini | Organiser tous les onglets |
 | Non défini | Enregistrer la fenêtre comme session |
 | `Ctrl + Shift + 1` | Ouvrir la popup de l'extension |
+| Non défini | Passer à l'espace suivant |
+| Non défini | Passer à l'espace précédent |
+| Non défini | Passer au dernier espace utilisé |
 | `D` | Changer de thème (clair, sombre, système) |
 

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -760,6 +760,9 @@
 
   "cmdOrganizeAllTabs": { "message": "Organize all tabs in the current window" },
   "cmdSaveSession": { "message": "Save the current window as a session" },
+  "cmdSwitchWorkspaceNext": { "message": "Switch to the next workspace" },
+  "cmdSwitchWorkspacePrev": { "message": "Switch to the previous workspace" },
+  "cmdSwitchWorkspaceLast": { "message": "Switch to the last used workspace" },
 
   "shortcutsPanelTitle": { "message": "Keyboard shortcuts" },
   "shortcutsPanelDescription": { "message": "Quick reference for all available shortcuts." },
@@ -783,6 +786,7 @@
   "shortcutsGroupGlobal": { "message": "Browser-wide" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Options page" },
+  "shortcutsGroupWorkspace": { "message": "Workspace switching" },
   "shortcutsGroupListHome": { "message": "Home page" },
   "shortcutsGroupListRules": { "message": "Rules list" },
   "shortcutsGroupListSessions": { "message": "Sessions list" },
@@ -814,6 +818,16 @@
   "shortcutDescNavigateImportExport": { "message": "Go to Import / Export" },
   "shortcutDescNavigateSettings": { "message": "Go to Settings" },
   "shortcutDescNavigateWorkspaces": { "message": "Go to Workspaces" },
+  "shortcutDescWorkspaceNext": { "message": "Switch to next workspace" },
+  "shortcutDescWorkspacePrev": { "message": "Switch to previous workspace" },
+  "shortcutDescWorkspaceLast": { "message": "Switch to last used workspace" },
+  "workspaceSwitchedAnnounce": {
+    "message": "Active workspace: $NAME$",
+    "placeholders": {
+      "name": { "content": "$1", "example": "Personal" }
+    }
+  },
+  "workspaceSwitchUnavailableAnnounce": { "message": "No other workspace to switch to" },
   "shortcutDescFocusSearch": { "message": "Focus the search field" },
   "shortcutDescClearSearch": { "message": "Clear search or close panel" },
   "shortcutDescListNavigate": { "message": "Move focus between cards" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -761,6 +761,9 @@
 
   "cmdOrganizeAllTabs": { "message": "Organizar todas las pestañas de la ventana" },
   "cmdSaveSession": { "message": "Guardar la ventana actual como sesión" },
+  "cmdSwitchWorkspaceNext": { "message": "Cambiar al siguiente espacio de trabajo" },
+  "cmdSwitchWorkspacePrev": { "message": "Cambiar al espacio de trabajo anterior" },
+  "cmdSwitchWorkspaceLast": { "message": "Cambiar al último espacio de trabajo usado" },
 
   "shortcutsPanelTitle": { "message": "Atajos de teclado" },
   "shortcutsPanelDescription": { "message": "Referencia rápida de todos los atajos disponibles." },
@@ -784,6 +787,7 @@
   "shortcutsGroupGlobal": { "message": "Globales (navegador)" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Página de opciones" },
+  "shortcutsGroupWorkspace": { "message": "Cambio de espacio" },
   "shortcutsGroupListHome": { "message": "Página de inicio" },
   "shortcutsGroupListRules": { "message": "Lista de reglas" },
   "shortcutsGroupListSessions": { "message": "Lista de sesiones" },
@@ -815,6 +819,16 @@
   "shortcutDescNavigateImportExport": { "message": "Ir a Importar / Exportar" },
   "shortcutDescNavigateSettings": { "message": "Ir a los ajustes" },
   "shortcutDescNavigateWorkspaces": { "message": "Ir a los espacios de trabajo" },
+  "shortcutDescWorkspaceNext": { "message": "Cambiar al espacio siguiente" },
+  "shortcutDescWorkspacePrev": { "message": "Cambiar al espacio anterior" },
+  "shortcutDescWorkspaceLast": { "message": "Cambiar al último espacio usado" },
+  "workspaceSwitchedAnnounce": {
+    "message": "Espacio de trabajo activo: $NAME$",
+    "placeholders": {
+      "name": { "content": "$1", "example": "Personal" }
+    }
+  },
+  "workspaceSwitchUnavailableAnnounce": { "message": "No hay otro espacio de trabajo disponible" },
   "shortcutDescFocusSearch": { "message": "Enfocar el campo de búsqueda" },
   "shortcutDescClearSearch": { "message": "Borrar la búsqueda o cerrar el panel" },
   "shortcutDescListNavigate": { "message": "Mover el foco entre tarjetas" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -761,6 +761,9 @@
 
   "cmdOrganizeAllTabs": { "message": "Organiser tous les onglets de la fenêtre" },
   "cmdSaveSession": { "message": "Enregistrer la fenêtre courante en session" },
+  "cmdSwitchWorkspaceNext": { "message": "Passer à l'espace de travail suivant" },
+  "cmdSwitchWorkspacePrev": { "message": "Passer à l'espace de travail précédent" },
+  "cmdSwitchWorkspaceLast": { "message": "Passer au dernier espace de travail utilisé" },
 
   "shortcutsPanelTitle": { "message": "Raccourcis clavier" },
   "shortcutsPanelDescription": { "message": "Référence rapide de tous les raccourcis disponibles." },
@@ -784,6 +787,7 @@
   "shortcutsGroupGlobal": { "message": "Globaux navigateur" },
   "shortcutsGroupPopup": { "message": "Popup" },
   "shortcutsGroupOptions": { "message": "Page d'options" },
+  "shortcutsGroupWorkspace": { "message": "Changement d'espace" },
   "shortcutsGroupListHome": { "message": "Page d'accueil" },
   "shortcutsGroupListRules": { "message": "Liste des règles" },
   "shortcutsGroupListSessions": { "message": "Liste des sessions" },
@@ -815,6 +819,16 @@
   "shortcutDescNavigateImportExport": { "message": "Aller à Import / Export" },
   "shortcutDescNavigateSettings": { "message": "Aller aux réglages" },
   "shortcutDescNavigateWorkspaces": { "message": "Aller aux espaces de travail" },
+  "shortcutDescWorkspaceNext": { "message": "Passer à l'espace suivant" },
+  "shortcutDescWorkspacePrev": { "message": "Passer à l'espace précédent" },
+  "shortcutDescWorkspaceLast": { "message": "Passer au dernier espace utilisé" },
+  "workspaceSwitchedAnnounce": {
+    "message": "Espace de travail actif : $NAME$",
+    "placeholders": {
+      "name": { "content": "$1", "example": "Personnel" }
+    }
+  },
+  "workspaceSwitchUnavailableAnnounce": { "message": "Aucun autre espace de travail disponible" },
   "shortcutDescFocusSearch": { "message": "Focus sur le champ de recherche" },
   "shortcutDescClearSearch": { "message": "Effacer la recherche ou fermer le panneau" },
   "shortcutDescListNavigate": { "message": "Déplacer le focus entre les cartes" },

--- a/src/background/event-handlers.ts
+++ b/src/background/event-handlers.ts
@@ -11,6 +11,7 @@ import {
 import { processTabForDeduplication } from './deduplication.js';
 import { processGroupingForNewTab } from './grouping.js';
 import { handleOrganizeAllTabs } from './organize.js';
+import { switchWorkspaceRelative, type WorkspaceSwitchDirection } from '@/utils/workspaceSwitch.js';
 import { openOptionsWithHash } from '@/utils/openOptions.js';
 import type { BackgroundMessage, MessageResponse } from '@/types/messages.js';
 
@@ -18,6 +19,13 @@ function isBackgroundMessage(value: unknown): value is BackgroundMessage {
     return typeof value === 'object' && value !== null && 'type' in value
         && typeof (value as { type: unknown }).type === 'string';
 }
+
+// Maps the workspace-switch manifest commands to the shared switch direction.
+const WORKSPACE_COMMAND_DIRECTIONS: Record<string, WorkspaceSwitchDirection> = {
+    'switch-workspace-next': 'next',
+    'switch-workspace-prev': 'prev',
+    'switch-workspace-last': 'last',
+};
 export function setupInstallationHandler(): void {
     browser.runtime.onInstalled.addListener(async (details: Browser.runtime.InstalledDetails) => {
         logger.debug("SmartTab Organizer installed/updated.", details.reason);
@@ -70,6 +78,12 @@ export function setupCommandHandler(): void {
         if (name === 'save-current-window-session') {
             openOptionsWithHash('#sessions?action=snapshot')
                 .catch(e => logger.error('[COMMANDS] save-current-window-session failed:', e));
+            return;
+        }
+        const workspaceDirection = WORKSPACE_COMMAND_DIRECTIONS[name];
+        if (workspaceDirection) {
+            switchWorkspaceRelative(workspaceDirection)
+                .catch(e => logger.error(`[COMMANDS] ${name} failed:`, e));
         }
     });
 }

--- a/src/components/UI/Workspace/WorkspaceSwitchShortcuts.tsx
+++ b/src/components/UI/Workspace/WorkspaceSwitchShortcuts.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useState } from 'react';
+import { useShortcuts } from '@/hooks/useShortcuts.js';
+import {
+  switchWorkspaceRelative,
+  type WorkspaceSwitchDirection,
+  type WorkspaceSwitchOutcome,
+} from '@/utils/workspaceSwitch.js';
+import { getMessage } from '@/utils/i18n.js';
+import { logger } from '@/utils/logger.js';
+
+interface WorkspaceSwitchShortcutsProps {
+  /**
+   * Forwarded to `useShortcuts` so the host surface can render its sequence
+   * indicator while the `w` prefix is buffered (options page). Omitted in the
+   * popup, which has no indicator.
+   */
+  onSequenceState?: (state: { activePrefix: string[] | null }) => void;
+}
+
+/** Invisible, unspoken character toggled to force re-announcement of identical
+ *  consecutive messages in the aria-live region (U+200B zero-width space). */
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+
+const SR_ONLY: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+function buildAnnouncement(outcome: WorkspaceSwitchOutcome): string {
+  if (!outcome.switched) {
+    return getMessage('workspaceSwitchUnavailableAnnounce');
+  }
+  const name = outcome.active?.name ?? getMessage('workspaceDefaultName');
+  return getMessage('workspaceSwitchedAnnounce', name);
+}
+
+/**
+ * Non-visual companion that wires the workspace-switch keyboard sequences
+ * (`w n` next, `w p` previous, `w l` last used) at the `global` scope and
+ * announces the result through an aria-live region. Mounted in both the popup
+ * and the options surface so the same gestures work everywhere; the underlying
+ * `switchWorkspaceRelative` handler is shared with the background command layer.
+ */
+export function WorkspaceSwitchShortcuts({ onSequenceState }: WorkspaceSwitchShortcutsProps) {
+  // `nonce` parity toggles a trailing zero-width space so two identical
+  // consecutive messages (e.g. repeated "no other workspace") still re-announce.
+  const [announcement, setAnnouncement] = useState('');
+  const [nonce, setNonce] = useState(0);
+
+  const handleSwitch = useCallback((direction: WorkspaceSwitchDirection) => {
+    switchWorkspaceRelative(direction)
+      .then((outcome) => {
+        setAnnouncement(buildAnnouncement(outcome));
+        setNonce((n) => n + 1);
+      })
+      .catch((error) => logger.error('[WORKSPACE_SWITCH] failed:', error));
+  }, []);
+
+  useShortcuts(
+    {
+      'workspace.next': () => handleSwitch('next'),
+      'workspace.prev': () => handleSwitch('prev'),
+      'workspace.last': () => handleSwitch('last'),
+    },
+    { scope: 'global', onSequenceState },
+  );
+
+  const text =
+    announcement === '' || nonce % 2 === 0 ? announcement : `${announcement}${ZERO_WIDTH_SPACE}`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="workspace-switch-announcer"
+      style={SR_ONLY}
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/contexts/ActiveWorkspaceContext.tsx
+++ b/src/contexts/ActiveWorkspaceContext.tsx
@@ -10,6 +10,8 @@ import {
   type ScopedItems,
 } from '@/utils/workspaceStorage.js';
 import type { WorkspaceMeta, WorkspaceAccentColor } from '@/schemas/workspace.js';
+import { performWorkspaceSwitch } from '@/utils/workspaceSwitch.js';
+import { previousWorkspaceIdItem } from '@/utils/workspaceStorage.js';
 import { logger } from '@/utils/logger.js';
 
 export interface ActiveWorkspaceContextValue {
@@ -104,15 +106,11 @@ export function ActiveWorkspaceProvider({ children }: ActiveWorkspaceProviderPro
   }, []);
 
   const switchTo = useCallback(async (id: string) => {
-    // Stamp lastActivatedAt on the target workspace. The default workspace may
-    // be absent from the index: the map leaves it untouched, and we still flip
-    // the active id below so the switch always happens.
-    const current = (await workspacesIndexItem.getValue()) ?? [];
-    const next = current.map((w) =>
-      w.id === id ? { ...w, lastActivatedAt: new Date().toISOString() } : w,
-    );
-    await workspacesIndexItem.setValue(next);
-    await activeWorkspaceIdItem.setValue(id);
+    // Delegate to the shared switch routine so the "previous workspace" pointer
+    // (powering the "last used" shortcut) stays in sync no matter how the
+    // switch was triggered. It stamps lastActivatedAt on the target and records
+    // the outgoing workspace as the previous one.
+    await performWorkspaceSwitch(id);
   }, []);
 
   const createWorkspace = useCallback(
@@ -127,6 +125,12 @@ export function ActiveWorkspaceProvider({ children }: ActiveWorkspaceProviderPro
       };
       const current = (await workspacesIndexItem.getValue()) ?? [];
       await workspacesIndexItem.setValue([...current, meta]);
+      // Creating a workspace auto-switches to it: record the outgoing one as
+      // the previous pointer so "last used" can jump straight back.
+      const outgoing = (await activeWorkspaceIdItem.getValue()) ?? DEFAULT_WORKSPACE_ID;
+      if (outgoing !== meta.id) {
+        await previousWorkspaceIdItem.setValue(outgoing);
+      }
       await activeWorkspaceIdItem.setValue(meta.id);
       return meta;
     },
@@ -169,6 +173,13 @@ export function ActiveWorkspaceProvider({ children }: ActiveWorkspaceProviderPro
     if (currentActive === id) {
       const fallback = next.find((w) => w.id === DEFAULT_WORKSPACE_ID) ?? next[0];
       await activeWorkspaceIdItem.setValue(fallback.id);
+    }
+
+    // Drop a now-dangling "last used" pointer so the shortcut never targets a
+    // deleted workspace.
+    const previous = await previousWorkspaceIdItem.getValue();
+    if (previous === id) {
+      await previousWorkspaceIdItem.setValue(null);
     }
 
     await deleteScopedKeys(id);

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -166,6 +166,12 @@ export function useShortcuts(
       for (const { entry, action } of scoped) {
         for (const binding of entry.defaultBindings) {
           if (!matchesBinding(candidateBuffer, binding as Binding, event)) continue;
+          // A single-key action must not fire when the key was already consumed
+          // by an earlier-registered handler, typically the tail of a sequence
+          // in another hook (e.g. `w p` switching workspaces in the popup must
+          // not also trigger the `p` "open options" action). Sequence bindings
+          // are unaffected: they keep completing even after preventDefault.
+          if (typeof binding === 'string' && event.defaultPrevented) continue;
           if (!passesContextualFilters(entry, event)) {
             reset();
             return true;

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -27,6 +27,7 @@ import type { SidebarSection } from '@/components/UI/Sidebar/Sidebar';
 import { OptionsHeader, OptionsHeaderCollapsed } from '@/components/UI/OptionsLayout/OptionsHeader';
 import { OptionsTopbar } from '@/components/UI/OptionsLayout/OptionsTopbar';
 import { WorkspaceFooter, WorkspaceFooterCollapsed } from '@/components/UI/Workspace/WorkspaceFooter';
+import { WorkspaceSwitchShortcuts } from '@/components/UI/Workspace/WorkspaceSwitchShortcuts';
 import { ShortcutsAside, type PageContext } from '@/components/UI/ShortcutsPanel';
 import { SequenceIndicator } from '@/components/UI/SequenceIndicator';
 import { HomePage } from './HomePage';
@@ -362,6 +363,7 @@ export function OptionsContent() {
                 color="orange"
             />
             <SequenceIndicator activePrefix={sequencePrefix} />
+            <WorkspaceSwitchShortcuts onSequenceState={({ activePrefix }) => setSequencePrefix(activePrefix)} />
         </div>
         </ImportExportWizardsProvider>
         </ShortcutsControlProvider>

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -10,6 +10,7 @@ import { SettingsToggles } from '@/components/UI/SettingsToggles/SettingsToggles
 import { PopupToolbar } from '@/components/UI/PopupToolbar/PopupToolbar';
 import { PopupProfilesList } from '@/components/UI/PopupProfilesList/PopupProfilesList';
 import { PopupWorkspaceSwitcher } from '@/components/UI/Workspace/PopupWorkspaceSwitcher';
+import { WorkspaceSwitchShortcuts } from '@/components/UI/Workspace/WorkspaceSwitchShortcuts';
 import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
 import { openOptionsWithHash } from '@/utils/openOptions';
 import { getActiveTabGroupId } from '@/utils/tabCapture';
@@ -100,6 +101,7 @@ export function PopupContent() {
           <PopupToolbar organizeButtonRef={organizeButtonRef} />
 
           <PopupWorkspaceSwitcher onManage={handleManageWorkspaces} />
+          <WorkspaceSwitchShortcuts />
 
           {isLoaded && !hasRules ? (
             <SettingsToggles

--- a/src/shortcuts/README.md
+++ b/src/shortcuts/README.md
@@ -77,7 +77,9 @@ first key must never be reused as a simple combo within the same scope
 ```
 
 `tests/shortcuts/registry.test.ts` enforces that the prefixes `i` and `e` are
-not also reserved by simple combos on `page:importexport`.
+not also reserved by simple combos on `page:importexport`, and that `w` (the
+workspace-switch prefix: `w n` / `w p` / `w l`) stays free as a simple combo on
+the `global` scope.
 
 ## Adding a widget shortcut (focused card)
 

--- a/src/shortcuts/groups.ts
+++ b/src/shortcuts/groups.ts
@@ -32,6 +32,7 @@ export const GROUP_DESCRIPTORS: Record<ShortcutGroupId, ShortcutGroupDescriptor>
   global: { id: 'global', titleKey: 'shortcutsGroupGlobal', topLevel: true },
   options: { id: 'options', titleKey: 'shortcutsGroupOptions', topLevel: true },
   popup: { id: 'popup', titleKey: 'shortcutsGroupPopup', topLevel: true },
+  workspace: { id: 'workspace', titleKey: 'shortcutsGroupWorkspace', topLevel: true },
   'list-home': {
     id: 'list-home',
     titleKey: 'shortcutsGroupListHome',
@@ -85,6 +86,7 @@ export const TOP_LEVEL_GROUP_ORDER: ShortcutGroupId[] = [
   'list-stats',
   'importexport',
   'list-workspaces',
+  'workspace',
   'options',
   'popup',
   'global',
@@ -104,6 +106,7 @@ export const VISIBLE_GROUPS_BY_SURFACE: Record<Surface, ShortcutGroupId[]> = {
     'list-stats',
     'importexport',
     'list-workspaces',
+    'workspace',
     'options',
     'popup',
     'global',
@@ -159,6 +162,11 @@ export function isGroupOpenByDefault(
     case 'global':
     case 'options':
       return true;
+    case 'workspace':
+      // Relevant everywhere (works on every surface); open by default in the
+      // drawer and when managing workspaces, collapsed on other options pages
+      // to keep them tidy.
+      return pageContext === undefined || pageContext === 'workspaces';
     case 'popup':
       return pageContext === undefined;
     case 'list-home':

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -42,6 +42,35 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     scope: 'global',
     commandName: '_execute_action',
   },
+  // Browser-layer workspace switching: manifest commands without a default key
+  // (every letter combo clashes with a browser built-in), assignable by the
+  // user via chrome://extensions/shortcuts so they work from any tab. The in
+  // -page `w`-prefixed sequences (group `workspace`) cover the popup/options
+  // surfaces; both layers call the same `switchWorkspaceRelative` handler.
+  'global.workspaceNext': {
+    id: 'global.workspaceNext',
+    defaultBindings: [],
+    descriptionKey: 'shortcutDescWorkspaceNext',
+    group: 'global',
+    scope: 'global',
+    commandName: 'switch-workspace-next',
+  },
+  'global.workspacePrev': {
+    id: 'global.workspacePrev',
+    defaultBindings: [],
+    descriptionKey: 'shortcutDescWorkspacePrev',
+    group: 'global',
+    scope: 'global',
+    commandName: 'switch-workspace-prev',
+  },
+  'global.workspaceLast': {
+    id: 'global.workspaceLast',
+    defaultBindings: [],
+    descriptionKey: 'shortcutDescWorkspaceLast',
+    group: 'global',
+    scope: 'global',
+    commandName: 'switch-workspace-last',
+  },
   // Cycles the theme (light -> dark -> system), mirroring the header
   // ThemeToggle button. Mnemonic `d` ("Dark"). Document-level so the same
   // shortcut works on the options pages and inside the popup.
@@ -50,6 +79,34 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     defaultBindings: ['d'],
     descriptionKey: 'shortcutDescToggleTheme',
     group: 'global',
+    scope: 'global',
+  },
+
+  // Workspace switching (in-page layer). Mnemonic two-key sequences prefixed by
+  // `w` (workspace): `w n` next, `w p` previous, `w l` last used. The `w` letter
+  // is reserved as a sequence prefix at the `global` scope (same rule as `m`):
+  // no simple combo may use it so the sequence timeout never delays a keypress.
+  // Switching only flips the active context; it never moves a tab. Document
+  // -level so the same gestures work in the popup and on the options pages.
+  'workspace.next': {
+    id: 'workspace.next',
+    defaultBindings: [['w', 'n']],
+    descriptionKey: 'shortcutDescWorkspaceNext',
+    group: 'workspace',
+    scope: 'global',
+  },
+  'workspace.prev': {
+    id: 'workspace.prev',
+    defaultBindings: [['w', 'p']],
+    descriptionKey: 'shortcutDescWorkspacePrev',
+    group: 'workspace',
+    scope: 'global',
+  },
+  'workspace.last': {
+    id: 'workspace.last',
+    defaultBindings: [['w', 'l']],
+    descriptionKey: 'shortcutDescWorkspaceLast',
+    group: 'workspace',
     scope: 'global',
   },
 

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -16,6 +16,7 @@ export type ShortcutGroupId =
   | 'global'
   | 'options'
   | 'popup'
+  | 'workspace'
   | 'list-rules'
   | 'list-sessions'
   | 'list-stats'

--- a/src/utils/workspaceStorage.ts
+++ b/src/utils/workspaceStorage.ts
@@ -182,6 +182,18 @@ export const activeWorkspaceIdItem = storage.defineItem<string>(
   { defaultValue: DEFAULT_WORKSPACE_ID },
 );
 
+/**
+ * ID of the workspace that was active right before the current one. Powers the
+ * "last used workspace" shortcut (a two-entry MRU: a single back-and-forth
+ * pointer, not a full ring). `null` until the first switch happens. Updated by
+ * every switch path (`performWorkspaceSwitch`) so the keyboard, the dropdown
+ * and the background command layer stay consistent.
+ */
+export const previousWorkspaceIdItem = storage.defineItem<string | null>(
+  'local:previousWorkspaceId',
+  { defaultValue: null },
+);
+
 /** Test-only helper to clear the scoped-items memo. */
 export function _resetWorkspaceItemsCacheForTests(): void {
   scopedItemsCache.clear();

--- a/src/utils/workspaceSwitch.ts
+++ b/src/utils/workspaceSwitch.ts
@@ -1,0 +1,125 @@
+/**
+ * Active-workspace switching logic, shared by every access layer so a single
+ * handler drives them all (anti-duplication, per the feature brief):
+ *
+ * - the in-page keyboard sequences (`w n` / `w p` / `w l`) mounted in the popup
+ *   and the options page,
+ * - the browser manifest commands handled in the background service worker,
+ * - the workspace dropdown / page (via `ActiveWorkspaceContext.switchTo`).
+ *
+ * Switching a workspace only flips a context pointer (rules, sessions,
+ * settings, statistics scoped storage); it never moves a tab. The cycle order
+ * is the fixed order of the workspaces index, wrapping around at both ends. The
+ * "last used" gesture is a two-entry MRU (a single back-and-forth pointer).
+ */
+
+import {
+  DEFAULT_WORKSPACE_ID,
+  activeWorkspaceIdItem,
+  previousWorkspaceIdItem,
+  workspacesIndexItem,
+} from './workspaceStorage.js';
+import type { WorkspaceMeta } from '@/schemas/workspace.js';
+
+export type WorkspaceSwitchDirection = 'next' | 'prev' | 'last';
+
+/** Why a relative switch produced no change, used to phrase the announcement. */
+export type WorkspaceSwitchSkipReason = 'single' | 'no-previous';
+
+export interface WorkspaceSwitchOutcome {
+  /** True when the active workspace actually changed. */
+  switched: boolean;
+  /** Workspace active after the operation (the target on success, the
+   *  unchanged current one otherwise). `null` when it is not in the index. */
+  active: WorkspaceMeta | null;
+  /** ID active after the operation. */
+  activeId: string;
+  /** Present only when `switched` is false. */
+  reason?: WorkspaceSwitchSkipReason;
+}
+
+/**
+ * Resolve the target workspace ID for a relative move, or `null` when no move
+ * is possible (a single workspace for next/prev, or no valid previous pointer
+ * for last). Pure: callers pass the current index snapshot.
+ */
+export function computeRelativeTargetId(
+  workspaces: WorkspaceMeta[],
+  activeId: string,
+  previousId: string | null,
+  direction: WorkspaceSwitchDirection,
+): string | null {
+  if (direction === 'last') {
+    if (!previousId || previousId === activeId) return null;
+    if (!workspaces.some((w) => w.id === previousId)) return null;
+    return previousId;
+  }
+
+  const count = workspaces.length;
+  if (count <= 1) return null;
+
+  const currentIndex = workspaces.findIndex((w) => w.id === activeId);
+  const base = currentIndex === -1 ? 0 : currentIndex;
+  const targetIndex =
+    direction === 'next' ? (base + 1) % count : (base - 1 + count) % count;
+
+  const targetId = workspaces[targetIndex].id;
+  return targetId === activeId ? null : targetId;
+}
+
+/**
+ * Make `targetId` the active workspace, recording the outgoing one as the
+ * "previous" pointer and stamping `lastActivatedAt` on the target. No-op when
+ * the target is already active. Used by every switch path so the MRU pointer
+ * stays correct regardless of how the switch was triggered.
+ */
+export async function performWorkspaceSwitch(targetId: string): Promise<void> {
+  const currentActive = (await activeWorkspaceIdItem.getValue()) ?? DEFAULT_WORKSPACE_ID;
+  if (targetId === currentActive) return;
+
+  const index = (await workspacesIndexItem.getValue()) ?? [];
+  const stamped = index.map((w) =>
+    w.id === targetId ? { ...w, lastActivatedAt: new Date().toISOString() } : w,
+  );
+  await workspacesIndexItem.setValue(stamped);
+  await previousWorkspaceIdItem.setValue(currentActive);
+  await activeWorkspaceIdItem.setValue(targetId);
+}
+
+/**
+ * Read the current workspace state, compute the relative target and apply it.
+ * Returns an outcome the UI can turn into an aria-live announcement. The single
+ * entry point shared by the keyboard listener and the background command
+ * handler.
+ */
+export async function switchWorkspaceRelative(
+  direction: WorkspaceSwitchDirection,
+): Promise<WorkspaceSwitchOutcome> {
+  const [index, activeIdRaw, previousIdRaw] = await Promise.all([
+    workspacesIndexItem.getValue(),
+    activeWorkspaceIdItem.getValue(),
+    previousWorkspaceIdItem.getValue(),
+  ]);
+
+  const workspaces = index ?? [];
+  const activeId = activeIdRaw ?? DEFAULT_WORKSPACE_ID;
+  const previousId = previousIdRaw ?? null;
+
+  const targetId = computeRelativeTargetId(workspaces, activeId, previousId, direction);
+
+  if (targetId === null) {
+    return {
+      switched: false,
+      active: workspaces.find((w) => w.id === activeId) ?? null,
+      activeId,
+      reason: workspaces.length <= 1 ? 'single' : 'no-previous',
+    };
+  }
+
+  await performWorkspaceSwitch(targetId);
+  return {
+    switched: true,
+    active: workspaces.find((w) => w.id === targetId) ?? null,
+    activeId: targetId,
+  };
+}

--- a/tests/hooks/useShortcuts.test.tsx
+++ b/tests/hooks/useShortcuts.test.tsx
@@ -92,6 +92,36 @@ describe('useShortcuts (facade)', () => {
     dispatch({ key: '/' });
     expect(action).toHaveBeenCalledTimes(1);
   });
+
+  it('does not fire a single-key action consumed as a sequence tail by an earlier hook', () => {
+    const switchPrev = vi.fn();
+    const openOptions = vi.fn();
+    // The workspace (global) hook is registered first, so it runs first and
+    // completes `w p`, calling preventDefault. The popup `p` single-key action
+    // must then be suppressed instead of double-firing.
+    renderHook(() => {
+      useShortcuts({ 'workspace.prev': switchPrev }, { scope: 'global' });
+      useShortcuts({ 'popup.options': openOptions }, { scope: 'page:popup' });
+    });
+
+    dispatch({ key: 'w' });
+    dispatch({ key: 'p' });
+
+    expect(switchPrev).toHaveBeenCalledTimes(1);
+    expect(openOptions).not.toHaveBeenCalled();
+  });
+
+  it('still fires a lone single-key action that is not preceded by a sequence', () => {
+    const openOptions = vi.fn();
+    renderHook(() => {
+      useShortcuts({ 'workspace.prev': vi.fn() }, { scope: 'global' });
+      useShortcuts({ 'popup.options': openOptions }, { scope: 'page:popup' });
+    });
+
+    // A bare `p` (no `w` prefix buffered) must still open options.
+    dispatch({ key: 'p' });
+    expect(openOptions).toHaveBeenCalledTimes(1);
+  });
 });
 
 function dispatchOn(

--- a/tests/shortcuts/groups.test.ts
+++ b/tests/shortcuts/groups.test.ts
@@ -27,7 +27,7 @@ describe('getDisplayTree("popup")', () => {
 });
 
 describe('getDisplayTree("options")', () => {
-  it('returns the 9 top-level groups in sidebar order (page groups first, options/popup next, global last)', () => {
+  it('returns the 10 top-level groups in sidebar order (page groups first, workspace/options/popup next, global last)', () => {
     const tree = getDisplayTree('options');
     expect(tree.map((n) => n.descriptor.id)).toEqual([
       'list-home',
@@ -36,6 +36,7 @@ describe('getDisplayTree("options")', () => {
       'list-stats',
       'importexport',
       'list-workspaces',
+      'workspace',
       'options',
       'popup',
       'global',
@@ -49,7 +50,7 @@ describe('getDisplayTree("options")', () => {
     );
     expect(subIdsByGroup['list-home']).toEqual(['session-card']);
     expect(subIdsByGroup['list-sessions']).toEqual(['session-card']);
-    for (const id of ['global', 'list-rules', 'list-workspaces', 'importexport', 'options', 'popup'] as const) {
+    for (const id of ['global', 'list-rules', 'list-workspaces', 'workspace', 'importexport', 'options', 'popup'] as const) {
       expect(subIdsByGroup[id]).toEqual([]);
     }
   });

--- a/tests/shortcuts/registry.test.ts
+++ b/tests/shortcuts/registry.test.ts
@@ -110,7 +110,8 @@ describe('SHORTCUTS_REGISTRY', () => {
   });
 
   it('contains the expected number of entries per group (parity with legacy panel)', () => {
-    expect(getShortcutsByGroup('global')).toHaveLength(4);
+    expect(getShortcutsByGroup('global')).toHaveLength(7);
+    expect(getShortcutsByGroup('workspace')).toHaveLength(3);
     expect(getShortcutsByGroup('popup')).toHaveLength(5);
     expect(getShortcutsByGroup('options')).toHaveLength(11);
     expect(getShortcutsByGroup('list-rules')).toHaveLength(11);
@@ -141,12 +142,34 @@ describe('SHORTCUTS_REGISTRY', () => {
     expect(offending).toEqual([]);
   });
 
+  it('reserves w as a sequence prefix in the global scope', () => {
+    const globalScope = getShortcutsByScope('global');
+    expect(globalScope.length).toBeGreaterThan(0);
+
+    const offending: { id: string; combo: string }[] = [];
+    for (const entry of globalScope) {
+      for (const binding of entry.defaultBindings) {
+        // Only simple combos can shadow a sequence prefix; sequences are fine.
+        const combos = typeof binding === 'string' ? [binding] : [];
+        for (const combo of combos) {
+          if (parseCombo(combo).key === 'w') {
+            offending.push({ id: entry.id, combo });
+          }
+        }
+      }
+    }
+    expect(offending).toEqual([]);
+  });
+
   it('attaches commandName only on global manifest entries', () => {
     const withCommand = Object.values(SHORTCUTS_REGISTRY).filter((e) => e.commandName);
     expect(withCommand.map((e) => e.commandName).sort()).toEqual([
       '_execute_action',
       'organize-all-tabs',
       'save-current-window-session',
+      'switch-workspace-last',
+      'switch-workspace-next',
+      'switch-workspace-prev',
     ]);
     for (const entry of withCommand) {
       expect(entry.scope).toBe('global');

--- a/tests/utils/workspaceSwitch.test.ts
+++ b/tests/utils/workspaceSwitch.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import {
+  computeRelativeTargetId,
+  performWorkspaceSwitch,
+  switchWorkspaceRelative,
+} from '../../src/utils/workspaceSwitch';
+import {
+  activeWorkspaceIdItem,
+  previousWorkspaceIdItem,
+  workspacesIndexItem,
+  _resetWorkspaceItemsCacheForTests,
+} from '../../src/utils/workspaceStorage';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+
+function ws(id: string): WorkspaceMeta {
+  return { id, name: id.toUpperCase(), accentColor: 'indigo', createdAt: 'x', updatedAt: 'x' };
+}
+
+const A = ws('a');
+const B = ws('b');
+const C = ws('c');
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  _resetWorkspaceItemsCacheForTests();
+});
+
+describe('computeRelativeTargetId', () => {
+  const list = [A, B, C];
+
+  it('cycles to the next workspace', () => {
+    expect(computeRelativeTargetId(list, 'a', null, 'next')).toBe('b');
+    expect(computeRelativeTargetId(list, 'b', null, 'next')).toBe('c');
+  });
+
+  it('wraps around at the end going next', () => {
+    expect(computeRelativeTargetId(list, 'c', null, 'next')).toBe('a');
+  });
+
+  it('cycles to the previous workspace and wraps around at the start', () => {
+    expect(computeRelativeTargetId(list, 'b', null, 'prev')).toBe('a');
+    expect(computeRelativeTargetId(list, 'a', null, 'prev')).toBe('c');
+  });
+
+  it('returns null for next/prev when a single workspace exists', () => {
+    expect(computeRelativeTargetId([A], 'a', null, 'next')).toBeNull();
+    expect(computeRelativeTargetId([A], 'a', null, 'prev')).toBeNull();
+  });
+
+  it('returns the previous pointer for last', () => {
+    expect(computeRelativeTargetId(list, 'b', 'a', 'last')).toBe('a');
+  });
+
+  it('returns null for last when no valid previous pointer', () => {
+    expect(computeRelativeTargetId(list, 'b', null, 'last')).toBeNull();
+    expect(computeRelativeTargetId(list, 'b', 'b', 'last')).toBeNull();
+    expect(computeRelativeTargetId(list, 'b', 'gone', 'last')).toBeNull();
+  });
+});
+
+describe('performWorkspaceSwitch', () => {
+  it('records the outgoing workspace as previous and stamps lastActivatedAt', async () => {
+    await workspacesIndexItem.setValue([A, B, C]);
+    await activeWorkspaceIdItem.setValue('a');
+
+    await performWorkspaceSwitch('b');
+
+    expect(await activeWorkspaceIdItem.getValue()).toBe('b');
+    expect(await previousWorkspaceIdItem.getValue()).toBe('a');
+    const index = await workspacesIndexItem.getValue();
+    expect(index?.find((w) => w.id === 'b')?.lastActivatedAt).toBeDefined();
+    expect(index?.find((w) => w.id === 'a')?.lastActivatedAt).toBeUndefined();
+  });
+
+  it('is a no-op when the target is already active', async () => {
+    await workspacesIndexItem.setValue([A, B]);
+    await activeWorkspaceIdItem.setValue('a');
+
+    await performWorkspaceSwitch('a');
+
+    expect(await activeWorkspaceIdItem.getValue()).toBe('a');
+    expect(await previousWorkspaceIdItem.getValue()).toBeNull();
+  });
+});
+
+describe('switchWorkspaceRelative', () => {
+  beforeEach(async () => {
+    await workspacesIndexItem.setValue([A, B, C]);
+    await activeWorkspaceIdItem.setValue('a');
+  });
+
+  it('advances by one and reports the new active workspace', async () => {
+    const outcome = await switchWorkspaceRelative('next');
+    expect(outcome.switched).toBe(true);
+    expect(outcome.activeId).toBe('b');
+    expect(outcome.active?.id).toBe('b');
+    expect(await activeWorkspaceIdItem.getValue()).toBe('b');
+  });
+
+  it('advances by two across two next calls (discrete sequence)', async () => {
+    await switchWorkspaceRelative('next');
+    const outcome = await switchWorkspaceRelative('next');
+    expect(outcome.activeId).toBe('c');
+  });
+
+  it('toggles back and forth with last', async () => {
+    // Start at a, switch to c so the previous pointer is a.
+    await performWorkspaceSwitch('c');
+    const back = await switchWorkspaceRelative('last');
+    expect(back.activeId).toBe('a');
+    const forth = await switchWorkspaceRelative('last');
+    expect(forth.activeId).toBe('c');
+  });
+
+  it('does nothing and flags single when only one workspace exists', async () => {
+    await workspacesIndexItem.setValue([A]);
+    await activeWorkspaceIdItem.setValue('a');
+
+    const outcome = await switchWorkspaceRelative('next');
+    expect(outcome.switched).toBe(false);
+    expect(outcome.reason).toBe('single');
+    expect(outcome.activeId).toBe('a');
+    expect(await activeWorkspaceIdItem.getValue()).toBe('a');
+  });
+
+  it('flags no-previous when last has no target', async () => {
+    const outcome = await switchWorkspaceRelative('last');
+    expect(outcome.switched).toBe(false);
+    expect(outcome.reason).toBe('no-previous');
+  });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -125,6 +125,19 @@ export default defineConfig({
       'save-current-window-session': {
         description: '__MSG_cmdSaveSession__',
       },
+      // Workspace switching from any tab. No `suggested_key` (same letter
+      // -conflict reasoning as the two commands above); the user assigns them
+      // via chrome://extensions/shortcuts. In the popup/options the `w n`/`w p`
+      // /`w l` in-page sequences cover the same actions.
+      'switch-workspace-next': {
+        description: '__MSG_cmdSwitchWorkspaceNext__',
+      },
+      'switch-workspace-prev': {
+        description: '__MSG_cmdSwitchWorkspacePrev__',
+      },
+      'switch-workspace-last': {
+        description: '__MSG_cmdSwitchWorkspaceLast__',
+      },
       // Single global default: a digit combo avoids the letter conflicts above
       // and is free on Chrome and Firefox (Ctrl+Shift+digit is unbound; plain
       // Ctrl+1..8 selects tabs). On macOS Cmd+Shift+1 is not OS-reserved.


### PR DESCRIPTION
Ajoute trois gestes pour changer d'espace de travail actif sans la souris,
sur deux couches indépendantes qui partagent un seul handler :

- Couche extension (popup + page Options) : séquences clavier `w n` (suivant),
  `w p` (précédent), `w l` (dernier utilisé), avec annonce aria-live de
  l'espace actif (ou de l'impossibilité de basculer).
- Couche navigateur : commandes manifest `switch-workspace-{next,prev,last}`
  sans touche par défaut, assignables via chrome://extensions/shortcuts et
  traitées dans le background.

Détails :
- `workspaceSwitch.ts` : logique partagée (cycle à ordre fixe avec rebouclage,
  MRU à deux entrées pour le dernier espace). Pointeur `previousWorkspaceId`
  persisté en storage.local, maintenu par tous les chemins de bascule
  (clavier, commandes, dropdown via `performWorkspaceSwitch`).
- `WorkspaceSwitchShortcuts` : composant non visuel montant les séquences au
  scope global et exposant la région aria-live.
- `useShortcuts` : une action à touche simple ne se déclenche plus quand la
  touche a déjà été consommée comme fin de séquence par un handler antérieur
  (évite que `w p` ouvre aussi les options dans la popup).
- Registry : groupe d'affichage `workspace` (couche en page) + entrées
  `global.workspace*` (couche navigateur). Réservation du préfixe `w`.
- i18n (en/fr/es), doc Starlight régénérée, tests unitaires.

Closes #423