### PR TITLE
docs: couvrir filtre/tri/groupage, bascule workspace clavier et aide intégrée

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig({
             { slug: 'guides/import-export' },
             { slug: 'guides/statistiques' },
             { slug: 'guides/parametres' },
+            { slug: 'guides/aide-et-documentation' },
           ],
         },
         {

--- a/docs/src/content/docs/en/guides/aide-et-documentation.mdx
+++ b/docs/src/content/docs/en/guides/aide-et-documentation.mdx
@@ -1,0 +1,64 @@
+---
+title: Help and documentation
+description: "The help built into the extension: shortcuts panel, contextual documentation (F1), home page tips and the onboarding welcome screen."
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+The extension ships several help touchpoints so you never have to go hunting: a
+shortcuts panel, contextual documentation, tips on the home page, and a welcome
+screen for newcomers.
+
+## The shortcuts panel
+
+Press `?` from the popup or the Options page to open the **shortcuts panel**. It
+is a quick reference of every available keyboard command, grouped by surface
+(popup, Options navigation, rule or session lists, card actions, global
+shortcuts).
+
+The panel content is derived from the central shortcuts registry, so it always
+stays in sync with the shortcuts that are actually active. Global commands show
+the key you assigned them in the browser rather than a default value.
+
+## Contextual documentation
+
+Press `F1` from the Options page to open, in a new tab, the page of this
+documentation matching the current tab. No need to look for the right page: the
+extension takes you straight there, in the interface language (French, English
+or Spanish).
+
+| Options tab | Page opened |
+|---|---|
+| Home | Why this extension |
+| Rules | Domain rules |
+| Sessions | Sessions |
+| Statistics | Statistics |
+| Import / Export | Import / Export |
+| Settings | Settings |
+| Workspaces | Workspaces |
+
+A documentation button is also present in the header, next to the theme toggle.
+
+## Home page tips
+
+The home page shows a **Tips** section that highlights useful, often overlooked
+features. The tips scroll through a carousel, with arrow and dot navigation.
+
+## The onboarding welcome
+
+On first launch, the home page shows a welcome screen summarizing the three
+pillars of the extension (group, deduplicate, save) and offering two direct
+actions: **import a pack** of ready-to-use rules, or **create a first rule**.
+
+<Aside type="tip">
+The whole documentation stays reachable offline via `F1` once the page is cached
+by the browser, and online at [docs.esprit-vorace.fr](https://docs.esprit-vorace.fr).
+</Aside>
+
+## Next steps
+
+<CardGrid>
+  <LinkCard title="Keyboard shortcuts" href="/reference/raccourcis-clavier" description="The full list of shortcuts, by surface." />
+  <LinkCard title="The home page" href="/decouverte/page-accueil" description="Pinned profiles, quick actions and tips." />
+  <LinkCard title="Domain rules" href="/guides/regles-de-domaine" description="The nerve center of the extension." />
+</CardGrid>

--- a/docs/src/content/docs/en/guides/regles-de-domaine.mdx
+++ b/docs/src/content/docs/en/guides/regles-de-domaine.mdx
@@ -28,6 +28,22 @@ Each row covers a domain and shows its label, its configuration mode (preset, ma
 
 A search bar filters the list by rule name or domain. Multi-selection lets you run bulk actions: enable, disable, delete, export.
 
+## Filter, sort and group the list
+
+Next to the search box, a view button opens a menu to rearrange how the list is
+displayed. It only affects presentation: it changes neither the rules nor their
+evaluation priority (which stays the manual order).
+
+| Setting | Options |
+|---|---|
+| **Sort** | Manual order (drag and drop), by date, by category, by color, or by domain (groups rules sharing the same root domain). Ascending or descending. |
+| **Filter** | By color (the nine colors or "no color"), by category (or "no category"), by state (enabled or disabled). |
+| **Grouping** | None, by category, by color, or by state. |
+
+When a grouping is active, each section gets a collapsible header with a
+tri-state checkbox to select every rule in the group at once. The chosen view
+(sort, filter, grouping) is remembered separately for each workspace.
+
 ## Create a rule
 
 Click **Add Rule** at the top of the list. The wizard opens in four steps.

--- a/docs/src/content/docs/en/guides/sessions.mdx
+++ b/docs/src/content/docs/en/guides/sessions.mdx
@@ -132,6 +132,21 @@ In the **Archived** sub-tab, click **Unarchive**. The session moves back to **Ac
 
 The URL `chrome-extension://[id]/options.html#sessions/archived` opens the **Archived** sub-tab directly. You can bookmark it to dig up an old session.
 
+## Filter and sort
+
+The headers of the **Active** and **Archived** sections (not the **Pinned**
+section) carry a view button that opens a sort and filter menu. Like for rules,
+it only affects how the section is displayed.
+
+| Setting | Options |
+|---|---|
+| **Sort** | Manual order, by date, by last restore, by category. Ascending or descending. |
+| **Filter** | By category. |
+
+Sorting **by last restore** relies on the timestamp recorded each time the
+session is restored. The view is remembered independently for the Active and
+the Archived section, and separately for each workspace.
+
 ## Search
 
 The search bar above the list filters by session name. A **deep** search is available too: it also looks at the captured tab titles, which helps you find a session by one of its contents.

--- a/docs/src/content/docs/en/guides/workspaces.mdx
+++ b/docs/src/content/docs/en/guides/workspaces.mdx
@@ -59,6 +59,24 @@ The `PopupWorkspaceSwitcher` mirrors the same mechanism in the popup. Handy to s
   </TabItem>
 </Tabs>
 
+### From the keyboard
+
+Three key sequences cycle through workspaces without going through the switcher,
+from the Options page or the popup:
+
+| Sequence | Effect |
+|---|---|
+| `W` then `N` | Switch to the next workspace |
+| `W` then `P` | Switch to the previous workspace |
+| `W` then `L` | Go back to the last used workspace |
+
+To switch from anywhere in the browser, three **global commands** also exist:
+`switch-workspace-next`, `switch-workspace-prev` and `switch-workspace-last`.
+They are bound to no key by default; you assign the shortcut of your choice from
+`chrome://extensions/shortcuts`.
+
+See [Keyboard shortcuts](/reference/raccourcis-clavier) for the full list.
+
 When you switch workspace:
 
 - the **Rules** page only shows the rules of the target workspace;

--- a/docs/src/content/docs/es/guides/aide-et-documentation.mdx
+++ b/docs/src/content/docs/es/guides/aide-et-documentation.mdx
@@ -1,0 +1,67 @@
+---
+title: Ayuda y documentación
+description: "La ayuda integrada en la extensión: panel de atajos, documentación contextual (F1), consejos de la página de inicio y pantalla de bienvenida."
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+La extensión incorpora varios puntos de ayuda para que nunca tengas que buscar:
+un panel de atajos, una documentación contextual, consejos en la página de inicio
+y una pantalla de bienvenida para los recién llegados.
+
+## El panel de atajos
+
+Pulsa `?` desde el popup o la página Opciones para abrir el **panel de atajos**.
+Es una referencia rápida de todos los comandos de teclado disponibles, agrupados
+por superficie (popup, navegación de Opciones, listas de reglas o de sesiones,
+acciones de tarjeta, atajos globales).
+
+El contenido del panel se deriva del registro central de atajos, por lo que
+siempre se mantiene sincronizado con los atajos realmente activos. Los comandos
+globales muestran la tecla que les hayas asignado en el navegador en lugar de un
+valor por defecto.
+
+## Documentación contextual
+
+Pulsa `F1` desde la página Opciones para abrir, en una pestaña nueva, la página
+de esta documentación que corresponde a la pestaña actual. No hace falta buscar
+la página correcta: la extensión te lleva directamente, en el idioma de la
+interfaz (francés, inglés o español).
+
+| Pestaña de Opciones | Página abierta |
+|---|---|
+| Inicio | Por qué esta extensión |
+| Reglas | Reglas de dominio |
+| Sesiones | Sesiones |
+| Estadísticas | Estadísticas |
+| Importar / Exportar | Importar / Exportar |
+| Ajustes | Ajustes |
+| Espacios de trabajo | Espacios de trabajo |
+
+También hay un botón de documentación en la cabecera, junto al selector de tema.
+
+## Consejos de la página de inicio
+
+La página de inicio muestra una sección de **Consejos** que destaca funciones
+útiles, a menudo desconocidas. Los consejos se desplazan en un carrusel, con
+navegación por flechas y puntos.
+
+## La bienvenida de incorporación
+
+En el primer arranque, la página de inicio muestra una pantalla de bienvenida que
+resume los tres pilares de la extensión (agrupar, deduplicar, guardar) y ofrece
+dos acciones directas: **importar un pack** de reglas listas para usar, o **crear
+una primera regla**.
+
+<Aside type="tip">
+Toda la documentación sigue siendo accesible sin conexión mediante `F1` una vez
+que el navegador almacena la página en caché, y en línea en [docs.esprit-vorace.fr](https://docs.esprit-vorace.fr).
+</Aside>
+
+## Siguiente paso
+
+<CardGrid>
+  <LinkCard title="Atajos de teclado" href="/reference/raccourcis-clavier" description="La lista completa de atajos, por superficie." />
+  <LinkCard title="La página de inicio" href="/decouverte/page-accueil" description="Perfiles anclados, acciones rápidas y consejos." />
+  <LinkCard title="Reglas de dominio" href="/guides/regles-de-domaine" description="El centro neurálgico de la extensión." />
+</CardGrid>

--- a/docs/src/content/docs/es/guides/regles-de-domaine.mdx
+++ b/docs/src/content/docs/es/guides/regles-de-domaine.mdx
@@ -28,6 +28,23 @@ Cada fila cubre un dominio y muestra su etiqueta, su modo de configuración (pre
 
 Una barra de búsqueda filtra la lista por nombre de regla o por dominio. Una selección múltiple permite ejecutar acciones en masa: activación, desactivación, eliminación, exportación.
 
+## Filtrar, ordenar y agrupar la lista
+
+Junto a la búsqueda, un botón de vista abre un menú para reorganizar cómo se
+muestra la lista. Solo afecta a la presentación: no modifica ni las reglas ni su
+prioridad de evaluación (que sigue siendo el orden manual).
+
+| Ajuste | Opciones |
+|---|---|
+| **Orden** | Orden manual (arrastrar y soltar), por fecha, por categoría, por color o por dominio (agrupa las reglas de un mismo dominio raíz). Ascendente o descendente. |
+| **Filtro** | Por color (los nueve colores o «sin color»), por categoría (o «sin categoría»), por estado (activada o desactivada). |
+| **Agrupación** | Ninguna, por categoría, por color o por estado. |
+
+Cuando hay una agrupación activa, cada sección recibe un encabezado plegable con
+una casilla de tres estados para seleccionar de golpe todas las reglas del grupo.
+La vista elegida (orden, filtro, agrupación) se recuerda por separado para cada
+espacio de trabajo.
+
 ## Crear una regla
 
 Pulsa **Nueva regla** en la parte superior de la lista. El asistente se abre en cuatro pasos.

--- a/docs/src/content/docs/es/guides/sessions.mdx
+++ b/docs/src/content/docs/es/guides/sessions.mdx
@@ -132,6 +132,22 @@ En la sub-pestaña **Archivadas**, pulsa **Desarchivar**. La sesión vuelve a **
 
 La URL `chrome-extension://[id]/options.html#sessions/archived` abre directamente la sub-pestaña **Archivadas**. Puedes usarla como marcador para ir a buscar una sesión antigua.
 
+## Filtrar y ordenar
+
+Los encabezados de las secciones **Activas** y **Archivadas** (no la sección
+**Ancladas**) incluyen un botón de vista que abre un menú de orden y filtro.
+Igual que con las reglas, solo afecta a cómo se muestra la sección.
+
+| Ajuste | Opciones |
+|---|---|
+| **Orden** | Orden manual, por fecha, por última restauración, por categoría. Ascendente o descendente. |
+| **Filtro** | Por categoría. |
+
+El orden **por última restauración** se basa en la marca de tiempo registrada
+cada vez que se restaura la sesión. La vista se recuerda de forma independiente
+para la sección Activas y la sección Archivadas, y por separado para cada
+espacio de trabajo.
+
 ## Búsqueda
 
 La barra de búsqueda sobre la lista filtra por nombre de sesión. También hay una búsqueda **profunda** disponible: inspecciona los títulos de las pestañas capturadas, lo que ayuda a localizar una sesión por uno de sus contenidos.

--- a/docs/src/content/docs/es/guides/workspaces.mdx
+++ b/docs/src/content/docs/es/guides/workspaces.mdx
@@ -59,6 +59,24 @@ El `PopupWorkspaceSwitcher` ofrece la misma mecánica en el popup. Práctico par
   </TabItem>
 </Tabs>
 
+### Con el teclado
+
+Tres secuencias de teclado recorren los espacios de trabajo sin pasar por el
+selector, desde la página Opciones o el popup:
+
+| Secuencia | Efecto |
+|---|---|
+| `W` y luego `N` | Pasar al espacio siguiente |
+| `W` y luego `P` | Pasar al espacio anterior |
+| `W` y luego `L` | Volver al último espacio utilizado |
+
+Para cambiar desde cualquier pestaña del navegador, también existen tres
+**comandos globales**: `switch-workspace-next`, `switch-workspace-prev` y
+`switch-workspace-last`. No están asignados a ninguna tecla por defecto; tú les
+asignas el atajo que prefieras desde `chrome://extensions/shortcuts`.
+
+Consulta [Atajos de teclado](/reference/raccourcis-clavier) para la lista completa.
+
 Al cambiar de espacio de trabajo:
 
 - la página **Reglas** ya solo muestra las reglas del espacio de destino;

--- a/docs/src/content/docs/guides/aide-et-documentation.mdx
+++ b/docs/src/content/docs/guides/aide-et-documentation.mdx
@@ -1,0 +1,68 @@
+---
+title: Aide et documentation
+description: "L'aide intégrée à l'extension : panneau de raccourcis, documentation contextuelle (F1), astuces de la page d'accueil et accueil d'onboarding."
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+L'extension embarque plusieurs points d'aide pour ne jamais vous laisser
+chercher : un panneau de raccourcis, une documentation contextuelle, des astuces
+sur la page d'accueil et un écran d'accueil pour les nouveaux venus.
+
+## Le panneau de raccourcis
+
+Pressez `?` depuis la popup ou la page Options pour ouvrir le **panneau de
+raccourcis**. C'est une référence rapide de toutes les commandes clavier
+disponibles, regroupées par surface (popup, navigation des Options, listes de
+règles ou de sessions, actions de carte, raccourcis globaux).
+
+Le contenu du panneau est dérivé du registre central des raccourcis : il reste
+donc toujours synchronisé avec les raccourcis réellement actifs. Les commandes
+globales y affichent la touche que vous leur avez assignée dans le navigateur
+plutôt qu'une valeur par défaut.
+
+## La documentation contextuelle
+
+Pressez `F1` depuis la page Options pour ouvrir, dans un nouvel onglet, la page
+de cette documentation qui correspond à l'onglet courant. Inutile de chercher la
+bonne page : l'extension vous y emmène directement, dans la langue de l'interface
+(français, anglais ou espagnol).
+
+| Onglet Options | Page ouverte |
+|---|---|
+| Accueil | Pourquoi cette extension |
+| Règles | Règles de domaine |
+| Sessions | Sessions |
+| Statistiques | Statistiques |
+| Import / Export | Import / Export |
+| Paramètres | Paramètres |
+| Espaces de travail | Espaces de travail |
+
+Un bouton de documentation est également présent dans l'entête, à côté du
+sélecteur de thème.
+
+## Les astuces de la page d'accueil
+
+La page d'accueil affiche une section **Astuces** qui met en avant des
+fonctionnalités utiles, souvent méconnues. Les astuces défilent dans un
+carrousel, avec navigation par flèches et pastilles.
+
+## L'accueil d'onboarding
+
+Au premier lancement, la page d'accueil présente un écran de bienvenue qui
+résume les trois piliers de l'extension (grouper, dédupliquer, sauvegarder) et
+propose deux actions directes : **importer un pack** de règles prêtes à l'emploi
+ou **créer une première règle**.
+
+<Aside type="tip">
+Toute la documentation reste accessible hors connexion via `F1` une fois la
+page mise en cache par le navigateur, et en ligne sur [docs.esprit-vorace.fr](https://docs.esprit-vorace.fr).
+</Aside>
+
+## Aller plus loin
+
+<CardGrid>
+  <LinkCard title="Raccourcis clavier" href="/reference/raccourcis-clavier" description="La liste complète des raccourcis, par surface." />
+  <LinkCard title="La page d'accueil" href="/decouverte/page-accueil" description="Profils épinglés, actions rapides et astuces." />
+  <LinkCard title="Règles de domaine" href="/guides/regles-de-domaine" description="Le centre névralgique de l'extension." />
+</CardGrid>

--- a/docs/src/content/docs/guides/regles-de-domaine.mdx
+++ b/docs/src/content/docs/guides/regles-de-domaine.mdx
@@ -28,6 +28,23 @@ Chaque ligne couvre un domaine et affiche son label, son mode de configuration (
 
 Une barre de recherche filtre la liste par nom de règle ou par domaine. Une sélection multiple permet d'effectuer des actions en masse : activation, désactivation, suppression, export.
 
+## Filtrer, trier et grouper la liste
+
+À côté de la recherche, un bouton de vue ouvre un menu pour réorganiser
+l'affichage de la liste. Il agit uniquement sur la présentation : il ne modifie
+ni les règles ni leur priorité d'évaluation (qui reste l'ordre manuel).
+
+| Réglage | Options |
+|---|---|
+| **Tri** | Ordre manuel (glisser-déposer), par date, par catégorie, par couleur, ou par domaine (regroupe les règles d'un même domaine racine). Sens croissant ou décroissant. |
+| **Filtre** | Par couleur (les neuf couleurs ou « sans couleur »), par catégorie (ou « sans catégorie »), par état (activée ou désactivée). |
+| **Groupage** | Aucun, par catégorie, par couleur, ou par état. |
+
+Quand un groupage est actif, chaque section reçoit un entête repliable avec une
+case à cocher tri-état pour sélectionner d'un coup toutes les règles du groupe.
+La vue choisie (tri, filtre, groupage) est mémorisée séparément pour chaque
+espace de travail.
+
 ## Créer une règle
 
 Cliquez sur **Nouvelle règle** en haut de la liste. L'assistant s'ouvre en quatre étapes.

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -132,6 +132,21 @@ Dans le sous-onglet **Archivées**, cliquez sur **Désarchiver**. La session ret
 
 L'URL `chrome-extension://[id]/options.html#sessions/archived` ouvre directement le sous-onglet **Archivées**. Vous pouvez l'utiliser comme marque-page pour aller chercher une vieille session.
 
+## Filtrer et trier
+
+Les entêtes des sections **Actives** et **Archivées** (pas la section
+**Épinglées**) portent un bouton de vue qui ouvre un menu de tri et de filtre.
+Comme pour les règles, il n'agit que sur l'affichage de la section concernée.
+
+| Réglage | Options |
+|---|---|
+| **Tri** | Ordre manuel, par date, par dernière restauration, par catégorie. Sens croissant ou décroissant. |
+| **Filtre** | Par catégorie. |
+
+Le tri **par dernière restauration** s'appuie sur l'horodatage mémorisé à chaque
+restauration de la session. La vue est mémorisée indépendamment pour la section
+Actives et la section Archivées, et séparément pour chaque espace de travail.
+
 ## Recherche
 
 La barre de recherche au-dessus de la liste filtre par nom de session. Une recherche **profonde** est disponible : elle inspecte aussi les titres des onglets capturés, ce qui aide à retrouver une session par l'un de ses contenus.

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -59,6 +59,24 @@ Le `PopupWorkspaceSwitcher` reprend la même mécanique dans la popup. Pratique 
   </TabItem>
 </Tabs>
 
+### Au clavier
+
+Trois séquences clavier font défiler les workspaces sans passer par le sélecteur,
+depuis la page Options ou la popup :
+
+| Séquence | Effet |
+|---|---|
+| `W` puis `N` | Passer au workspace suivant |
+| `W` puis `P` | Passer au workspace précédent |
+| `W` puis `L` | Revenir au dernier workspace utilisé |
+
+Pour basculer depuis n'importe quel onglet du navigateur, trois **commandes
+globales** existent aussi : `switch-workspace-next`, `switch-workspace-prev` et
+`switch-workspace-last`. Elles ne sont liées à aucune touche par défaut ; vous
+leur assignez le raccourci de votre choix depuis `chrome://extensions/shortcuts`.
+
+Voir [Raccourcis clavier](/reference/raccourcis-clavier) pour la liste complète.
+
 Quand vous changez de workspace :
 
 - la page **Règles** n'affiche plus que les règles du workspace cible ;


### PR DESCRIPTION
Ajoute la couverture Starlight (FR/EN/ES) des fonctionnalités récentes
absentes de la doc :
- filtre, tri et groupage de la liste des règles (regles-de-domaine)
- filtre et tri des sections de sessions, tri par dernière restauration
- bascule de workspace au clavier (séquences W N/P/L + commandes globales)
- nouvelle page Aide et documentation (panneau de raccourcis, doc
  contextuelle F1, astuces, onboarding) + entrée sidebar