### PR TITLE
docs: declare AI content usage preferences via Content-Signal in robots.txt

### DIFF
--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,5 +1,13 @@
 # Autorise tout le monde, y compris les robots IA, a indexer la documentation.
+#
+# Content-Signal declare les preferences d'usage du contenu (contentsignals.org) :
+#   ai-train  : utilisation pour l'entrainement de modeles IA
+#   search    : indexation et affichage dans les resultats de recherche
+#   ai-input  : utilisation comme entree d'un systeme IA (ex. RAG, generation de reponses)
+# Valeur "yes" : usage autorise. La documentation etant publique et ouverte,
+# les trois preferences sont a "yes".
 User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /
 
 # Robots IA explicitement autorises (listes a titre de clarte).


### PR DESCRIPTION
Add a Content-Signal directive under User-agent: * declaring ai-train,
search and ai-input preferences (all yes), consistent with the docs site
being public and AI-friendly.

Ref: contentsignals.org, draft-romm-aipref-contentsignals

https://claude.ai/code/session_01H8k9gjxhS435qL5XCaR5BK