### PR TITLE
feat(stats): auto-focus la zone de contenu sans contour visible

### DIFF
--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Box, TabNav } from '@radix-ui/themes';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { getMessage } from '@/utils/i18n';
@@ -49,6 +49,20 @@ const SUB_TAB_LABEL_KEY: Record<StatsSubTab, string> = {
 
 export function StatisticsPage({ syncSettings, statisticsData, sessionStats, storageUsage, onReset, statsTab, onStatsTabChange }: StatisticsPageProps) {
   const activeRulesCount = syncSettings.domainRules.filter(r => r.enabled).length;
+
+  // The scrollable content region carries tabIndex={0} so keyboard users can
+  // scroll it with the arrow keys / PageUp-Down / Space. Give it the focus once
+  // on mount so those keys work right away, without an initial click or tab.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Don't steal focus the user already moved inside the region between mount
+    // and this effect firing; focus coming from outside (sidebar, body on a
+    // fresh load) is fair game.
+    if (el.contains(document.activeElement)) return;
+    el.focus({ preventScroll: true });
+  }, []);
 
   const firstUsedAtFormatted = statisticsData?.firstUsedAt
     ? new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'long', year: 'numeric' }).format(statisticsData.firstUsedAt)
@@ -183,8 +197,11 @@ export function StatisticsPage({ syncSettings, statisticsData, sessionStats, sto
           {/* Only the sub-tab content scrolls; the tabs above stay fixed. The
               region is focusable (tabIndex={0}) so keyboard users get a tab stop
               and native arrow / PageUp-Down / Space scrolling on pages that have
-              no other focusable content (e.g. the summary sub-tab). */}
+              no other focusable content (e.g. the summary sub-tab). It is
+              auto-focused on mount (see effect above) so those keys work on
+              arrival; its focus outline is suppressed in radix-themes.css. */}
           <Box
+            ref={scrollRef}
             data-testid="page-stats-scroll"
             role="region"
             aria-label={getMessage(SUB_TAB_LABEL_KEY[statsTab])}

--- a/src/styles/radix-themes.css
+++ b/src/styles/radix-themes.css
@@ -57,14 +57,15 @@ button[data-rules-nav-item]:focus {
   border-radius: var(--radius-3);
 }
 
-/* Focus ring for the keyboard-scrollable statistics content region.
- * The region is focusable (tabindex=0) so keyboard users can reach it and
- * scroll with the arrow keys on sub-tabs that hold no other focusable control.
- * focus-visible keeps the outline off on pointer interaction. */
+/* The statistics content region is focusable (tabindex=0) only to enable
+ * keyboard scrolling (arrow keys / PageUp-Down / Space). It is auto-focused on
+ * arrival (see StatisticsPage), so we suppress the focus outline to avoid a
+ * frame drawn around the whole page. Targeting both :focus and :focus-visible
+ * guarantees no outline ever shows, even if the browser flips to focus-visible
+ * after an arrow keypress. */
+[data-testid="page-stats-scroll"]:focus,
 [data-testid="page-stats-scroll"]:focus-visible {
-  outline: 2px solid var(--accent-9);
-  outline-offset: -2px;
-  border-radius: var(--radius-3);
+  outline: none;
 }
 
 /* Focusable controls using aria-disabled instead of native disabled (keeps element in tab order). */


### PR DESCRIPTION
La navigation au clavier (flèches haut/bas, PageUp/PageDown) ne marchait
que si la zone scrollable des statistiques avait déjà le focus. On lui
donne maintenant le focus au montage de la page, et on masque son contour
pour éviter un cadre bleu autour de toute la page.