### PR TITLE
Bump version to 1.2.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,45 @@
 # Changelog
 
-## Unreleased
+## 1.2.4 — since 1.2.3
 
 ### New Features
 - Onboarding hero now suggests rule packs matching your open tabs, pre-selected, behind a single "Import and organize" button (local analysis, persistent dismissal)
 - "Organize now" reward offered right after a pack import to rearrange open tabs immediately, with the outcome announced to screen readers
 - Pack gallery lifts packs matching your open tabs to the top and flags them with a "Matches your open tabs" label
+- Statistics page split into four deep-linked sub-pages
+- Local storage usage breakdown added to the statistics page, split per workspace
+- Keyboard workspace switching (next, previous, last) reachable from any tab
+- Domain rules list gains filter, sort and group controls
+- Sessions section headers gain a filter/sort button
+- Live regex syntax highlighting for the domain filter (step 1) and for the title/url fields in the rule wizard
+- Import/export overflow menu added to list toolbars, plus an "import-pack" empty-state action
+- Last used, restored and activated dates now remembered for sessions, rules and workspaces
+- Sidebar shows non-archived counters and bolds the active item
+- Global theme toggle shortcut (D) and Kbd hints on the docs and theme buttons
+- Keyboard shortcuts for the session preview toggle and section jumps
+- Search box gains a clear button, a "/" shortcut hint and an Esc tooltip
+- Smarter initial focus across the popup and list pages (first pinned session or the Organize button, first result on search), plus loading skeletons and domain-rules group keyboard navigation
+- Per-mode internal state preserved when switching config modes in the rule wizard
+
+### Improvements
+- Workspace cards harmonised with the session and rule cards
+- Grouped rules indented to the right for a clearer hierarchy
+- Rule categories turned into read-only in-memory constants
+- Type-safe getMessage via @wxt-dev/i18n: an unknown i18n key now fails at compile time
+- Public JSON assets minified at build time
+- Shared useCodeMirrorSingleLine hook extracted from the domain and regex code fields
+- Documentation migrated to English-rooted locales and slugs, with a browser-language redirect for root visitors
+- Documentation served as Markdown via content negotiation; AI content usage preferences declared via Content-Signal in robots.txt
+- Import/export JSON schema reference page generated, and the statistics sub-pages documented
+- CI runs two Playwright workers per shard; domain-rules keyboard drag-and-drop de-flaked
+
+### Bug Fixes
+- Popup: the S shortcut now scopes the snapshot to the active tab group
+- Popup: the o/s/p shortcuts stay active when a pinned card is focused
+- Shortcuts: conflicting global keyboard shortcuts replaced
+- UX: domain field alignment, sessions tab focus and statistics tab shortcuts fixed
+- Dev: reuse the React root so HMR no longer doubles the keyboard shortcuts
+- Scripts: escape backslashes in the JSON-schema doc table cells
 
 ## 1.2.3 — since 1.2.2
 

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -2238,6 +2238,35 @@ With WXT, you must import the `browser` variable to use the extension APIs. The 
 Additionally, WXT overrides types to provide additional type safety for some APIs, like `browser.runtime.getURL` and `browser.i18n.getMessage`. With `@types/chrome`'s nested namespace approach, it's not possible to override the types for those functions.
 
 ==============================================================================
+@wxt-dev/i18n 0.2.5
+License: MIT
+Author: Aaron Klinker
+Repository: https://github.com/wxt-dev/wxt
+==============================================================================
+
+MIT License
+
+Copyright (c) 2023 Aaron
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==============================================================================
 @wxt-dev/storage 1.2.8
 License: MIT
 Author: Aaron Klinker

--- a/docs/src/content/docs/es/reference/open-source-licenses.mdx
+++ b/docs/src/content/docs/es/reference/open-source-licenses.mdx
@@ -92,6 +92,7 @@ SmartTab Organizer se distribuye bajo la licencia GPLv3. La extension incluye lo
 | @shikijs/vscode-textmate | 10.0.2 | MIT | [github.com/shikijs/vscode-textmate](https://github.com/shikijs/vscode-textmate) |
 | @webext-core/match-patterns | 1.0.3 | MIT | [github.com/aklinker1/webext-core](https://github.com/aklinker1/webext-core) |
 | @wxt-dev/browser | 0.1.42 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
+| @wxt-dev/i18n | 0.2.5 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | @wxt-dev/storage | 1.2.8 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | aria-hidden | 1.2.6 | MIT | [github.com/theKashey/aria-hidden](https://github.com/theKashey/aria-hidden) |
 | async-mutex | 0.5.0 | MIT | [github.com/DirtyHairy/async-mutex](https://github.com/DirtyHairy/async-mutex) |

--- a/docs/src/content/docs/fr/reference/open-source-licenses.mdx
+++ b/docs/src/content/docs/fr/reference/open-source-licenses.mdx
@@ -92,6 +92,7 @@ SmartTab Organizer est distribué sous licence GPLv3. L'extension embarque les c
 | @shikijs/vscode-textmate | 10.0.2 | MIT | [github.com/shikijs/vscode-textmate](https://github.com/shikijs/vscode-textmate) |
 | @webext-core/match-patterns | 1.0.3 | MIT | [github.com/aklinker1/webext-core](https://github.com/aklinker1/webext-core) |
 | @wxt-dev/browser | 0.1.42 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
+| @wxt-dev/i18n | 0.2.5 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | @wxt-dev/storage | 1.2.8 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | aria-hidden | 1.2.6 | MIT | [github.com/theKashey/aria-hidden](https://github.com/theKashey/aria-hidden) |
 | async-mutex | 0.5.0 | MIT | [github.com/DirtyHairy/async-mutex](https://github.com/DirtyHairy/async-mutex) |

--- a/docs/src/content/docs/reference/open-source-licenses.mdx
+++ b/docs/src/content/docs/reference/open-source-licenses.mdx
@@ -92,6 +92,7 @@ SmartTab Organizer is distributed under the GPLv3 license. The extension bundles
 | @shikijs/vscode-textmate | 10.0.2 | MIT | [github.com/shikijs/vscode-textmate](https://github.com/shikijs/vscode-textmate) |
 | @webext-core/match-patterns | 1.0.3 | MIT | [github.com/aklinker1/webext-core](https://github.com/aklinker1/webext-core) |
 | @wxt-dev/browser | 0.1.42 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
+| @wxt-dev/i18n | 0.2.5 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | @wxt-dev/storage | 1.2.8 | MIT | [github.com/wxt-dev/wxt](https://github.com/wxt-dev/wxt) |
 | aria-hidden | 1.2.6 | MIT | [github.com/theKashey/aria-hidden](https://github.com/theKashey/aria-hidden) |
 | async-mutex | 0.5.0 | MIT | [github.com/DirtyHairy/async-mutex](https://github.com/DirtyHairy/async-mutex) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-tab-organizer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@11.4.0",
   "type": "module",

--- a/public/data/third-party-licenses.json
+++ b/public/data/third-party-licenses.json
@@ -264,6 +264,14 @@
     "scope": "dev"
   },
   {
+    "name": "@wxt-dev/i18n",
+    "version": "0.2.5",
+    "license": "MIT",
+    "publisher": "Aaron Klinker",
+    "repository": "https://github.com/wxt-dev/wxt",
+    "scope": "dev"
+  },
+  {
     "name": "axe-playwright",
     "version": "2.2.2",
     "license": "MIT",

--- a/public/data/third-party-licenses.txt
+++ b/public/data/third-party-licenses.txt
@@ -2238,6 +2238,35 @@ With WXT, you must import the `browser` variable to use the extension APIs. The 
 Additionally, WXT overrides types to provide additional type safety for some APIs, like `browser.runtime.getURL` and `browser.i18n.getMessage`. With `@types/chrome`'s nested namespace approach, it's not possible to override the types for those functions.
 
 ==============================================================================
+@wxt-dev/i18n 0.2.5
+License: MIT
+Author: Aaron Klinker
+Repository: https://github.com/wxt-dev/wxt
+==============================================================================
+
+MIT License
+
+Copyright (c) 2023 Aaron
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==============================================================================
 @wxt-dev/storage 1.2.8
 License: MIT
 Author: Aaron Klinker

--- a/scripts/bundled-dependencies.json
+++ b/scripts/bundled-dependencies.json
@@ -336,6 +336,10 @@
     "version": "0.1.42"
   },
   {
+    "name": "@wxt-dev/i18n",
+    "version": "0.2.5"
+  },
+  {
     "name": "@wxt-dev/storage",
     "version": "1.2.8"
   },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -99,7 +99,7 @@ export default defineConfig({
   manifest: {
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
-    version: '1.2.3',
+    version: '1.2.4',
     author: 'EspritVorace',
     homepage_url: 'https://github.com/EspritVorace/smart-tab-organizer',
     default_locale: 'en',


### PR DESCRIPTION
Update project version to 1.2.4 (package.json and extension manifest) and
add CHANGELOG entries for 1.2.4 covering the work since 1.2.3: onboarding
pack suggestions, statistics sub-pages and per-workspace storage breakdown,
keyboard workspace switching, rules/sessions filter-sort-group, live regex
highlighting, remembered usage dates, plus assorted UI, docs and shortcut
fixes.

Regenerate the keyboard-shortcuts and import/export JSON-schema reference
pages, and refresh the third-party license attribution (adds @wxt-dev/i18n).

https://claude.ai/code/session_01Jk5YBAi45FToifZ16hWCdw