### PR TITLE
fix(exploration): stop dropping discoveries so capabilities unlock

### DIFF
--- a/src/background/grouping.ts
+++ b/src/background/grouping.ts
@@ -223,9 +223,13 @@ export async function createNewGroup(
     await incrementStat('grouping', ruleId);
     await stampRuleLastUsed(ruleId);
     // Exploration: creating a group means the "create a rule" capability is in
-    // use. Also record the distinct color seen (multi-valued capability).
+    // use. Also record the color: mark the capability discovered (coverage reads
+    // `discovered`, never `values`) AND record the distinct color seen.
     void markDiscovered('grouping.create');
-    if (groupColor) void markValue('grouping.color', groupColor);
+    if (groupColor) {
+        void markDiscovered('grouping.color');
+        void markValue('grouping.color', groupColor);
+    }
 
     return newGroupId;
 }

--- a/src/components/Core/DomainRule/WizardStep1Identity.tsx
+++ b/src/components/Core/DomainRule/WizardStep1Identity.tsx
@@ -132,7 +132,7 @@ export function WizardStep1Identity({ control, errors, setValue }: WizardStep1Id
               render={({ field }) => (
                 <ChromeColorPicker
                   value={(field.value ?? 'grey') as ChromeGroupColor}
-                  onChange={(color) => field.onChange(color)}
+                  onChange={(color) => { void markDiscovered('grouping.color'); field.onChange(color); }}
                 />
               )}
             />

--- a/src/components/Core/Pack/PackGallery/PackGallery.tsx
+++ b/src/components/Core/Pack/PackGallery/PackGallery.tsx
@@ -104,6 +104,9 @@ export function PackGallery({
   useEffect(() => {
     if (activeCategory === ALL_CATEGORIES) return;
     void markDiscovered('packs.filterCategory');
+    // Mark the capability discovered (coverage reads `discovered`, never
+    // `values`) AND record the distinct category explored.
+    void markDiscovered('packs.categoriesExplored');
     void markValue('packs.categoriesExplored', activeCategory);
   }, [activeCategory]);
 

--- a/src/components/UI/ImportExportWizards/Classification/ConflictModeSelector.tsx
+++ b/src/components/UI/ImportExportWizards/Classification/ConflictModeSelector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Flex, SegmentedControl, Text } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { markDiscovered } from '@/exploration/progressStore';
@@ -17,15 +17,17 @@ const CONFLICT_MODE_CAPABILITY: Record<ConflictMode, string> = {
 };
 
 export function ConflictModeSelector({ value, onChange }: ConflictModeSelectorProps) {
+  // Exploration: mark the currently selected mode (mount + every change), so the
+  // default mode is discovered just by reaching the selector, mirroring how the
+  // rule wizard marks `grouping.mode.*`.
+  useEffect(() => { void markDiscovered(CONFLICT_MODE_CAPABILITY[value]); }, [value]);
+
   return (
     <Flex align="center" gap="2" mb="1">
       <Text size="2" color="gray">{getMessage('conflictResolutionMode')}</Text>
       <SegmentedControl.Root
         value={value}
-        onValueChange={(v: string) => {
-          void markDiscovered(CONFLICT_MODE_CAPABILITY[v as ConflictMode]);
-          onChange(v as ConflictMode);
-        }}
+        onValueChange={(v: string) => onChange(v as ConflictMode)}
         size="1"
       >
         <SegmentedControl.Item value="overwrite" data-testid="conflict-mode-overwrite">{getMessage('conflictModeOverwrite')}</SegmentedControl.Item>

--- a/src/components/UI/ImportExportWizards/Source/SourceModeSegmented.tsx
+++ b/src/components/UI/ImportExportWizards/Source/SourceModeSegmented.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { SegmentedControl } from '@radix-ui/themes';
 import { getMessage, type MessageKey } from '@/utils/i18n';
 import { markDiscovered } from '@/exploration/progressStore';
@@ -27,14 +27,19 @@ export function SourceModeSegmented<T>({
   source,
   availableModes = DEFAULT_AVAILABLE_MODES,
 }: SourceModeSegmentedProps<T>) {
+  // Exploration: mark the currently selected source (mount + every change), so
+  // the default mode is discovered just by reaching the selector, mirroring how
+  // the rule wizard marks `grouping.mode.*`. `pack` has no capability entry.
+  const sourceMode = source.sourceMode;
+  useEffect(() => {
+    const cap = SOURCE_MODE_CAPABILITY[sourceMode];
+    if (cap) void markDiscovered(cap);
+  }, [sourceMode]);
+
   return (
     <SegmentedControl.Root
       value={source.sourceMode}
-      onValueChange={(v: string) => {
-        const cap = SOURCE_MODE_CAPABILITY[v as SourceMode];
-        if (cap) void markDiscovered(cap);
-        source.setSourceMode(v as SourceMode);
-      }}
+      onValueChange={(v: string) => source.setSourceMode(v as SourceMode)}
       size="2"
     >
       {availableModes.map((mode) => (

--- a/src/exploration/progressStore.ts
+++ b/src/exploration/progressStore.ts
@@ -25,21 +25,26 @@ function ensureInitialized(progress: ExplorationProgress): ExplorationProgress {
 }
 
 async function flush(): Promise<void> {
-  const ops = pendingOps;
-  pendingOps = [];
-  if (ops.length === 0) return;
+  // Drain in a loop: a transform enqueued while we await the async storage I/O
+  // below must not be orphaned. Re-checking `pendingOps` after every await keeps
+  // every queued mark in this flush, so the promise callers awaited only settles
+  // once their op has actually been persisted (no silently dropped discoveries).
+  while (pendingOps.length > 0) {
+    const ops = pendingOps;
+    pendingOps = [];
 
-  const raw = await explorationProgressItem.getValue();
-  const parsed = parseExplorationProgress(raw, (e) =>
-    logger.warn('[EXPLORATION] Corrupt progress, resetting:', e),
-  );
-  let after = ensureInitialized(parsed);
-  for (const op of ops) after = op(after);
+    const raw = await explorationProgressItem.getValue();
+    const parsed = parseExplorationProgress(raw, (e) =>
+      logger.warn('[EXPLORATION] Corrupt progress, resetting:', e),
+    );
+    let after = ensureInitialized(parsed);
+    for (const op of ops) after = op(after);
 
-  // Skip the write when nothing actually changed (idempotent marks). Compare
-  // against the raw parsed value so an `initializedAt` stamp still persists.
-  if (JSON.stringify(after) !== JSON.stringify(parsed)) {
-    await explorationProgressItem.setValue(after);
+    // Skip the write when nothing actually changed (idempotent marks). Compare
+    // against the raw parsed value so an `initializedAt` stamp still persists.
+    if (JSON.stringify(after) !== JSON.stringify(parsed)) {
+      await explorationProgressItem.setValue(after);
+    }
   }
 }
 

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -71,6 +71,12 @@ export function useListNavigation<T extends HTMLElement>(
 
   const handleNavigationKey = useCallback(
     (e: KeyboardEvent<HTMLElement>, index: number): boolean => {
+      // Modifier+arrow combos (e.g. Mod+ArrowUp to reorder a card) are reserved
+      // for the registry shortcut layer, dispatched at document level. Consuming
+      // them here (preventDefault) would flag the event as handled and the
+      // dispatch would then skip the reorder action, so plain navigation only
+      // responds to unmodified keys and lets modifier combos fall through.
+      if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return false;
       const items = listRef.current?.querySelectorAll<HTMLElement>(itemSelector);
       if (!items || items.length === 0) return false;
 

--- a/src/pages/DomainRulesPage.tsx
+++ b/src/pages/DomainRulesPage.tsx
@@ -469,6 +469,7 @@ export function DomainRulesPage({
   );
 
   const handleAddRule = useCallback(() => {
+    void markDiscovered('grouping.create');
     setEditingRule(undefined);
     setIsModalOpen(true);
   }, []);

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { mountExtensionApp } from '@/utils/mountExtensionApp.js';
 import { Box, Flex, Separator, Theme } from '@radix-ui/themes';
@@ -13,6 +13,7 @@ import { PopupWorkspaceSwitcher } from '@/components/UI/Workspace/PopupWorkspace
 import { WorkspaceSwitchShortcuts } from '@/components/UI/Workspace/WorkspaceSwitchShortcuts';
 import { ShortcutsDrawer } from '@/components/UI/ShortcutsPanel';
 import { openOptionsWithHash } from '@/utils/openOptions';
+import { markDiscovered } from '@/exploration/progressStore';
 import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { buildSnapshotHash } from '@/utils/snapshotHash';
 import { useSettings } from '@/hooks/useSettings';
@@ -88,6 +89,12 @@ export function PopupContent() {
   );
 
   useThemeToggleShortcut();
+
+  // Exploration: opening the popup is the `_execute_action` global command (the
+  // only global command shipping a default keyboard binding). Chrome never
+  // surfaces `_execute_action` through `browser.commands.onCommand`, so the
+  // background handler cannot observe it; mark the capability here on mount.
+  useEffect(() => { void markDiscovered('nav.globalCommands'); }, []);
 
   const hasRules = isLoaded && (settings?.domainRules?.length ?? 0) > 0;
 

--- a/tests/exploration/progressStore.test.ts
+++ b/tests/exploration/progressStore.test.ts
@@ -42,6 +42,15 @@ describe('markDiscovered', () => {
     const p = await getExplorationProgress();
     expect(p.discovered.sort()).toEqual(['a', 'b']);
   });
+
+  it('does not orphan a mark enqueued while a flush is in flight', async () => {
+    const p1 = markDiscovered('a'); // schedules the flush microtask
+    await Promise.resolve(); // let the flush start and await storage I/O
+    const p2 = markDiscovered('b'); // enqueued mid-flush: must not be dropped
+    await Promise.all([p1, p2]);
+    const p = await getExplorationProgress();
+    expect(p.discovered.sort()).toEqual(['a', 'b']);
+  });
 });
 
 describe('markValue', () => {

--- a/tests/exploration/wiring.test.ts
+++ b/tests/exploration/wiring.test.ts
@@ -76,4 +76,29 @@ describe('exploration catalogue wiring', () => {
     const unwired = CATALOG.map((c) => c.id).filter((id) => !isWired(id));
     expect(unwired).toEqual([]);
   });
+
+  // Regression guard: `markValue(id, v)` only records a distinct value into
+  // `values[id]`; it never adds `id` to `discovered`, and coverage reads
+  // `discovered` (union with `manuallyMarked`), never `values`. A capability
+  // wired through `markValue` alone can therefore never light up. This shipped
+  // for `grouping.color` and `packs.categoriesExplored`. Every catalogue id
+  // recorded via `markValue` MUST also have a `markDiscovered` touchpoint.
+  it('never records a capability through markValue alone (also needs markDiscovered)', () => {
+    const literals = (fn: string): Set<string> =>
+      new Set(
+        [...SOURCE_TEXT.matchAll(new RegExp(`${fn}\\(\\s*['"]([a-zA-Z0-9._]+)['"]`, 'g'))].map(
+          (m) => m[1],
+        ),
+      );
+    const valueMarked = literals('markValue');
+    const discoveredMarked = literals('markDiscovered');
+    const catalogIds = new Set(CATALOG.map((c) => c.id));
+
+    // Non-catalogue value keys (e.g. `dedup.matchMode`, a supplementary record
+    // alongside `dedup.match.*`) are exempt: they never feed coverage.
+    const markValueOnly = [...valueMarked].filter(
+      (id) => catalogIds.has(id) && !discoveredMarked.has(id),
+    );
+    expect(markValueOnly).toEqual([]);
+  });
 });

--- a/tests/hooks/useListNavigation.test.tsx
+++ b/tests/hooks/useListNavigation.test.tsx
@@ -33,13 +33,21 @@ function setup(itemCount: number, options?: UseListNavigationOptions): SetupResu
   return { list, items, api: result.current };
 }
 
-function pressKey(target: HTMLElement, key: string): React.KeyboardEvent<HTMLElement> {
+function pressKey(
+  target: HTMLElement,
+  key: string,
+  modifiers: { altKey?: boolean; ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean } = {},
+): React.KeyboardEvent<HTMLElement> {
   // Build a minimal React-like keyboard event the hook can consume.
   let prevented = false;
   const event = {
     key,
     target,
     currentTarget: target,
+    altKey: modifiers.altKey ?? false,
+    ctrlKey: modifiers.ctrlKey ?? false,
+    metaKey: modifiers.metaKey ?? false,
+    shiftKey: modifiers.shiftKey ?? false,
     preventDefault: () => { prevented = true; },
     get defaultPrevented() { return prevented; },
   } as unknown as React.KeyboardEvent<HTMLElement>;
@@ -64,6 +72,21 @@ describe('useListNavigation', () => {
     items[2].focus();
     api.handleNavigationKey(pressKey(items[2], 'ArrowUp'), 2);
     expect(document.activeElement).toBe(items[1]);
+  });
+
+  it('ignores modifier+arrow combos so reorder shortcuts fall through', () => {
+    // Mod+ArrowUp/Down are registry shortcuts (e.g. reorder a card). Navigation
+    // must not consume or preventDefault them, otherwise the document-level
+    // dispatch skips the reorder action (event.defaultPrevented guard).
+    for (const mods of [{ ctrlKey: true }, { metaKey: true }, { shiftKey: true }, { altKey: true }]) {
+      const { items, api } = setup(3);
+      items[2].focus();
+      const event = pressKey(items[2], 'ArrowUp', mods);
+      const consumed = api.handleNavigationKey(event, 2);
+      expect(consumed).toBe(false);
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.activeElement).toBe(items[2]);
+    }
   });
 
   it('does not consume horizontal arrows when axis is vertical', () => {


### PR DESCRIPTION
Several capabilities never moved to discovered in the exploration
référentiel even after the user performed the matching action.

- progressStore: the coalesced flush grabbed pendingOps once and could
  orphan any mark enqueued while it awaited storage I/O, silently losing
  that discovery (e.g. keyboard reordering). Drain in a loop so every
  queued mark is persisted before the awaited promise settles.
- grouping.color: the background only recorded the color via markValue
  (writes values, not discovered), so it could never unlock. Also mark it
  discovered, and wire the wizard color picker like the category field.
- grouping.create: creating a rule in the wizard never marked it (only
  real background grouping did). Mark it on add, mirroring grouping.edit.
- packs.categoriesExplored: same markValue-only bug, now also discovered.

https://claude.ai/code/session_01HBhhoYCRBLsSf9SxgkoZsk