### PR TITLE
feat(settings): clavier - focus initial + navigation flèches haut/bas

### DIFF
--- a/docs/src/content/docs/es/reference/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/es/reference/keyboard-shortcuts.mdx
@@ -119,6 +119,12 @@ Todos los atajos de teclado disponibles en SmartTab Organizer, agrupados por sup
 | `E` | Editar el elemento con foco |
 | `Delete` | Eliminar el elemento con foco |
 
+## Ajustes \{#list-settings}
+
+| Atajo | Acción |
+| --- | --- |
+| `↑` o `↓` | Mover el foco entre los ajustes |
+
 ## Cambio de espacio \{#workspace}
 
 | Atajo | Acción |

--- a/docs/src/content/docs/fr/reference/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/fr/reference/keyboard-shortcuts.mdx
@@ -119,6 +119,12 @@ Tous les raccourcis clavier disponibles dans SmartTab Organizer, groupés par su
 | `E` | Modifier l'élément focus |
 | `Delete` | Supprimer l'élément focus |
 
+## Paramètres \{#list-settings}
+
+| Raccourci | Action |
+| --- | --- |
+| `↑` ou `↓` | Déplacer le focus entre les paramètres |
+
 ## Changement d'espace \{#workspace}
 
 | Raccourci | Action |

--- a/docs/src/content/docs/reference/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/reference/keyboard-shortcuts.mdx
@@ -119,6 +119,12 @@ All keyboard shortcuts available in SmartTab Organizer, grouped by surface. Brow
 | `E` | Edit focused item |
 | `Delete` | Delete focused item |
 
+## Settings \{#list-settings}
+
+| Shortcut | Action |
+| --- | --- |
+| `↑` or `↓` | Move focus between settings |
+
 ## Workspace switching \{#workspace}
 
 | Shortcut | Action |

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -792,6 +792,7 @@
   "shortcutsGroupListStats": { "message": "Statistics" },
   "shortcutsGroupListExploration": { "message": "Exploration list" },
   "shortcutsGroupListWorkspaces": { "message": "Workspaces list" },
+  "shortcutsGroupListSettings": { "message": "Settings" },
   "shortcutsGroupSessionCard": { "message": "Session card (focused)" },
   "shortcutsGroupImportExport": { "message": "Import / Export" },
 
@@ -831,6 +832,7 @@
   "shortcutDescFocusSearch": { "message": "Focus the search field" },
   "shortcutDescClearSearch": { "message": "Clear search or close panel" },
   "shortcutDescListNavigate": { "message": "Move focus between cards" },
+  "shortcutDescSettingsNavigate": { "message": "Move focus between settings" },
   "shortcutDescListNew": { "message": "Create new item" },
   "shortcutDescListEdit": { "message": "Edit focused item" },
   "shortcutDescListToggleSelection": { "message": "Toggle selection on focused rule" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -793,6 +793,7 @@
   "shortcutsGroupListStats": { "message": "Estadísticas" },
   "shortcutsGroupListExploration": { "message": "Lista de exploración" },
   "shortcutsGroupListWorkspaces": { "message": "Lista de espacios" },
+  "shortcutsGroupListSettings": { "message": "Ajustes" },
   "shortcutsGroupSessionCard": { "message": "Tarjeta de sesión (con foco)" },
   "shortcutsGroupImportExport": { "message": "Importar / Exportar" },
 
@@ -832,6 +833,7 @@
   "shortcutDescFocusSearch": { "message": "Enfocar el campo de búsqueda" },
   "shortcutDescClearSearch": { "message": "Borrar la búsqueda o cerrar el panel" },
   "shortcutDescListNavigate": { "message": "Mover el foco entre tarjetas" },
+  "shortcutDescSettingsNavigate": { "message": "Mover el foco entre los ajustes" },
   "shortcutDescListNew": { "message": "Crear nuevo elemento" },
   "shortcutDescListEdit": { "message": "Editar el elemento con foco" },
   "shortcutDescListToggleSelection": { "message": "Marcar o desmarcar la regla con foco" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -793,6 +793,7 @@
   "shortcutsGroupListStats": { "message": "Statistiques" },
   "shortcutsGroupListExploration": { "message": "Liste d'exploration" },
   "shortcutsGroupListWorkspaces": { "message": "Liste des espaces" },
+  "shortcutsGroupListSettings": { "message": "Paramètres" },
   "shortcutsGroupSessionCard": { "message": "Carte session (focus)" },
   "shortcutsGroupImportExport": { "message": "Import / Export" },
 
@@ -832,6 +833,7 @@
   "shortcutDescFocusSearch": { "message": "Focus sur le champ de recherche" },
   "shortcutDescClearSearch": { "message": "Effacer la recherche ou fermer le panneau" },
   "shortcutDescListNavigate": { "message": "Déplacer le focus entre les cartes" },
+  "shortcutDescSettingsNavigate": { "message": "Déplacer le focus entre les paramètres" },
   "shortcutDescListNew": { "message": "Créer un nouvel élément" },
   "shortcutDescListEdit": { "message": "Modifier l'élément focus" },
   "shortcutDescListToggleSelection": { "message": "Cocher ou décocher la règle focus" },

--- a/src/components/UI/SettingsPage/SettingsPage.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,8 @@
+import { useRef, type KeyboardEvent } from 'react';
 import { Box, Flex, Text, Switch, Card, RadioGroup } from '@radix-ui/themes';
 import { Bell, Copy, RotateCcw } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
+import { useListNavigation } from '@/hooks/useListNavigation';
 import { getMessage } from '@/utils/i18n';
 import { markDiscovered } from '@/exploration/progressStore';
 import type { AppSettings } from '@/types/syncSettings';
@@ -24,7 +26,48 @@ interface SettingsPageProps {
   updateSettings: (settings: Partial<AppSettings>) => void;
 }
 
+/** CSS selector for the controls that take part in Up/Down navigation. */
+const NAV_SELECTOR = '[data-settings-nav]';
+
 export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  // Up/Down moves focus between settings; the first item (first Switch) is
+  // focused on arrival via `autoFocus`. Radio groups keep Radix's native arrow
+  // handling and only delegate to this helper at their boundaries (see below).
+  const { handleNavigationKey } = useListNavigation(listRef, NAV_SELECTOR, {
+    autoFocus: { ready: true },
+  });
+
+  /** Position of `el` among the navigable controls, in DOM order. */
+  const navIndex = (el: HTMLElement): number =>
+    listRef.current
+      ? [...listRef.current.querySelectorAll<HTMLElement>(NAV_SELECTOR)].indexOf(el)
+      : -1;
+
+  /** Up/Down handler for a Switch: move to the previous/next setting. */
+  const handleSwitchKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    handleNavigationKey(e, navIndex(e.currentTarget));
+  };
+
+  /**
+   * Up/Down handler for a radio option. Inside the group Radix keeps its native
+   * behavior (moves focus and selects). Only at the group's boundaries do we
+   * jump out to the neighbouring setting so the Up/Down journey stays
+   * continuous across the whole page.
+   */
+  const handleRadioKeyDown = (
+    e: KeyboardEvent<HTMLElement>,
+    index: number,
+    optionsCount: number,
+  ) => {
+    const atFirst = index === 0;
+    const atLast = index === optionsCount - 1;
+    if ((e.key === 'ArrowDown' && atLast) || (e.key === 'ArrowUp' && atFirst)) {
+      handleNavigationKey(e, navIndex(e.currentTarget));
+    }
+    // Otherwise: let Radix handle the arrow natively (move + select).
+  };
+
   return (
     <PageLayout
       titleKey="settingsTab"
@@ -33,7 +76,7 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
     >
       {() => (
         <Box data-testid="page-settings">
-          <Flex direction="column" gap="4">
+          <Flex direction="column" gap="4" ref={listRef}>
             <Card>
               <Box p="4">
                 <Flex align="center" gap="2" mb="4">
@@ -46,9 +89,11 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     <Text size="2">{getMessage('notifyOnGrouping')}</Text>
                     <Switch
                       data-testid="page-settings-toggle-notify-group"
+                      data-settings-nav=""
                       aria-label={getMessage('notifyOnGrouping')}
                       checked={syncSettings.notifyOnGrouping}
                       onCheckedChange={(checked) => { void markDiscovered('settings.notif.grouping'); updateSettings({ notifyOnGrouping: checked }); }}
+                      onKeyDown={handleSwitchKeyDown}
                     />
                   </Flex>
 
@@ -56,9 +101,11 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     <Text size="2">{getMessage('notifyOnDeduplication')}</Text>
                     <Switch
                       data-testid="page-settings-toggle-notify-dedup"
+                      data-settings-nav=""
                       aria-label={getMessage('notifyOnDeduplication')}
                       checked={syncSettings.notifyOnDeduplication}
                       onCheckedChange={(checked) => { void markDiscovered('settings.notif.dedup'); updateSettings({ notifyOnDeduplication: checked }); }}
+                      onKeyDown={handleSwitchKeyDown}
                     />
                   </Flex>
 
@@ -66,9 +113,11 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     <Text size="2">{getMessage('notifyOnOrganize')}</Text>
                     <Switch
                       data-testid="page-settings-toggle-notify-organize"
+                      data-settings-nav=""
                       aria-label={getMessage('notifyOnOrganize')}
                       checked={syncSettings.notifyOnOrganize}
                       onCheckedChange={(checked) => { void markDiscovered('settings.notif.organize'); updateSettings({ notifyOnOrganize: checked }); }}
+                      onKeyDown={handleSwitchKeyDown}
                     />
                   </Flex>
                 </Flex>
@@ -90,6 +139,7 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     id="page-settings-default-restore-action"
                     data-testid="page-settings-default-restore-action"
                     aria-labelledby="page-settings-default-restore-action-label"
+                    loop={false}
                     value={syncSettings.defaultRestoreAction}
                     onValueChange={(value) => {
                       void markDiscovered('sessions.defaultRestore');
@@ -97,12 +147,14 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     }}
                   >
                     <Flex direction="column" gap="2">
-                      {defaultRestoreActionOptions.map((option) => (
+                      {defaultRestoreActionOptions.map((option, index) => (
                         <Text as="label" size="2" key={option.value}>
                           <Flex gap="2" align="center">
                             <RadioGroup.Item
                               value={option.value}
+                              data-settings-nav=""
                               data-testid={`page-settings-default-restore-action-${option.value}`}
+                              onKeyDown={(e) => handleRadioKeyDown(e, index, defaultRestoreActionOptions.length)}
                             />
                             {getMessage(option.keyLabel)}
                           </Flex>
@@ -130,9 +182,11 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                       <Text size="2">{getMessage('deduplicateUnmatchedDomainsLabel')}</Text>
                       <Switch
                         data-testid="page-settings-toggle-dedup-unmatched"
+                        data-settings-nav=""
                         aria-label={getMessage('deduplicateUnmatchedDomainsLabel')}
                         checked={syncSettings.deduplicateUnmatchedDomains}
                         onCheckedChange={(checked) => { void markDiscovered('dedup.uncoveredScope'); updateSettings({ deduplicateUnmatchedDomains: checked }); }}
+                        onKeyDown={handleSwitchKeyDown}
                       />
                     </Flex>
                     <Text size="1" color="gray">
@@ -148,6 +202,7 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                       id="page-settings-dedup-keep-strategy"
                       data-testid="page-settings-dedup-keep-strategy"
                       aria-labelledby="page-settings-dedup-keep-strategy-label"
+                      loop={false}
                       value={syncSettings.deduplicationKeepStrategy}
                       onValueChange={(value) => {
                         void markDiscovered(KEEP_STRATEGY_CAPABILITY[value as DeduplicationKeepStrategyValue]);
@@ -156,12 +211,16 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                       disabled={!syncSettings.globalDeduplicationEnabled}
                     >
                       <Flex direction="column" gap="2">
-                        {deduplicationKeepStrategyOptions.map((option) => (
+                        {deduplicationKeepStrategyOptions.map((option, index) => (
                           <Text as="label" size="2" key={option.value}>
                             <Flex gap="2" align="center">
                               <RadioGroup.Item
                                 value={option.value}
+                                // Disabled radios are not focusable, so they stay out of the
+                                // Up/Down flat list: only tag them when the group is active.
+                                {...(syncSettings.globalDeduplicationEnabled ? { 'data-settings-nav': '' } : {})}
                                 data-testid={`page-settings-dedup-keep-${option.value}`}
+                                onKeyDown={(e) => handleRadioKeyDown(e, index, deduplicationKeepStrategyOptions.length)}
                               />
                               {getMessage(option.keyLabel)}
                             </Flex>

--- a/src/shortcuts/groups.ts
+++ b/src/shortcuts/groups.ts
@@ -66,6 +66,11 @@ export const GROUP_DESCRIPTORS: Record<ShortcutGroupId, ShortcutGroupDescriptor>
     titleKey: 'shortcutsGroupListWorkspaces',
     topLevel: true,
   },
+  'list-settings': {
+    id: 'list-settings',
+    titleKey: 'shortcutsGroupListSettings',
+    topLevel: true,
+  },
   'session-card': {
     id: 'session-card',
     titleKey: 'shortcutsGroupSessionCard',
@@ -93,6 +98,7 @@ export const TOP_LEVEL_GROUP_ORDER: ShortcutGroupId[] = [
   'list-exploration',
   'importexport',
   'list-workspaces',
+  'list-settings',
   'workspace',
   'options',
   'popup',
@@ -114,6 +120,7 @@ export const VISIBLE_GROUPS_BY_SURFACE: Record<Surface, ShortcutGroupId[]> = {
     'list-exploration',
     'importexport',
     'list-workspaces',
+    'list-settings',
     'workspace',
     'options',
     'popup',
@@ -189,6 +196,8 @@ export function isGroupOpenByDefault(
       return pageContext === 'exploration';
     case 'list-workspaces':
       return pageContext === 'workspaces';
+    case 'list-settings':
+      return pageContext === 'settings';
     case 'importexport':
       return pageContext === 'importexport';
     case 'session-card':

--- a/src/shortcuts/registry.ts
+++ b/src/shortcuts/registry.ts
@@ -554,6 +554,18 @@ export const SHORTCUTS_REGISTRY: Record<string, ShortcutEntry> = {
     scope: 'widget:workspace-card',
   },
 
+  // List-level: Settings. Up/Down move focus between the settings controls
+  // (documentation-only, handled by `useListNavigation` in SettingsPage). Inside
+  // a radio group the arrows keep their native Radix behavior; navigation
+  // resumes across settings at the group boundaries.
+  'list.settings.navigate': {
+    id: 'list.settings.navigate',
+    defaultBindings: ['ArrowUp', 'ArrowDown'],
+    descriptionKey: 'shortcutDescSettingsNavigate',
+    group: 'list-settings',
+    scope: 'page:settings',
+  },
+
   // List-level: Home
   'list.home.navigate': {
     id: 'list.home.navigate',

--- a/src/shortcuts/types.ts
+++ b/src/shortcuts/types.ts
@@ -25,6 +25,7 @@ export type ShortcutGroupId =
   | 'list-stats'
   | 'list-exploration'
   | 'list-workspaces'
+  | 'list-settings'
   | 'list-home'
   | 'session-card'
   | 'importexport';

--- a/tests/e2e/helpers/navigation.ts
+++ b/tests/e2e/helpers/navigation.ts
@@ -121,6 +121,24 @@ export async function goToExplorationSection(page: Page, extensionId: string): P
   await page.getByTestId('page-exploration').waitFor({ state: 'visible', timeout: 10_000 });
 }
 
+/**
+ * Navigate to the Settings section via hash routing and wait until the page is
+ * rendered (settings loaded + SettingsPage mounted).
+ */
+export async function goToSettingsSection(page: Page, extensionId: string): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/options.html#settings`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => {
+      const body = document.body.textContent ?? '';
+      return !body.includes('Chargement') && body.length > 50;
+    },
+    null,
+    { timeout: 10_000 },
+  );
+  await page.getByTestId('page-settings').waitFor({ state: 'visible', timeout: 10_000 });
+}
+
 /** Navigate to the extension popup page. */
 export async function goToPopup(page: Page, extensionId: string): Promise<void> {
   await page.goto(`chrome-extension://${extensionId}/popup.html`);

--- a/tests/e2e/page-initial-focus.spec.ts
+++ b/tests/e2e/page-initial-focus.spec.ts
@@ -14,7 +14,11 @@
 import { test, expect } from './fixtures';
 import type { BrowserContext, Page } from '@playwright/test';
 import { SessionsListPage, WorkspaceListPage } from '../../e2e-shared/pages/index.js';
-import { goToDomainRulesSection, goToSessionsSection } from './helpers/navigation';
+import {
+  goToDomainRulesSection,
+  goToSessionsSection,
+  goToSettingsSection,
+} from './helpers/navigation';
 import {
   seedSessions,
   clearSessions,
@@ -239,6 +243,24 @@ test.describe('[focus-management] Workspaces initial focus', () => {
     await goToWorkspacesSection(page, extensionId);
 
     await expect(new WorkspaceListPage(page).firstCard()).toBeFocused();
+
+    await page.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+test.describe('[focus-management] Settings initial focus', () => {
+  test('focuses the first Switch on arrival', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToSettingsSection(page, extensionId);
+
+    await expect(page.getByTestId('page-settings-toggle-notify-group')).toBeFocused();
 
     await page.close();
   });

--- a/tests/shortcuts/groups.test.ts
+++ b/tests/shortcuts/groups.test.ts
@@ -28,7 +28,7 @@ describe('getDisplayTree("popup")', () => {
 });
 
 describe('getDisplayTree("options")', () => {
-  it('returns the 11 top-level groups in sidebar order (page groups first, workspace/options/popup next, global last)', () => {
+  it('returns the 12 top-level groups in sidebar order (page groups first, workspace/options/popup next, global last)', () => {
     const tree = getDisplayTree('options');
     expect(tree.map((n) => n.descriptor.id)).toEqual([
       'list-home',
@@ -38,6 +38,7 @@ describe('getDisplayTree("options")', () => {
       'list-exploration',
       'importexport',
       'list-workspaces',
+      'list-settings',
       'workspace',
       'options',
       'popup',
@@ -52,7 +53,7 @@ describe('getDisplayTree("options")', () => {
     );
     expect(subIdsByGroup['list-home']).toEqual(['session-card']);
     expect(subIdsByGroup['list-sessions']).toEqual(['session-card']);
-    for (const id of ['global', 'list-rules', 'list-stats', 'list-exploration', 'list-workspaces', 'workspace', 'importexport', 'options', 'popup'] as const) {
+    for (const id of ['global', 'list-rules', 'list-stats', 'list-exploration', 'list-workspaces', 'list-settings', 'workspace', 'importexport', 'options', 'popup'] as const) {
       expect(subIdsByGroup[id]).toEqual([]);
     }
   });
@@ -92,6 +93,12 @@ describe('isGroupOpenByDefault', () => {
   it('opens list-workspaces only on the workspaces page', () => {
     for (const ctx of ALL_CONTEXTS) {
       expect(isGroupOpenByDefault('list-workspaces', ctx)).toBe(ctx === 'workspaces');
+    }
+  });
+
+  it('opens list-settings only on the settings page', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      expect(isGroupOpenByDefault('list-settings', ctx)).toBe(ctx === 'settings');
     }
   });
 

--- a/tests/shortcuts/registry.test.ts
+++ b/tests/shortcuts/registry.test.ts
@@ -122,6 +122,7 @@ describe('SHORTCUTS_REGISTRY', () => {
     expect(getShortcutsByGroup('list-stats')).toHaveLength(2);
     expect(getShortcutsByGroup('list-exploration')).toHaveLength(8);
     expect(getShortcutsByGroup('list-workspaces')).toHaveLength(3);
+    expect(getShortcutsByGroup('list-settings')).toHaveLength(1);
     expect(getShortcutsByGroup('list-home')).toHaveLength(9);
     expect(getShortcutsByGroup('session-card')).toHaveLength(7);
     expect(getShortcutsByGroup('importexport')).toHaveLength(6);

--- a/wxt-i18n-structure.d.ts
+++ b/wxt-i18n-structure.d.ts
@@ -758,6 +758,7 @@ export type GeneratedI18nStructure = {
   "shortcutsGroupListStats": { substitutions: 0, plural: false };
   "shortcutsGroupListExploration": { substitutions: 0, plural: false };
   "shortcutsGroupListWorkspaces": { substitutions: 0, plural: false };
+  "shortcutsGroupListSettings": { substitutions: 0, plural: false };
   "shortcutsGroupSessionCard": { substitutions: 0, plural: false };
   "shortcutsGroupImportExport": { substitutions: 0, plural: false };
   "shortcutSequenceSeparator": { substitutions: 0, plural: false };
@@ -785,6 +786,7 @@ export type GeneratedI18nStructure = {
   "shortcutDescFocusSearch": { substitutions: 0, plural: false };
   "shortcutDescClearSearch": { substitutions: 0, plural: false };
   "shortcutDescListNavigate": { substitutions: 0, plural: false };
+  "shortcutDescSettingsNavigate": { substitutions: 0, plural: false };
   "shortcutDescListNew": { substitutions: 0, plural: false };
   "shortcutDescListEdit": { substitutions: 0, plural: false };
   "shortcutDescListToggleSelection": { substitutions: 0, plural: false };
@@ -1087,8 +1089,6 @@ export type GeneratedI18nStructure = {
   "explorationEntry_grouping_presetApplied_desc": { substitutions: 0, plural: false };
   "explorationEntry_grouping_reorder_drag_label": { substitutions: 0, plural: false };
   "explorationEntry_grouping_reorder_drag_desc": { substitutions: 0, plural: false };
-  "explorationEntry_grouping_reorder_keyboard_label": { substitutions: 0, plural: false };
-  "explorationEntry_grouping_reorder_keyboard_desc": { substitutions: 0, plural: false };
   "explorationEntry_grouping_toggle_label": { substitutions: 0, plural: false };
   "explorationEntry_grouping_toggle_desc": { substitutions: 0, plural: false };
   "explorationEntry_grouping_overlaps_label": { substitutions: 0, plural: false };
@@ -1097,12 +1097,6 @@ export type GeneratedI18nStructure = {
   "explorationEntry_grouping_merge_desc": { substitutions: 0, plural: false };
   "explorationEntry_grouping_view_filterSort_label": { substitutions: 0, plural: false };
   "explorationEntry_grouping_view_filterSort_desc": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_exact_label": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_exact_desc": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_includes_label": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_includes_desc": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_ignoreParams_label": { substitutions: 0, plural: false };
-  "explorationEntry_dedup_match_ignoreParams_desc": { substitutions: 0, plural: false };
   "explorationEntry_dedup_togglePerRule_label": { substitutions: 0, plural: false };
   "explorationEntry_dedup_togglePerRule_desc": { substitutions: 0, plural: false };
   "explorationEntry_dedup_keep_old_label": { substitutions: 0, plural: false };
@@ -1137,8 +1131,6 @@ export type GeneratedI18nStructure = {
   "explorationEntry_sessions_pin_desc": { substitutions: 0, plural: false };
   "explorationEntry_sessions_archive_label": { substitutions: 0, plural: false };
   "explorationEntry_sessions_archive_desc": { substitutions: 0, plural: false };
-  "explorationEntry_sessions_subtab_active_label": { substitutions: 0, plural: false };
-  "explorationEntry_sessions_subtab_active_desc": { substitutions: 0, plural: false };
   "explorationEntry_sessions_subtab_archived_label": { substitutions: 0, plural: false };
   "explorationEntry_sessions_subtab_archived_desc": { substitutions: 0, plural: false };
   "explorationEntry_sessions_unarchive_label": { substitutions: 0, plural: false };
@@ -1165,6 +1157,8 @@ export type GeneratedI18nStructure = {
   "explorationEntry_sessions_search_desc": { substitutions: 0, plural: false };
   "explorationEntry_sessions_view_filterSort_label": { substitutions: 0, plural: false };
   "explorationEntry_sessions_view_filterSort_desc": { substitutions: 0, plural: false };
+  "explorationEntry_sessions_sectionNav_label": { substitutions: 0, plural: false };
+  "explorationEntry_sessions_sectionNav_desc": { substitutions: 0, plural: false };
   "explorationEntry_workspaces_create_label": { substitutions: 0, plural: false };
   "explorationEntry_workspaces_create_desc": { substitutions: 0, plural: false };
   "explorationEntry_workspaces_switch_label": { substitutions: 0, plural: false };
@@ -1227,6 +1221,8 @@ export type GeneratedI18nStructure = {
   "explorationEntry_stats_storage_desc": { substitutions: 0, plural: false };
   "explorationEntry_stats_reset_label": { substitutions: 0, plural: false };
   "explorationEntry_stats_reset_desc": { substitutions: 0, plural: false };
+  "explorationEntry_stats_tabNav_label": { substitutions: 0, plural: false };
+  "explorationEntry_stats_tabNav_desc": { substitutions: 0, plural: false };
   "explorationEntry_stats_exploration_label": { substitutions: 0, plural: false };
   "explorationEntry_stats_exploration_desc": { substitutions: 0, plural: false };
   "explorationEntry_nav_pinExtension_label": { substitutions: 0, plural: false };
@@ -1245,10 +1241,6 @@ export type GeneratedI18nStructure = {
   "explorationEntry_nav_globalCommands_desc": { substitutions: 0, plural: false };
   "explorationEntry_nav_workspaceSwitchKeyboard_label": { substitutions: 0, plural: false };
   "explorationEntry_nav_workspaceSwitchKeyboard_desc": { substitutions: 0, plural: false };
-  "explorationEntry_nav_listKeyboard_label": { substitutions: 0, plural: false };
-  "explorationEntry_nav_listKeyboard_desc": { substitutions: 0, plural: false };
-  "explorationEntry_nav_reorderKeyboard_label": { substitutions: 0, plural: false };
-  "explorationEntry_nav_reorderKeyboard_desc": { substitutions: 0, plural: false };
   "explorationEntry_help_drawer_label": { substitutions: 0, plural: false };
   "explorationEntry_help_drawer_desc": { substitutions: 0, plural: false };
   "explorationEntry_help_contextF1_label": { substitutions: 0, plural: false };


### PR DESCRIPTION
La page des paramètres pose désormais le focus sur le premier Switch à
l'arrivée et permet de naviguer entre les paramètres avec les flèches
haut/bas (réutilisation de useListNavigation).

- Switch : haut/bas déplacent le focus vers le contrôle voisin.
- Groupes radio : les flèches gardent leur comportement natif Radix
  (déplacement + sélection) ; la navigation reprend entre paramètres aux
  bornes du groupe (navigation continue). loop={false} évite le bouclage.
- Le groupe keep-strategy désactivé est exclu de la navigation.

Ajoute le raccourci documenté list.settings.navigate (groupe list-settings,
scope page:settings), les clés i18n (en/fr/es) et régénère la page de
référence des raccourcis. Met à jour les tests groups/registry et ajoute un
test E2E de focus initial sur la page des paramètres.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SGfuNtKuJvvYvm36maKfUM