### PR TITLE
Fix: Mark sessions.snapshot discovered when wizard opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - About dialog widened on the options page (540px to 680px); popup stays unchanged
 
 ### Bug Fixes
+- Exploration: the "Take a snapshot" capability now lights up when the snapshot wizard opens (the touchpoint), instead of only after a session is actually saved, so opening it from the catalogue is enough to mark it discovered
 - Dropped unreachable catalogue entries (io.deepLink, help.tipVariants) and made the onboarding hero capability reachable from the pack-suggestion variant
 - CatalogRow story wrapped in role=list to fix an axe aria-required-parent violation
 - PhaseBar nested ternaries extracted into helpers to clear sonarjs lint errors

--- a/src/exploration/catalog.ts
+++ b/src/exploration/catalog.ts
@@ -105,7 +105,7 @@ export const CATALOG: readonly CatalogEntry[] = [
   e('dedup.undo', 'dedup', '#settings', 'ephemeral', { doc: 'guides/deduplicate#undo', prerequisites: DEDUP_ENABLED }),
 
   // 3. Sessions
-  e('sessions.snapshot', 'sessions', '#sessions?action=snapshot', 'counter', { doc: 'guides/sessions#snapshot' }),
+  e('sessions.snapshot', 'sessions', '#sessions?action=snapshot', 'touchpoint', { doc: 'guides/sessions#snapshot' }),
   e('sessions.restore.current', 'sessions', '#sessions', 'touchpoint', { doc: 'guides/sessions#restore', prerequisites: HAS_SESSION }),
   e('sessions.restore.new', 'sessions', '#sessions', 'touchpoint', { doc: 'guides/sessions#restore', prerequisites: HAS_SESSION }),
   e('sessions.restore.replace', 'sessions', '#sessions', 'touchpoint', { doc: 'guides/sessions#restore', prerequisites: HAS_SESSION }),

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -470,6 +470,15 @@ export function SessionsPage({
     return () => onSnapshotWizardOpenChange?.(false);
   }, [onSnapshotWizardOpenChange]);
 
+  // Exploration: opening the snapshot wizard is the discovery touchpoint for
+  // `sessions.snapshot` (marked on display, never on save). Covers every entry
+  // point that opens the wizard: the toolbar button, the empty-state CTA, the
+  // keyboard shortcut, and the `#sessions?action=snapshot` deep link (popup or
+  // exploration catalogue). Idempotent, so re-opening it costs nothing.
+  useEffect(() => {
+    if (snapshotOpen) void markDiscovered('sessions.snapshot');
+  }, [snapshotOpen]);
+
   const [restoreSession, setRestoreSession] = useState<Session | null>(null);
   const [refreshTarget, setRefreshTarget] = useState<Session | null>(null);
   const [refreshGroupId, setRefreshGroupId] = useState<number | null>(null);
@@ -890,7 +899,8 @@ export function SessionsPage({
 
   const handleSaveSession = useCallback(
     async (session: Session) => {
-      void markDiscovered('sessions.snapshot');
+      // Discovery of `sessions.snapshot` is marked when the wizard opens (see the
+      // effect above), not here: opening the wizard is the touchpoint, saving is not.
       await createSession(session);
     },
     [createSession],

--- a/tests/e2e/exploration.spec.ts
+++ b/tests/e2e/exploration.spec.ts
@@ -39,6 +39,19 @@ test.describe('[US-A004] Exploration page renders', () => {
 });
 
 test.describe('[US-A009] Touchpoint discovery', () => {
+  /**
+   * Expand the "sessions" domain group, collapsed by default on a fresh
+   * catalogue (the seed only opens the first incomplete domain, "grouping").
+   * Its rows are unmounted while collapsed, so they must be revealed before
+   * any interaction. Conditional-free to satisfy `playwright/no-conditional-in-test`.
+   */
+  async function expandSessionsDomain(page: import('@playwright/test').Page): Promise<void> {
+    const header = page.getByTestId('exploration-domain-sessions').getByRole('button').first();
+    await expect(header).toHaveAttribute('aria-expanded', 'false');
+    await header.click();
+    await expect(header).toHaveAttribute('aria-expanded', 'true');
+  }
+
   test('opening the snapshot wizard marks sessions.snapshot discovered (no save needed)', async ({
     extensionContext,
     extensionId,
@@ -48,15 +61,12 @@ test.describe('[US-A009] Touchpoint discovery', () => {
     await resetExploration(page);
 
     // The snapshot capability lives in the (collapsed) "sessions" domain group.
-    const gotoBtn = page.getByTestId('exploration-goto-sessions.snapshot');
-    if (!(await gotoBtn.isVisible())) {
-      await page.getByTestId('exploration-domain-sessions').getByRole('button').first().click();
-    }
+    await expandSessionsDomain(page);
     // Not discovered yet: the row exposes the manual-mark toggle, no static badge.
     await expect(page.getByTestId('exploration-mark-sessions.snapshot')).toBeVisible();
 
     // Open the wizard from the catalogue, then cancel WITHOUT saving.
-    await gotoBtn.click();
+    await page.getByTestId('exploration-goto-sessions.snapshot').click();
     await expect(page.getByTestId('wizard-snapshot')).toBeVisible({ timeout: 5_000 });
     await page.getByTestId('wizard-snapshot-btn-cancel').click();
     await expect(page.getByTestId('wizard-snapshot')).toBeHidden({ timeout: 5_000 });
@@ -65,9 +75,7 @@ test.describe('[US-A009] Touchpoint discovery', () => {
     // badge, no more mark toggle), even though no session was created.
     await page.getByTestId('sidebar-nav-item-exploration').click();
     await expect(page.getByTestId('page-exploration')).toBeVisible();
-    if (!(await page.getByTestId('exploration-badge-sessions.snapshot').isVisible())) {
-      await page.getByTestId('exploration-domain-sessions').getByRole('button').first().click();
-    }
+    await expandSessionsDomain(page);
     await expect(page.getByTestId('exploration-badge-sessions.snapshot')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId('exploration-mark-sessions.snapshot')).toHaveCount(0);
 

--- a/tests/e2e/exploration.spec.ts
+++ b/tests/e2e/exploration.spec.ts
@@ -38,6 +38,43 @@ test.describe('[US-A004] Exploration page renders', () => {
   });
 });
 
+test.describe('[US-A009] Touchpoint discovery', () => {
+  test('opening the snapshot wizard marks sessions.snapshot discovered (no save needed)', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    const page = await extensionContext.newPage();
+    await goToExplorationSection(page, extensionId);
+    await resetExploration(page);
+
+    // The snapshot capability lives in the (collapsed) "sessions" domain group.
+    const gotoBtn = page.getByTestId('exploration-goto-sessions.snapshot');
+    if (!(await gotoBtn.isVisible())) {
+      await page.getByTestId('exploration-domain-sessions').getByRole('button').first().click();
+    }
+    // Not discovered yet: the row exposes the manual-mark toggle, no static badge.
+    await expect(page.getByTestId('exploration-mark-sessions.snapshot')).toBeVisible();
+
+    // Open the wizard from the catalogue, then cancel WITHOUT saving.
+    await gotoBtn.click();
+    await expect(page.getByTestId('wizard-snapshot')).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId('wizard-snapshot-btn-cancel').click();
+    await expect(page.getByTestId('wizard-snapshot')).toBeHidden({ timeout: 5_000 });
+
+    // Back to the catalogue: the capability is now auto-discovered (static green
+    // badge, no more mark toggle), even though no session was created.
+    await page.getByTestId('sidebar-nav-item-exploration').click();
+    await expect(page.getByTestId('page-exploration')).toBeVisible();
+    if (!(await page.getByTestId('exploration-badge-sessions.snapshot').isVisible())) {
+      await page.getByTestId('exploration-domain-sessions').getByRole('button').first().click();
+    }
+    await expect(page.getByTestId('exploration-badge-sessions.snapshot')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('exploration-mark-sessions.snapshot')).toHaveCount(0);
+
+    await page.close();
+  });
+});
+
 test.describe('[US-A017] Reversible manual marking', () => {
   test('marks a to-discover entry, unmarks it, and persists across reload', async ({
     extensionContext,


### PR DESCRIPTION
## Summary
Changed the discovery touchpoint for the "Take a snapshot" capability from saving a session to opening the snapshot wizard. This allows users to mark the capability as discovered simply by opening the wizard from the exploration catalogue, without needing to actually create and save a session.

## Changes
- **Catalog entry**: Updated `sessions.snapshot` discovery type from `counter` to `touchpoint` in `src/exploration/catalog.ts`
- **Discovery logic**: Moved the `markDiscovered('sessions.snapshot')` call from `handleSaveSession` to a new `useEffect` hook that triggers when the snapshot wizard opens (`snapshotOpen` state change)
- **Implementation details**: 
  - The effect is idempotent, so re-opening the wizard has no side effects
  - Covers all entry points that open the wizard: toolbar button, empty-state CTA, keyboard shortcut, and deep links
  - Added explanatory comments documenting the discovery touchpoint and why it's on open rather than save
- **E2E test**: Added comprehensive test case `[US-A009] Touchpoint discovery` that verifies opening and canceling the snapshot wizard marks the capability as discovered without saving

## Rationale
The previous behavior required users to complete the entire session creation flow to mark the capability discovered. The new behavior recognizes that opening the wizard itself is the meaningful user interaction that demonstrates discovery of the feature, making the exploration catalogue more responsive to user actions.

https://claude.ai/code/session_01VUyCoY7wLQUkpCB6B9QXUV