### PR TITLE
feat(ux): libelle du bouton restaurer sur les cartes de session + masquage de la liste workspace unique

### DIFF
--- a/src/components/Core/Session/SessionCard.tsx
+++ b/src/components/Core/Session/SessionCard.tsx
@@ -519,6 +519,7 @@ function SessionCardFullHeader({
           onRefresh={onRefresh}
           defaultRestoreAction={defaultRestoreAction}
           onDefaultRestoreActionChange={onDefaultRestoreActionChange}
+          presentation="tile"
           data-testid={`session-card-${session.id}-btn-restore`}
         />
       )}

--- a/src/components/UI/Workspace/WorkspaceSwitcherDropdown.tsx
+++ b/src/components/UI/Workspace/WorkspaceSwitcherDropdown.tsx
@@ -22,6 +22,10 @@ export function WorkspaceSwitcherDropdown({ trigger, onManage }: WorkspaceSwitch
   const { workspaces, activeId, switchTo } = useActiveWorkspaceContext();
   const [aboutOpen, setAboutOpen] = useState(false);
 
+  // With a single workspace there is nothing to choose between: hide the
+  // selection list (and its label) but keep the manage/about actions.
+  const showWorkspaceChoice = workspaces.length > 1;
+
   return (
     <>
       <DropdownMenu.Root>
@@ -32,28 +36,32 @@ export function WorkspaceSwitcherDropdown({ trigger, onManage }: WorkspaceSwitch
           data-testid="workspace-switcher-content"
           aria-label={getMessage('workspaceSwitcherLabel')}
         >
-          <DropdownMenu.Label>
-            {getMessage('workspaceSwitcherLabel')}
-          </DropdownMenu.Label>
-          {workspaces.map((ws) => {
-            const isActive = ws.id === activeId;
-            return (
-              <DropdownMenu.Item
-                key={ws.id}
-                data-testid={`workspace-switcher-item-${ws.id}`}
-                onSelect={() => {
-                  if (!isActive) void switchTo(ws.id);
-                }}
-              >
-                <Flex align="center" gap="2" style={{ width: '100%' }}>
-                  <WorkspaceAvatar name={ws.name} accentColor={ws.accentColor} size="sm" />
-                  <Text size="2" style={{ flex: 1 }}>{ws.name}</Text>
-                  {isActive ? <Check size={14} /> : null}
-                </Flex>
-              </DropdownMenu.Item>
-            );
-          })}
-          <DropdownMenu.Separator />
+          {showWorkspaceChoice && (
+            <>
+              <DropdownMenu.Label>
+                {getMessage('workspaceSwitcherLabel')}
+              </DropdownMenu.Label>
+              {workspaces.map((ws) => {
+                const isActive = ws.id === activeId;
+                return (
+                  <DropdownMenu.Item
+                    key={ws.id}
+                    data-testid={`workspace-switcher-item-${ws.id}`}
+                    onSelect={() => {
+                      if (!isActive) void switchTo(ws.id);
+                    }}
+                  >
+                    <Flex align="center" gap="2" style={{ width: '100%' }}>
+                      <WorkspaceAvatar name={ws.name} accentColor={ws.accentColor} size="sm" />
+                      <Text size="2" style={{ flex: 1 }}>{ws.name}</Text>
+                      {isActive ? <Check size={14} /> : null}
+                    </Flex>
+                  </DropdownMenu.Item>
+                );
+              })}
+              <DropdownMenu.Separator />
+            </>
+          )}
           <DropdownMenu.Item
             disabled={!onManage}
             data-testid="workspace-switcher-manage"

--- a/tests/e2e/workspaces.spec.ts
+++ b/tests/e2e/workspaces.spec.ts
@@ -145,7 +145,7 @@ test.describe('Workspaces — create + switch + delete', () => {
 });
 
 test.describe('Workspaces — switcher dropdown', () => {
-  test('opens from the sidebar footer and lists every workspace', async ({
+  test('with a single workspace, hides the choice list but keeps Manage', async ({
     optionsPage,
     extensionId,
   }) => {
@@ -153,7 +153,38 @@ test.describe('Workspaces — switcher dropdown', () => {
     await optionsPage.getByTestId('workspace-footer-trigger').click();
     const dropdown = optionsPage.getByTestId('workspace-switcher-content');
     await expect(dropdown).toBeVisible();
+    // Only the default workspace exists: the selection list is pointless and
+    // should not render, but the manage action stays available.
+    await expect(optionsPage.getByTestId('workspace-switcher-item-default')).toHaveCount(0);
+    await expect(optionsPage.getByTestId('workspace-switcher-manage')).toBeVisible();
+  });
+
+  test('with several workspaces, lists every workspace', async ({
+    optionsPage,
+    extensionId,
+    extensionContext,
+  }) => {
+    // Seed a second workspace so there is an actual choice to surface.
+    const sw = await getServiceWorker(extensionContext);
+    await sw.evaluate(async () => {
+      const { workspaces } = await chrome.storage.local.get('workspaces');
+      const list = Array.isArray(workspaces) ? workspaces : [];
+      list.push({
+        id: 'personal',
+        name: 'Personal',
+        accentColor: 'jade',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      await chrome.storage.local.set({ workspaces: list });
+    });
+
+    await goToOptionsPage(optionsPage, extensionId);
+    await optionsPage.getByTestId('workspace-footer-trigger').click();
+    const dropdown = optionsPage.getByTestId('workspace-switcher-content');
+    await expect(dropdown).toBeVisible();
     await expect(optionsPage.getByTestId('workspace-switcher-item-default')).toBeVisible();
+    await expect(optionsPage.getByTestId('workspace-switcher-item-personal')).toBeVisible();
     await expect(optionsPage.getByTestId('workspace-switcher-manage')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Changements

Deux ajustements UX :

### 1. Libelle du bouton « Restaurer » sur les cartes de session
- `SessionCard` passe desormais `presentation=tile` au `SessionRestoreButton`, comme la tuile de la page d'accueil.
- Le bouton affiche son libelle « Restaurer » a cote de l'icone au lieu de l'icone seule. La taille reste compacte (`size=1`) pour coller a la mise en page de la carte.

### 2. Masquage de la liste de choix quand il n'y a qu'un seul espace de travail
- Dans le menu de la sidebar (en bas), la liste de selection des espaces de travail (label + entrees + separateur) n'est plus affichee lorsqu'un seul workspace existe : il n'y a rien a choisir.
- Les actions « Gerer » (personnaliser) et « A propos » restent disponibles.
- A partir de deux workspaces, le comportement est inchange.

## Tests
- `pnpm compile` : OK.
- Test E2E `workspaces.spec.ts` mis a jour : deux scenarios (un seul workspace -> liste masquee mais « Gerer » present ; plusieurs workspaces -> liste complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)