### PR TITLE
feat(rule-wizard): domain-aware preset suggestions in step 2

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -149,6 +149,7 @@
   "presetRuleLabel": { "message": "Rule Preset" },
   "searchPresetPlaceholder": { "message": "Search a preset..." },
   "noPresetFound": { "message": "No preset found" },
+  "presetSuggestedGroupHeading": { "message": "Suggested for this domain" },
   "searchableSelectTriggerLabel": { "message": "Open options" },
   "searchableSelectSearchLabel": { "message": "Search options" },
   "ruleSelectAriaLabel": { "message": "Select rule" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -149,6 +149,7 @@
   "presetRuleLabel": { "message": "Preset de regla" },
   "searchPresetPlaceholder": { "message": "Buscar un preset..." },
   "noPresetFound": { "message": "Ningún preset encontrado" },
+  "presetSuggestedGroupHeading": { "message": "Sugeridos para este dominio" },
   "searchableSelectTriggerLabel": { "message": "Abrir opciones" },
   "searchableSelectSearchLabel": { "message": "Buscar opciones" },
   "ruleSelectAriaLabel": { "message": "Seleccionar regla" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -149,6 +149,7 @@
   "presetRuleLabel": { "message": "Preset de règle" },
   "searchPresetPlaceholder": { "message": "Rechercher un preset..." },
   "noPresetFound": { "message": "Aucun preset trouvé" },
+  "presetSuggestedGroupHeading": { "message": "Suggérés pour ce domaine" },
   "searchableSelectTriggerLabel": { "message": "Ouvrir les options" },
   "searchableSelectSearchLabel": { "message": "Rechercher les options" },
   "ruleSelectAriaLabel": { "message": "Sélectionner la règle" },

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.stories.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.stories.tsx
@@ -5,6 +5,31 @@ import { setRegexFieldValue } from '@/components/UI/RegexCodeField';
 import { DomainRuleConfigForm, type DomainRuleConfigFormProps } from './DomainRuleConfigForm';
 import type { ConfigMode } from './ConfigModeSelector';
 import type { GroupNameSourceValue, UrlExtractionModeValue } from '@/schemas/enums';
+import type { PresetCategory } from '@/types/preset';
+
+// Minimal catalog mixing a domain-specific preset with a cross-domain ("*") one
+// so the leading "Suggested for this domain" group can be demonstrated.
+const SAMPLE_PRESET_CATEGORIES: PresetCategory[] = [
+  {
+    id: 'development',
+    presets: [
+      {
+        id: 'github-issue',
+        name: 'GitHub Issue',
+        domainFilters: ['github.com'],
+        groupNameSource: 'smart',
+        description: '',
+      },
+      {
+        id: 'numeric-id',
+        name: 'Numeric ID',
+        domainFilters: ['*'],
+        groupNameSource: 'smart',
+        description: '',
+      },
+    ],
+  },
+] as PresetCategory[];
 
 type WrapperProps = Omit<
   DomainRuleConfigFormProps,
@@ -109,6 +134,45 @@ export const DomainRuleConfigFormSwitchToAsk: Story = {
     const askBtn = canvas.getByRole('radio', { name: /ask/i });
     await userEvent.click(askBtn);
     await expect(canvas.getByRole('radio', { name: /ask/i })).toBeChecked();
+  },
+};
+
+// Preset mode with a step 1 domain that matches a domain-specific preset: a
+// leading "Suggested for this domain" group is prepended to the library.
+export const DomainRuleConfigFormPresetSuggested: Story = {
+  render: () => (
+    <Wrapper
+      presetId={null}
+      onPresetChange={() => {}}
+      presetCategories={SAMPLE_PRESET_CATEGORIES}
+      isLoadingPresets={false}
+      suggestionDomain="github.com"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The leading group heading is shown, and the matching preset moves into it.
+    await expect(canvas.getByText('Suggested for this domain')).toBeInTheDocument();
+    await expect(canvas.getByText('GitHub Issue')).toBeInTheDocument();
+  },
+};
+
+// Preset mode with a non-matching domain: no leading group, library as today.
+export const DomainRuleConfigFormPresetNoSuggestion: Story = {
+  render: () => (
+    <Wrapper
+      presetId={null}
+      onPresetChange={() => {}}
+      presetCategories={SAMPLE_PRESET_CATEGORIES}
+      isLoadingPresets={false}
+      suggestionDomain="example.com"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Suggested for this domain')).not.toBeInTheDocument();
+    // The cross-domain preset stays available in its usual section.
+    await expect(canvas.getByText('Numeric ID')).toBeInTheDocument();
   },
 };
 

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
@@ -190,6 +190,13 @@ export function DomainRuleConfigForm({
                 )}
                 searchPlaceholder={getMessage('searchPresetPlaceholder')}
                 emptyMessage={getMessage('noPresetFound')}
+                // Land focus on the search input when entering Preset mode with
+                // nothing selected yet; a managed field on mode entry, not a
+                // page-load autofocus. Skipped when a preset is already chosen
+                // (the list centers the selected item instead) and when the
+                // host owns first-field focus (edit modal), to avoid a race.
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus={!presetId && !autoFocusFirstField}
               />
             </Flex>
           )}

--- a/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
+++ b/src/components/Core/DomainRule/DomainRuleConfigForm.tsx
@@ -13,7 +13,7 @@ import {
   type UrlExtractionModeValue,
 } from '@/schemas/enums';
 import type { PresetCategory } from '@/utils/presetUtils';
-import { presetsToSearchableGroups } from '@/utils/presetsToSearchableGroups';
+import { presetsToSearchableGroupsWithSuggestions } from '@/utils/presetsToSearchableGroups';
 import { RegexCodeField } from '@/components/UI/RegexCodeField';
 import { ConfigModeSelector, MODE_HELP_LABELS, type ConfigMode } from './ConfigModeSelector';
 
@@ -35,6 +35,12 @@ export interface DomainRuleConfigFormProps {
   onPresetChange: (presetId: string) => void;
   presetCategories: PresetCategory[];
   isLoadingPresets: boolean;
+  /**
+   * Domain filter used to surface a leading "Suggested for this domain" group
+   * in the preset selector. Only wired from the create wizard (step 2); left
+   * undefined elsewhere (e.g. the edit dialog) so the library renders as today.
+   */
+  suggestionDomain?: string;
   groupNameSource: GroupNameSourceValue;
   onGroupNameSourceChange: (source: GroupNameSourceValue) => void;
   titleParsingRegEx: string;
@@ -68,6 +74,7 @@ export function DomainRuleConfigForm({
   onPresetChange,
   presetCategories,
   isLoadingPresets,
+  suggestionDomain,
   groupNameSource,
   onGroupNameSourceChange,
   titleParsingRegEx,
@@ -176,7 +183,11 @@ export function DomainRuleConfigForm({
                 id={presetInputId}
                 value={presetId ?? ''}
                 onValueChange={handlePresetChange}
-                groups={presetsToSearchableGroups(presetCategories)}
+                groups={presetsToSearchableGroupsWithSuggestions(
+                  presetCategories,
+                  suggestionDomain,
+                  getMessage('presetSuggestedGroupHeading'),
+                )}
                 searchPlaceholder={getMessage('searchPresetPlaceholder')}
                 emptyMessage={getMessage('noPresetFound')}
               />

--- a/src/components/Core/DomainRule/WizardStep2Config.tsx
+++ b/src/components/Core/DomainRule/WizardStep2Config.tsx
@@ -1,4 +1,4 @@
-import { useController, type Control, type FieldErrors } from 'react-hook-form';
+import { useController, useWatch, type Control, type FieldErrors } from 'react-hook-form';
 import type { DomainRule } from '@/schemas/domainRule';
 import type { PresetCategory } from '@/utils/presetUtils';
 import { type GroupNameSourceValue, type UrlExtractionModeValue } from '@/schemas/enums';
@@ -30,6 +30,9 @@ export function WizardStep2Config({
   handlePresetChange,
   groupNameSource,
 }: WizardStep2ConfigProps) {
+  // Reactive read of the step 1 domain so the preset suggestions recompute when
+  // the user changes the domain and returns to step 2.
+  const domainFilter = useWatch({ control, name: 'domainFilter' });
   const { field: presetField } = useController({ name: 'presetId', control });
   const { field: groupNameSourceField } = useController({ name: 'groupNameSource', control });
   const { field: titleField } = useController({ name: 'titleParsingRegEx', control });
@@ -46,6 +49,7 @@ export function WizardStep2Config({
       onPresetChange={handlePresetChange}
       presetCategories={presetCategories}
       isLoadingPresets={isLoadingPresets}
+      suggestionDomain={domainFilter ?? ''}
       groupNameSource={groupNameSource}
       onGroupNameSourceChange={(value) => groupNameSourceField.onChange(value)}
       titleParsingRegEx={titleField.value ?? ''}

--- a/src/components/Form/FormFields/SearchableInlineList.stories.tsx
+++ b/src/components/Form/FormFields/SearchableInlineList.stories.tsx
@@ -57,6 +57,61 @@ export const SearchableInlineListDefault: Story = {
   },
 };
 
+// Pressing Enter from the empty search input selects the first result.
+export const SearchableInlineListEnterSelectsFirst: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <SearchableInlineList
+        value={value}
+        onValueChange={setValue}
+        options={fruits}
+        searchPlaceholder="Search a fruit..."
+        emptyMessage="No fruit found."
+        aria-label="Fruits"
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText('Search a fruit...');
+    input.focus();
+    // Enter on the empty query lands on the first item (Apple).
+    await userEvent.keyboard('{Enter}');
+    await expect(canvas.getByText('Apple').closest('[cmdk-item=""]')).toHaveClass(
+      'ss-item--selected',
+    );
+  },
+};
+
+// Typing then Enter selects the first filtered result.
+export const SearchableInlineListEnterSelectsFirstFiltered: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <SearchableInlineList
+        value={value}
+        onValueChange={setValue}
+        options={fruits}
+        searchPlaceholder="Search a fruit..."
+        emptyMessage="No fruit found."
+        aria-label="Fruits"
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText('Search a fruit...');
+    input.focus();
+    await userEvent.type(input, 'e');
+    await userEvent.keyboard('{Enter}');
+    // "e" matches several fruits; the first rendered result becomes selected.
+    await expect(
+      canvasElement.querySelector('[cmdk-item=""].ss-item--selected'),
+    ).toBeInTheDocument();
+  },
+};
+
 // Custom render path: the renderItem prop supplies rich rows with a trailing badge.
 export const SearchableInlineListCustomRenderItem: Story = {
   render: () => {

--- a/src/components/Form/FormFields/SearchableInlineList.tsx
+++ b/src/components/Form/FormFields/SearchableInlineList.tsx
@@ -78,6 +78,26 @@ export function SearchableInlineList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Enter on the search input should land on the first result. cmdk only
+  // activates the item it has highlighted (aria-selected), but on mount with an
+  // empty query no item is highlighted yet, so a plain Enter does nothing. When
+  // nothing is highlighted, select the first rendered (matching, enabled) item
+  // ourselves. When cmdk already highlights one (e.g. after arrow navigation),
+  // defer to it.
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    const root = containerRef.current;
+    if (!root) return;
+    if (root.querySelector('[cmdk-item=""][aria-selected="true"]')) return;
+    const first = root.querySelector<HTMLElement>(
+      '[cmdk-item=""]:not([aria-disabled="true"])',
+    );
+    if (first) {
+      e.preventDefault();
+      first.click();
+    }
+  };
+
   const renderOption = (option: SearchableSelectOption) =>
     renderItem ? (
       renderItem(option)
@@ -105,6 +125,7 @@ export function SearchableInlineList({
             placeholder={searchPlaceholder}
             aria-label={searchPlaceholder ?? getMessage('searchableSelectSearchLabel')}
             className="ss-search__input"
+            onKeyDown={handleInputKeyDown}
           />
         </div>
         <Command.List id={listboxId} className="ss-list ss-list--inline">

--- a/src/components/Form/FormFields/SearchableSelect.css
+++ b/src/components/Form/FormFields/SearchableSelect.css
@@ -177,7 +177,9 @@
 
 .ss-item--selected {
   background: var(--accent-a5);
-  color: var(--accent-11);
+  /* High-contrast accent text: --accent-11 drops below the 4.5:1 threshold on
+     the darker --accent-a6 background of the selected + highlighted state. */
+  color: var(--accent-12);
   font-weight: 500;
   box-shadow: inset 3px 0 0 var(--accent-9);
 }

--- a/src/utils/presetSuggestions.ts
+++ b/src/utils/presetSuggestions.ts
@@ -1,0 +1,45 @@
+import type { PresetCategory } from '@/types/preset';
+import { matchesDomain } from './utils.js';
+
+/**
+ * Build a representative http(s) URL from an entered domain filter so the
+ * preset matcher can be reused verbatim. A leading `*.` is stripped (the bare
+ * apex is the most representative sample), mirroring how `domainToRegex`
+ * normalizes filters at runtime.
+ */
+function buildSampleUrl(domain: string): string | null {
+  const trimmed = domain.trim();
+  if (!trimmed) return null;
+  const cleaned = trimmed.startsWith('*.') ? trimmed.slice(2) : trimmed;
+  if (!cleaned) return null;
+  return `https://${cleaned}/`;
+}
+
+/**
+ * Return the preset ids that specifically target the entered domain, in catalog
+ * order. A preset qualifies when at least one of its non-`*` `domainFilters`
+ * matches a sample URL built from the domain, using the runtime matcher
+ * {@link matchesDomain} (via `domainToRegex`). Generic (`*`) filters never
+ * count, so cross-domain presets are never suggested. An empty or whitespace
+ * domain yields no suggestions.
+ *
+ * Pure function: no storage, no network, no side effects.
+ */
+export function getSuggestedPresetIds(
+  domain: string | null | undefined,
+  categories: PresetCategory[],
+): string[] {
+  const sampleUrl = domain ? buildSampleUrl(domain) : null;
+  if (!sampleUrl) return [];
+
+  const ids: string[] = [];
+  for (const category of categories) {
+    for (const preset of category.presets) {
+      const specificFilters = preset.domainFilters.filter((filter) => filter !== '*');
+      if (specificFilters.some((filter) => matchesDomain(sampleUrl, filter))) {
+        ids.push(preset.id);
+      }
+    }
+  }
+  return ids;
+}

--- a/src/utils/presetsToSearchableGroups.ts
+++ b/src/utils/presetsToSearchableGroups.ts
@@ -1,6 +1,7 @@
 import type { SearchableSelectGroup } from '@/components/Form/FormFields/SearchableSelect';
 import type { PresetCategory } from '@/types/preset';
 import { getRuleCategory, getCategoryLabel } from './categoriesStore';
+import { getSuggestedPresetIds } from './presetSuggestions';
 
 /**
  * Transforms an array of preset categories into groups for SearchableSelect.
@@ -22,4 +23,46 @@ export function presetsToSearchableGroups(categories: PresetCategory[]): Searcha
       })),
     };
   });
+}
+
+/**
+ * Like {@link presetsToSearchableGroups}, but prepends a leading "Suggested for
+ * this domain" group built from the presets whose non-`*` domain filters match
+ * `domain` (see {@link getSuggestedPresetIds}). Suggested presets are removed
+ * from their category group (dedupe by id, leading group wins), and any group
+ * emptied by that removal is dropped to avoid an orphan heading. When `domain`
+ * is empty or no specific preset matches, the result is identical to
+ * {@link presetsToSearchableGroups}.
+ *
+ * The heading label is injected by the caller so this module stays free of i18n
+ * concerns and remains trivially testable.
+ */
+export function presetsToSearchableGroupsWithSuggestions(
+  categories: PresetCategory[],
+  domain: string | null | undefined,
+  suggestedHeading: string,
+): SearchableSelectGroup[] {
+  const baseGroups = presetsToSearchableGroups(categories);
+  const suggestedIds = getSuggestedPresetIds(domain, categories);
+  if (suggestedIds.length === 0) return baseGroups;
+
+  const suggestedSet = new Set(suggestedIds);
+  const idToName = new Map<string, string>();
+  for (const cat of categories) {
+    for (const preset of cat.presets) idToName.set(preset.id, preset.name);
+  }
+
+  const leadingGroup: SearchableSelectGroup = {
+    label: suggestedHeading,
+    options: suggestedIds.map((id) => ({ value: id, label: idToName.get(id) ?? id })),
+  };
+
+  const dedupedBase = baseGroups
+    .map((group) => ({
+      ...group,
+      options: group.options.filter((option) => !suggestedSet.has(option.value)),
+    }))
+    .filter((group) => group.options.length > 0);
+
+  return [leadingGroup, ...dedupedBase];
 }

--- a/tests/components/DomainRuleConfigForm.stories.test.tsx
+++ b/tests/components/DomainRuleConfigForm.stories.test.tsx
@@ -9,6 +9,8 @@ const {
   DomainRuleConfigFormSwitchToManual,
   DomainRuleConfigFormSwitchToAsk,
   DomainRuleConfigFormManualWithRegex,
+  DomainRuleConfigFormPresetSuggested,
+  DomainRuleConfigFormPresetNoSuggestion,
 } = composeStories(stories);
 
 describe('DomainRuleConfigForm — static renders', () => {
@@ -42,5 +44,21 @@ describe('DomainRuleConfigForm — mode switching', () => {
     await DomainRuleConfigFormManualWithRegex.run();
 
     expect(screen.getByRole('radio', { name: /manual/i })).toBeInTheDocument();
+  });
+});
+
+describe('DomainRuleConfigForm — domain-aware preset suggestions', () => {
+  it('shows a leading "Suggested for this domain" group for a matching domain', async () => {
+    await DomainRuleConfigFormPresetSuggested.run();
+
+    expect(screen.getByText('Suggested for this domain')).toBeInTheDocument();
+    expect(screen.getByText('GitHub Issue')).toBeInTheDocument();
+  });
+
+  it('shows no leading group for a non-matching domain', async () => {
+    await DomainRuleConfigFormPresetNoSuggestion.run();
+
+    expect(screen.queryByText('Suggested for this domain')).not.toBeInTheDocument();
+    expect(screen.getByText('Numeric ID')).toBeInTheDocument();
   });
 });

--- a/tests/components/DomainRuleConfigForm.stories.test.tsx
+++ b/tests/components/DomainRuleConfigForm.stories.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/Core/DomainRule/DomainRuleConfigForm.stories';
 
@@ -60,5 +60,13 @@ describe('DomainRuleConfigForm — domain-aware preset suggestions', () => {
 
     expect(screen.queryByText('Suggested for this domain')).not.toBeInTheDocument();
     expect(screen.getByText('Numeric ID')).toBeInTheDocument();
+  });
+
+  it('focuses the preset search input on arrival when nothing is selected', async () => {
+    await DomainRuleConfigFormPresetSuggested.run();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search a preset...')).toHaveFocus();
+    });
   });
 });

--- a/tests/components/SearchableInlineList.stories.test.tsx
+++ b/tests/components/SearchableInlineList.stories.test.tsx
@@ -3,8 +3,12 @@ import { screen } from '@testing-library/react';
 import { composeStories } from '@storybook/react';
 import * as stories from '../../src/components/Form/FormFields/SearchableInlineList.stories';
 
-const { SearchableInlineListDefault, SearchableInlineListCustomRenderItem } =
-  composeStories(stories);
+const {
+  SearchableInlineListDefault,
+  SearchableInlineListCustomRenderItem,
+  SearchableInlineListEnterSelectsFirst,
+  SearchableInlineListEnterSelectsFirstFiltered,
+} = composeStories(stories);
 
 describe('SearchableInlineList — render paths', () => {
   it('default path renders SearchableSelectItem rows and filters on search', async () => {
@@ -15,5 +19,21 @@ describe('SearchableInlineList — render paths', () => {
   it('custom renderItem path renders rich rows', async () => {
     await SearchableInlineListCustomRenderItem.run();
     expect(screen.getByLabelText('Apple (custom)')).toBeInTheDocument();
+  });
+});
+
+describe('SearchableInlineList — Enter selects the first result', () => {
+  it('selects the first item from the empty query', async () => {
+    await SearchableInlineListEnterSelectsFirst.run();
+    expect(screen.getByText('Apple').closest('[cmdk-item=""]')).toHaveClass(
+      'ss-item--selected',
+    );
+  });
+
+  it('selects the first filtered item after typing', async () => {
+    await SearchableInlineListEnterSelectsFirstFiltered.run();
+    expect(
+      document.querySelector('[cmdk-item=""].ss-item--selected'),
+    ).toBeInTheDocument();
   });
 });

--- a/tests/utils/presetSuggestions.test.ts
+++ b/tests/utils/presetSuggestions.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type { Preset, PresetCategory } from '../../src/types/preset';
+import { getSuggestedPresetIds } from '../../src/utils/presetSuggestions';
+
+const makePreset = (id: string, domainFilters: string[]): Preset =>
+  ({
+    id,
+    name: id,
+    domainFilters,
+    groupNameSource: 'smart',
+    description: '',
+  }) as Preset;
+
+const catalog: PresetCategory[] = [
+  {
+    id: 'generic',
+    presets: [
+      makePreset('numeric-id', ['*']),
+      makePreset('jira-title', ['*']),
+    ],
+  },
+  {
+    id: 'development',
+    presets: [
+      makePreset('atlassian', ['*.atlassian.net']),
+      makePreset('github', ['github.com']),
+      makePreset('npm', ['*.npmjs.com']),
+    ],
+  },
+];
+
+describe('getSuggestedPresetIds', () => {
+  it('suggests a preset whose specific filter matches the entered domain', () => {
+    expect(getSuggestedPresetIds('myteam.atlassian.net', catalog)).toEqual(['atlassian']);
+    expect(getSuggestedPresetIds('github.com', catalog)).toEqual(['github']);
+  });
+
+  it('never suggests wildcard-only presets', () => {
+    // No specific filter matches "example.com", so nothing is suggested even
+    // though the generic presets ("*") would match every domain at runtime.
+    expect(getSuggestedPresetIds('example.com', catalog)).toEqual([]);
+  });
+
+  it('returns nothing for an empty or whitespace domain', () => {
+    expect(getSuggestedPresetIds('', catalog)).toEqual([]);
+    expect(getSuggestedPresetIds('   ', catalog)).toEqual([]);
+    expect(getSuggestedPresetIds(null, catalog)).toEqual([]);
+    expect(getSuggestedPresetIds(undefined, catalog)).toEqual([]);
+  });
+
+  it('matches a "*.example.com" filter against a subdomain and the bare apex', () => {
+    const cat: PresetCategory[] = [
+      { id: 'misc', presets: [makePreset('wild', ['*.example.com'])] },
+    ];
+    expect(getSuggestedPresetIds('team.example.com', cat)).toEqual(['wild']);
+    expect(getSuggestedPresetIds('example.com', cat)).toEqual(['wild']);
+    // Consistent with the runtime matcher: an unrelated domain does not match.
+    expect(getSuggestedPresetIds('example.org', cat)).toEqual([]);
+  });
+
+  it('preserves catalog order across categories', () => {
+    const cat: PresetCategory[] = [
+      { id: 'a', presets: [makePreset('p1', ['acme.com']), makePreset('p2', ['*'])] },
+      { id: 'b', presets: [makePreset('p3', ['*.acme.com'])] },
+    ];
+    expect(getSuggestedPresetIds('acme.com', cat)).toEqual(['p1', 'p3']);
+  });
+});

--- a/tests/utils/presetsToSearchableGroups.test.ts
+++ b/tests/utils/presetsToSearchableGroups.test.ts
@@ -10,10 +10,10 @@ vi.mock('../../src/utils/i18n', () => ({
   getMessage: vi.fn((key: string) => `i18n(${key})`),
 }));
 
-const makePreset = (id: string, name: string) => ({
+const makePreset = (id: string, name: string, domainFilters: string[] = []) => ({
   id,
   name,
-  domainFilters: [],
+  domainFilters,
   titleRegex: '',
   urlRegex: '',
   groupNameSource: 'smart' as const,
@@ -90,5 +90,68 @@ describe('presetsToSearchableGroups', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].options).toHaveLength(0);
+  });
+});
+
+describe('presetsToSearchableGroupsWithSuggestions', () => {
+  const categories = (): PresetCategory[] => [
+    {
+      id: 'development',
+      presets: [
+        makePreset('gh-issue', 'GitHub Issue', ['github.com']),
+        makePreset('jira', 'Jira Ticket', ['*']),
+      ],
+    },
+  ];
+
+  it('renders exactly like the base function when the domain is empty', async () => {
+    const { presetsToSearchableGroups, presetsToSearchableGroupsWithSuggestions } =
+      await import('../../src/utils/presetsToSearchableGroups');
+
+    expect(presetsToSearchableGroupsWithSuggestions(categories(), '', 'Suggested')).toEqual(
+      presetsToSearchableGroups(categories()),
+    );
+  });
+
+  it('renders like the base function when no specific preset matches', async () => {
+    const { presetsToSearchableGroups, presetsToSearchableGroupsWithSuggestions } =
+      await import('../../src/utils/presetsToSearchableGroups');
+
+    expect(
+      presetsToSearchableGroupsWithSuggestions(categories(), 'example.com', 'Suggested'),
+    ).toEqual(presetsToSearchableGroups(categories()));
+  });
+
+  it('prepends a leading group and dedupes the suggested preset from its category', async () => {
+    const { presetsToSearchableGroupsWithSuggestions } =
+      await import('../../src/utils/presetsToSearchableGroups');
+
+    const result = presetsToSearchableGroupsWithSuggestions(
+      categories(),
+      'github.com',
+      'Suggested for this domain',
+    );
+
+    expect(result[0]).toEqual({
+      label: 'Suggested for this domain',
+      options: [{ value: 'gh-issue', label: 'GitHub Issue' }],
+    });
+    // The development category keeps only the non-suggested (wildcard) preset.
+    expect(result[1].options).toEqual([{ value: 'jira', label: 'Jira Ticket' }]);
+  });
+
+  it('drops a category group fully emptied by deduplication', async () => {
+    const { presetsToSearchableGroupsWithSuggestions } =
+      await import('../../src/utils/presetsToSearchableGroups');
+
+    const cats: PresetCategory[] = [
+      { id: 'development', presets: [makePreset('only', 'Only One', ['acme.com'])] },
+    ];
+
+    const result = presetsToSearchableGroupsWithSuggestions(cats, 'acme.com', 'Suggested');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Suggested');
+    expect(result[0].options).toEqual([{ value: 'only', label: 'Only One' }]);
   });
 });

--- a/wxt-i18n-structure.d.ts
+++ b/wxt-i18n-structure.d.ts
@@ -149,6 +149,7 @@ export type GeneratedI18nStructure = {
   "presetRuleLabel": { substitutions: 0, plural: false };
   "searchPresetPlaceholder": { substitutions: 0, plural: false };
   "noPresetFound": { substitutions: 0, plural: false };
+  "presetSuggestedGroupHeading": { substitutions: 0, plural: false };
   "searchableSelectTriggerLabel": { substitutions: 0, plural: false };
   "searchableSelectSearchLabel": { substitutions: 0, plural: false };
   "ruleSelectAriaLabel": { substitutions: 0, plural: false };


### PR DESCRIPTION
Surface the presets that specifically target the step 1 domain at the
top of the preset selector, as a leading "Suggested for this domain"
group, without changing how the rest of the library is presented.

- getSuggestedPresetIds: pure matcher reusing matchesDomain (via
  domainToRegex) on a sample URL built from the entered domain. Generic
  ("*") filters never count, so cross-domain presets are never suggested.
  A "*.example.com" filter also matches the bare apex, consistent with
  runtime.
- presetsToSearchableGroupsWithSuggestions: prepends the leading group
  and dedupes suggested presets out of their category group (leading
  group wins), dropping any group emptied by that removal.
- Wire WizardStep2Config to the reactive step 1 domainFilter via
  useWatch; DomainRuleConfigForm gains an optional suggestionDomain prop
  (left undefined by the edit dialog, so it renders as today).
- i18n key presetSuggestedGroupHeading (FR/EN/ES).
- Unit tests for the matcher and the group builder, Storybook stories
  plus story tests for the matching and non-matching cases.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5UMga2ZtzN6gJfULNkvqj