### PR TITLE
feat(wizards): keyboard navigation with Ctrl+Enter / Ctrl+Backspace

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -683,6 +683,8 @@
   "wizardStepOptions": { "message": "Options" },
   "wizardStepSummary": { "message": "Summary" },
   "wizardStepAnnouncement": { "message": "Step {step}: {label}" },
+  "wizardShortcutNextTooltip": { "message": "Next step" },
+  "wizardShortcutPreviousTooltip": { "message": "Previous step" },
   "configSummaryPreset": { "message": "Preset: {name}" },
   "configSummaryAsk": { "message": "Ask (group name requested on each tab opening)" },
   "configSummaryManual": { "message": "Manual: {source}" },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -684,6 +684,8 @@
   "wizardStepOptions": { "message": "Opciones" },
   "wizardStepSummary": { "message": "Resumen" },
   "wizardStepAnnouncement": { "message": "Paso {step}: {label}" },
+  "wizardShortcutNextTooltip": { "message": "Paso siguiente" },
+  "wizardShortcutPreviousTooltip": { "message": "Paso anterior" },
   "configSummaryPreset": { "message": "Preajuste: {name}" },
   "configSummaryAsk": { "message": "Preguntar (nombre solicitado al abrir cada pestaña)" },
   "configSummaryManual": { "message": "Manual: {source}" },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -684,6 +684,8 @@
   "wizardStepOptions": { "message": "Options" },
   "wizardStepSummary": { "message": "Résumé" },
   "wizardStepAnnouncement": { "message": "Étape {step} : {label}" },
+  "wizardShortcutNextTooltip": { "message": "Étape suivante" },
+  "wizardShortcutPreviousTooltip": { "message": "Étape précédente" },
   "configSummaryPreset": { "message": "Préréglage : {name}" },
   "configSummaryAsk": { "message": "Demander (nom saisi à chaque ouverture d'onglet)" },
   "configSummaryManual": { "message": "Manuel : {source}" },

--- a/src/components/Core/DomainRule/RuleWizardModal.tsx
+++ b/src/components/Core/DomainRule/RuleWizardModal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm, useWatch, type Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { getMessage } from '@/utils/i18n';
-import { WizardModal } from '@/components/UI/WizardModal';
+import { WizardModal, WizardNavTooltip } from '@/components/UI/WizardModal';
 import { WizardStepper } from '@/components/UI/WizardStepper/WizardStepper';
 import { AriaButton } from '@/components/UI/AriaButton/AriaButton';
 import { WizardStep1Identity } from './WizardStep1Identity';
@@ -106,6 +106,28 @@ function getManualModeFieldsToValidate(
     fields.push(extractionMode === 'query_param' ? 'urlQueryParamName' : 'urlParsingRegEx');
   }
   return fields;
+}
+
+/** Resolve the Ctrl+Enter / Ctrl+Backspace handlers for the current wizard state. */
+function computeWizardNav(args: {
+  isEditing: boolean;
+  step: number;
+  isPresetSelectionMissing: boolean;
+  handleNext: () => void;
+  handlePrev: () => void;
+  submitForm: () => void;
+}): { onNext?: () => void; onPrevious?: () => void } {
+  const { isEditing, step, isPresetSelectionMissing, handleNext, handlePrev, submitForm } = args;
+  if (isEditing) {
+    return { onNext: submitForm };
+  }
+  if (step >= 3) {
+    return { onNext: submitForm, onPrevious: handlePrev };
+  }
+  return {
+    onNext: isPresetSelectionMissing ? undefined : handleNext,
+    onPrevious: step > 0 ? handlePrev : undefined,
+  };
 }
 
 const STEP_LABELS_KEYS = [
@@ -388,6 +410,18 @@ export function RuleWizardModal({
     if (!open) handleClose();
   };
 
+  // Keyboard navigation (Ctrl+Enter / Ctrl+Backspace). On the last step (or in
+  // edit mode) Ctrl+Enter triggers the final submit; an undefined handler makes
+  // the shortcut inert (e.g. when the preset selection is still missing).
+  const { onNext: wizardOnNext, onPrevious: wizardOnPrevious } = computeWizardNav({
+    isEditing,
+    step,
+    isPresetSelectionMissing,
+    handleNext,
+    handlePrev,
+    submitForm: () => handleSubmit(handleFormSubmit)(),
+  });
+
   const title = isEditing ? getMessage('editRule') : getMessage('createRule');
   const stepLabels = STEP_LABELS_KEYS.map((k) => ({ label: getMessage(k) }));
 
@@ -417,6 +451,8 @@ export function RuleWizardModal({
       description={description}
       maxWidth={820}
       fillHeight={!isEditing && step === 1}
+      onNext={wizardOnNext}
+      onPrevious={wizardOnPrevious}
       onOpenAutoFocus={(e) => {
         e.preventDefault();
         // The domain filter is a CodeMirror editor (no <input>): focus its
@@ -527,7 +563,9 @@ export function RuleWizardModal({
               <Dialog.Close>
                 <Button variant="soft" color="gray" highContrast type="button">{getMessage('cancel')}</Button>
               </Dialog.Close>
-              <Button data-testid="wizard-rule-btn-save" type="submit">{getMessage('save')}</Button>
+              <WizardNavTooltip kind="next">
+                <Button data-testid="wizard-rule-btn-save" type="submit">{getMessage('save')}</Button>
+              </WizardNavTooltip>
             </>
           ) : (
             <>
@@ -537,23 +575,29 @@ export function RuleWizardModal({
                 </Dialog.Close>
               )}
               {step > 0 && (
-                <Button variant="soft" color="gray" highContrast type="button" onClick={handlePrev}>
-                  {getMessage('previous')}
-                </Button>
+                <WizardNavTooltip kind="previous">
+                  <Button variant="soft" color="gray" highContrast type="button" onClick={handlePrev}>
+                    {getMessage('previous')}
+                  </Button>
+                </WizardNavTooltip>
               )}
               {step < 3 && (
-                <AriaButton
-                  data-testid="wizard-rule-btn-next"
-                  type="button"
-                  onClick={handleNext}
-                  ariaDisabled={isPresetSelectionMissing}
-                  disabledReason={isPresetSelectionMissing ? getMessage('errorPresetRequired') : undefined}
-                >
-                  {getMessage('next')}
-                </AriaButton>
+                <WizardNavTooltip kind="next" hidden={isPresetSelectionMissing}>
+                  <AriaButton
+                    data-testid="wizard-rule-btn-next"
+                    type="button"
+                    onClick={handleNext}
+                    ariaDisabled={isPresetSelectionMissing}
+                    disabledReason={isPresetSelectionMissing ? getMessage('errorPresetRequired') : undefined}
+                  >
+                    {getMessage('next')}
+                  </AriaButton>
+                </WizardNavTooltip>
               )}
               {step === 3 && (
-                <Button data-testid="wizard-rule-btn-create" type="submit">{getMessage('create')}</Button>
+                <WizardNavTooltip kind="next">
+                  <Button data-testid="wizard-rule-btn-create" type="submit">{getMessage('create')}</Button>
+                </WizardNavTooltip>
               )}
             </>
           )}

--- a/src/components/UI/DialogShell/DialogShell.tsx
+++ b/src/components/UI/DialogShell/DialogShell.tsx
@@ -28,6 +28,8 @@ interface DialogShellProps {
   onEscapeKeyDown?: DialogContentProps['onEscapeKeyDown'];
   onPointerDownOutside?: DialogContentProps['onPointerDownOutside'];
   onOpenAutoFocus?: DialogContentProps['onOpenAutoFocus'];
+  /** Forwarded to Dialog.Content (composed with Radix's internal handlers). */
+  onKeyDown?: DialogContentProps['onKeyDown'];
 
   /** Render a separator below the header. Default true. */
   showHeaderSeparator?: boolean;
@@ -93,6 +95,7 @@ export function DialogShell({
   onEscapeKeyDown,
   onPointerDownOutside,
   onOpenAutoFocus,
+  onKeyDown,
   showHeaderSeparator = true,
   'data-testid': dataTestId,
 }: DialogShellProps) {
@@ -118,6 +121,7 @@ export function DialogShell({
         onPointerDownOutside={resolvedPointerDownOutside}
         onEscapeKeyDown={onEscapeKeyDown}
         onOpenAutoFocus={resolvedOnOpenAutoFocus}
+        onKeyDown={onKeyDown}
       >
         <div style={{ flexShrink: 0 }}>
           <Dialog.Title tabIndex={-1} data-dialog-title style={{ outline: 'none' }}>

--- a/src/components/UI/ImportExportWizards/Export/ExportWizardFooter.tsx
+++ b/src/components/UI/ImportExportWizards/Export/ExportWizardFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Dialog, Flex } from '@radix-ui/themes';
 import { ClipboardCopy, FileDown } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
+import { WizardNavTooltip } from '@/components/UI/WizardModal';
 import type { ExportActions } from './useExportActions';
 
 interface ExportWizardFooterProps {
@@ -55,14 +56,16 @@ export function ExportWizardFooter({
           <ClipboardCopy size={14} aria-hidden="true" />
           {getMessage('exportToClipboard')}
         </Button>
-        <Button
-          onClick={actions.exportToFile}
-          disabled={disabled}
-          data-testid={primaryTestId}
-        >
-          <FileDown size={14} aria-hidden="true" />
-          {getMessage('exportToFile')}
-        </Button>
+        <WizardNavTooltip kind="next" hidden={disabled}>
+          <Button
+            onClick={actions.exportToFile}
+            disabled={disabled}
+            data-testid={primaryTestId}
+          >
+            <FileDown size={14} aria-hidden="true" />
+            {getMessage('exportToFile')}
+          </Button>
+        </WizardNavTooltip>
       </Flex>
     </>
   );

--- a/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ExportWizardShell.tsx
@@ -56,6 +56,7 @@ export function ExportWizardShell<TItem extends { id: string }>({
   cancelTestId,
 }: ExportWizardShellProps<TItem>) {
   const { selection, selectAll, exportNote, setExportNote, actions } = state;
+  const isEmpty = selection.size === 0;
 
   return (
     <WizardModal
@@ -65,6 +66,7 @@ export function ExportWizardShell<TItem extends { id: string }>({
       title={title}
       description={description}
       maxWidth={680}
+      onNext={isEmpty ? undefined : actions.exportToFile}
     >
       <WizardModal.Body>
         <Box>
@@ -83,7 +85,7 @@ export function ExportWizardShell<TItem extends { id: string }>({
         <ExportWizardFooter
           labelKey={buttonLabelKey}
           actions={actions}
-          disabled={selection.size === 0}
+          disabled={isEmpty}
           primaryTestId={primaryTestId}
           clipboardTestId={clipboardTestId}
           cancelTestId={cancelTestId}

--- a/src/components/UI/ImportExportWizards/ImportWizardFooter.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizardFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Dialog } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { AriaButton } from '@/components/UI/AriaButton/AriaButton';
+import { WizardNavTooltip } from '@/components/UI/WizardModal';
 import type { SourceMode } from './Source';
 
 interface ImportWizardFooterProps {
@@ -42,14 +43,16 @@ export function ImportWizardFooter({
         <Dialog.Close>
           <Button variant="soft" color="gray">{getMessage('cancel')}</Button>
         </Dialog.Close>
-        <AriaButton
-          ariaDisabled={noPackSelected}
-          disabledReason={noPackSelected ? getMessage('packGalleryNextDisabledReason') : undefined}
-          onClick={packFooter.onConfirm}
-          data-testid="import-wizard-pack-next"
-        >
-          {getMessage('next')}
-        </AriaButton>
+        <WizardNavTooltip kind="next" hidden={noPackSelected}>
+          <AriaButton
+            ariaDisabled={noPackSelected}
+            disabledReason={noPackSelected ? getMessage('packGalleryNextDisabledReason') : undefined}
+            onClick={packFooter.onConfirm}
+            data-testid="import-wizard-pack-next"
+          >
+            {getMessage('next')}
+          </AriaButton>
+        </WizardNavTooltip>
       </>
     );
   }
@@ -60,21 +63,27 @@ export function ImportWizardFooter({
         <Dialog.Close>
           <Button variant="soft" color="gray" data-testid="import-wizard-btn-cancel">{getMessage('cancel')}</Button>
         </Dialog.Close>
-        <Button onClick={onNext} disabled={!hasParsedData} data-testid="import-wizard-btn-next">
-          {getMessage('next')}
-        </Button>
+        <WizardNavTooltip kind="next" hidden={!hasParsedData}>
+          <Button onClick={onNext} disabled={!hasParsedData} data-testid="import-wizard-btn-next">
+            {getMessage('next')}
+          </Button>
+        </WizardNavTooltip>
       </>
     );
   }
 
   return (
     <>
-      <Button variant="soft" color="gray" onClick={onBack} data-testid="import-wizard-btn-previous">
-        {getMessage('previous')}
-      </Button>
-      <Button onClick={onConfirm} disabled={importCount === 0} data-testid="import-wizard-btn-confirm">
-        {getMessage('confirmImport')}
-      </Button>
+      <WizardNavTooltip kind="previous">
+        <Button variant="soft" color="gray" onClick={onBack} data-testid="import-wizard-btn-previous">
+          {getMessage('previous')}
+        </Button>
+      </WizardNavTooltip>
+      <WizardNavTooltip kind="next" hidden={importCount === 0}>
+        <Button onClick={onConfirm} disabled={importCount === 0} data-testid="import-wizard-btn-confirm">
+          {getMessage('confirmImport')}
+        </Button>
+      </WizardNavTooltip>
     </>
   );
 }

--- a/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
+++ b/src/components/UI/ImportExportWizards/ImportWizardShell.tsx
@@ -55,6 +55,26 @@ interface ImportWizardShellProps<TItem extends { id: string }, TConflict>
   };
 }
 
+/** Resolve the Ctrl+Enter handler for the import wizard's current step. */
+function computeImportNext(args: {
+  step: 0 | 1;
+  sourceMode: SourceMode;
+  hasParsedData: boolean;
+  importCount: number;
+  goToStep1: () => void;
+  onConfirm: () => void;
+  packFooter?: { ruleCount: number; onConfirm: () => void };
+}): (() => void) | undefined {
+  const { step, sourceMode, hasParsedData, importCount, goToStep1, onConfirm, packFooter } = args;
+  if (step === 1) {
+    return importCount > 0 ? onConfirm : undefined;
+  }
+  if (sourceMode === 'pack' && packFooter) {
+    return packFooter.ruleCount > 0 ? packFooter.onConfirm : undefined;
+  }
+  return hasParsedData ? goToStep1 : undefined;
+}
+
 /**
  * Two-step import wizard shell shared by every import flow (rules, sessions,
  * ...). Owns the WizardModal frame, source step, classification step (3
@@ -97,6 +117,16 @@ export function ImportWizardShell<TItem extends { id: string }, TConflict>({
     goToStep1,
   } = state;
 
+  const wizardOnNext = computeImportNext({
+    step,
+    sourceMode: source.sourceMode,
+    hasParsedData: !!source.parsedData,
+    importCount,
+    goToStep1,
+    onConfirm,
+    packFooter,
+  });
+
   return (
     <WizardModal
       open={open}
@@ -106,6 +136,8 @@ export function ImportWizardShell<TItem extends { id: string }, TConflict>({
       description={getMessage(stepDescriptionKeys[step] as MessageKey)}
       maxWidth={maxWidth}
       fillHeight={fillHeight}
+      onNext={wizardOnNext}
+      onPrevious={step === 1 ? goToStep0 : undefined}
     >
       <WizardModal.Body>
         {step === 0 && (

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -3,9 +3,8 @@ import { Dialog, Flex, Button, Text, Separator, Box, RadioGroup, Callout } from 
 import { RotateCcw, AlertCircle } from 'lucide-react';
 import { browser } from 'wxt/browser';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
-import { WizardModal } from '@/components/UI/WizardModal';
+import { WizardModal, WizardNavTooltip } from '@/components/UI/WizardModal';
 import { ConflictResolutionStep } from './ConflictResolutionStep';
-import { Tooltip } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast, showErrorToast } from '@/utils/toast';
 import { showSuccessNotification } from '@/utils/notifications';
@@ -26,6 +25,25 @@ const STEP_DESCRIPTION_KEYS = [
   'restoreStepSelectionDescription',
   'restoreStepConflictDescription',
 ] as const;
+
+/** Resolve the Ctrl+Enter / Ctrl+Backspace handlers for the current restore step. */
+function computeRestoreNav(args: {
+  step: number;
+  canRestore: boolean;
+  isRestoring: boolean;
+  handleRestoreOrNext: () => void;
+  onConfirm: () => void;
+  onBack: () => void;
+}): { onNext?: () => void; onPrevious?: () => void } {
+  const { step, canRestore, isRestoring, handleRestoreOrNext, onConfirm, onBack } = args;
+  if (step === 0) {
+    return { onNext: canRestore ? handleRestoreOrNext : undefined };
+  }
+  return {
+    onNext: isRestoring ? undefined : onConfirm,
+    onPrevious: isRestoring ? undefined : onBack,
+  };
+}
 
 function RadioOption({ testId, value, label }: { testId: string; value: string; label: string }) {
   return (
@@ -216,6 +234,17 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
     });
   }, []);
 
+  // Keyboard navigation (Ctrl+Enter advances/restores, Ctrl+Backspace steps back).
+  const canRestore = selectedTabIds.size > 0 && !isAnalyzing && !isRestoring;
+  const { onNext: wizardOnNext, onPrevious: wizardOnPrevious } = computeRestoreNav({
+    step,
+    canRestore,
+    isRestoring,
+    handleRestoreOrNext,
+    onConfirm: () => executeRestore(conflictAnalysis, duplicateTabAction, groupActions),
+    onBack: () => setStep(0),
+  });
+
   if (!session) return null;
 
   return (
@@ -226,6 +255,8 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
       icon={RotateCcw}
       title={getMessage('restoreTitle', [session.name])}
       description={getMessage(STEP_DESCRIPTION_KEYS[step])}
+      onNext={wizardOnNext}
+      onPrevious={wizardOnPrevious}
     >
       <WizardModal.Body>
         {step === 0 && (
@@ -293,9 +324,12 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
                 {getMessage('cancel')}
               </Button>
             </Dialog.Close>
-            <Tooltip
-              content={getMessage('wizardRestoreNoTabsHint')}
-              hidden={selectedTabIds.size > 0 || isAnalyzing || isRestoring}
+            <WizardNavTooltip
+              kind="next"
+              hidden={isAnalyzing || isRestoring}
+              content={
+                selectedTabIds.size === 0 ? getMessage('wizardRestoreNoTabsHint') : undefined
+              }
             >
               <Button
                 data-testid="wizard-restore-btn-restore"
@@ -307,28 +341,32 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
                 <RotateCcw size={14} />
                 {isAnalyzing ? getMessage('loadingText') : getMessage('sessionRestore')}
               </Button>
-            </Tooltip>
+            </WizardNavTooltip>
           </>
         )}
 
         {step === 1 && (
           <>
-            <Button
-              variant="soft"
-              color="gray"
-              onClick={() => setStep(0)}
-              disabled={isRestoring}
-            >
-              {getMessage('previous')}
-            </Button>
-            <Button
-              data-autofocus="true"
-              onClick={() => executeRestore(conflictAnalysis, duplicateTabAction, groupActions)}
-              disabled={isRestoring}
-            >
-              <RotateCcw size={14} />
-              {getMessage('sessionRestore')}
-            </Button>
+            <WizardNavTooltip kind="previous">
+              <Button
+                variant="soft"
+                color="gray"
+                onClick={() => setStep(0)}
+                disabled={isRestoring}
+              >
+                {getMessage('previous')}
+              </Button>
+            </WizardNavTooltip>
+            <WizardNavTooltip kind="next">
+              <Button
+                data-autofocus="true"
+                onClick={() => executeRestore(conflictAnalysis, duplicateTabAction, groupActions)}
+                disabled={isRestoring}
+              >
+                <RotateCcw size={14} />
+                {getMessage('sessionRestore')}
+              </Button>
+            </WizardNavTooltip>
           </>
         )}
       </WizardModal.Footer>

--- a/src/components/UI/SessionWizards/SnapshotWizard.tsx
+++ b/src/components/UI/SessionWizards/SnapshotWizard.tsx
@@ -6,7 +6,7 @@ import {
 import { Camera, AlertCircle, Info, RotateCw } from 'lucide-react';
 import { TabTree } from '@/components/Core/TabTree/TabTree';
 import { TextFieldWithCategory } from '@/components/Form/FormFields/TextFieldWithCategory';
-import { WizardModal } from '@/components/UI/WizardModal';
+import { WizardModal, WizardNavTooltip } from '@/components/UI/WizardModal';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast } from '@/utils/toast';
 import { captureCurrentTabs } from '@/utils/tabCapture';
@@ -157,6 +157,9 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
     }
   }, [ungroupedTabs, groups, selectedSavedTabIds, sessionName, categoryId, note, onSave, onOpenChange, existingSessions, isRefresh, refreshSession, onRefresh]);
 
+  const canSave =
+    !!sessionName.trim() && selectedTabIds.size > 0 && !isCapturing && !isSaving;
+
   const wizardIcon = isRefresh ? RotateCw : Camera;
   const wizardTitle = isRefresh ? getMessage('refreshTitle') : getMessage('snapshotTitle');
   const wizardDescription = isRefresh ? getMessage('refreshDescription') : getMessage('snapshotDescription');
@@ -171,6 +174,7 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
       icon={wizardIcon}
       title={wizardTitle}
       description={wizardDescription}
+      onNext={canSave ? handleSave : undefined}
       onOpenAutoFocus={(e) => {
         e.preventDefault();
         const input = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>('input[aria-label]');
@@ -256,14 +260,16 @@ export function SnapshotWizard({ open, onOpenChange, onSave, existingSessions, i
             {getMessage('cancel')}
           </Button>
         </Dialog.Close>
-        <Button
-          data-testid={`${testIdPrefix}-btn-save`}
-          onClick={handleSave}
-          disabled={!sessionName.trim() || selectedTabIds.size === 0 || isCapturing || isSaving}
-        >
-          {isRefresh ? <RotateCw size={14} /> : <Camera size={14} />}
-          {saveLabel}
-        </Button>
+        <WizardNavTooltip kind="next" hidden={!canSave}>
+          <Button
+            data-testid={`${testIdPrefix}-btn-save`}
+            onClick={handleSave}
+            disabled={!canSave}
+          >
+            {isRefresh ? <RotateCw size={14} /> : <Camera size={14} />}
+            {saveLabel}
+          </Button>
+        </WizardNavTooltip>
       </WizardModal.Footer>
     </WizardModal>
   );

--- a/src/components/UI/WizardModal/WizardModal.tsx
+++ b/src/components/UI/WizardModal/WizardModal.tsx
@@ -22,6 +22,17 @@ interface WizardModalProps {
   'data-testid'?: string;
   /** Forwarded to Dialog.Content (e.g. to pre-focus an input on open). */
   onOpenAutoFocus?: React.ComponentProps<typeof DialogShell>['onOpenAutoFocus'];
+  /**
+   * Wired to Ctrl/Cmd+Enter. Advances the wizard (or triggers the final
+   * confirm action on the last step). Leave undefined when the forward
+   * button is absent or disabled, which makes the shortcut inert.
+   */
+  onNext?: () => void;
+  /**
+   * Wired to Ctrl/Cmd+Backspace. Steps back. Leave undefined when there is
+   * no previous step, which makes the shortcut inert.
+   */
+  onPrevious?: () => void;
 }
 
 const wizardContentStyle: React.CSSProperties = {
@@ -43,10 +54,24 @@ function WizardModalRoot({
   children,
   'data-testid': dataTestId,
   onOpenAutoFocus,
+  onNext,
+  onPrevious,
 }: WizardModalProps) {
   const contentStyle: React.CSSProperties = fillHeight
     ? { ...wizardContentStyle, height: '80vh' }
     : wizardContentStyle;
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.defaultPrevented) return;
+    // Mirror the project's `Mod` convention: Ctrl on Win/Linux, Cmd on Mac.
+    if (!(event.ctrlKey || event.metaKey)) return;
+    if (event.key === 'Enter' && onNext) {
+      event.preventDefault();
+      onNext();
+    } else if (event.key === 'Backspace' && onPrevious) {
+      event.preventDefault();
+      onPrevious();
+    }
+  };
   return (
     <DialogShell
       open={open}
@@ -57,6 +82,7 @@ function WizardModalRoot({
       hideDescription={hideDescription}
       data-testid={dataTestId}
       onOpenAutoFocus={onOpenAutoFocus}
+      onKeyDown={handleKeyDown}
       preventOutsideClose
       maxWidth={maxWidth}
       minHeight={fillHeight ? undefined : 'min(520px, 85vh)'}

--- a/src/components/UI/WizardModal/WizardNavTooltip.tsx
+++ b/src/components/UI/WizardModal/WizardNavTooltip.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Flex, Kbd, Tooltip } from '@radix-ui/themes';
+import { getMessage } from '@/utils/i18n';
+
+interface WizardNavTooltipProps {
+  /** Forward navigation (Ctrl+Enter) or backward navigation (Ctrl+Backspace). */
+  kind: 'next' | 'previous';
+  /** The navigation button to wrap. */
+  children: React.ReactNode;
+  /** Hide the tooltip entirely (e.g. while a higher-priority hint is shown). */
+  hidden?: boolean;
+  /**
+   * Override the tooltip body. When provided, the keyboard hint is replaced by
+   * this content (e.g. a "no tabs selected" hint that takes precedence).
+   */
+  content?: React.ReactNode;
+}
+
+/**
+ * Wraps a wizard navigation button with a tooltip surfacing its keyboard
+ * shortcut: Ctrl+Enter advances, Ctrl+Backspace steps back. The combos are
+ * literal `Kbd` chips (not translated); only the action label is localized.
+ */
+export function WizardNavTooltip({ kind, children, hidden, content }: WizardNavTooltipProps) {
+  const label = getMessage(
+    kind === 'next' ? 'wizardShortcutNextTooltip' : 'wizardShortcutPreviousTooltip',
+  );
+  const tooltipContent = content ?? (
+    <Flex align="center" gap="2" aria-hidden="true">
+      {label}
+      <Kbd>Ctrl</Kbd>
+      <Kbd>{kind === 'next' ? 'Enter' : 'Backspace'}</Kbd>
+    </Flex>
+  );
+  return (
+    <Tooltip content={tooltipContent} hidden={hidden}>
+      {children}
+    </Tooltip>
+  );
+}

--- a/src/components/UI/WizardModal/WizardNavTooltip.tsx
+++ b/src/components/UI/WizardModal/WizardNavTooltip.tsx
@@ -25,11 +25,14 @@ export function WizardNavTooltip({ kind, children, hidden, content }: WizardNavT
   const label = getMessage(
     kind === 'next' ? 'wizardShortcutNextTooltip' : 'wizardShortcutPreviousTooltip',
   );
+  // The label stays in the accessibility tree so the tooltip node has an
+  // accessible name (axe rule aria-tooltip-name); only the Kbd chips are hidden
+  // from assistive tech to avoid reading out "Ctrl Enter" as prose.
   const tooltipContent = content ?? (
-    <Flex align="center" gap="2" aria-hidden="true">
+    <Flex align="center" gap="2">
       {label}
-      <Kbd>Ctrl</Kbd>
-      <Kbd>{kind === 'next' ? 'Enter' : 'Backspace'}</Kbd>
+      <Kbd aria-hidden="true">Ctrl</Kbd>
+      <Kbd aria-hidden="true">{kind === 'next' ? 'Enter' : 'Backspace'}</Kbd>
     </Flex>
   );
   return (

--- a/src/components/UI/WizardModal/index.ts
+++ b/src/components/UI/WizardModal/index.ts
@@ -1,1 +1,2 @@
 export { WizardModal } from './WizardModal';
+export { WizardNavTooltip } from './WizardNavTooltip';

--- a/tests/components/ImportWizard.integration.test.tsx
+++ b/tests/components/ImportWizard.integration.test.tsx
@@ -125,6 +125,50 @@ describe('ImportWizard integration : mode pack', () => {
     expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
   });
 
+  it('advances to step 1 on Ctrl+Enter once a pack is selected', () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+        initialSourceMode="pack"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('pack-card-pack-sample-checkbox'));
+    fireEvent.keyDown(screen.getByTestId('import-wizard-pack-next'), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(screen.getByText('newRulesGroup')).toBeInTheDocument();
+    expect(screen.queryByTestId('pack-gallery')).not.toBeInTheDocument();
+  });
+
+  it('returns to step 0 on Ctrl+Backspace', () => {
+    wrap(
+      <ImportWizard
+        open
+        onOpenChange={vi.fn()}
+        existingRules={[] as DomainRuleSetting[]}
+        onImport={vi.fn()}
+        initialSourceMode="pack"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('pack-card-pack-sample-checkbox'));
+    fireEvent.click(screen.getByTestId('import-wizard-pack-next'));
+    expect(screen.getByText('newRulesGroup')).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByText('previous').closest('button')!, {
+      key: 'Backspace',
+      ctrlKey: true,
+    });
+
+    expect(screen.getByTestId('pack-gallery')).toBeInTheDocument();
+  });
+
   it('does not touch the default mode when initialSourceMode is missing', () => {
     wrap(
       <ImportWizard

--- a/tests/components/RuleWizardModal.stories.test.tsx
+++ b/tests/components/RuleWizardModal.stories.test.tsx
@@ -100,6 +100,27 @@ describe('RuleWizardModal — step navigation', () => {
   });
 });
 
+describe('RuleWizardModal — keyboard navigation', () => {
+  it('steps back from step 2 to step 1 on Ctrl+Backspace', async () => {
+    await RuleWizardModalStep2.run();
+    expect(screen.getByTestId('wizard-rule-step-2')).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByTestId('wizard-rule'), { key: 'Backspace', ctrlKey: true });
+
+    expect(await screen.findByTestId('wizard-rule-step-1')).toBeInTheDocument();
+  });
+
+  it('advances back to step 2 on Ctrl+Enter with the previously filled fields', async () => {
+    await RuleWizardModalStep2.run();
+    fireEvent.keyDown(screen.getByTestId('wizard-rule'), { key: 'Backspace', ctrlKey: true });
+    expect(await screen.findByTestId('wizard-rule-step-1')).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByTestId('wizard-rule'), { key: 'Enter', ctrlKey: true });
+
+    expect(await screen.findByTestId('wizard-rule-step-2')).toBeInTheDocument();
+  });
+});
+
 describe('RuleWizardModal — step 2 config mode state', () => {
   it('keeps an editable manual config after transiting through ask (no empty manual)', async () => {
     await RuleWizardModalStep2.run();

--- a/wxt-i18n-structure.d.ts
+++ b/wxt-i18n-structure.d.ts
@@ -655,6 +655,8 @@ export type GeneratedI18nStructure = {
   "wizardStepOptions": { substitutions: 0, plural: false };
   "wizardStepSummary": { substitutions: 0, plural: false };
   "wizardStepAnnouncement": { substitutions: 0, plural: false };
+  "wizardShortcutNextTooltip": { substitutions: 0, plural: false };
+  "wizardShortcutPreviousTooltip": { substitutions: 0, plural: false };
   "configSummaryPreset": { substitutions: 0, plural: false };
   "configSummaryAsk": { substitutions: 0, plural: false };
   "configSummaryManual": { substitutions: 0, plural: false };


### PR DESCRIPTION
Wire every wizard's forward action to Ctrl+Enter and the back action to
Ctrl+Backspace, with a tooltip on each navigation button surfacing the
shortcut. On the last step Ctrl+Enter triggers the final confirm action
(Create, Confirm Import, Restore, Save, Export to File). Single-step
wizards map Ctrl+Enter to their primary action. Ctrl+Backspace steps
back even while typing in a field.

The handling is centralized in WizardModal (forwarded to Dialog.Content
via a new DialogShell onKeyDown prop): each wizard passes onNext /
onPrevious computed from its current step and disabled state, so the
shortcut stays inert when the matching button is unavailable. A shared
WizardNavTooltip wraps the buttons with a localized label plus Kbd
chips.

These shortcuts stay local (like Enter/Escape on an input): they are not
added to the shortcuts registry nor to the documentation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014zwMxxhUL7iBTskY6rjTNJ