### PR TITLE
refactor(dedupe): extract shared helpers, hooks and components to remove code duplication

### DIFF
--- a/src/components/Core/Statistics/StatisticsRulesDetail.tsx
+++ b/src/components/Core/Statistics/StatisticsRulesDetail.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Card, Flex, Grid, Heading, Text } from '@radix-ui/themes';
-import { Layers, Copy, RotateCcw } from 'lucide-react';
+import { RotateCcw } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import { KpiTile, BarRow } from '@/components/Core/Statistics/primitives';
+import { BarRow, GroupingDeduplicationKpiPair } from '@/components/Core/Statistics/primitives';
 import { ThisWeekStatsCard } from './ThisWeekStatsCard';
 import type { StatisticsAggregates } from '@/types/statistics';
 
@@ -59,18 +59,7 @@ export function StatisticsRulesDetail({ data, activeRulesCount, firstUsedAtForma
           <Flex direction="column" gap="3" p="2">
             <Heading size="3">{getMessage('statsHistoricalTotals')}</Heading>
             <Flex gap="3" wrap="wrap">
-              <KpiTile
-                testId="page-stats-card-groups"
-                icon={<Layers size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
-                label={getMessage('groupsCreated')}
-                value={data.totalGrouping}
-              />
-              <KpiTile
-                testId="page-stats-card-dedup"
-                icon={<Copy size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
-                label={getMessage('tabsDeduplicated')}
-                value={data.totalDedup}
-              />
+              <GroupingDeduplicationKpiPair data={data} />
             </Flex>
             <Flex gap="4" wrap="wrap">
               <Text size="2" color="gray">

--- a/src/components/Core/Statistics/StatisticsSummary.tsx
+++ b/src/components/Core/Statistics/StatisticsSummary.tsx
@@ -1,8 +1,8 @@
 import { Box, Grid } from '@radix-ui/themes';
-import { Layers, Copy, Pin, FolderOpen, Archive, HardDrive } from 'lucide-react';
+import { Pin, FolderOpen, Archive, HardDrive } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { formatBytes } from '@/utils/formatBytes';
-import { KpiTile } from '@/components/Core/Statistics/primitives';
+import { KpiTile, GroupingDeduplicationKpiPair } from '@/components/Core/Statistics/primitives';
 import { ThisWeekStatsCard } from './ThisWeekStatsCard';
 import type { StatisticsAggregates } from '@/types/statistics';
 import type { SessionStatisticsSnapshot } from '@/hooks/useSessionStatistics';
@@ -25,18 +25,7 @@ export function StatisticsSummary({ data, snapshot, storageUsage }: StatisticsSu
   return (
     <Box data-testid="page-stats-summary">
       <Grid columns={{ initial: '2', sm: '3' }} gap="3">
-        <KpiTile
-          testId="page-stats-card-groups"
-          icon={<Layers size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
-          label={getMessage('groupsCreated')}
-          value={data.totalGrouping}
-        />
-        <KpiTile
-          testId="page-stats-card-dedup"
-          icon={<Copy size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
-          label={getMessage('tabsDeduplicated')}
-          value={data.totalDedup}
-        />
+        <GroupingDeduplicationKpiPair data={data} />
         <KpiTile
           testId="page-stats-summary-storage"
           icon={<HardDrive size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}

--- a/src/components/Core/Statistics/primitives.tsx
+++ b/src/components/Core/Statistics/primitives.tsx
@@ -1,5 +1,6 @@
 import { Box, Card, Flex, Heading, Separator, Text, Tooltip } from '@radix-ui/themes';
 import type { MarginProps } from '@radix-ui/themes/dist/esm/props/margin.props.js';
+import { Layers, Copy } from 'lucide-react';
 import { getMessage, type MessageKey } from '@/utils/i18n';
 import { TrendBadge } from '@/components/Core/Statistics/TrendBadge';
 import type { GroupColorStat } from '@/hooks/useSessionStatistics';
@@ -177,6 +178,33 @@ export function BarRow({ label, value, maxValue, index, testId, rightDetail, val
         }} />
       </Box>
     </Box>
+  );
+}
+
+interface GroupingDeduplicationKpiPairProps {
+  data: { totalGrouping: number; totalDedup: number };
+}
+
+/**
+ * The two headline KpiTiles shared by StatisticsRulesDetail and StatisticsSummary:
+ * groups created (Layers icon) and tabs deduplicated (Copy icon).
+ */
+export function GroupingDeduplicationKpiPair({ data }: GroupingDeduplicationKpiPairProps) {
+  return (
+    <>
+      <KpiTile
+        testId="page-stats-card-groups"
+        icon={<Layers size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
+        label={getMessage('groupsCreated')}
+        value={data.totalGrouping}
+      />
+      <KpiTile
+        testId="page-stats-card-dedup"
+        icon={<Copy size={18} style={{ color: 'var(--accent-9)' }} aria-hidden="true" />}
+        label={getMessage('tabsDeduplicated')}
+        value={data.totalDedup}
+      />
+    </>
   );
 }
 

--- a/src/components/Core/TabTree/GroupEditRow.tsx
+++ b/src/components/Core/TabTree/GroupEditRow.tsx
@@ -4,6 +4,7 @@ import { getMessage } from '@/utils/i18n';
 import { EditRowShell } from './EditRowShell';
 import { ChromeColorPicker } from './ChromeColorPicker';
 import type { ChromeGroupColor } from '@/types/tabTree';
+import { makeEditKeyDownHandler } from './editRowUtils';
 
 export interface GroupEditRowProps {
   name: string;
@@ -32,10 +33,7 @@ export function GroupEditRow({
             ref={inputRef}
             value={name}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => onNameChange(e.target.value)}
-            onKeyDown={(e: React.KeyboardEvent) => {
-              if (e.key === 'Enter') onSave();
-              if (e.key === 'Escape') onCancel();
-            }}
+            onKeyDown={makeEditKeyDownHandler(onSave, onCancel)}
             size="1"
             style={{ flex: 1 }}
             placeholder={getMessage('tabEditorGroupNameLabel')}

--- a/src/components/Core/TabTree/TabEditRow.tsx
+++ b/src/components/Core/TabTree/TabEditRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Flex, Text, TextField } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import { EditRowShell } from './EditRowShell';
+import { makeEditKeyDownHandler } from './editRowUtils';
 import styles from './TabTreeEditor.module.css';
 
 export interface TabEditRowProps {
@@ -26,10 +27,7 @@ export function TabEditRow({ url, error, level, onChange, onSave, onCancel }: Ta
               ref={inputRef}
               value={url}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-              onKeyDown={(e: React.KeyboardEvent) => {
-                if (e.key === 'Enter') onSave();
-                if (e.key === 'Escape') onCancel();
-              }}
+              onKeyDown={makeEditKeyDownHandler(onSave, onCancel)}
               size="1"
               style={{ flex: 1 }}
               placeholder="https://example.com"

--- a/src/components/Core/TabTree/TabTreeEditor.tsx
+++ b/src/components/Core/TabTree/TabTreeEditor.tsx
@@ -6,12 +6,9 @@ import {
 } from '@radix-ui/themes';
 import { ChevronUp, ChevronDown, Pencil, Trash2 } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
-import { extractDomain } from '@/utils/tabTreeUtils';
-import { TabRowBase } from './TabRowBase';
 import { GroupRowBase } from './GroupRowBase';
-import { TabEditRow } from './TabEditRow';
 import { GroupEditRow } from './GroupEditRow';
-import { MoveTabDropdown } from './MoveTabDropdown';
+import { TabTreeEditorTabRow } from './TabTreeEditorTabRow';
 import { AlertDialogShell } from './AlertDialogShell';
 import { useTabTreeEditor } from './useTabTreeEditor';
 import type { Session } from '@/types/session';
@@ -142,178 +139,61 @@ export function TabTreeEditor({ session, onSessionChange, maxHeight }: TabTreeEd
 
             {/* Group's tabs */}
             {isExpanded &&
-              group.tabs.map((tab, tabIdx) => {
-                const isEditingTab = editingItemId === tab.id;
-                return (
-                  <Box key={tab.id} role="listitem" className={styles.row}>
-                    {isEditingTab ? (
-                      <TabEditRow
-                        url={editUrl}
-                        error={urlError}
-                        level={2}
-                        onChange={(url) => {
-                          setEditUrl(url);
-                          setUrlError(null);
-                        }}
-                        onSave={() => saveTabEdit(tab.id)}
-                        onCancel={cancelEdit}
-                      />
-                    ) : (
-                      <TabRowBase
-                        favIconUrl={tab.favIconUrl}
-                        title={tab.title}
-                        domain={extractDomain(tab.url)}
-                        fullUrl={tab.url}
-                        level={2}
-                        showTooltip={false}
-                        rightSlot={
-                          <div className={styles.actions}>
-                            <IconButton
-                              size="1"
-                              variant="ghost"
-                              color="gray"
-                              disabled={tabIdx === 0}
-                              onClick={() => moveTabInContext(tab.id, 'up', group.id)}
-                              aria-label={getMessage('tabEditorMoveUp')}
-                              title={getMessage('tabEditorMoveUp')}
-                            >
-                              <ChevronUp size={12} />
-                            </IconButton>
-                            <IconButton
-                              size="1"
-                              variant="ghost"
-                              color="gray"
-                              disabled={tabIdx === group.tabs.length - 1}
-                              onClick={() => moveTabInContext(tab.id, 'down', group.id)}
-                              aria-label={getMessage('tabEditorMoveDown')}
-                              title={getMessage('tabEditorMoveDown')}
-                            >
-                              <ChevronDown size={12} />
-                            </IconButton>
-                            <IconButton
-                              size="1"
-                              variant="ghost"
-                              color="gray"
-                              onClick={() => openTabEdit(tab)}
-                              aria-label={getMessage('tabEditorEditTab')}
-                              title={getMessage('tabEditorEditTab')}
-                            >
-                              <Pencil size={12} />
-                            </IconButton>
-                            <MoveTabDropdown
-                              currentGroupId={group.id}
-                              groups={session.groups}
-                              onMove={(targetGroupId) =>
-                                moveTabToGroup(tab.id, group.id, targetGroupId)
-                              }
-                            />
-                            <IconButton
-                              size="1"
-                              variant="ghost"
-                              color="red"
-                              onClick={() => handleDeleteTab(tab.id, group.id)}
-                              aria-label={getMessage('tabEditorDeleteTab')}
-                              title={getMessage('tabEditorDeleteTab')}
-                            >
-                              <Trash2 size={12} />
-                            </IconButton>
-                          </div>
-                        }
-                      />
-                    )}
-                  </Box>
-                );
-              })}
+              group.tabs.map((tab, tabIdx) => (
+                <Box key={tab.id} role="listitem" className={styles.row}>
+                  <TabTreeEditorTabRow
+                    tab={tab}
+                    tabIdx={tabIdx}
+                    level={2}
+                    groupId={group.id}
+                    contextLength={group.tabs.length}
+                    groups={session.groups}
+                    showMoveDropdown={true}
+                    isEditing={editingItemId === tab.id}
+                    editUrl={editUrl}
+                    urlError={urlError}
+                    onEditUrlChange={setEditUrl}
+                    onClearUrlError={() => setUrlError(null)}
+                    onSaveEdit={() => saveTabEdit(tab.id)}
+                    onCancelEdit={cancelEdit}
+                    onOpenEdit={() => openTabEdit(tab)}
+                    onMoveUp={() => moveTabInContext(tab.id, 'up', group.id)}
+                    onMoveDown={() => moveTabInContext(tab.id, 'down', group.id)}
+                    onMoveToGroup={(targetGroupId) => moveTabToGroup(tab.id, group.id, targetGroupId)}
+                    onDelete={() => handleDeleteTab(tab.id, group.id)}
+                  />
+                </Box>
+              ))}
           </React.Fragment>
         );
       })}
 
       {/* Ungrouped tabs */}
-      {session.ungroupedTabs.map((tab, tabIdx) => {
-        const isEditingTab = editingItemId === tab.id;
-        const hasMoveTargets = session.groups.length > 0;
-        return (
-          <Box key={tab.id} role="listitem" className={styles.row}>
-            {isEditingTab ? (
-              <TabEditRow
-                url={editUrl}
-                error={urlError}
-                level={1}
-                onChange={(url) => {
-                  setEditUrl(url);
-                  setUrlError(null);
-                }}
-                onSave={() => saveTabEdit(tab.id)}
-                onCancel={cancelEdit}
-              />
-            ) : (
-              <TabRowBase
-                favIconUrl={tab.favIconUrl}
-                title={tab.title}
-                domain={extractDomain(tab.url)}
-                fullUrl={tab.url}
-                level={1}
-                showTooltip={false}
-                rightSlot={
-                  <div className={styles.actions}>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      disabled={tabIdx === 0}
-                      onClick={() => moveTabInContext(tab.id, 'up', null)}
-                      aria-label={getMessage('tabEditorMoveUp')}
-                      title={getMessage('tabEditorMoveUp')}
-                    >
-                      <ChevronUp size={12} />
-                    </IconButton>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      disabled={tabIdx === session.ungroupedTabs.length - 1}
-                      onClick={() => moveTabInContext(tab.id, 'down', null)}
-                      aria-label={getMessage('tabEditorMoveDown')}
-                      title={getMessage('tabEditorMoveDown')}
-                    >
-                      <ChevronDown size={12} />
-                    </IconButton>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      onClick={() => openTabEdit(tab)}
-                      aria-label={getMessage('tabEditorEditTab')}
-                      title={getMessage('tabEditorEditTab')}
-                    >
-                      <Pencil size={12} />
-                    </IconButton>
-                    {hasMoveTargets && (
-                      <MoveTabDropdown
-                        currentGroupId={null}
-                        groups={session.groups}
-                        onMove={(targetGroupId) =>
-                          moveTabToGroup(tab.id, null, targetGroupId)
-                        }
-                      />
-                    )}
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="red"
-                      onClick={() => handleDeleteTab(tab.id, null)}
-                      aria-label={getMessage('tabEditorDeleteTab')}
-                      title={getMessage('tabEditorDeleteTab')}
-                    >
-                      <Trash2 size={12} />
-                    </IconButton>
-                  </div>
-                }
-              />
-            )}
-          </Box>
-        );
-      })}
+      {session.ungroupedTabs.map((tab, tabIdx) => (
+        <Box key={tab.id} role="listitem" className={styles.row}>
+          <TabTreeEditorTabRow
+            tab={tab}
+            tabIdx={tabIdx}
+            level={1}
+            groupId={null}
+            contextLength={session.ungroupedTabs.length}
+            groups={session.groups}
+            showMoveDropdown={session.groups.length > 0}
+            isEditing={editingItemId === tab.id}
+            editUrl={editUrl}
+            urlError={urlError}
+            onEditUrlChange={setEditUrl}
+            onClearUrlError={() => setUrlError(null)}
+            onSaveEdit={() => saveTabEdit(tab.id)}
+            onCancelEdit={cancelEdit}
+            onOpenEdit={() => openTabEdit(tab)}
+            onMoveUp={() => moveTabInContext(tab.id, 'up', null)}
+            onMoveDown={() => moveTabInContext(tab.id, 'down', null)}
+            onMoveToGroup={(targetGroupId) => moveTabToGroup(tab.id, null, targetGroupId)}
+            onDelete={() => handleDeleteTab(tab.id, null)}
+          />
+        </Box>
+      ))}
 
       {/* AlertDialog: delete last tab in group */}
       <AlertDialogShell

--- a/src/components/Core/TabTree/TabTreeEditorTabRow.tsx
+++ b/src/components/Core/TabTree/TabTreeEditorTabRow.tsx
@@ -1,0 +1,151 @@
+import { IconButton } from '@radix-ui/themes';
+import { ChevronUp, ChevronDown, Pencil, Trash2 } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { extractDomain } from '@/utils/tabTreeUtils';
+import { TabRowBase } from './TabRowBase';
+import { TabEditRow } from './TabEditRow';
+import { MoveTabDropdown } from './MoveTabDropdown';
+import type { SavedTab, SavedTabGroup } from '@/types/session';
+import styles from './TabTreeEditor.module.css';
+
+export interface TabTreeEditorTabRowProps {
+  tab: SavedTab;
+  /** Zero-based index within the current context (group or ungrouped list). */
+  tabIdx: number;
+  /** Tree indentation level: 2 for grouped tabs, 1 for ungrouped tabs. */
+  level: 1 | 2;
+  /** Id of the parent group, or null for ungrouped tabs. */
+  groupId: string | null;
+  /** Total number of tabs in the current context (used to compute last-item disabled state). */
+  contextLength: number;
+  /** Groups in the session, used to populate the MoveTabDropdown. */
+  groups: SavedTabGroup[];
+  /**
+   * Whether the MoveTab dropdown should be shown. For grouped tabs this is
+   * always true; for ungrouped tabs it is only shown when at least one group
+   * exists in the session.
+   */
+  showMoveDropdown: boolean;
+  /** Whether this tab is currently being edited. */
+  isEditing: boolean;
+  /** Current edit URL value (only relevant when isEditing = true). */
+  editUrl: string;
+  /** Current URL validation error (null = no error). */
+  urlError: string | null;
+  onEditUrlChange: (url: string) => void;
+  onClearUrlError: () => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onOpenEdit: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onMoveToGroup: (targetGroupId: string | null) => void;
+  onDelete: () => void;
+}
+
+/**
+ * Renders a single tab row inside the TabTreeEditor, handling both the
+ * read view (TabRowBase + action buttons) and the edit view (TabEditRow).
+ * Used for both grouped tabs (level=2) and ungrouped tabs (level=1).
+ */
+export function TabTreeEditorTabRow({
+  tab,
+  tabIdx,
+  level,
+  groupId,
+  contextLength,
+  groups,
+  showMoveDropdown,
+  isEditing,
+  editUrl,
+  urlError,
+  onEditUrlChange,
+  onClearUrlError,
+  onSaveEdit,
+  onCancelEdit,
+  onOpenEdit,
+  onMoveUp,
+  onMoveDown,
+  onMoveToGroup,
+  onDelete,
+}: TabTreeEditorTabRowProps) {
+  if (isEditing) {
+    return (
+      <TabEditRow
+        url={editUrl}
+        error={urlError}
+        level={level}
+        onChange={(url) => {
+          onEditUrlChange(url);
+          onClearUrlError();
+        }}
+        onSave={onSaveEdit}
+        onCancel={onCancelEdit}
+      />
+    );
+  }
+
+  return (
+    <TabRowBase
+      favIconUrl={tab.favIconUrl}
+      title={tab.title}
+      domain={extractDomain(tab.url)}
+      fullUrl={tab.url}
+      level={level}
+      showTooltip={false}
+      rightSlot={
+        <div className={styles.actions}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            disabled={tabIdx === 0}
+            onClick={onMoveUp}
+            aria-label={getMessage('tabEditorMoveUp')}
+            title={getMessage('tabEditorMoveUp')}
+          >
+            <ChevronUp size={12} />
+          </IconButton>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            disabled={tabIdx === contextLength - 1}
+            onClick={onMoveDown}
+            aria-label={getMessage('tabEditorMoveDown')}
+            title={getMessage('tabEditorMoveDown')}
+          >
+            <ChevronDown size={12} />
+          </IconButton>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={onOpenEdit}
+            aria-label={getMessage('tabEditorEditTab')}
+            title={getMessage('tabEditorEditTab')}
+          >
+            <Pencil size={12} />
+          </IconButton>
+          {showMoveDropdown && (
+            <MoveTabDropdown
+              currentGroupId={groupId}
+              groups={groups}
+              onMove={onMoveToGroup}
+            />
+          )}
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="red"
+            onClick={onDelete}
+            aria-label={getMessage('tabEditorDeleteTab')}
+            title={getMessage('tabEditorDeleteTab')}
+          >
+            <Trash2 size={12} />
+          </IconButton>
+        </div>
+      }
+    />
+  );
+}

--- a/src/components/Core/TabTree/editRowUtils.ts
+++ b/src/components/Core/TabTree/editRowUtils.ts
@@ -1,0 +1,15 @@
+import type React from 'react';
+
+/**
+ * Returns a `onKeyDown` handler for edit-row inputs.
+ * Pressing Enter confirms the edit; pressing Escape cancels it.
+ */
+export function makeEditKeyDownHandler(
+  onSave: () => void,
+  onCancel: () => void,
+): (e: React.KeyboardEvent) => void {
+  return (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onSave();
+    if (e.key === 'Escape') onCancel();
+  };
+}

--- a/src/components/HomePage/HomePageSkeleton.tsx
+++ b/src/components/HomePage/HomePageSkeleton.tsx
@@ -1,5 +1,17 @@
 import { Box, Card, Flex, Grid, Skeleton } from '@radix-ui/themes';
 
+interface GridSectionConfig {
+  titleWidth: string;
+  columns: { initial: string; sm: string; md: string };
+  itemCount: number;
+  itemHeight: string;
+}
+
+const GRID_SECTIONS: GridSectionConfig[] = [
+  { titleWidth: '160px', columns: { initial: '1', sm: '2', md: '3' }, itemCount: 3, itemHeight: '116px' },
+  { titleWidth: '140px', columns: { initial: '1', sm: '2', md: '3' }, itemCount: 5, itemHeight: '88px' },
+];
+
 export function HomePageSkeleton() {
   return (
     <Box aria-busy="true" data-testid="home-skeleton">
@@ -11,27 +23,18 @@ export function HomePageSkeleton() {
           </Flex>
         </Card>
 
-        <Card>
-          <Flex direction="column" gap="3">
-            <Skeleton width="160px" height="16px" />
-            <Grid columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
-              {[0, 1, 2].map((i) => (
-                <Skeleton key={i} height="116px" />
-              ))}
-            </Grid>
-          </Flex>
-        </Card>
-
-        <Card>
-          <Flex direction="column" gap="3">
-            <Skeleton width="140px" height="16px" />
-            <Grid columns={{ initial: '1', sm: '2', md: '3' }} gap="3">
-              {[0, 1, 2, 3, 4].map((i) => (
-                <Skeleton key={i} height="88px" />
-              ))}
-            </Grid>
-          </Flex>
-        </Card>
+        {GRID_SECTIONS.map((section, i) => (
+          <Card key={i}>
+            <Flex direction="column" gap="3">
+              <Skeleton width={section.titleWidth} height="16px" />
+              <Grid columns={section.columns} gap="3">
+                {Array.from({ length: section.itemCount }, (_, j) => (
+                  <Skeleton key={j} height={section.itemHeight} />
+                ))}
+              </Grid>
+            </Flex>
+          </Card>
+        ))}
 
         <Card>
           <Flex direction="column" gap="3">

--- a/src/components/UI/ImportExportWizards/RuleImportRows.tsx
+++ b/src/components/UI/ImportExportWizards/RuleImportRows.tsx
@@ -2,18 +2,13 @@ import { Flex, Badge, Checkbox } from '@radix-ui/themes';
 import { getMessage, type MessageKey } from '@/utils/i18n';
 import type { DomainRuleSetting } from '@/types/syncSettings';
 import type { ConflictingRule } from '@/utils/importClassification';
-import { DiffPopover, DiffPropertyValues } from './Shared';
+import { DiffPopover, DiffPropertyValues, type ImportRowBaseProps } from './Shared';
 import { DomainRuleCard } from '@/components/Core/DomainRule/DomainRuleCard';
 
 /* ─── RuleRow ───────────────────────────────────────────────────────────── */
 
-export interface RuleRowProps {
+export interface RuleRowProps extends ImportRowBaseProps {
   rule: DomainRuleSetting;
-  checkbox?: boolean;
-  checked?: boolean;
-  onToggle?: () => void;
-  dimmed?: boolean;
-  statusBadge?: string;
 }
 
 export function RuleRow({ rule, checkbox, checked, onToggle, dimmed, statusBadge }: RuleRowProps) {

--- a/src/components/UI/ImportExportWizards/SessionImportRows.tsx
+++ b/src/components/UI/ImportExportWizards/SessionImportRows.tsx
@@ -2,18 +2,13 @@ import { Flex, Text, Box, Badge, Checkbox } from '@radix-ui/themes';
 import { getMessage } from '@/utils/i18n';
 import type { Session } from '@/types/session';
 import type { ConflictingSession, SessionDiff, GroupDiff } from '@/utils/sessionClassification';
-import { DiffPopover, DiffPropertyValues } from './Shared';
+import { DiffPopover, DiffPropertyValues, type ImportRowBaseProps } from './Shared';
 import { SessionCard } from '@/components/Core/Session/SessionCard';
 
 /* ─── SessionRow ─────────────────────────────────────────────────────────── */
 
-export interface SessionRowProps {
+export interface SessionRowProps extends ImportRowBaseProps {
   session: Session;
-  checkbox?: boolean;
-  checked?: boolean;
-  onToggle?: () => void;
-  dimmed?: boolean;
-  statusBadge?: string;
 }
 
 export function SessionRow({ session, checkbox, checked, onToggle, dimmed, statusBadge }: SessionRowProps) {

--- a/src/components/UI/ImportExportWizards/Shared/importRowTypes.ts
+++ b/src/components/UI/ImportExportWizards/Shared/importRowTypes.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared props for import row components (RuleRow, SessionRow).
+ * Each row can optionally show a leading checkbox and/or a trailing status badge.
+ */
+export interface ImportRowBaseProps {
+  /** Render a leading checkbox when true. */
+  checkbox?: boolean;
+  /** Controlled checked state for the leading checkbox. */
+  checked?: boolean;
+  /** Called when the checkbox value changes. */
+  onToggle?: () => void;
+  /** When true, renders the row in a dimmed / muted style (used for identical items). */
+  dimmed?: boolean;
+  /** Text for a trailing status badge (e.g. "identical", "new"). */
+  statusBadge?: string;
+}

--- a/src/components/UI/ImportExportWizards/Shared/index.ts
+++ b/src/components/UI/ImportExportWizards/Shared/index.ts
@@ -3,3 +3,4 @@ export { DiffPopover } from './DiffPopover';
 export { DiffPropertyValues } from './DiffPropertyValues';
 export { useDialogReset } from './useDialogReset';
 export { useToggleSet, type ToggleSetState } from './useToggleSet';
+export type { ImportRowBaseProps } from './importRowTypes';

--- a/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
+++ b/src/components/UI/PopupProfilesList/PopupProfilesList.tsx
@@ -10,7 +10,7 @@ import { openOptionsWithHash } from '@/utils/openOptions';
 import { getFocusedSessionFromDOM } from '@/utils/sessionUtils';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { getActiveTabGroupId } from '@/utils/tabCapture';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSessionSwitchedNotification } from '@/utils/notifications';
 import { getRuleCategory } from '@/utils/categoriesStore';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext';
 import { useListNavigation } from '@/hooks/useListNavigation';
@@ -137,10 +137,7 @@ export function PopupProfilesList({ autoFocusFirstPinned, onLoaded }: PopupProfi
     restoreSessionTabs(session, target)
       .then(() => {
         if (target === 'replace') {
-          void showSuccessNotification(
-            getMessage('sessionSwitchedNotificationTitle'),
-            getMessage('sessionSwitchedNotificationMessage', [session.name]),
-          );
+          void showSessionSwitchedNotification(session.name);
           window.close();
         }
       })

--- a/src/components/UI/RuleViewMenu/RuleViewMenu.tsx
+++ b/src/components/UI/RuleViewMenu/RuleViewMenu.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { Box, DropdownMenu, Flex } from '@radix-ui/themes';
 import { RotateCcw } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
@@ -16,6 +15,8 @@ import {
   type RuleStatusFilter,
   type RuleViewState,
 } from '@/utils/ruleViewUtils';
+import { toggleInArray } from '@/utils/arrayUtils';
+import { useViewMenuFocusGuard } from '@/hooks/useViewMenuFocusGuard';
 
 const NONE = '__none__';
 
@@ -32,12 +33,6 @@ export interface RuleViewMenuProps {
   /** Categories used to populate the category filter sub-menu. Defaults to the built-in set. */
   categories?: RuleCategory[];
   testId?: string;
-}
-
-/** Adds or removes a value from an array, preserving order, no duplicates. */
-function toggleInArray<T>(arr: readonly T[], item: T, checked: boolean): T[] {
-  if (checked) return arr.includes(item) ? [...arr] : [...arr, item];
-  return arr.filter(v => v !== item);
 }
 
 /** Small color swatch reused inside the color filter items. */
@@ -59,24 +54,8 @@ function ColorSwatch({ color }: { color: ColorValue }) {
 export function RuleViewMenu({ value, onChange, onApplied, categories, testId }: RuleViewMenuProps) {
   const activeOps = countActiveViewOps(value);
   const isActive = activeOps > 0;
-  // Tracks whether a change happened while the menu was open, so we only move
-  // focus to the first result on close when the view actually changed.
-  const changedRef = useRef(false);
 
-  // On close, if the view changed, prevent Radix from returning focus to the
-  // trigger and let the caller move focus to the first resulting rule instead.
-  const handleCloseAutoFocus = (event: Event) => {
-    if (changedRef.current && onApplied) {
-      changedRef.current = false;
-      event.preventDefault();
-      onApplied();
-    }
-  };
-
-  const apply = (next: RuleViewState) => {
-    changedRef.current = true;
-    onChange(next);
-  };
+  const { apply, handleCloseAutoFocus } = useViewMenuFocusGuard<RuleViewState>(onChange, onApplied);
 
   const setColor = (color: ColorValue | '__none__', checked: boolean) =>
     apply({ ...value, filterColors: toggleInArray(value.filterColors, color, checked) });

--- a/src/components/UI/SessionViewMenu/SessionViewMenu.tsx
+++ b/src/components/UI/SessionViewMenu/SessionViewMenu.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { DropdownMenu, Flex } from '@radix-ui/themes';
 import { RotateCcw } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
@@ -12,6 +11,8 @@ import {
   type SessionSortMode,
   type SessionViewState,
 } from '@/utils/sessionViewUtils';
+import { toggleInArray } from '@/utils/arrayUtils';
+import { useViewMenuFocusGuard } from '@/hooks/useViewMenuFocusGuard';
 
 export interface SessionViewMenuProps {
   value: SessionViewState;
@@ -29,12 +30,6 @@ export interface SessionViewMenuProps {
   testIdPrefix?: string;
 }
 
-/** Adds or removes a value from an array, preserving order, no duplicates. */
-function toggleInArray<T>(arr: readonly T[], item: T, checked: boolean): T[] {
-  if (checked) return arr.includes(item) ? [...arr] : [...arr, item];
-  return arr.filter(v => v !== item);
-}
-
 /**
  * Filter / sort menu rendered on the right of a session section header.
  * Mirrors `RuleViewMenu` but simplified for sessions (category filter; sort by
@@ -48,24 +43,8 @@ export function SessionViewMenu({
   testIdPrefix = 'page-sessions-view',
 }: SessionViewMenuProps) {
   const activeOps = countActiveSessionViewOps(value);
-  // Tracks whether a change happened while the menu was open, so we only move
-  // focus to the first result on close when the view actually changed.
-  const changedRef = useRef(false);
 
-  // On close, if the view changed, prevent Radix from returning focus to the
-  // trigger and let the caller move focus to the first resulting card instead.
-  const handleCloseAutoFocus = (event: Event) => {
-    if (changedRef.current && onApplied) {
-      changedRef.current = false;
-      event.preventDefault();
-      onApplied();
-    }
-  };
-
-  const apply = (next: SessionViewState) => {
-    changedRef.current = true;
-    onChange(next);
-  };
+  const { apply, handleCloseAutoFocus } = useViewMenuFocusGuard<SessionViewState>(onChange, onApplied);
 
   const setCategory = (id: string, checked: boolean) =>
     apply({ ...value, filterCategories: toggleInArray(value.filterCategories, id, checked) });

--- a/src/components/UI/SessionWizards/RestoreWizard.tsx
+++ b/src/components/UI/SessionWizards/RestoreWizard.tsx
@@ -7,7 +7,7 @@ import { WizardModal, WizardNavTooltip } from '@/components/UI/WizardModal';
 import { ConflictResolutionStep } from './ConflictResolutionStep';
 import { getMessage } from '@/utils/i18n';
 import { showSuccessToast, showErrorToast } from '@/utils/toast';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSessionSwitchedNotification } from '@/utils/notifications';
 import { markDiscovered } from '@/exploration/progressStore';
 import { sessionToTabTreeData, resolveTabUuids } from '@/utils/sessionUtils';
 import {
@@ -174,10 +174,7 @@ export function RestoreWizard({ open, onOpenChange, session }: RestoreWizardProp
           ]),
         );
         if (target === 'replace') {
-          void showSuccessNotification(
-            getMessage('sessionSwitchedNotificationTitle'),
-            getMessage('sessionSwitchedNotificationMessage', [session.name]),
-          );
+          void showSessionSwitchedNotification(session.name);
         }
       }
     } catch {

--- a/src/components/UI/SettingsPage/SettingsPage.tsx
+++ b/src/components/UI/SettingsPage/SettingsPage.tsx
@@ -1,10 +1,11 @@
 import { useRef, type KeyboardEvent } from 'react';
-import { Box, Flex, Text, Switch, Card, RadioGroup } from '@radix-ui/themes';
+import { Box, Flex, Text, Switch, RadioGroup } from '@radix-ui/themes';
 import { Bell, Copy, RotateCcw } from 'lucide-react';
 import { PageLayout } from '@/components/UI/PageLayout/PageLayout';
 import { useListNavigation } from '@/hooks/useListNavigation';
 import { getMessage } from '@/utils/i18n';
 import { markDiscovered } from '@/exploration/progressStore';
+import { SettingsSectionCard } from './SettingsSectionCard';
 import type { AppSettings } from '@/types/syncSettings';
 import {
   deduplicationKeepStrategyOptions,
@@ -77,84 +78,139 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
       {() => (
         <Box data-testid="page-settings">
           <Flex direction="column" gap="4" ref={listRef}>
-            <Card>
-              <Box p="4">
-                <Flex align="center" gap="2" mb="4">
-                  <Bell size={20} style={{ color: 'var(--accent-9)' }} />
-                  <Text size="3" weight="bold">{getMessage('notificationsSection')}</Text>
+            <SettingsSectionCard
+              icon={<Bell size={20} style={{ color: 'var(--accent-9)' }} />}
+              title={getMessage('notificationsSection')}
+            >
+              <Flex direction="column" gap="4">
+                <Flex justify="between" align="center">
+                  <Text size="2">{getMessage('notifyOnGrouping')}</Text>
+                  <Switch
+                    data-testid="page-settings-toggle-notify-group"
+                    data-settings-nav=""
+                    aria-label={getMessage('notifyOnGrouping')}
+                    checked={syncSettings.notifyOnGrouping}
+                    onCheckedChange={(checked) => { void markDiscovered('settings.notif.grouping'); updateSettings({ notifyOnGrouping: checked }); }}
+                    onKeyDown={handleSwitchKeyDown}
+                  />
                 </Flex>
 
-                <Flex direction="column" gap="4">
-                  <Flex justify="between" align="center">
-                    <Text size="2">{getMessage('notifyOnGrouping')}</Text>
-                    <Switch
-                      data-testid="page-settings-toggle-notify-group"
-                      data-settings-nav=""
-                      aria-label={getMessage('notifyOnGrouping')}
-                      checked={syncSettings.notifyOnGrouping}
-                      onCheckedChange={(checked) => { void markDiscovered('settings.notif.grouping'); updateSettings({ notifyOnGrouping: checked }); }}
-                      onKeyDown={handleSwitchKeyDown}
-                    />
-                  </Flex>
-
-                  <Flex justify="between" align="center">
-                    <Text size="2">{getMessage('notifyOnDeduplication')}</Text>
-                    <Switch
-                      data-testid="page-settings-toggle-notify-dedup"
-                      data-settings-nav=""
-                      aria-label={getMessage('notifyOnDeduplication')}
-                      checked={syncSettings.notifyOnDeduplication}
-                      onCheckedChange={(checked) => { void markDiscovered('settings.notif.dedup'); updateSettings({ notifyOnDeduplication: checked }); }}
-                      onKeyDown={handleSwitchKeyDown}
-                    />
-                  </Flex>
-
-                  <Flex justify="between" align="center">
-                    <Text size="2">{getMessage('notifyOnOrganize')}</Text>
-                    <Switch
-                      data-testid="page-settings-toggle-notify-organize"
-                      data-settings-nav=""
-                      aria-label={getMessage('notifyOnOrganize')}
-                      checked={syncSettings.notifyOnOrganize}
-                      onCheckedChange={(checked) => { void markDiscovered('settings.notif.organize'); updateSettings({ notifyOnOrganize: checked }); }}
-                      onKeyDown={handleSwitchKeyDown}
-                    />
-                  </Flex>
+                <Flex justify="between" align="center">
+                  <Text size="2">{getMessage('notifyOnDeduplication')}</Text>
+                  <Switch
+                    data-testid="page-settings-toggle-notify-dedup"
+                    data-settings-nav=""
+                    aria-label={getMessage('notifyOnDeduplication')}
+                    checked={syncSettings.notifyOnDeduplication}
+                    onCheckedChange={(checked) => { void markDiscovered('settings.notif.dedup'); updateSettings({ notifyOnDeduplication: checked }); }}
+                    onKeyDown={handleSwitchKeyDown}
+                  />
                 </Flex>
-              </Box>
-            </Card>
 
-            <Card>
-              <Box p="4">
-                <Flex align="center" gap="2" mb="4">
-                  <RotateCcw size={20} style={{ color: 'var(--accent-9)' }} />
-                  <Text size="3" weight="bold">{getMessage('sessionRestore')}</Text>
+                <Flex justify="between" align="center">
+                  <Text size="2">{getMessage('notifyOnOrganize')}</Text>
+                  <Switch
+                    data-testid="page-settings-toggle-notify-organize"
+                    data-settings-nav=""
+                    aria-label={getMessage('notifyOnOrganize')}
+                    checked={syncSettings.notifyOnOrganize}
+                    onCheckedChange={(checked) => { void markDiscovered('settings.notif.organize'); updateSettings({ notifyOnOrganize: checked }); }}
+                    onKeyDown={handleSwitchKeyDown}
+                  />
+                </Flex>
+              </Flex>
+            </SettingsSectionCard>
+
+            <SettingsSectionCard
+              icon={<RotateCcw size={20} style={{ color: 'var(--accent-9)' }} />}
+              title={getMessage('sessionRestore')}
+            >
+              <Flex direction="column" gap="2">
+                <Text size="2" id="page-settings-default-restore-action-label">
+                  {getMessage('defaultRestoreActionLabel')}
+                </Text>
+                <RadioGroup.Root
+                  id="page-settings-default-restore-action"
+                  data-testid="page-settings-default-restore-action"
+                  aria-labelledby="page-settings-default-restore-action-label"
+                  loop={false}
+                  value={syncSettings.defaultRestoreAction}
+                  onValueChange={(value) => {
+                    void markDiscovered('sessions.defaultRestore');
+                    updateSettings({ defaultRestoreAction: value as DefaultRestoreActionValue });
+                  }}
+                >
+                  <Flex direction="column" gap="2">
+                    {defaultRestoreActionOptions.map((option, index) => (
+                      <Text as="label" size="2" key={option.value}>
+                        <Flex gap="2" align="center">
+                          <RadioGroup.Item
+                            value={option.value}
+                            data-settings-nav=""
+                            data-testid={`page-settings-default-restore-action-${option.value}`}
+                            onKeyDown={(e) => handleRadioKeyDown(e, index, defaultRestoreActionOptions.length)}
+                          />
+                          {getMessage(option.keyLabel)}
+                        </Flex>
+                      </Text>
+                    ))}
+                  </Flex>
+                </RadioGroup.Root>
+                <Text size="1" color="gray">
+                  {getMessage('defaultRestoreActionDescription')}
+                </Text>
+              </Flex>
+            </SettingsSectionCard>
+
+            <SettingsSectionCard
+              icon={<Copy size={20} style={{ color: 'var(--accent-9)' }} />}
+              title={getMessage('deduplicationScopeSection')}
+            >
+              <Flex direction="column" gap="4">
+                <Flex direction="column" gap="2">
+                  <Flex justify="between" align="center" gap="4">
+                    <Text size="2">{getMessage('deduplicateUnmatchedDomainsLabel')}</Text>
+                    <Switch
+                      data-testid="page-settings-toggle-dedup-unmatched"
+                      data-settings-nav=""
+                      aria-label={getMessage('deduplicateUnmatchedDomainsLabel')}
+                      checked={syncSettings.deduplicateUnmatchedDomains}
+                      onCheckedChange={(checked) => { void markDiscovered('dedup.uncoveredScope'); updateSettings({ deduplicateUnmatchedDomains: checked }); }}
+                      onKeyDown={handleSwitchKeyDown}
+                    />
+                  </Flex>
+                  <Text size="1" color="gray">
+                    {getMessage('deduplicateUnmatchedDomainsDescription')}
+                  </Text>
                 </Flex>
 
                 <Flex direction="column" gap="2">
-                  <Text size="2" id="page-settings-default-restore-action-label">
-                    {getMessage('defaultRestoreActionLabel')}
+                  <Text size="2" id="page-settings-dedup-keep-strategy-label">
+                    {getMessage('deduplicationKeepStrategyLabel')}
                   </Text>
                   <RadioGroup.Root
-                    id="page-settings-default-restore-action"
-                    data-testid="page-settings-default-restore-action"
-                    aria-labelledby="page-settings-default-restore-action-label"
+                    id="page-settings-dedup-keep-strategy"
+                    data-testid="page-settings-dedup-keep-strategy"
+                    aria-labelledby="page-settings-dedup-keep-strategy-label"
                     loop={false}
-                    value={syncSettings.defaultRestoreAction}
+                    value={syncSettings.deduplicationKeepStrategy}
                     onValueChange={(value) => {
-                      void markDiscovered('sessions.defaultRestore');
-                      updateSettings({ defaultRestoreAction: value as DefaultRestoreActionValue });
+                      void markDiscovered(KEEP_STRATEGY_CAPABILITY[value as DeduplicationKeepStrategyValue]);
+                      updateSettings({ deduplicationKeepStrategy: value as DeduplicationKeepStrategyValue });
                     }}
+                    disabled={!syncSettings.globalDeduplicationEnabled}
                   >
                     <Flex direction="column" gap="2">
-                      {defaultRestoreActionOptions.map((option, index) => (
+                      {deduplicationKeepStrategyOptions.map((option, index) => (
                         <Text as="label" size="2" key={option.value}>
                           <Flex gap="2" align="center">
                             <RadioGroup.Item
                               value={option.value}
-                              data-settings-nav=""
-                              data-testid={`page-settings-default-restore-action-${option.value}`}
-                              onKeyDown={(e) => handleRadioKeyDown(e, index, defaultRestoreActionOptions.length)}
+                              // Disabled radios are not focusable, so they stay out of the
+                              // Up/Down flat list: only tag them when the group is active.
+                              {...(syncSettings.globalDeduplicationEnabled ? { 'data-settings-nav': '' } : {})}
+                              data-testid={`page-settings-dedup-keep-${option.value}`}
+                              onKeyDown={(e) => handleRadioKeyDown(e, index, deduplicationKeepStrategyOptions.length)}
                             />
                             {getMessage(option.keyLabel)}
                           </Flex>
@@ -163,78 +219,11 @@ export function SettingsPage({ syncSettings, updateSettings }: SettingsPageProps
                     </Flex>
                   </RadioGroup.Root>
                   <Text size="1" color="gray">
-                    {getMessage('defaultRestoreActionDescription')}
+                    {getMessage('deduplicationKeepStrategyDescription')}
                   </Text>
                 </Flex>
-              </Box>
-            </Card>
-
-            <Card>
-              <Box p="4">
-                <Flex align="center" gap="2" mb="4">
-                  <Copy size={20} style={{ color: 'var(--accent-9)' }} />
-                  <Text size="3" weight="bold">{getMessage('deduplicationScopeSection')}</Text>
-                </Flex>
-
-                <Flex direction="column" gap="4">
-                  <Flex direction="column" gap="2">
-                    <Flex justify="between" align="center" gap="4">
-                      <Text size="2">{getMessage('deduplicateUnmatchedDomainsLabel')}</Text>
-                      <Switch
-                        data-testid="page-settings-toggle-dedup-unmatched"
-                        data-settings-nav=""
-                        aria-label={getMessage('deduplicateUnmatchedDomainsLabel')}
-                        checked={syncSettings.deduplicateUnmatchedDomains}
-                        onCheckedChange={(checked) => { void markDiscovered('dedup.uncoveredScope'); updateSettings({ deduplicateUnmatchedDomains: checked }); }}
-                        onKeyDown={handleSwitchKeyDown}
-                      />
-                    </Flex>
-                    <Text size="1" color="gray">
-                      {getMessage('deduplicateUnmatchedDomainsDescription')}
-                    </Text>
-                  </Flex>
-
-                  <Flex direction="column" gap="2">
-                    <Text size="2" id="page-settings-dedup-keep-strategy-label">
-                      {getMessage('deduplicationKeepStrategyLabel')}
-                    </Text>
-                    <RadioGroup.Root
-                      id="page-settings-dedup-keep-strategy"
-                      data-testid="page-settings-dedup-keep-strategy"
-                      aria-labelledby="page-settings-dedup-keep-strategy-label"
-                      loop={false}
-                      value={syncSettings.deduplicationKeepStrategy}
-                      onValueChange={(value) => {
-                        void markDiscovered(KEEP_STRATEGY_CAPABILITY[value as DeduplicationKeepStrategyValue]);
-                        updateSettings({ deduplicationKeepStrategy: value as DeduplicationKeepStrategyValue });
-                      }}
-                      disabled={!syncSettings.globalDeduplicationEnabled}
-                    >
-                      <Flex direction="column" gap="2">
-                        {deduplicationKeepStrategyOptions.map((option, index) => (
-                          <Text as="label" size="2" key={option.value}>
-                            <Flex gap="2" align="center">
-                              <RadioGroup.Item
-                                value={option.value}
-                                // Disabled radios are not focusable, so they stay out of the
-                                // Up/Down flat list: only tag them when the group is active.
-                                {...(syncSettings.globalDeduplicationEnabled ? { 'data-settings-nav': '' } : {})}
-                                data-testid={`page-settings-dedup-keep-${option.value}`}
-                                onKeyDown={(e) => handleRadioKeyDown(e, index, deduplicationKeepStrategyOptions.length)}
-                              />
-                              {getMessage(option.keyLabel)}
-                            </Flex>
-                          </Text>
-                        ))}
-                      </Flex>
-                    </RadioGroup.Root>
-                    <Text size="1" color="gray">
-                      {getMessage('deduplicationKeepStrategyDescription')}
-                    </Text>
-                  </Flex>
-                </Flex>
-              </Box>
-            </Card>
+              </Flex>
+            </SettingsSectionCard>
           </Flex>
         </Box>
       )}

--- a/src/components/UI/SettingsPage/SettingsSectionCard.tsx
+++ b/src/components/UI/SettingsPage/SettingsSectionCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+import { Box, Card, Flex, Text } from '@radix-ui/themes';
+
+interface SettingsSectionCardProps {
+  icon: ReactNode;
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a settings section in the shared Card + heading row pattern:
+ * a Card containing a padded Box, an icon + bold title row, then the
+ * section content below.
+ */
+export function SettingsSectionCard({ icon, title, children }: SettingsSectionCardProps) {
+  return (
+    <Card>
+      <Box p="4">
+        <Flex align="center" gap="2" mb="4">
+          {icon}
+          <Text size="3" weight="bold">{title}</Text>
+        </Flex>
+        {children}
+      </Box>
+    </Card>
+  );
+}

--- a/src/components/UI/SettingsPage/index.ts
+++ b/src/components/UI/SettingsPage/index.ts
@@ -1,1 +1,2 @@
 export { SettingsPage } from './SettingsPage';
+export { SettingsSectionCard } from './SettingsSectionCard';

--- a/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
+++ b/src/components/UI/Workspace/PopupWorkspaceSwitcher.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import { Flex, Text } from '@radix-ui/themes';
-import { ChevronDown } from 'lucide-react';
+import { Flex } from '@radix-ui/themes';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext.js';
 import { getMessage } from '@/utils/i18n.js';
-import { WorkspaceAvatar } from '@/components/UI/Workspace/WorkspaceAvatar.js';
 import { WorkspaceSwitcherDropdown } from '@/components/UI/Workspace/WorkspaceSwitcherDropdown.js';
+import { WorkspaceTrigger } from './WorkspaceTrigger';
 
 interface PopupWorkspaceSwitcherProps {
   /** Open the manage page; the popup typically closes itself afterwards. */
@@ -25,50 +23,19 @@ export function PopupWorkspaceSwitcher({ onManage }: PopupWorkspaceSwitcherProps
 
   const name = active?.name ?? getMessage('workspaceDefaultName');
 
-  const trigger = (
-    <Flex
-      data-testid="popup-workspace-trigger"
-      align="center"
-      gap="2"
-      style={{
-        flex: 1,
-        minWidth: 0,
-        padding: '6px 8px',
-        cursor: 'pointer',
-        borderRadius: 'var(--radius-2)',
-        border: '1px solid var(--gray-a4)',
-        background: 'var(--gray-a2)',
-      }}
-      role="button"
-      tabIndex={0}
-      aria-label={getMessage('workspaceSwitcherLabel')}
-    >
-      <WorkspaceAvatar name={name} accentColor={accentColor} size="sm" />
-      <Flex direction="column" gap="0" style={{ flex: 1, minWidth: 0 }}>
-        <Text size="1" color="gray" style={{ lineHeight: 1.2 }}>
-          {getMessage('popupWorkspaceLabel')}
-        </Text>
-        <Text
-          size="2"
-          weight="medium"
-          style={{
-            color: 'var(--gray-12)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            lineHeight: 1.2,
-          }}
-        >
-          {name}
-        </Text>
-      </Flex>
-      <ChevronDown size={14} style={{ color: 'var(--gray-11)', flexShrink: 0 }} />
-    </Flex>
-  );
-
   return (
     <Flex data-testid="popup-workspace-switcher" align="center" style={{ width: '100%' }}>
-      <WorkspaceSwitcherDropdown trigger={trigger} onManage={onManage} />
+      <WorkspaceSwitcherDropdown
+        trigger={
+          <WorkspaceTrigger
+            name={name}
+            accentColor={accentColor}
+            variant="popup"
+            testId="popup-workspace-trigger"
+          />
+        }
+        onManage={onManage}
+      />
     </Flex>
   );
 }

--- a/src/components/UI/Workspace/WorkspaceFooter.tsx
+++ b/src/components/UI/Workspace/WorkspaceFooter.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { Flex, Text } from '@radix-ui/themes';
-import { ChevronDown } from 'lucide-react';
+import { Flex } from '@radix-ui/themes';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext.js';
 import { getMessage } from '@/utils/i18n.js';
-import { WorkspaceAvatar } from './WorkspaceAvatar.js';
 import { WorkspaceSwitcherDropdown } from './WorkspaceSwitcherDropdown.js';
+import { WorkspaceTrigger } from './WorkspaceTrigger';
+import { WorkspaceAvatar } from './WorkspaceAvatar.js';
 
 interface WorkspaceFooterProps {
   /** Lot 4 wires the manage page; left undefined in Lot 3 (button disabled). */
@@ -24,39 +23,23 @@ function useWorkspaceName() {
 export function WorkspaceFooter({ onManage }: WorkspaceFooterProps) {
   const { name, accentColor } = useWorkspaceName();
 
-  const trigger = (
-    <Flex
-      data-testid="workspace-footer-trigger"
-      align="center"
-      gap="3"
-      style={{
-        flex: 1,
-        minWidth: 0,
-        padding: '8px 10px',
-        cursor: 'pointer',
-        borderRadius: 'var(--radius-2)',
-        background: 'transparent',
-        transition: 'background-color 0.15s ease',
-      }}
-      role="button"
-      tabIndex={0}
-      aria-label={getMessage('workspaceSwitcherLabel')}
-    >
-      <WorkspaceAvatar name={name} accentColor={accentColor} size="sm" />
-      <Text size="2" weight="medium" style={{ color: 'var(--gray-12)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {name}
-      </Text>
-      <ChevronDown size={14} style={{ color: 'var(--gray-11)', flexShrink: 0 }} />
-    </Flex>
-  );
-
   return (
     <Flex
       data-testid="workspace-footer"
       align="center"
       style={{ width: '100%', padding: '4px 6px' }}
     >
-      <WorkspaceSwitcherDropdown trigger={trigger} onManage={onManage} />
+      <WorkspaceSwitcherDropdown
+        trigger={
+          <WorkspaceTrigger
+            name={name}
+            accentColor={accentColor}
+            variant="sidebar"
+            testId="workspace-footer-trigger"
+          />
+        }
+        onManage={onManage}
+      />
     </Flex>
   );
 }

--- a/src/components/UI/Workspace/WorkspaceTrigger.tsx
+++ b/src/components/UI/Workspace/WorkspaceTrigger.tsx
@@ -4,7 +4,7 @@ import { ChevronDown } from 'lucide-react';
 import { getMessage } from '@/utils/i18n';
 import { WorkspaceAvatar } from './WorkspaceAvatar';
 
-interface WorkspaceTriggerProps {
+type WorkspaceTriggerProps = ComponentProps<typeof Flex> & {
   name: string;
   accentColor: ComponentProps<typeof WorkspaceAvatar>['accentColor'];
   /**
@@ -14,21 +14,38 @@ interface WorkspaceTriggerProps {
    */
   variant: 'popup' | 'sidebar';
   testId: string;
-}
+};
 
 /**
  * The trigger element passed to WorkspaceSwitcherDropdown.
  * Shared between PopupWorkspaceSwitcher (variant="popup") and
  * WorkspaceFooter (variant="sidebar").
+ *
+ * WorkspaceSwitcherDropdown renders this through Radix's DropdownMenu.Trigger
+ * (asChild/Slot semantics), so the root element must forward `ref` and the
+ * injected props (onClick, data-state, aria-*) to open the menu on click.
  */
-export function WorkspaceTrigger({ name, accentColor, variant, testId }: WorkspaceTriggerProps) {
+export function WorkspaceTrigger({
+  name,
+  accentColor,
+  variant,
+  testId,
+  ref,
+  style,
+  ...props
+}: WorkspaceTriggerProps) {
   const isPopup = variant === 'popup';
 
   return (
     <Flex
+      ref={ref}
       data-testid={testId}
       align="center"
       gap={isPopup ? '2' : '3'}
+      role="button"
+      tabIndex={0}
+      aria-label={getMessage('workspaceSwitcherLabel')}
+      {...props}
       style={{
         flex: 1,
         minWidth: 0,
@@ -44,10 +61,8 @@ export function WorkspaceTrigger({ name, accentColor, variant, testId }: Workspa
               background: 'transparent',
               transition: 'background-color 0.15s ease',
             }),
+        ...style,
       }}
-      role="button"
-      tabIndex={0}
-      aria-label={getMessage('workspaceSwitcherLabel')}
     >
       <WorkspaceAvatar name={name} accentColor={accentColor} size="sm" />
       {isPopup ? (

--- a/src/components/UI/Workspace/WorkspaceTrigger.tsx
+++ b/src/components/UI/Workspace/WorkspaceTrigger.tsx
@@ -1,0 +1,91 @@
+import type { ComponentProps } from 'react';
+import { Flex, Text } from '@radix-ui/themes';
+import { ChevronDown } from 'lucide-react';
+import { getMessage } from '@/utils/i18n';
+import { WorkspaceAvatar } from './WorkspaceAvatar';
+
+interface WorkspaceTriggerProps {
+  name: string;
+  accentColor: ComponentProps<typeof WorkspaceAvatar>['accentColor'];
+  /**
+   * Visual variant:
+   * - "popup": bordered box with a two-line label (sublabel + workspace name).
+   * - "sidebar": transparent background with workspace name only.
+   */
+  variant: 'popup' | 'sidebar';
+  testId: string;
+}
+
+/**
+ * The trigger element passed to WorkspaceSwitcherDropdown.
+ * Shared between PopupWorkspaceSwitcher (variant="popup") and
+ * WorkspaceFooter (variant="sidebar").
+ */
+export function WorkspaceTrigger({ name, accentColor, variant, testId }: WorkspaceTriggerProps) {
+  const isPopup = variant === 'popup';
+
+  return (
+    <Flex
+      data-testid={testId}
+      align="center"
+      gap={isPopup ? '2' : '3'}
+      style={{
+        flex: 1,
+        minWidth: 0,
+        padding: isPopup ? '6px 8px' : '8px 10px',
+        cursor: 'pointer',
+        borderRadius: 'var(--radius-2)',
+        ...(isPopup
+          ? {
+              border: '1px solid var(--gray-a4)',
+              background: 'var(--gray-a2)',
+            }
+          : {
+              background: 'transparent',
+              transition: 'background-color 0.15s ease',
+            }),
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={getMessage('workspaceSwitcherLabel')}
+    >
+      <WorkspaceAvatar name={name} accentColor={accentColor} size="sm" />
+      {isPopup ? (
+        <Flex direction="column" gap="0" style={{ flex: 1, minWidth: 0 }}>
+          <Text size="1" color="gray" style={{ lineHeight: 1.2 }}>
+            {getMessage('popupWorkspaceLabel')}
+          </Text>
+          <Text
+            size="2"
+            weight="medium"
+            style={{
+              color: 'var(--gray-12)',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              lineHeight: 1.2,
+            }}
+          >
+            {name}
+          </Text>
+        </Flex>
+      ) : (
+        <Text
+          size="2"
+          weight="medium"
+          style={{
+            color: 'var(--gray-12)',
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {name}
+        </Text>
+      )}
+      <ChevronDown size={14} style={{ color: 'var(--gray-11)', flexShrink: 0 }} aria-hidden="true" />
+    </Flex>
+  );
+}

--- a/src/entrypoints/content.content.ts
+++ b/src/entrypoints/content.content.ts
@@ -9,25 +9,7 @@ export default defineContentScript({
   runAt: 'document_start',
   allFrames: false,
   main() {
-    function handleAuxClick(event: MouseEvent) {
-      if (event.button === 1) {
-        let target = event.target as HTMLElement | null;
-        while (target && target.tagName !== 'A') {
-          target = target.parentNode as HTMLElement | null;
-        }
-        if (target && (target as HTMLAnchorElement).href && /^https?:\/\//.test((target as HTMLAnchorElement).href)) {
-          browser.runtime.sendMessage(
-            { type: 'middleClickLink', url: (target as HTMLAnchorElement).href } as MiddleClickMessage,
-            () => {
-              if (browser.runtime.lastError)
-                logger.error('Msg err:', browser.runtime.lastError.message);
-            }
-          );
-        }
-      }
-    }
-
-    function handleContextMenu(event: MouseEvent) {
+    function sendLinkMessage(event: MouseEvent): void {
       let target = event.target as HTMLElement | null;
       while (target && target.tagName !== 'A') {
         target = target.parentNode as HTMLElement | null;
@@ -41,6 +23,16 @@ export default defineContentScript({
           }
         );
       }
+    }
+
+    function handleAuxClick(event: MouseEvent) {
+      if (event.button === 1) {
+        sendLinkMessage(event);
+      }
+    }
+
+    function handleContextMenu(event: MouseEvent) {
+      sendLinkMessage(event);
     }
 
     document.addEventListener('auxclick', handleAuxClick, true);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import { storage } from 'wxt/utils/storage';
 import type { AppSettings, DomainRuleSettings } from '@/types/syncSettings.js';
 import type { DeduplicationKeepStrategyValue, DefaultRestoreActionValue } from '@/schemas/enums.js';
 import type { ScopedItems } from '@/utils/workspaceStorage.js';
+import { buildSettingsItemMap, type SettingsItemMap } from '@/utils/settingsUtils.js';
 import { useActiveWorkspaceContext } from '@/contexts/ActiveWorkspaceContext.js';
 import { useStorageState } from './useStorageState.js';
 
@@ -30,24 +31,6 @@ export interface UseSettingsReturn {
 
   updateSettings: (updates: Partial<AppSettings>) => Promise<void>;
   reloadSettings: () => Promise<void>;
-}
-
-type SettingsItemMap = {
-  [K in keyof AppSettings]: { watch: (cb: (v: AppSettings[K]) => void) => () => void };
-};
-
-function buildSettingsItemMap(items: ScopedItems): SettingsItemMap {
-  return {
-    globalGroupingEnabled: items.globalGroupingEnabledItem,
-    globalDeduplicationEnabled: items.globalDeduplicationEnabledItem,
-    deduplicateUnmatchedDomains: items.deduplicateUnmatchedDomainsItem,
-    deduplicationKeepStrategy: items.deduplicationKeepStrategyItem,
-    defaultRestoreAction: items.defaultRestoreActionItem,
-    domainRules: items.domainRulesItem,
-    notifyOnGrouping: items.notifyOnGroupingItem,
-    notifyOnDeduplication: items.notifyOnDeduplicationItem,
-    notifyOnOrganize: items.notifyOnOrganizeItem,
-  } as SettingsItemMap;
 }
 
 async function loadSettingsFromStorage(items: ScopedItems): Promise<AppSettings> {

--- a/src/hooks/useViewMenuFocusGuard.ts
+++ b/src/hooks/useViewMenuFocusGuard.ts
@@ -1,0 +1,36 @@
+import { useRef } from 'react';
+
+/**
+ * Encapsulates the focus-guard pattern shared by view menus (RuleViewMenu,
+ * SessionViewMenu). Tracks whether a change occurred while the menu was open
+ * and, on close, either hands focus back to the trigger (no change) or calls
+ * `onApplied` so the caller can move focus to the first visible result
+ * (accessibility: keep keyboard users on relevant content after filtering).
+ *
+ * @returns `apply` - call instead of `onChange` for every state mutation
+ * @returns `handleCloseAutoFocus` - pass to `DropdownMenu.Content.onCloseAutoFocus`
+ */
+export function useViewMenuFocusGuard<T>(
+  onChange: (next: T) => void,
+  onApplied?: () => void,
+): {
+  apply: (next: T) => void;
+  handleCloseAutoFocus: (event: Event) => void;
+} {
+  const changedRef = useRef(false);
+
+  const handleCloseAutoFocus = (event: Event) => {
+    if (changedRef.current && onApplied) {
+      changedRef.current = false;
+      event.preventDefault();
+      onApplied();
+    }
+  };
+
+  const apply = (next: T) => {
+    changedRef.current = true;
+    onChange(next);
+  };
+
+  return { apply, handleCloseAutoFocus };
+}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -34,7 +34,7 @@ import { useListNavigation } from '@/hooks/useListNavigation';
 import { useImportExportWizards } from '@/contexts/ImportExportWizardsContext';
 import { restoreSessionTabs, type RestoreTarget } from '@/utils/tabRestore';
 import { updateSession, type SessionBucket } from '@/utils/sessionStorage';
-import { showSuccessNotification } from '@/utils/notifications';
+import { showSessionSwitchedNotification } from '@/utils/notifications';
 import { markDiscovered } from '@/exploration/progressStore';
 import { getActiveTabGroupId } from '@/utils/tabCapture';
 import { browser } from 'wxt/browser';
@@ -628,10 +628,7 @@ export function SessionsPage({
       const result = await restoreSessionTabs(session, target, protectedTabId);
       setQuickRestoreMessage(getMessage('restoreResultTabsCreated', [String(result.tabsCreated)]));
       if (target === 'replace') {
-        void showSuccessNotification(
-          getMessage('sessionSwitchedNotificationTitle'),
-          getMessage('sessionSwitchedNotificationMessage', [session.name]),
-        );
+        void showSessionSwitchedNotification(session.name);
       }
     } catch {
       setQuickRestoreMessage(getMessage('restoreError'));

--- a/src/pages/skeletons/DomainRulesPageSkeleton.tsx
+++ b/src/pages/skeletons/DomainRulesPageSkeleton.tsx
@@ -1,31 +1,30 @@
-import { Box, Card, Flex, Skeleton } from '@radix-ui/themes';
-import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
-import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
-
-const ROWS = [0, 1, 2];
+import { Card, Flex, Skeleton } from '@radix-ui/themes';
+import { PageListSkeleton } from './PageListSkeleton';
 
 export function DomainRulesPageSkeleton() {
   return (
-    <PageLayoutSkeleton titleKey="domainRulesTab" descriptionKey="domainRulesPageDescription">
-      <Box data-testid="page-rules-skeleton">
-        <ListToolbarSkeleton hasFilter hasMenu />
-        <Flex direction="column" gap="3">
-          {ROWS.map((i) => (
-            <Card key={i} variant="surface" size="2">
-              <Flex align="center" justify="between" gap="4">
-                <Skeleton width="16px" height="20px" />
-                <Skeleton width="20px" height="20px" />
-                <Flex direction="column" gap="2" style={{ flex: 1 }}>
-                  <Skeleton width="140px" height="22px" />
-                  <Skeleton width="200px" height="16px" />
-                </Flex>
-                <Skeleton width="40px" height="22px" />
-                <Skeleton width="28px" height="28px" />
-              </Flex>
-            </Card>
-          ))}
-        </Flex>
-      </Box>
-    </PageLayoutSkeleton>
+    <PageListSkeleton
+      titleKey="domainRulesTab"
+      descriptionKey="domainRulesPageDescription"
+      testId="page-rules-skeleton"
+      hasFilter
+      hasMenu
+      rowCount={3}
+      rowGap="3"
+      renderRow={(i) => (
+        <Card key={i} variant="surface" size="2">
+          <Flex align="center" justify="between" gap="4">
+            <Skeleton width="16px" height="20px" />
+            <Skeleton width="20px" height="20px" />
+            <Flex direction="column" gap="2" style={{ flex: 1 }}>
+              <Skeleton width="140px" height="22px" />
+              <Skeleton width="200px" height="16px" />
+            </Flex>
+            <Skeleton width="40px" height="22px" />
+            <Skeleton width="28px" height="28px" />
+          </Flex>
+        </Card>
+      )}
+    />
   );
 }

--- a/src/pages/skeletons/PageListSkeleton.tsx
+++ b/src/pages/skeletons/PageListSkeleton.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { Box, Flex } from '@radix-ui/themes';
+import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
+import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
+
+interface PageListSkeletonProps {
+  titleKey: string;
+  descriptionKey: string;
+  testId: string;
+  /** Pass `true` to render a filter placeholder in the toolbar. */
+  hasFilter?: boolean;
+  /** Pass `true` to render an overflow-menu placeholder in the toolbar. */
+  hasMenu?: boolean;
+  /** Number of skeleton card rows to render. */
+  rowCount: number;
+  /** Gap between rows (Radix spacing token). Defaults to "3". */
+  rowGap?: '2' | '3' | '4';
+  /**
+   * Render the interior of each skeleton row Card.
+   * Receives the row index so dimensions can vary per row if needed.
+   */
+  renderRow: (index: number) => ReactNode;
+}
+
+/**
+ * Generic skeleton shell for list pages: PageLayoutSkeleton wrapper + toolbar
+ * placeholder + N card rows whose content is provided via a render prop.
+ */
+export function PageListSkeleton({
+  titleKey,
+  descriptionKey,
+  testId,
+  hasFilter,
+  hasMenu,
+  rowCount,
+  rowGap = '3',
+  renderRow,
+}: PageListSkeletonProps) {
+  return (
+    <PageLayoutSkeleton titleKey={titleKey} descriptionKey={descriptionKey}>
+      <Box data-testid={testId}>
+        <ListToolbarSkeleton hasFilter={hasFilter} hasMenu={hasMenu} />
+        <Flex direction="column" gap={rowGap}>
+          {Array.from({ length: rowCount }, (_, i) => renderRow(i))}
+        </Flex>
+      </Box>
+    </PageLayoutSkeleton>
+  );
+}

--- a/src/pages/skeletons/WorkspacesPageSkeleton.tsx
+++ b/src/pages/skeletons/WorkspacesPageSkeleton.tsx
@@ -1,31 +1,29 @@
-import { Box, Card, Flex, Skeleton } from '@radix-ui/themes';
-import { PageLayoutSkeleton } from '@/components/UI/PageLayout';
-import { ListToolbarSkeleton } from '@/components/UI/ListToolbar';
-
-const ROWS = [0, 1];
+import { Card, Flex, Skeleton } from '@radix-ui/themes';
+import { PageListSkeleton } from './PageListSkeleton';
 
 export function WorkspacesPageSkeleton() {
   return (
-    <PageLayoutSkeleton titleKey="workspacesTab" descriptionKey="workspacesDescription">
-      <Box data-testid="page-workspaces-skeleton">
-        <ListToolbarSkeleton hasMenu />
-        <Flex direction="column" gap="2">
-          {ROWS.map((i) => (
-            <Card key={i} variant="surface">
-              <Flex align="center" gap="3">
-                <Skeleton width="40px" height="40px" />
-                <Flex direction="column" gap="2" style={{ flex: 1 }}>
-                  <Skeleton width="200px" height="22px" />
-                  <Skeleton width="140px" height="14px" />
-                </Flex>
-                <Skeleton width="72px" height="32px" />
-                <Skeleton width="32px" height="32px" />
-                <Skeleton width="32px" height="32px" />
-              </Flex>
-            </Card>
-          ))}
-        </Flex>
-      </Box>
-    </PageLayoutSkeleton>
+    <PageListSkeleton
+      titleKey="workspacesTab"
+      descriptionKey="workspacesDescription"
+      testId="page-workspaces-skeleton"
+      hasMenu
+      rowCount={2}
+      rowGap="2"
+      renderRow={(i) => (
+        <Card key={i} variant="surface">
+          <Flex align="center" gap="3">
+            <Skeleton width="40px" height="40px" />
+            <Flex direction="column" gap="2" style={{ flex: 1 }}>
+              <Skeleton width="200px" height="22px" />
+              <Skeleton width="140px" height="14px" />
+            </Flex>
+            <Skeleton width="72px" height="32px" />
+            <Skeleton width="32px" height="32px" />
+            <Skeleton width="32px" height="32px" />
+          </Flex>
+        </Card>
+      )}
+    />
   );
 }

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,0 +1,5 @@
+/** Adds or removes a value from an array, preserving order, no duplicates. */
+export function toggleInArray<T>(arr: readonly T[], item: T, checked: boolean): T[] {
+  if (checked) return arr.includes(item) ? [...arr] : [...arr, item];
+  return arr.filter(v => v !== item);
+}

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -188,3 +188,16 @@ export function showSuccessNotification(title: string, message: string): Promise
 export function showErrorNotification(title: string, message: string): Promise<string> {
   return showNotification({ title, message, type: 'error' });
 }
+
+/**
+ * Shows the native "session switched" success notification that appears after
+ * a restore completes with target = 'replace'. Extracted from three call sites
+ * that shared identical showSuccessNotification(sessionSwitchedNotification*)
+ * calls: RestoreWizard, SessionsPage (quick restore), and PopupProfilesList.
+ */
+export function showSessionSwitchedNotification(sessionName: string): Promise<string> {
+  return showSuccessNotification(
+    getMessage('sessionSwitchedNotificationTitle'),
+    getMessage('sessionSwitchedNotificationMessage', [sessionName]),
+  );
+}

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,8 +1,27 @@
 import { storage } from 'wxt/utils/storage';
 import type { AppSettings } from '@/types/syncSettings.js';
 import { defaultAppSettings } from '@/types/syncSettings.js';
+import type { ScopedItems } from './workspaceStorage.js';
 import { logger } from './logger.js';
 import { getActiveScopedItems, getActiveScopedItemsSync } from './workspaceContext.js';
+
+export type SettingsItemMap = {
+  [K in keyof AppSettings]: { watch: (cb: (v: AppSettings[K]) => void) => () => void };
+};
+
+export function buildSettingsItemMap(items: ScopedItems): SettingsItemMap {
+  return {
+    globalGroupingEnabled: items.globalGroupingEnabledItem,
+    globalDeduplicationEnabled: items.globalDeduplicationEnabledItem,
+    deduplicateUnmatchedDomains: items.deduplicateUnmatchedDomainsItem,
+    deduplicationKeepStrategy: items.deduplicationKeepStrategyItem,
+    defaultRestoreAction: items.defaultRestoreActionItem,
+    domainRules: items.domainRulesItem,
+    notifyOnGrouping: items.notifyOnGroupingItem,
+    notifyOnDeduplication: items.notifyOnDeduplicationItem,
+    notifyOnOrganize: items.notifyOnOrganizeItem,
+  } as SettingsItemMap;
+}
 
 /**
  * Settings utilities usable from all contexts (background, content scripts,
@@ -118,16 +137,6 @@ export function watchSettingsField<K extends keyof AppSettings>(
   callback: (value: AppSettings[K]) => void,
 ): () => void {
   const items = getActiveScopedItemsSync();
-  const fieldToItem: Record<keyof AppSettings, { watch: (cb: (v: unknown) => void) => () => void }> = {
-    globalGroupingEnabled: items.globalGroupingEnabledItem,
-    globalDeduplicationEnabled: items.globalDeduplicationEnabledItem,
-    deduplicateUnmatchedDomains: items.deduplicateUnmatchedDomainsItem,
-    deduplicationKeepStrategy: items.deduplicationKeepStrategyItem,
-    defaultRestoreAction: items.defaultRestoreActionItem,
-    domainRules: items.domainRulesItem,
-    notifyOnGrouping: items.notifyOnGroupingItem,
-    notifyOnDeduplication: items.notifyOnDeduplicationItem,
-    notifyOnOrganize: items.notifyOnOrganizeItem,
-  };
+  const fieldToItem = buildSettingsItemMap(items);
   return fieldToItem[field].watch((newValue) => callback(newValue as AppSettings[K]));
 }


### PR DESCRIPTION
## Contexte

Passe de déduplication menée avec l'agent `code-deduplicator` (skill `jscpd`). Le projet était déjà très sain (~0,6 % de duplication) ; cette PR traite les points les plus douloureux remontés par le scan, du plus lourd ([HIGH]) aux [LOW], sans changement de comportement.

## Refactors appliqués (10 commits)

### Composants / hooks / utils partagés
- **`toggleInArray` + `useViewMenuFocusGuard`** : mutualisés entre `RuleViewMenu` et `SessionViewMenu` (le clone le plus lourd, ~56 lignes).
- **`TabTreeEditorTabRow`** : composant unique pour les rows groupées et non groupées de `TabTreeEditor`.
- **`showSessionSwitchedNotification`** : notification native du cas `replace`, factorisée dans `notifications.ts` (3 sites d'appel, dont `PopupProfilesList`).
- **`WorkspaceTrigger`** (variant popup/sidebar) : partagé par `PopupWorkspaceSwitcher` et `WorkspaceFooter`.
- **`PageListSkeleton`** (render prop) : partagé par les skeletons DomainRules et Workspaces.
- **`SettingsSectionCard`** : sections de `SettingsPage`.
- **`HomePageSkeleton`** : sections répétées collapsées en une boucle `map()`.
- **`ImportRowBaseProps`** : interface partagée par `RuleRow` et `SessionRow`.
- **`makeEditKeyDownHandler`** : handler Enter/Escape partagé par `GroupEditRow` et `TabEditRow`.
- **`GroupingDeduplicationKpiPair`** : paire de KPI partagée par `StatisticsRulesDetail` et `StatisticsSummary`.

### Entrypoints / settings
- **`sendLinkMessage`** : logique commune à `handleAuxClick` et `handleContextMenu` dans le content script.
- **`buildSettingsItemMap`** : mapping `AppSettings → ScopedItem` consolidé dans `settingsUtils.ts`, réutilisé par `useSettings`.

## Garde-fous
- `pnpm compile` : OK (aucune erreur TypeScript)
- `pnpm test` : OK (2418 tests, 177 fichiers)
- Conventions respectées : pas de `console.log`, pas de `any`, i18n via `getMessage` (aucune clé inventée), React 19 (`ref` en prop), primitives Radix, a11y.
- Comportement préservé à l'identique pour chaque refactor (testids, niveaux d'indentation, conditions disabled, focus management, succès/erreur des notifications).

## Hors périmètre
Le lot de clones [LOW] dans `utils/`/`background/` (migration, tabRestore, etc.) n'est pas inclus : 2 d'entre eux touchent les écritures storage / l'API extension (risque moyen) et méritent une passe dédiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtQ4A8hFMbocDpy1pC51eM)_