### PR TITLE
test: cover the least-tested logic modules

### DIFF
--- a/tests/background/pinDetection.test.ts
+++ b/tests/background/pinDetection.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+type Listener = (change: { isOnToolbar?: boolean }, isOnToolbar?: boolean) => void;
+
+const hoisted = vi.hoisted(() => ({
+  markDiscovered: vi.fn(async () => undefined),
+  // Mutable browser shape, reconfigured per test.
+  browser: {} as Record<string, unknown>,
+}));
+
+vi.mock('wxt/browser', () => ({
+  get browser() {
+    return hoisted.browser;
+  },
+}));
+
+vi.mock('@/exploration/progressStore.js', () => ({
+  markDiscovered: hoisted.markDiscovered,
+}));
+
+import { setupPinDetection } from '../../src/background/pinDetection';
+
+/** Lets pending microtasks (the fire-and-forget probe) settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hoisted.browser = {};
+});
+
+describe('setupPinDetection', () => {
+  it('is a no-op when neither action nor browserAction exists', async () => {
+    expect(() => setupPinDetection()).not.toThrow();
+    await flush();
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+  });
+
+  it('marks nav.pinExtension when the initial probe reports the icon pinned', async () => {
+    hoisted.browser.action = {
+      getUserSettings: vi.fn(async () => ({ isOnToolbar: true })),
+    };
+    setupPinDetection();
+    await flush();
+    expect(hoisted.markDiscovered).toHaveBeenCalledWith('nav.pinExtension');
+  });
+
+  it('does not mark when the probe reports the icon not pinned', async () => {
+    hoisted.browser.action = {
+      getUserSettings: vi.fn(async () => ({ isOnToolbar: false })),
+    };
+    setupPinDetection();
+    await flush();
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+  });
+
+  it('swallows a throwing getUserSettings without marking', async () => {
+    hoisted.browser.action = {
+      getUserSettings: vi.fn(async () => {
+        throw new Error('unavailable');
+      }),
+    };
+    expect(() => setupPinDetection()).not.toThrow();
+    await flush();
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+  });
+
+  it('skips the probe when getUserSettings is not a function', async () => {
+    hoisted.browser.action = {};
+    setupPinDetection();
+    await flush();
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+  });
+
+  it('falls back to browserAction (Firefox MV2) when action is absent', async () => {
+    hoisted.browser.browserAction = {
+      getUserSettings: vi.fn(async () => ({ isOnToolbar: true })),
+    };
+    setupPinDetection();
+    await flush();
+    expect(hoisted.markDiscovered).toHaveBeenCalledWith('nav.pinExtension');
+  });
+
+  it('marks on a live Chromium pin event (single {isOnToolbar} object)', async () => {
+    let listener: Listener | undefined;
+    hoisted.browser.action = {
+      onUserSettingsChanged: {
+        addListener: (l: Listener) => {
+          listener = l;
+        },
+      },
+    };
+    setupPinDetection();
+    await flush();
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+
+    listener!({ isOnToolbar: true });
+    expect(hoisted.markDiscovered).toHaveBeenCalledWith('nav.pinExtension');
+  });
+
+  it('marks on a live Firefox pin event (change, isOnToolbar args)', async () => {
+    let listener: Listener | undefined;
+    hoisted.browser.action = {
+      onUserSettingsChanged: {
+        addListener: (l: Listener) => {
+          listener = l;
+        },
+      },
+    };
+    setupPinDetection();
+
+    listener!({}, true);
+    expect(hoisted.markDiscovered).toHaveBeenCalledWith('nav.pinExtension');
+  });
+
+  it('does not mark when a pin event reports unpinned', async () => {
+    let listener: Listener | undefined;
+    hoisted.browser.action = {
+      onUserSettingsChanged: {
+        addListener: (l: Listener) => {
+          listener = l;
+        },
+      },
+    };
+    setupPinDetection();
+
+    listener!({ isOnToolbar: false });
+    listener!({}, false);
+    expect(hoisted.markDiscovered).not.toHaveBeenCalled();
+  });
+
+  it('only probes when onUserSettingsChanged is missing', async () => {
+    hoisted.browser.action = {
+      getUserSettings: vi.fn(async () => ({ isOnToolbar: false })),
+    };
+    expect(() => setupPinDetection()).not.toThrow();
+    await flush();
+  });
+});

--- a/tests/components/CatalogRow.stories.test.tsx
+++ b/tests/components/CatalogRow.stories.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/Exploration/CatalogRow.stories';
+
+const composed = composeStories(stories);
+const {
+  CatalogRowDiscoveredAuto,
+  CatalogRowDiscoveredManual,
+  CatalogRowToDiscover,
+  CatalogRowNotPossible,
+} = composed;
+
+describe('CatalogRow (stories)', () => {
+  it('renders an automatically discovered capability', () => {
+    render(<CatalogRowDiscoveredAuto />);
+    expect(screen.getByText('Create a rule')).toBeInTheDocument();
+  });
+
+  it('renders a manually marked capability', () => {
+    render(<CatalogRowDiscoveredManual />);
+    expect(screen.getByText('Create a rule')).toBeInTheDocument();
+  });
+
+  it('renders a still-to-discover capability', () => {
+    render(<CatalogRowToDiscover />);
+    expect(screen.getByText('Create a rule')).toBeInTheDocument();
+  });
+
+  it('renders a not-yet-possible capability (unmet prerequisites)', () => {
+    render(<CatalogRowNotPossible />);
+    expect(screen.getByText('Edit a rule')).toBeInTheDocument();
+  });
+});

--- a/tests/components/ExplorationCoverageSummary.test.tsx
+++ b/tests/components/ExplorationCoverageSummary.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { ExplorationCoverageSummary } from '../../src/components/Core/Exploration/ExplorationCoverageSummary';
+import { computeCoverage } from '../../src/exploration/coverage';
+import type { ExplorationProgress } from '../../src/types/exploration';
+import { CATALOG } from '../../src/exploration/catalog';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<Theme>{ui}</Theme>);
+}
+
+function progress(p: Partial<ExplorationProgress> = {}): ExplorationProgress {
+  return { discovered: [], manuallyMarked: [], values: {}, initializedAt: 1, ...p };
+}
+
+// matchMedia is consulted by the count-up animation. Default it to "no reduced
+// motion" so the requestAnimationFrame path runs; individual tests override it.
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+beforeEach(() => {
+  stubMatchMedia(false);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ExplorationCoverageSummary', () => {
+  it('renders the coverage ratio and the phase bar bands', async () => {
+    const someIds = CATALOG.slice(0, 5).map((c) => c.id);
+    const coverage = computeCoverage(progress({ discovered: someIds }));
+
+    renderWithTheme(<ExplorationCoverageSummary coverage={coverage} />);
+
+    expect(screen.getByTestId('exploration-coverage-summary')).toBeInTheDocument();
+    // The exact ratio text ("5 of N capabilities discovered") is rendered
+    // regardless of the count-up animation.
+    expect(
+      screen.getByText(new RegExp(`${coverage.discovered} of ${coverage.total}`)),
+    ).toBeInTheDocument();
+    // Four phase bands, each exposed as a labelled group.
+    expect(screen.getAllByRole('group').length).toBe(4);
+  });
+
+  it('jumps straight to the final percentage under prefers-reduced-motion', async () => {
+    stubMatchMedia(true);
+    const allIds = CATALOG.map((c) => c.id);
+    const coverage = computeCoverage(progress({ discovered: allIds }));
+
+    renderWithTheme(<ExplorationCoverageSummary coverage={coverage} />);
+
+    // 100% coverage, no animation: the big number is the final value immediately.
+    await waitFor(() => expect(screen.getByText('100')).toBeInTheDocument());
+  });
+
+  it('handles an empty (0%) coverage without throwing', () => {
+    const coverage = computeCoverage(progress());
+    renderWithTheme(<ExplorationCoverageSummary coverage={coverage} />);
+    expect(screen.getByTestId('exploration-coverage-summary')).toBeInTheDocument();
+  });
+});

--- a/tests/components/ExplorationDomainGroup.stories.test.tsx
+++ b/tests/components/ExplorationDomainGroup.stories.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/Exploration/ExplorationDomainGroup.stories';
+
+const composed = composeStories(stories);
+
+/** The collapsible header button (a nav item) of a rendered domain group. */
+function headerButton(): HTMLButtonElement {
+  return document.querySelector('[data-exploration-nav-item]') as HTMLButtonElement;
+}
+
+describe('ExplorationDomainGroup (stories)', () => {
+  it('renders every story variant without throwing', () => {
+    for (const Story of Object.values(composed)) {
+      const { container, unmount } = render(<Story />);
+      expect(container).not.toBeEmptyDOMElement();
+      unmount();
+    }
+  });
+
+  it('renders the expanded group with its capability rows mounted', () => {
+    const { container } = render(<composed.ExplorationDomainGroupOpen />);
+    // An open group mounts its rows (role="listitem").
+    expect(container.querySelectorAll('[role="listitem"]').length).toBeGreaterThan(0);
+  });
+
+  it('keeps rows unmounted when the group is collapsed', () => {
+    const { container } = render(<composed.ExplorationDomainGroupCollapsed />);
+    expect(container.querySelectorAll('[role="listitem"]').length).toBe(0);
+  });
+
+  it('forces rows visible when forceOpen is set even though open is false', () => {
+    const { container } = render(<composed.ExplorationDomainGroupForcedOpen />);
+    expect(container.querySelectorAll('[role="listitem"]').length).toBeGreaterThan(0);
+  });
+
+  it('toggles the group when the header is clicked', () => {
+    const onToggle = vi.fn();
+    render(<composed.ExplorationDomainGroupCollapsed onToggle={onToggle} />);
+    fireEvent.click(headerButton());
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('expands a collapsed group on ArrowRight from the header', () => {
+    const onToggle = vi.fn();
+    render(<composed.ExplorationDomainGroupCollapsed onToggle={onToggle} />);
+    const btn = headerButton();
+    fireEvent.keyDown(btn, { key: 'ArrowRight' });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // ArrowLeft on an already-collapsed group is a no-op (nothing to close).
+    fireEvent.keyDown(btn, { key: 'ArrowLeft' });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses an open group on ArrowLeft and forwards other nav keys', () => {
+    const onToggle = vi.fn();
+    const onNavKeyDown = vi.fn();
+    render(<composed.ExplorationDomainGroupOpen onToggle={onToggle} onNavKeyDown={onNavKeyDown} />);
+    const btn = headerButton();
+    fireEvent.keyDown(btn, { key: 'ArrowLeft' });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // A non-arrow key is delegated to the cross-group navigation handler.
+    fireEvent.keyDown(btn, { key: 'ArrowDown' });
+    expect(onNavKeyDown).toHaveBeenCalled();
+  });
+
+  it('renders the completion badge at 100%', () => {
+    render(<composed.ExplorationDomainGroupComplete />);
+    expect(screen.getByText(/complete/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/ExplorationReviewCallout.stories.test.tsx
+++ b/tests/components/ExplorationReviewCallout.stories.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import * as stories from '../../src/components/Core/Exploration/ExplorationReviewCallout.stories';
+
+const composed = composeStories(stories);
+
+describe('ExplorationReviewCallout (stories)', () => {
+  it('shows the discreet prompt once eligible and the dismissed flag has loaded', async () => {
+    render(<composed.ExplorationReviewCalloutEligible />);
+    const prompt = await screen.findByTestId('exploration-review-prompt');
+    expect(prompt).toBeInTheDocument();
+    // The review link points at the store reviews page.
+    expect(screen.getByTestId('exploration-review-link')).toHaveAttribute('href');
+  });
+
+  it('hides the prompt after the user dismisses it', async () => {
+    render(<composed.ExplorationReviewCalloutEligible />);
+    const dismiss = await screen.findByTestId('exploration-review-dismiss');
+    fireEvent.click(dismiss);
+    await waitFor(() =>
+      expect(screen.queryByTestId('exploration-review-prompt')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('renders nothing when below the eligibility milestone', () => {
+    const { container } = render(<composed.ExplorationReviewCalloutNotEligible />);
+    expect(container.textContent?.trim()).toBe('');
+  });
+});

--- a/tests/components/editRowUtils.test.ts
+++ b/tests/components/editRowUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import type React from 'react';
+import { makeEditKeyDownHandler } from '../../src/components/Core/TabTree/editRowUtils';
+
+function keyEvent(key: string): React.KeyboardEvent {
+  return { key } as React.KeyboardEvent;
+}
+
+describe('makeEditKeyDownHandler', () => {
+  it('calls onSave on Enter and never onCancel', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    makeEditKeyDownHandler(onSave, onCancel)(keyEvent('Enter'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel on Escape and never onSave', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    makeEditKeyDownHandler(onSave, onCancel)(keyEvent('Escape'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('ignores any other key', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    const handler = makeEditKeyDownHandler(onSave, onCancel);
+    for (const k of ['a', 'Tab', 'ArrowDown', 'Shift', ' ']) {
+      handler(keyEvent(k));
+    }
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('returns a reusable handler invoked once per call', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    const handler = makeEditKeyDownHandler(onSave, onCancel);
+    handler(keyEvent('Enter'));
+    handler(keyEvent('Enter'));
+    expect(onSave).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/components/explorationUi.test.ts
+++ b/tests/components/explorationUi.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  capabilityLabel,
+  formatMissingPrerequisite,
+  DOMAIN_ICONS,
+  EXPLORATION_ICON,
+} from '../../src/components/Core/Exploration/explorationUi';
+import type { MissingPrerequisite } from '../../src/exploration/prerequisites';
+
+// getMessage is wired to the real EN catalog via tests/setup-storybook.ts, so
+// known keys resolve to their English text and unknown keys echo the key back.
+
+describe('capabilityLabel', () => {
+  it('returns the localized label for a known catalog id', () => {
+    expect(capabilityLabel('grouping.create')).toBe('Create a rule');
+  });
+
+  it('falls back to the raw id for an unknown capability', () => {
+    expect(capabilityLabel('does.not.exist')).toBe('does.not.exist');
+  });
+});
+
+describe('formatMissingPrerequisite', () => {
+  it('renders a leaf as its localized label', () => {
+    const missing: MissingPrerequisite = { kind: 'leaf', id: 'grouping.create' };
+    expect(formatMissingPrerequisite(missing)).toBe('Create a rule');
+  });
+
+  it('joins allOf parts with the "and" connector', () => {
+    const missing: MissingPrerequisite = {
+      kind: 'allOf',
+      parts: [
+        { kind: 'leaf', id: 'grouping.create' },
+        { kind: 'leaf', id: 'grouping.edit' },
+      ],
+    };
+    expect(formatMissingPrerequisite(missing)).toBe('Create a rule and Edit a rule');
+  });
+
+  it('joins anyOf parts with the "or" connector', () => {
+    const missing: MissingPrerequisite = {
+      kind: 'anyOf',
+      parts: [
+        { kind: 'leaf', id: 'grouping.create' },
+        { kind: 'leaf', id: 'grouping.edit' },
+      ],
+    };
+    expect(formatMissingPrerequisite(missing)).toBe('Create a rule or Edit a rule');
+  });
+
+  it('renders nested mixed trees recursively', () => {
+    const missing: MissingPrerequisite = {
+      kind: 'allOf',
+      parts: [
+        { kind: 'leaf', id: 'grouping.create' },
+        {
+          kind: 'anyOf',
+          parts: [
+            { kind: 'leaf', id: 'grouping.edit' },
+            { kind: 'leaf', id: 'does.not.exist' },
+          ],
+        },
+      ],
+    };
+    expect(formatMissingPrerequisite(missing)).toBe(
+      'Create a rule and Edit a rule or does.not.exist',
+    );
+  });
+});
+
+describe('DOMAIN_ICONS', () => {
+  it('maps every exploration domain to a defined icon component', () => {
+    for (const icon of Object.values(DOMAIN_ICONS)) {
+      expect(icon).toBeDefined();
+    }
+  });
+
+  it('exposes a dedicated exploration icon', () => {
+    expect(EXPLORATION_ICON).toBeDefined();
+  });
+});

--- a/tests/hooks/useStorageUsage.test.tsx
+++ b/tests/hooks/useStorageUsage.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { fakeBrowser } from 'wxt/testing';
+import {
+  ActiveWorkspaceContext,
+  type ActiveWorkspaceContextValue,
+} from '../../src/contexts/ActiveWorkspaceContext';
+import {
+  defineWorkspaceItems,
+  DEFAULT_WORKSPACE_ID,
+} from '../../src/utils/workspaceStorage';
+import type { WorkspaceMeta } from '../../src/schemas/workspace';
+import { useStorageUsage } from '../../src/hooks/useStorageUsage';
+
+const encoder = new TextEncoder();
+const entryBytes = (rawKey: string, value: unknown): number =>
+  encoder.encode(rawKey).length + encoder.encode(JSON.stringify(value)).length;
+
+function makeWrapper(
+  workspaces: WorkspaceMeta[],
+  activeId: string,
+): React.FC<{ children: React.ReactNode }> {
+  const value: ActiveWorkspaceContextValue = {
+    workspaces,
+    activeId,
+    active: workspaces.find((w) => w.id === activeId) ?? null,
+    accentColor: 'indigo',
+    scopedItems: defineWorkspaceItems(activeId),
+    isLoaded: true,
+    switchTo: async () => undefined,
+    createWorkspace: async () => workspaces[0],
+    renameWorkspace: async () => undefined,
+    setWorkspaceColor: async () => undefined,
+    removeWorkspace: async () => undefined,
+  };
+  return ({ children }) => (
+    <ActiveWorkspaceContext.Provider value={value}>
+      {children}
+    </ActiveWorkspaceContext.Provider>
+  );
+}
+
+const DEFAULT_META: WorkspaceMeta = {
+  id: DEFAULT_WORKSPACE_ID,
+  name: 'Default',
+  accentColor: 'indigo',
+};
+const WORK_META: WorkspaceMeta = {
+  id: 'work',
+  name: 'Work',
+  accentColor: 'blue',
+};
+
+beforeEach(() => {
+  fakeBrowser.reset();
+});
+
+describe('useStorageUsage', () => {
+  it('starts from an empty, not-loaded snapshot', async () => {
+    const wrapper = makeWrapper([DEFAULT_META], DEFAULT_WORKSPACE_ID);
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+    // Synchronous first render, before the async recompute resolves.
+    expect(result.current.isLoaded).toBe(false);
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.globalTotalBytes).toBe(0);
+    // Let the pending recompute settle so the state update happens inside act().
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+  });
+
+  it('measures the active workspace, sorts categories by size desc, and computes the quota percentage', async () => {
+    const rules = [{ id: 'r1' }, { id: 'r2' }];
+    const bigSessions = Array.from({ length: 5 }, (_, i) => ({ id: `s${i}`, payload: 'x'.repeat(40) }));
+    await fakeBrowser.storage.local.set({
+      domainRules: rules,
+      sessions: bigSessions,
+    });
+
+    const wrapper = makeWrapper([DEFAULT_META], DEFAULT_WORKSPACE_ID);
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    // Categories sorted by descending size: the big sessions blob outweighs rules.
+    const nonEmpty = result.current.categories.filter((c) => c.bytes > 0).map((c) => c.id);
+    expect(nonEmpty[0]).toBe('sessions-active');
+    expect(nonEmpty).toContain('domain-rules');
+
+    const expectedRules = entryBytes('domainRules', rules);
+    const expectedSessions = entryBytes('sessions', bigSessions);
+    expect(result.current.workspaceTotalBytes).toBe(expectedRules + expectedSessions);
+
+    // Global total counts the raw keys present in storage.local.
+    expect(result.current.globalTotalBytes).toBe(expectedRules + expectedSessions);
+
+    expect(result.current.quotaBytes).toBeGreaterThan(0);
+    expect(result.current.quotaPercent).toBeCloseTo(
+      (result.current.globalTotalBytes / result.current.quotaBytes) * 100,
+      6,
+    );
+  });
+
+  it('splits per-workspace breakdowns and sorts them by total size desc', async () => {
+    const defaultRules = [{ id: 'r1' }];
+    const workRules = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+    await fakeBrowser.storage.local.set({
+      domainRules: defaultRules,
+      'ws:work:domainRules': workRules,
+    });
+
+    const wrapper = makeWrapper([DEFAULT_META, WORK_META], DEFAULT_WORKSPACE_ID);
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    expect(result.current.workspaces).toHaveLength(2);
+    // The "work" workspace stores more, so it sorts first.
+    expect(result.current.workspaces[0].workspaceId).toBe('work');
+    expect(result.current.workspaces[0].name).toBe('Work');
+    expect(result.current.workspaces[0].accentColor).toBe('blue');
+    expect(result.current.workspaces[1].workspaceId).toBe(DEFAULT_WORKSPACE_ID);
+  });
+
+  it('keeps empty active categories when the active workspace has no measured entry', async () => {
+    // activeId is not part of the workspaces list, so no entry matches it.
+    const wrapper = makeWrapper([DEFAULT_META], 'orphan');
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.categories).toEqual([]);
+    expect(result.current.workspaceTotalBytes).toBe(0);
+  });
+
+  it('recomputes when a watched storage item changes', async () => {
+    await fakeBrowser.storage.local.set({ domainRules: [{ id: 'r1' }] });
+    const wrapper = makeWrapper([DEFAULT_META], DEFAULT_WORKSPACE_ID);
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    const before = result.current.workspaceTotalBytes;
+
+    await act(async () => {
+      await fakeBrowser.storage.local.set({
+        domainRules: [{ id: 'r1' }, { id: 'r2' }, { id: 'r3' }],
+      });
+    });
+
+    await waitFor(() => expect(result.current.workspaceTotalBytes).toBeGreaterThan(before));
+  });
+
+  it('swallows measurement errors and stays not-loaded', async () => {
+    vi.spyOn(fakeBrowser.storage.local, 'get').mockRejectedValue(new Error('boom'));
+    const wrapper = makeWrapper([DEFAULT_META], DEFAULT_WORKSPACE_ID);
+    const { result } = renderHook(() => useStorageUsage(), { wrapper });
+
+    // Give the rejected recompute a chance to settle.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.isLoaded).toBe(false);
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/pages/ExplorationPage.test.tsx
+++ b/tests/pages/ExplorationPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { fakeBrowser } from 'wxt/testing';
+import { ExplorationPage } from '../../src/pages/ExplorationPage';
+import { defaultAppSettings } from '../../src/types/syncSettings';
+
+function stubMatchMedia() {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function renderPage(onSequencePrefixChange?: (p: string[] | null) => void) {
+  return render(
+    <Theme>
+      <ExplorationPage
+        syncSettings={defaultAppSettings}
+        onSequencePrefixChange={onSequencePrefixChange}
+      />
+    </Theme>,
+  );
+}
+
+beforeEach(() => {
+  fakeBrowser.reset();
+  stubMatchMedia();
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ExplorationPage', () => {
+  it('renders the coverage summary, filters, search and the per-domain catalogue', async () => {
+    renderPage();
+
+    expect(await screen.findByTestId('page-exploration')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-coverage-summary')).toBeInTheDocument();
+    expect(screen.getByTestId('exploration-filter')).toBeInTheDocument();
+    expect(screen.getByTestId('page-exploration-search')).toBeInTheDocument();
+
+    // Domain groups are rendered (at least the first incomplete one).
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-exploration-nav-item]').length).toBeGreaterThan(0),
+    );
+  });
+
+  it('marks stats.exploration as discovered on mount', async () => {
+    renderPage();
+    await screen.findByTestId('page-exploration');
+    await waitFor(async () => {
+      const raw = await fakeBrowser.storage.local.get('explorationProgress');
+      const progress = raw.explorationProgress as { discovered?: string[] } | undefined;
+      expect(progress?.discovered).toContain('stats.exploration');
+    });
+  });
+
+  it('filters down to the empty state when a search matches nothing', async () => {
+    renderPage();
+    await screen.findByTestId('page-exploration');
+
+    const searchRoot = screen.getByTestId('page-exploration-search');
+    const search = (searchRoot.tagName === 'INPUT'
+      ? searchRoot
+      : searchRoot.querySelector('input')) as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'zzz-no-such-capability-zzz' } });
+
+    expect(await screen.findByTestId('exploration-empty')).toBeInTheDocument();
+  });
+
+  it('persists the filter choice when a segment is selected', async () => {
+    renderPage();
+    await screen.findByTestId('page-exploration');
+
+    // Radix SegmentedControl items expose role="radio" with an accessible name.
+    const discovered = screen.getByRole('radio', { name: /discovered/i });
+    fireEvent.click(discovered);
+
+    await waitFor(async () => {
+      const raw = await fakeBrowser.storage.local.get('explorationFilter');
+      expect(raw.explorationFilter).toBe('discovered');
+    });
+  });
+});

--- a/tests/utils/arrayUtils.test.ts
+++ b/tests/utils/arrayUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { toggleInArray } from '../../src/utils/arrayUtils';
+
+describe('toggleInArray', () => {
+  it('adds the item when checked and absent', () => {
+    expect(toggleInArray([1, 2], 3, true)).toEqual([1, 2, 3]);
+  });
+
+  it('does not duplicate when checked and already present', () => {
+    expect(toggleInArray([1, 2, 3], 2, true)).toEqual([1, 2, 3]);
+  });
+
+  it('removes the item when unchecked and present', () => {
+    expect(toggleInArray([1, 2, 3], 2, false)).toEqual([1, 3]);
+  });
+
+  it('is a no-op when unchecked and absent', () => {
+    expect(toggleInArray([1, 2], 9, false)).toEqual([1, 2]);
+  });
+
+  it('preserves the original order when adding', () => {
+    expect(toggleInArray(['b', 'a'], 'c', true)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('removes every occurrence of a duplicated value', () => {
+    // Pre-existing duplicates are not the function contract, but uncheck must
+    // strip all matches to leave the value fully absent.
+    expect(toggleInArray([1, 2, 2, 3], 2, false)).toEqual([1, 3]);
+  });
+
+  it('returns a fresh array, never the same reference', () => {
+    const input = [1, 2];
+    expect(toggleInArray(input, 3, true)).not.toBe(input);
+    expect(toggleInArray(input, 9, true)).not.toBe(input); // add branch
+    expect(toggleInArray(input, 1, true)).not.toBe(input); // already-present branch
+    expect(toggleInArray(input, 1, false)).not.toBe(input); // remove branch
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [1, 2, 3];
+    toggleInArray(input, 4, true);
+    toggleInArray(input, 2, false);
+    expect(input).toEqual([1, 2, 3]);
+  });
+
+  it('uses strict (referential) equality for objects', () => {
+    const a = { id: 1 };
+    const b = { id: 1 };
+    // b is a different reference, so removing it leaves a untouched.
+    expect(toggleInArray([a], b, false)).toEqual([a]);
+    // The same reference is removed.
+    expect(toggleInArray([a], a, false)).toEqual([]);
+  });
+});

--- a/tests/utils/browserUrls.test.ts
+++ b/tests/utils/browserUrls.test.ts
@@ -54,3 +54,23 @@ describe('openShortcutsCustomizePage', () => {
     expect(createMock).toHaveBeenCalledWith({ url: 'about:addons' });
   });
 });
+
+describe('getStoreReviewUrl', () => {
+  it('returns the Chrome Web Store reviews URL on Chromium', async () => {
+    vi.stubEnv('FIREFOX', '');
+    const { getStoreReviewUrl } = await import('../../src/utils/browserUrls');
+
+    const url = getStoreReviewUrl();
+    expect(url).toContain('chromewebstore.google.com');
+    expect(url).toContain('/reviews');
+  });
+
+  it('returns the AMO reviews URL on Firefox', async () => {
+    vi.stubEnv('FIREFOX', '1');
+    const { getStoreReviewUrl } = await import('../../src/utils/browserUrls');
+
+    const url = getStoreReviewUrl();
+    expect(url).toContain('addons.mozilla.org');
+    expect(url).toMatch(/reviews\/?$/);
+  });
+});


### PR DESCRIPTION
Add focused unit tests for previously untested or weakly covered
pure-logic modules, raising each to full or near-full coverage:

- arrayUtils.toggleInArray (0 -> 100%): add/remove/no-op branches,
  referential equality, immutability.
- background/pinDetection (0 -> 100%): probe + live event paths,
  Chromium vs Firefox event shapes, error swallowing, API fallback.
- Exploration/explorationUi (37 -> 100%): capabilityLabel fallback and
  recursive formatMissingPrerequisite (allOf/anyOf/nested).
- TabTree/editRowUtils (60 -> 100%): Enter/Escape/other-key handling.
- browserUrls.getStoreReviewUrl (62 -> 100%): Chromium and Firefox URLs.
- hooks/useStorageUsage (66 -> 100% lines): per-workspace breakdown,
  sorting, quota percentage, watch-triggered recompute, error path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BjzktjLFhEeMgcHGqaBBej