### PR TITLE
feat(presets): suggest self-hosted presets via first-label subdomain filter

### DIFF
--- a/public/data/presets.json
+++ b/public/data/presets.json
@@ -229,7 +229,7 @@
         {
           "id": "github-repo",
           "name": "GitHub - Repository",
-          "domainFilters": ["github.com"],
+          "domainFilters": ["github.com", "github.*"],
           "urlRegex": "github\\.com/([^/]+/[^/]+)",
           "groupNameSource": "url",
           "urlExample": "URL: '/microsoft/vscode' → Groupe: 'microsoft/vscode'",
@@ -238,7 +238,7 @@
         {
           "id": "github-issue",
           "name": "GitHub - Issues",
-          "domainFilters": ["github.com"],
+          "domainFilters": ["github.com", "github.*"],
           "titleRegex": "·\\s*Issue\\s*#(\\d+)",
           "urlRegex": "issues/(\\d+)",
           "groupNameSource": "smart_preset",
@@ -258,7 +258,7 @@
         {
           "id": "gitlab-project",
           "name": "GitLab - Projets",
-          "domainFilters": ["gitlab.com", "*.gitlab.io"],
+          "domainFilters": ["gitlab.com", "*.gitlab.io", "gitlab.*"],
           "urlRegex": "gitlab\\.com/([^/]+/[^/]+)",
           "groupNameSource": "url",
           "urlExample": "URL: '/gitlab-org/gitlab' → Groupe: 'gitlab-org/gitlab'",
@@ -292,7 +292,7 @@
         {
           "id": "jira-ticket",
           "name": "Jira - Tickets",
-          "domainFilters": ["*.atlassian.net"],
+          "domainFilters": ["*.atlassian.net", "jira.*"],
           "titleRegex": "([A-Z]+-\\d+)",
           "urlRegex": "browse/([A-Z]+-\\d+)",
           "groupNameSource": "smart",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,12 +9,41 @@ export function domainToRegex(domainFilter: string | null): RegExp | null {
   if (!domainFilter) return null;
   try {
     const trimmed = domainFilter.trim();
-    // Defensive strip: handle legacy *.domain rules not yet migrated
-    const cleaned = trimmed.startsWith('*.') ? trimmed.slice(2) : trimmed;
+    // Bare generic wildcard is handled by callers, not by a regex.
+    if (!trimmed || trimmed === '*') return null;
+
+    // Recognize an optional leading `*.` (any subdomain) and an optional
+    // trailing `.*` (any registrable domain after the first label, e.g. a
+    // self-hosted instance such as `gitlab.*`). Both are stripped before
+    // escaping the body. The trailing wildcard is only honored when there is
+    // no leading `*.`: a combined `*.x.*` form keeps its prior literal
+    // behavior so this change stays scoped to first-label self-hosted filters
+    // and never alters the matching of existing combined catalog filters.
+    let body = trimmed;
+    let leadingWildcard = false;
+    let trailingWildcard = false;
+    if (body.startsWith('*.')) {
+      leadingWildcard = true;
+      body = body.slice(2);
+    }
+    if (!leadingWildcard && body.endsWith('.*')) {
+      trailingWildcard = true;
+      body = body.slice(0, -2);
+    }
+
     // Plain domain: only letters, digits, dots and hyphens — not localhost
-    const isPlainDomain = cleaned !== 'localhost' && /^[a-zA-Z0-9][a-zA-Z0-9.\-]*$/.test(cleaned);
-    const escaped = cleaned.replace(/[\\.]/g, '\\$&');
-    const p = isPlainDomain ? `([^.]+\\.)*${escaped}` : escaped;
+    const isPlainDomain = body !== 'localhost' && /^[a-zA-Z0-9][a-zA-Z0-9.\-]*$/.test(body);
+    const escaped = body.replace(/[\\.]/g, '\\$&');
+
+    // Subdomains match implicitly for a plain domain or an explicit leading
+    // `*.`. A trailing-only filter (e.g. `gitlab.*`) must anchor on the first
+    // label, so it does NOT opt into the subdomain prefix.
+    const allowSubdomains = leadingWildcard || (isPlainDomain && !trailingWildcard);
+    const prefix = allowSubdomains ? '([^.]+\\.)*' : '';
+    // Trailing `.*` means "followed by any registrable domain".
+    const suffix = trailingWildcard ? '\\.[^/]+' : '';
+
+    const p = `${prefix}${escaped}${suffix}`;
     return new RegExp(`^https?:\\/\\/(${p})(\\/|$)`, 'i');
   } catch (e) {
     logger.error('Err domainToRegex:', domainFilter, e);

--- a/tests/e2e/grouping.spec.ts
+++ b/tests/e2e/grouping.spec.ts
@@ -445,8 +445,8 @@ test.describe('Tab Grouping', () => {
         groupNameSource: 'label',
       });
       await helpers.addDomainRule({
-        label: 'Httpbin Red',
-        domainFilter: 'httpbin.org',
+        label: 'Example Org Red',
+        domainFilter: 'example.org',
         deduplicationEnabled: false,
         groupingEnabled: true,
         color: 'red',
@@ -458,9 +458,9 @@ test.describe('Tab Grouping', () => {
       await helpers.createTabFromOpener(exampleOpener, 'https://example.com/child');
       await helpers.waitForGrouping();
 
-      const httpbinOpener = await helpers.createTab('https://httpbin.org/opener');
+      const exampleOrgOpener = await helpers.createTab('https://example.org/opener');
       await helpers.waitForGrouping();
-      await helpers.createTabFromOpener(httpbinOpener, 'https://httpbin.org/child');
+      await helpers.createTabFromOpener(exampleOrgOpener, 'https://example.org/child');
       await helpers.waitForGrouping();
 
       const groups = await helpers.getTabGroups();
@@ -469,7 +469,7 @@ test.describe('Tab Grouping', () => {
       const blueGroup = groups.find(g => g.color === 'blue');
       const redGroup = groups.find(g => g.color === 'red');
       expect(blueGroup?.title).toBe('Example Blue');
-      expect(redGroup?.title).toBe('Httpbin Red');
+      expect(redGroup?.title).toBe('Example Org Red');
     });
 
     test('first matching rule wins when multiple rules match the same domain [US-G006]', async ({ helpers }) => {
@@ -535,15 +535,15 @@ test.describe('Tab Grouping', () => {
       await helpers.clearDomainRules();
       await helpers.addDomainRule({
         label: 'Stats Group 2',
-        domainFilter: 'httpbin.org',
+        domainFilter: 'example.org',
         deduplicationEnabled: false,
         groupingEnabled: true,
         groupNameSource: 'label',
       });
 
-      const opener2 = await helpers.createTab('https://httpbin.org/opener');
+      const opener2 = await helpers.createTab('https://example.org/opener');
       await helpers.waitForGrouping();
-      await helpers.createTabFromOpener(opener2, 'https://httpbin.org/child');
+      await helpers.createTabFromOpener(opener2, 'https://example.org/child');
       await helpers.waitForGrouping();
       stats = await helpers.getStatistics();
       expect(stats.tabGroupsCreatedCount).toBe(2);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -29,6 +29,35 @@ test('domainToRegex legacy wildcard domain (defensive strip during migration)', 
   assert.ok(regex.test('https://example.com'));
 });
 
+test('domainToRegex trailing wildcard (self-hosted instance, first label anchored)', () => {
+  // `gitlab.*` matches any host whose first label is `gitlab`, regardless of
+  // the registrable domain (self-hosted GitLab on a custom domain).
+  const regex = domainToRegex('gitlab.*');
+  assert.ok(regex instanceof RegExp);
+  assert.ok(regex.test('https://gitlab.example.fr'));
+  assert.ok(regex.test('https://gitlab.example.fr/group/project'));
+  assert.ok(regex.test('https://gitlab.com'));
+  // First label must be exactly `gitlab`: neither a different label nor a
+  // deeper subdomain qualifies.
+  assert.ok(!regex.test('https://git.example.fr'));
+  assert.ok(!regex.test('https://www.gitlab.com'));
+});
+
+test('domainToRegex leaves a combined *.x.* filter with its prior literal behavior', () => {
+  // The trailing wildcard is only honored for first-label filters (e.g.
+  // `gitlab.*`). A combined `*.x.*` form keeps its previous behavior so the
+  // matching of existing catalog filters (and the pack overlap guard) is not
+  // altered: it does not start matching arbitrary `*.x.<tld>` hosts.
+  const regex = domainToRegex('*.amazon.*');
+  assert.ok(regex instanceof RegExp);
+  assert.ok(!regex.test('https://www.amazon.com'));
+  assert.ok(!regex.test('https://amazon.fr'));
+});
+
+test('domainToRegex returns null for bare generic wildcard', () => {
+  assert.strictEqual(domainToRegex('*'), null);
+});
+
 test('matchesDomain typical', () => {
   assert.strictEqual(matchesDomain('https://example.com/page', 'example.com'), true);
   assert.strictEqual(matchesDomain('https://other.com', 'example.com'), false);

--- a/tests/utils/presetSuggestions.test.ts
+++ b/tests/utils/presetSuggestions.test.ts
@@ -58,6 +58,21 @@ describe('getSuggestedPresetIds', () => {
     expect(getSuggestedPresetIds('example.org', cat)).toEqual([]);
   });
 
+  it('suggests a self-hosted preset via a trailing-wildcard filter', () => {
+    const cat: PresetCategory[] = [
+      {
+        id: 'development',
+        presets: [makePreset('gitlab', ['gitlab.com', '*.gitlab.io', 'gitlab.*'])],
+      },
+    ];
+    // Self-hosted instance on a custom domain: matched through `gitlab.*`.
+    expect(getSuggestedPresetIds('gitlab.example.fr', cat)).toEqual(['gitlab']);
+    // The vendor cloud domain still matches.
+    expect(getSuggestedPresetIds('gitlab.com', cat)).toEqual(['gitlab']);
+    // An unrelated host (different first label) is not suggested.
+    expect(getSuggestedPresetIds('git.example.fr', cat)).toEqual([]);
+  });
+
   it('preserves catalog order across categories', () => {
     const cat: PresetCategory[] = [
       { id: 'a', presets: [makePreset('p1', ['acme.com']), makePreset('p2', ['*'])] },


### PR DESCRIPTION
Self-hosted apps (GitLab, Jira, GitHub Enterprise) live on custom domains
such as gitlab.example.fr, so the matching preset was never surfaced in the
rule-creation wizard's suggested list (Step 2), which keys off the domain
entered in Step 1 through getSuggestedPresetIds -> matchesDomain ->
domainToRegex.

- domainToRegex: support a trailing ".*" wildcard meaning "first label X,
  followed by any registrable domain" (e.g. gitlab.* matches
  gitlab.example.fr and gitlab.com, but not www.gitlab.com nor
  git.example.fr). The trailing wildcard is honored only when there is no
  leading "*.", so existing combined "*.x.*" catalog filters keep their
  prior behavior and the matching of current presets/packs is unchanged.
- presets.json: append (no existing entries modified) the self-hosted
  filter to gitlab-project (gitlab.*), jira-ticket (jira.*), github-repo
  and github-issue (github.*).
- Tests for the new trailing-wildcard matching and the self-hosted
  suggestion path.

URL-extraction regexes and rule-pack suggestions are intentionally left
unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Er9aP137q7ZM1ccikDcYMx