### PR TITLE
docs + runtime: document Vivaldi partial compatibility and surface notice in About dialog

### DIFF
--- a/docs/src/content/docs/contributing/stack.mdx
+++ b/docs/src/content/docs/contributing/stack.mdx
@@ -25,8 +25,13 @@ SmartTab Organizer is a cross-browser extension (Chromium MV3 and Firefox MV2), 
 | Browser | Manifest | Status |
 |---|---|---|
 | Chrome | MV3 | Primary target |
-| Edge, Brave, Vivaldi, Arc, Opera (Chromium-based) | MV3 | Compatible (same artifact as Chrome) |
+| Edge, Brave, Arc, Opera (Chromium-based) | MV3 | Compatible (same artifact as Chrome) |
+| Vivaldi | MV3 | Partial: native grouping is not supported. Deduplication and sessions work. |
 | Firefox | MV2 | Compatible (targets `pnpm build:firefox`, `pnpm zip:firefox`) |
+
+<Aside type="note">
+Vivaldi replaces Chromium's tab groups API with its own Tab Stacks system, which has no programmable interface for extensions. Automatic grouping therefore has no visible effect on Vivaldi. Other features are unaffected.
+</Aside>
 
 Browser APIs are accessed through `wxt/browser`, which normalizes the differences between `chrome.*` and `browser.*`. The extension uses a subset that exists on both: `browser.tabs`, `browser.tabGroups`, `browser.storage`, `browser.action` / `browser.browserAction`, `browser.notifications`, `browser.scripting`.
 

--- a/docs/src/content/docs/discover/installation.mdx
+++ b/docs/src/content/docs/discover/installation.mdx
@@ -15,7 +15,7 @@ import { Aside, CardGrid, LinkCard, Steps, Tabs, TabItem } from '@astrojs/starli
 
 <Tabs>
   <TabItem label="Chrome / Edge / Brave">
-[SmartTab Organizer on the Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible with every Chromium-based browser (Chrome, Edge, Brave, Vivaldi, Arc, Opera).
+[SmartTab Organizer on the Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible with every Chromium-based browser (Chrome, Edge, Brave, Vivaldi, Arc, Opera). On Vivaldi, automatic grouping is not available (Vivaldi does not expose Chromium's tab groups API); deduplication and sessions still work.
 
 <Steps>
 1. Click **Add to Chrome**.

--- a/docs/src/content/docs/es/contributing/stack.mdx
+++ b/docs/src/content/docs/es/contributing/stack.mdx
@@ -25,8 +25,13 @@ SmartTab Organizer es una extensión de navegador multinavegador (Chromium MV3 y
 | Navegador | Manifest | Estado |
 |---|---|---|
 | Chrome | MV3 | Objetivo principal |
-| Edge, Brave, Vivaldi, Arc, Opera (basados en Chromium) | MV3 | Compatible (mismo artefacto que Chrome) |
+| Edge, Brave, Arc, Opera (basados en Chromium) | MV3 | Compatible (mismo artefacto que Chrome) |
+| Vivaldi | MV3 | Parcial: la agrupación nativa no es compatible. La deduplicación y las sesiones funcionan. |
 | Firefox | MV2 | Compatible (objetivos `pnpm build:firefox`, `pnpm zip:firefox`) |
+
+<Aside type="note">
+Vivaldi reemplaza la API de grupos de pestañas de Chromium por su propio sistema de Tab Stacks, sin interfaz programable para las extensiones. Por lo tanto, la agrupación automática no tiene efecto visible en Vivaldi. Las demás funciones no se ven afectadas.
+</Aside>
 
 Las API del navegador se acceden mediante `wxt/browser`, que normaliza las diferencias entre `chrome.*` y `browser.*`. La extensión usa un subconjunto presente en ambos: `browser.tabs`, `browser.tabGroups`, `browser.storage`, `browser.action` / `browser.browserAction`, `browser.notifications`, `browser.scripting`.
 

--- a/docs/src/content/docs/es/discover/installation.mdx
+++ b/docs/src/content/docs/es/discover/installation.mdx
@@ -15,7 +15,7 @@ import { Aside, CardGrid, LinkCard, Steps, Tabs, TabItem } from '@astrojs/starli
 
 <Tabs>
   <TabItem label="Chrome / Edge / Brave">
-[SmartTab Organizer en el Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible con todos los navegadores basados en Chromium (Chrome, Edge, Brave, Vivaldi, Arc, Opera).
+[SmartTab Organizer en el Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible con todos los navegadores basados en Chromium (Chrome, Edge, Brave, Vivaldi, Arc, Opera). En Vivaldi, la agrupación automática no está disponible (Vivaldi no expone la API de grupos de pestañas de Chromium); la deduplicación y las sesiones siguen funcionando.
 
 <Steps>
 1. Haz clic en **Añadir a Chrome**.

--- a/docs/src/content/docs/es/faq.mdx
+++ b/docs/src/content/docs/es/faq.mdx
@@ -39,6 +39,10 @@ Exporta tus reglas desde el navegador de origen (página Importar / Exportar, bo
 
 Sí, Firefox es compatible mediante una build MV2 dedicada (`pnpm build:firefox` en local, o Firefox Add-ons para la instalación pública). Las API utilizadas son comunes a ambas plataformas. Consulta [Instalación](/discover/installation).
 
+## Compatibilidad con Vivaldi
+
+Parcialmente. La deduplicación, las sesiones y la extracción de nombres por regex funcionan, pero la agrupación automática no tiene efecto: Vivaldi no expone la API de grupos de pestañas de Chromium y se basa en sus propios Tab Stacks, que no pueden controlarse desde una extensión.
+
 ## ¿Puede la extensión leer el contenido de mis páginas?
 
 No. Los permisos solicitados son `tabs`, `storage`, `notifications` y `scripting`. El permiso `scripting` se usa únicamente para inyectar un pequeño script que captura los **clics** en los enlaces (para memorizar el enlace de destino antes de que se abra la pestaña). No se lee el DOM ni el contenido de las páginas.

--- a/docs/src/content/docs/faq.mdx
+++ b/docs/src/content/docs/faq.mdx
@@ -39,6 +39,10 @@ Export your rules from the source browser (Import / Export page, **Export** butt
 
 Yes, Firefox is supported via a dedicated MV2 build (`pnpm build:firefox` locally, or Firefox Add-ons for public installs). The APIs used are common to both platforms. See [Installation](/discover/installation).
 
+## Vivaldi compatibility
+
+Partially. Deduplication, sessions, and regex name extraction work, but automatic grouping has no effect: Vivaldi does not expose Chromium's tab groups API and relies on its own Tab Stacks, which cannot be controlled by an extension.
+
 ## Can the extension read the contents of my pages?
 
 No. The permissions requested are `tabs`, `storage`, `notifications`, and `scripting`. `scripting` is used only to inject a small script that captures **clicks** on links (so we can remember the target link before the tab opens). Nothing about the DOM or the page contents is ever read.

--- a/docs/src/content/docs/fr/contributing/stack.mdx
+++ b/docs/src/content/docs/fr/contributing/stack.mdx
@@ -25,8 +25,13 @@ SmartTab Organizer est une extension navigateur cross-browser (Chromium MV3 et F
 | Navigateur | Manifest | Statut |
 |---|---|---|
 | Chrome | MV3 | Cible principale |
-| Edge, Brave, Vivaldi, Arc, Opera (basés Chromium) | MV3 | Compatible (même artefact que Chrome) |
+| Edge, Brave, Arc, Opera (basés Chromium) | MV3 | Compatible (même artefact que Chrome) |
+| Vivaldi | MV3 | Partiel · le groupage natif n'est pas pris en charge. Déduplication et sessions fonctionnent. |
 | Firefox | MV2 | Compatible (cibles `pnpm build:firefox`, `pnpm zip:firefox`) |
+
+<Aside type="note">
+Vivaldi remplace l'API de groupes d'onglets de Chromium par son système maison de Tab Stacks, sans interface programmable pour les extensions. Le groupage automatique reste donc sans effet visible sur Vivaldi. Les autres fonctions ne sont pas affectées.
+</Aside>
 
 Les API navigateur sont accédées via `wxt/browser`, qui normalise les différences entre `chrome.*` et `browser.*`. L'extension utilise un sous-ensemble qui existe sur les deux : `browser.tabs`, `browser.tabGroups`, `browser.storage`, `browser.action` / `browser.browserAction`, `browser.notifications`, `browser.scripting`.
 

--- a/docs/src/content/docs/fr/discover/installation.mdx
+++ b/docs/src/content/docs/fr/discover/installation.mdx
@@ -15,7 +15,7 @@ import { Aside, CardGrid, LinkCard, Steps, Tabs, TabItem } from '@astrojs/starli
 
 <Tabs>
   <TabItem label="Chrome / Edge / Brave">
-[SmartTab Organizer sur le Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible avec tous les navigateurs basés sur Chromium (Chrome, Edge, Brave, Vivaldi, Arc, Opera).
+[SmartTab Organizer sur le Chrome Web Store](https://chromewebstore.google.com/detail/smarttab-organizer/ijnpdkkcbmfikocmboibffjgbohhlmah). Compatible avec tous les navigateurs basés sur Chromium (Chrome, Edge, Brave, Vivaldi, Arc, Opera). Sur Vivaldi, le groupage automatique n'est pas disponible (Vivaldi n'expose pas l'API de groupes d'onglets de Chromium) ; la déduplication et les sessions fonctionnent.
 
 <Steps>
 1. Cliquez sur **Ajouter à Chrome**.

--- a/docs/src/content/docs/fr/faq.mdx
+++ b/docs/src/content/docs/fr/faq.mdx
@@ -39,6 +39,10 @@ Exportez vos règles depuis le navigateur source (page Import / Export, bouton *
 
 Oui, Firefox est supporté via une build MV2 dédiée (`pnpm build:firefox` en local, ou Firefox Add-ons pour l'installation publique). Les API utilisées sont communes aux deux plateformes. Voir [Installation](/discover/installation).
 
+## Compatibilité avec Vivaldi
+
+Partiellement. La déduplication, les sessions et l'extraction regex du nom fonctionnent, mais le groupage automatique reste sans effet : Vivaldi n'expose pas l'API de groupes d'onglets de Chromium et s'appuie sur ses propres Tab Stacks, non pilotables par une extension.
+
 ## L'extension peut-elle lire le contenu de mes pages ?
 
 Non. Les permissions demandées sont `tabs`, `storage`, `notifications` et `scripting`. Le `scripting` est utilisé uniquement pour injecter un petit script qui capture les **clics** sur les liens (pour mémoriser le lien ciblé avant que l'onglet ne s'ouvre). Aucune lecture du DOM ni du contenu des pages.

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1067,6 +1067,7 @@
   "aboutDialogFooterAuthor": { "message": "EspritVorace" },
   "aboutDialogChangelogButton": { "message": "Full changelog" },
   "aboutDialogCloseButton": { "message": "Close" },
+  "aboutDialogVivaldiNotice": { "message": "On Vivaldi, native grouping is unavailable · this browser does not expose Chromium's tab groups API. Deduplication and sessions still work." },
   "explorationPrerequisitePrefix": { "message": "Requires: $1$", "placeholders": {"1":{"content":"$1","example":"Create a rule"}} },
   "explorationCoverageRatio": { "message": "$1$ of $2$ capabilities discovered", "placeholders": {"1":{"content":"$1","example":"12"},"2":{"content":"$2","example":"113"}} },
   "explorationMiniPhase": { "message": "Phase $1$", "placeholders": {"1":{"content":"$1","example":"Discovery"}} },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -1068,6 +1068,7 @@
   "aboutDialogFooterAuthor": { "message": "EspritVorace" },
   "aboutDialogChangelogButton": { "message": "Registro completo" },
   "aboutDialogCloseButton": { "message": "Cerrar" },
+  "aboutDialogVivaldiNotice": { "message": "En Vivaldi, la agrupación nativa no está disponible · este navegador no expone la API de grupos de pestañas de Chromium. La deduplicación y las sesiones siguen funcionando." },
   "explorationPrerequisitePrefix": { "message": "Requisito: $1$", "placeholders": {"1":{"content":"$1","example":"Create a rule"}} },
   "explorationTab": { "message": "Exploración" },
   "explorationPageDescription": { "message": "Una guía práctica para explorar todas las capacidades de la extensión y ver de un vistazo las que aún te quedan por descubrir. Un punto de referencia para avanzar a tu ritmo, no una nota." },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -1068,6 +1068,7 @@
   "aboutDialogFooterAuthor": { "message": "EspritVorace" },
   "aboutDialogChangelogButton": { "message": "Changelog complet" },
   "aboutDialogCloseButton": { "message": "Fermer" },
+  "aboutDialogVivaldiNotice": { "message": "Sur Vivaldi, le groupage natif n'est pas disponible · ce navigateur n'expose pas l'API de groupes d'onglets de Chromium. La déduplication et les sessions restent fonctionnelles." },
   "explorationPrerequisitePrefix": { "message": "Prérequis : $1$", "placeholders": {"1":{"content":"$1","example":"Create a rule"}} },
   "explorationTab": { "message": "Référentiel d'exploration" },
   "explorationPageDescription": { "message": "Un guide pratique pour explorer toutes les capacités de l'extension et repérer d'un coup d'œil celles qu'il vous reste à découvrir. Un repère pour avancer à votre rythme, pas une note." },

--- a/src/components/UI/AboutDialog/AboutDialog.tsx
+++ b/src/components/UI/AboutDialog/AboutDialog.tsx
@@ -50,6 +50,10 @@ function detectBrowserLabel(): string {
     const v = /OPR\/(\d+)/.exec(ua)?.[1] ?? '';
     return `Opera ${v}`.trim();
   }
+  if (/Vivaldi\/(\d+)/.test(ua)) {
+    const v = /Vivaldi\/(\d+)/.exec(ua)?.[1] ?? '';
+    return `Vivaldi ${v}`.trim();
+  }
   if (/Chrome\/(\d+)/.test(ua)) {
     const v = /Chrome\/(\d+)/.exec(ua)?.[1] ?? '';
     return `Chrome ${v}`.trim();
@@ -441,6 +445,19 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps) {
                 hint={languageCode}
               />
             </div>
+            {browserLabel.startsWith('Vivaldi') && (
+              <Text
+                as="p"
+                size="1"
+                style={{
+                  marginTop: 10,
+                  color: 'var(--gray-11)',
+                  lineHeight: 1.55,
+                }}
+              >
+                {getMessage('aboutDialogVivaldiNotice')}
+              </Text>
+            )}
           </div>
 
           {/* Links */}

--- a/wxt-i18n-structure.d.ts
+++ b/wxt-i18n-structure.d.ts
@@ -1020,6 +1020,7 @@ export type GeneratedI18nStructure = {
   "aboutDialogFooterAuthor": { substitutions: 0, plural: false };
   "aboutDialogChangelogButton": { substitutions: 0, plural: false };
   "aboutDialogCloseButton": { substitutions: 0, plural: false };
+  "aboutDialogVivaldiNotice": { substitutions: 0, plural: false };
   "explorationPrerequisitePrefix": { substitutions: 1, plural: false };
   "explorationCoverageRatio": { substitutions: 2, plural: false };
   "explorationMiniPhase": { substitutions: 1, plural: false };


### PR DESCRIPTION
Vivaldi replaces Chromium's tab groups API with its own Tab Stacks system,
which has no programmable interface for extensions. Automatic grouping is
therefore silently ineffective on Vivaldi, while deduplication and sessions
continue to work.

Lot 1 (docs):
- stack.mdx (EN/FR/ES): split Vivaldi out of the shared Chromium row with a
  Partial status, and add an Aside explaining the Tab Stacks limitation.
- faq.mdx (EN/FR/ES): add a Vivaldi section immediately after the Firefox
  section, mirroring its format.

Lot 2 (runtime):
- detectBrowserLabel(): add Vivaldi detection before the Chrome branch so
  the About dialog correctly labels the browser as Vivaldi.
- AboutDialog: show getMessage('aboutDialogVivaldiNotice') below the info
  grid whenever the detected browser label starts with "Vivaldi".
- Add aboutDialogVivaldiNotice to public/_locales/{en,fr,es}/messages.json
  and wxt-i18n-structure.d.ts (parity EN/FR/ES, middle dot separator, no
  em/en dash, browser.* API only).