### PR TITLE
Bump version to 1.2.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.2.6 — since 1.2.5
+
+### New Features
+- Tab coverage panel in the rule wizard's domain step, seeding the filter field from open tabs
+- Domain-aware preset suggestions in the rule wizard's preset step, plus self-hosted presets (GitLab, Jira, GitHub Enterprise) suggested via subdomain matching
+- Keyboard navigation in wizards: Ctrl+Enter to confirm, Ctrl+Backspace to go back
+- Vivaldi partial-compatibility notice surfaced in the About dialog (tab groups unsupported, dedup and sessions unaffected)
+
+### Improvements
+- Preset search automatically focused on entering Preset mode in the rule wizard
+- Enter on a searchable list's search input selects the first result
+- Workspace list hidden when only one workspace exists
+
+### Bug Fixes
+- Accessibility: high-contrast text for the selected searchable-list row and for tab-coverage badges
+- Session card restore button now renders with the correct tile presentation in the full header
+
 ## 1.2.5 — since 1.2.4
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-tab-organizer",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "GPL-3.0-only",
   "packageManager": "pnpm@11.4.0",
   "type": "module",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -99,7 +99,7 @@ export default defineConfig({
   manifest: {
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
-    version: '1.2.5',
+    version: '1.2.6',
     author: 'EspritVorace',
     homepage_url: 'https://github.com/EspritVorace/smart-tab-organizer',
     default_locale: 'en',


### PR DESCRIPTION
Update package.json and extension manifest to version 1.2.6 and add CHANGELOG entries for 1.2.6. Notes include new features (tab coverage panel, domain-aware preset suggestions and self-hosted presets, keyboard navigation, Vivaldi notice), improvements (preset search focus, Enter selects first search result, hide workspace list when single workspace), and bug fixes (high-contrast accessibility fixes and session card restore button rendering).